### PR TITLE
feat(api): harden the OpenAPI schema for client generation (ADR-0007)

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -187,6 +187,13 @@ jobs:
       - name: Lint profile contracts
         run: uv run python scripts/lint_profile_contracts.py
 
+      # Imports app.main, so it needs `uv sync --extra dev` above — it cannot move to
+      # the migration-lint job, which deliberately runs stdlib-only scripts. This job
+      # also runs on a bare checkout with no backend/static/, which matters: a built
+      # frontend adds SPA routes and changes the schema.
+      - name: Lint OpenAPI schema
+        run: uv run python scripts/lint_openapi.py
+
   backend-test-contract:
     name: Backend Test (Contract)
     runs-on: [self-hosted, Linux]

--- a/backend/Makefile
+++ b/backend/Makefile
@@ -1,4 +1,4 @@
-.PHONY: install dev run reset-db migrate test test-contract lint format backfill-artists
+.PHONY: install dev run reset-db migrate test test-contract lint lint-contracts openapi format backfill-artists
 
 # Install dependencies
 install:
@@ -33,6 +33,16 @@ test-contract:
 lint:
 	uv run ruff check .
 	uv run mypy app
+
+# Run the custom checks CI enforces (schema, migrations, profile contracts)
+lint-contracts:
+	uv run python scripts/lint_openapi.py
+	uv run python scripts/lint_migrations.py
+	uv run python scripts/lint_profile_contracts.py
+
+# Dump the OpenAPI schema for inspection or client generation
+openapi:
+	uv run python -c "import json; from app.main import app; print(json.dumps(app.openapi(), indent=2))"
 
 # Format code
 format:

--- a/backend/app/api/routes/_external_albums_schemas.py
+++ b/backend/app/api/routes/_external_albums_schemas.py
@@ -5,7 +5,6 @@ Used by:
 - ``library_discover.py`` for listening-profile recommendations (#2 in Discover)
 """
 
-from typing import Any
 
 from pydantic import BaseModel
 
@@ -26,7 +25,8 @@ class ExternalAlbumResponse(BaseModel):
     local_album_match: bool
     dismissed: bool
     discovered_at: str
-    purchase_links: dict[str, Any]
+    # {store_name: {"url": ..., "label": ...}} from generate_release_search_urls()
+    purchase_links: dict[str, dict[str, str]]
 
 
 class ExternalAlbumsResponse(BaseModel):

--- a/backend/app/api/routes/chat.py
+++ b/backend/app/api/routes/chat.py
@@ -107,7 +107,16 @@ async def generate_sse_events(
     yield "data: [DONE]\n\n"
 
 
-@router.post("/stream")
+@router.post(
+    "/stream",
+    response_class=StreamingResponse,
+    responses={
+        200: {
+            "content": {"text/event-stream": {}},
+            "description": "Server-sent events carrying chat deltas and tool calls.",
+        }
+    },
+)
 @limiter.limit(CHAT_RATE_LIMIT)
 async def chat_stream(
     request: Request,

--- a/backend/app/api/routes/library_artists.py
+++ b/backend/app/api/routes/library_artists.py
@@ -11,6 +11,7 @@ from sqlalchemy import func, select
 
 from app.api.deps import DbSession, RequiredProfile
 from app.api.exceptions import NotFoundError
+from app.api.schemas.artists import SimilarArtistInfo
 from app.db.models import Artist, ArtistAlias, Track, TrackAnalysis, TrackStatus
 from app.services.external_albums_helpers import normalize_artist_name
 from app.utils.time import utcnow
@@ -194,18 +195,6 @@ class ArtistTrack(BaseModel):
     track_number: int | None
     duration_seconds: float | None
     year: int | None
-
-
-class SimilarArtistInfo(BaseModel):
-    """Enriched similar artist with library status and external links."""
-
-    name: str
-    match_score: float  # 0-1 similarity from Last.fm
-    in_library: bool
-    track_count: int | None = None  # If in library
-    image_url: str | None = None
-    lastfm_url: str | None = None
-    bandcamp_url: str | None = None  # Search link for discovery
 
 
 class ArtistDetailResponse(BaseModel):

--- a/backend/app/api/routes/library_maps.py
+++ b/backend/app/api/routes/library_maps.py
@@ -103,7 +103,16 @@ async def get_music_map(
     )
 
 
-@router.get("/map/stream")
+@router.get(
+    "/map/stream",
+    response_class=StreamingResponse,
+    responses={
+        200: {
+            "content": {"text/event-stream": {}},
+            "description": "Server-sent events reporting map build progress.",
+        }
+    },
+)
 async def get_music_map_stream(
     db: DbSession,
     entity_type: Literal["artists", "albums"] = "artists",
@@ -282,7 +291,16 @@ async def get_3d_music_map(
     )
 
 
-@router.get("/map/3d/stream")
+@router.get(
+    "/map/3d/stream",
+    response_class=StreamingResponse,
+    responses={
+        200: {
+            "content": {"text/event-stream": {}},
+            "description": "Server-sent events reporting 3D map build progress.",
+        }
+    },
+)
 async def get_3d_music_map_stream(
     db: DbSession,
     entity_type: Literal["artists", "albums"] = "artists",

--- a/backend/app/api/routes/library_missing.py
+++ b/backend/app/api/routes/library_missing.py
@@ -43,12 +43,21 @@ class RelocateRequest(BaseModel):
     search_path: str
 
 
+class RelocatedTrack(BaseModel):
+    """A track whose file was found at a new path."""
+
+    id: str
+    title: str | None = None
+    old_path: str
+    new_path: str
+
+
 class RelocateResult(BaseModel):
     """Result of batch relocation."""
 
     found: int
     not_found: int
-    relocated_tracks: list[dict]
+    relocated_tracks: list[RelocatedTrack]
 
 
 class LocateRequest(BaseModel):
@@ -182,15 +191,18 @@ async def relocate_missing_tracks(
     for filename, track in missing_tracks.items():
         if filename in found_files:
             new_path = found_files[filename]
+            # Capture before mutating — reading track.file_path afterwards reported the
+            # new path as `old_path`, so both fields came back identical.
+            old_path = track.file_path
             track.file_path = str(new_path)
             track.status = TrackStatus.ACTIVE
             track.missing_since = None
-            relocated.append({
-                "id": str(track.id),
-                "title": track.title,
-                "old_path": track.file_path,
-                "new_path": str(new_path),
-            })
+            relocated.append(RelocatedTrack(
+                id=str(track.id),
+                title=track.title,
+                old_path=old_path,
+                new_path=str(new_path),
+            ))
 
     await db.commit()
 

--- a/backend/app/api/routes/mixtapes.py
+++ b/backend/app/api/routes/mixtapes.py
@@ -212,7 +212,16 @@ async def get_mixtape(
     return _serialize(mixtape, progress=progress)
 
 
-@router.get("/{mixtape_id}/download")
+@router.get(
+    "/{mixtape_id}/download",
+    response_class=FileResponse,
+    responses={
+        200: {
+            "content": {"application/zip": {}},
+            "description": "Mixtape bundle: audio, cover image and tracklist.",
+        }
+    },
+)
 async def download_mixtape(
     mixtape_id: UUID,
     db: DbSession,

--- a/backend/app/api/routes/profiles.py
+++ b/backend/app/api/routes/profiles.py
@@ -258,7 +258,11 @@ async def upload_avatar(
     return profile_to_response(profile, has_lastfm)
 
 
-@router.get("/{profile_id}/avatar")
+@router.get(
+    "/{profile_id}/avatar",
+    response_class=FileResponse,
+    responses={200: {"content": {"image/*": {}}, "description": "Profile avatar image."}},
+)
 async def get_avatar(
     profile_id: UUID,
     db: DbSession,

--- a/backend/app/api/routes/smart_playlists.py
+++ b/backend/app/api/routes/smart_playlists.py
@@ -56,7 +56,7 @@ class SmartPlaylistResponse(BaseModel):
     id: str
     name: str
     description: str | None
-    rules: list[dict[str, Any]]
+    rules: list[RuleSchema]
     match_mode: str
     order_by: str
     order_direction: str
@@ -287,7 +287,39 @@ async def convert_to_static(
     )
 
 
-@router.get("/fields/available")
+class RuleFieldInfo(BaseModel):
+    """A field a smart-playlist rule can be built against."""
+
+    name: str
+    type: str
+    description: str
+    # Analysis fields carry an inclusive [min, max] so the UI can render a slider.
+    # Omitted for string/date/boolean fields.
+    range: list[float] | None = None
+
+
+class RuleOperators(BaseModel):
+    """Operators valid for each field type."""
+
+    string: list[str]
+    number: list[str]
+    date: list[str]
+    boolean: list[str]
+    list: list[str]
+
+
+class AvailableFieldsResponse(BaseModel):
+    """Everything a client needs to build a smart-playlist rule."""
+
+    track_fields: list[RuleFieldInfo]
+    analysis_fields: list[RuleFieldInfo]
+    play_history_fields: list[RuleFieldInfo]
+    operators: RuleOperators
+    date_keywords: list[str]
+    relative_units: list[str]
+
+
+@router.get("/fields/available", response_model=AvailableFieldsResponse)
 async def get_available_fields() -> dict[str, Any]:
     """Get list of available fields and operators for building rules."""
     return {

--- a/backend/app/api/routes/tracks/discovery.py
+++ b/backend/app/api/routes/tracks/discovery.py
@@ -10,6 +10,7 @@ from sqlalchemy import func, select
 
 from app.api.deps import DbSession
 from app.api.exceptions import NotFoundError, TrackNotFoundError
+from app.api.schemas.artists import SimilarArtistInfo
 from app.db.models import Track, TrackAnalysis
 
 from . import TrackResponse
@@ -25,18 +26,6 @@ class AlbumGainResponse(BaseModel):
     album_gain_db: float | None = None
     album_peak: float | None = None
     track_count: int = 0
-
-
-class SimilarArtistInfo(BaseModel):
-    """Similar artist with library status and external links."""
-
-    name: str
-    match_score: float
-    in_library: bool
-    track_count: int | None = None
-    image_url: str | None = None
-    lastfm_url: str | None = None
-    bandcamp_url: str | None = None
 
 
 class TrackDiscoverResponse(BaseModel):

--- a/backend/app/api/routes/tracks/listing.py
+++ b/backend/app/api/routes/tracks/listing.py
@@ -411,7 +411,12 @@ async def get_tracks_batch(
     return ordered_tracks
 
 
-@router.get("/", response_model=TrackListResponse)
+# Registered twice on purpose — see the comment in tracks/__init__.py. The parent
+# router serves "" (/tracks) and this serves "/" (/tracks/), because the SPA catch-all
+# swallows FastAPI's redirect. They are one API operation, so only the parent
+# registration appears in the schema; otherwise a generated client would grow two
+# identical listTracks methods (ADR-0007).
+@router.get("/", response_model=TrackListResponse, include_in_schema=False)
 async def list_tracks(
     db: DbSession,
     profile: CurrentProfile,

--- a/backend/app/api/routes/tracks/playback.py
+++ b/backend/app/api/routes/tracks/playback.py
@@ -12,7 +12,7 @@ promises to leave alone.
 """
 
 import logging
-from typing import Any, Literal
+from typing import Literal
 from uuid import UUID
 
 from fastapi import APIRouter, Query
@@ -132,13 +132,24 @@ async def _get_track_or_404(db: DbSession, track_id: UUID) -> Track:
     return track
 
 
+class TopTrackStat(BaseModel):
+    """A track in the profile's most-played list."""
+
+    id: str
+    title: str | None = None
+    artist: str | None = None
+    play_count: int
+    total_play_seconds: float
+    last_played_at: str | None = None
+
+
 class ProfilePlayStatsResponse(BaseModel):
     """Profile play statistics."""
 
     total_plays: int
     total_play_seconds: float
     unique_tracks: int
-    top_tracks: list[dict[str, Any]]
+    top_tracks: list[TopTrackStat]
 
 
 @router.post("/{track_id}/played", response_model=PlayRecordResponse)
@@ -316,14 +327,14 @@ async def get_play_stats(
     unique_tracks = len(rows)
 
     top_tracks = [
-        {
-            "id": str(track.id),
-            "title": track.title,
-            "artist": track.artist,
-            "play_count": ph.play_count,
-            "total_play_seconds": ph.total_play_seconds,
-            "last_played_at": ph.last_played_at.isoformat() if ph.last_played_at else None,
-        }
+        TopTrackStat(
+            id=str(track.id),
+            title=track.title,
+            artist=track.artist,
+            play_count=ph.play_count,
+            total_play_seconds=ph.total_play_seconds,
+            last_played_at=ph.last_played_at.isoformat() if ph.last_played_at else None,
+        )
         for ph, track in rows[:limit]
     ]
 

--- a/backend/app/api/routes/tracks/streaming.py
+++ b/backend/app/api/routes/tracks/streaming.py
@@ -4,6 +4,7 @@ import asyncio
 import logging
 from collections.abc import Iterator
 from pathlib import Path
+from typing import Literal
 from uuid import UUID
 
 from fastapi import APIRouter, Query, Request, UploadFile
@@ -61,7 +62,19 @@ class LyricsResponse(BaseModel):
     source: str
 
 
-@router.get("/{track_id}/stream")
+@router.get(
+    "/{track_id}/stream",
+    # Declare the real media type. Without this the schema claims application/json and a
+    # generated client would try to JSON-decode audio (ADR-0007). This endpoint is
+    # hand-written per platform; the schema only needs to describe it honestly.
+    response_class=StreamingResponse,
+    responses={
+        200: {
+            "content": {"audio/*": {}},
+            "description": "Audio stream. Supports HTTP range requests for seeking.",
+        }
+    },
+)
 async def stream_track(
     db: DbSession,
     track_id: UUID,
@@ -147,11 +160,20 @@ async def _get_or_transcode(track_id: UUID, file_path: Path, request: Request) -
     return await stream_file(cached, request, "audio/flac")
 
 
-@router.post("/{track_id}/report-playback-error")
+class PlaybackErrorResponse(BaseModel):
+    """Outcome of reporting a playback error for a track."""
+
+    # 'retry' means a stale transcode was cleared and replaying may work;
+    # 'skip' means nothing could be repaired.
+    status: Literal["retry", "skip"]
+    reason: Literal["cache_cleared", "no_cache"]
+
+
+@router.post("/{track_id}/report-playback-error", response_model=PlaybackErrorResponse)
 async def report_playback_error(
     db: DbSession,
     track_id: UUID,
-) -> dict:
+) -> PlaybackErrorResponse:
     """Report a client-side playback/decode error for a track.
 
     Auto-repair has been removed. Returns a skip status.
@@ -179,13 +201,17 @@ async def report_playback_error(
 
     if cache_cleared:
         logger.info("Playback error reported for track %s (%s) — cache cleared, retry may help", track.title, file_path.name)
-        return {"status": "retry", "reason": "cache_cleared"}
+        return PlaybackErrorResponse(status="retry", reason="cache_cleared")
 
     logger.info("Playback error reported for track %s (%s) — skipped", track.title, file_path.name)
-    return {"status": "skip", "reason": "no_cache"}
+    return PlaybackErrorResponse(status="skip", reason="no_cache")
 
 
-@router.get("/{track_id}/artwork")
+@router.get(
+    "/{track_id}/artwork",
+    response_class=StreamingResponse,
+    responses={200: {"content": {"image/*": {}}, "description": "Album artwork image."}},
+)
 async def get_track_artwork(
     db: DbSession,
     track_id: UUID,

--- a/backend/app/api/schemas/__init__.py
+++ b/backend/app/api/schemas/__init__.py
@@ -3,6 +3,7 @@
 Centralising DTOs here breaks route-to-route import cycles.
 """
 
+from app.api.schemas.artists import SimilarArtistInfo
 from app.api.schemas.common import CancelResponse
 from app.api.schemas.tracks import (
     BatchTracksRequest,
@@ -16,6 +17,7 @@ from app.api.schemas.tracks import (
 __all__ = [
     "BatchTracksRequest",
     "CancelResponse",
+    "SimilarArtistInfo",
     "TrackDetailResponse",
     "TrackFeaturesResponse",
     "TrackIdsResponse",

--- a/backend/app/api/schemas/artists.py
+++ b/backend/app/api/schemas/artists.py
@@ -1,0 +1,21 @@
+"""Artist-related Pydantic schemas shared across route modules."""
+
+from pydantic import BaseModel
+
+
+class SimilarArtistInfo(BaseModel):
+    """A similar artist, with library status and external links.
+
+    Shared by the artist-detail and track-discovery endpoints, which previously
+    declared identical copies. Two same-named models made FastAPI emit one of them
+    fully qualified — `app__api__routes__tracks__discovery__SimilarArtistInfo` — which
+    a generated client would use verbatim as a type name (ADR-0007).
+    """
+
+    name: str
+    match_score: float  # 0-1 similarity from Last.fm
+    in_library: bool
+    track_count: int | None = None  # If in library
+    image_url: str | None = None
+    lastfm_url: str | None = None
+    bandcamp_url: str | None = None  # Search link for discovery

--- a/backend/app/main.py
+++ b/backend/app/main.py
@@ -19,6 +19,7 @@ from fastapi import FastAPI, HTTPException, Request
 from fastapi.exceptions import RequestValidationError
 from fastapi.middleware.cors import CORSMiddleware
 from fastapi.responses import FileResponse, JSONResponse
+from fastapi.routing import APIRoute
 from fastapi.staticfiles import StaticFiles
 from slowapi import _rate_limit_exceeded_handler
 from slowapi.errors import RateLimitExceeded
@@ -242,11 +243,32 @@ async def lifespan(app: FastAPI) -> AsyncGenerator[None, None]:
     logger.info("Background task manager stopped")
 
 
+def custom_generate_unique_id(route: APIRoute) -> str:
+    """Build a short, readable operationId from the route's tag and function name.
+
+    FastAPI's default derives the id from function name + path + method, producing
+    names up to 95 characters — `get_playlist_external_albums_api_v1_playlists__
+    playlist_id__recommendations_external_albums_get` — which a generated client turns
+    into an unusable method name (ADR-0007).
+
+    `{tag}_{name}` keeps them short and stable. Only three function names repeat across
+    the API (`list_tracks`, `update_track_metadata`, `get_stats`) and the tag prefix
+    separates all three. Uniqueness is not guaranteed by construction, so
+    `scripts/lint_openapi.py` asserts it.
+
+    Also improves auto-generated multipart body models, which FastAPI names after the
+    operationId (`Body_upload_avatar_api_v1_profiles__profile_id__avatar_post`).
+    """
+    tag = str(route.tags[0]).lower().replace(" ", "-") if route.tags else "root"
+    return f"{tag}_{route.name}"
+
+
 app = FastAPI(
     title="Familiar",
     description="LLM-powered local music player API",
     version=get_app_version(),
     lifespan=lifespan,
+    generate_unique_id_function=custom_generate_unique_id,
 )
 
 # Rate limiting

--- a/backend/scripts/lint_openapi.py
+++ b/backend/scripts/lint_openapi.py
@@ -1,0 +1,289 @@
+#!/usr/bin/env python3
+"""Lint the OpenAPI schema so typed clients can be generated from it (ADR-0007).
+
+Validates, for the surface a generated client will actually cover:
+  - No 2xx JSON response generates as an untyped ``object``
+  - No response model has fields that generate as ``Any``
+  - Every operation carries at least one tag (tags group the generated client)
+  - No endpoint claims ``application/json`` while returning audio, images or SSE
+  - operationIds are unique and short enough to read
+
+The generated surface is the native v1 listening path (ADR-0001 scope). Library
+management stays web-only (ADR-0002) and will never need a Swift client, so its
+existing looseness is allowlisted below rather than blocking.
+
+The allowlists are a burn-down list, not an approved state. Anything NEW fails,
+which makes adding an untyped response a visible decision in review.
+
+Exit code 0 on success, 1 with details on failure.
+"""
+
+import sys
+from pathlib import Path
+from typing import Any
+
+sys.path.insert(0, str(Path(__file__).resolve().parent.parent))
+
+# Tags whose operations a generated client will cover. Everything else is
+# management surface that stays web-only.
+GENERATED_SURFACE = {
+    "tracks",
+    "library",
+    "playlists",
+    "smart-playlists",
+    "profiles",
+    "favorites",
+    "chat",
+    "mixtapes",
+    "ambient",
+}
+
+# operationIds longer than this are unusable as generated method names. The
+# default FastAPI scheme produced names up to 95 characters before ADR-0007.
+MAX_OPERATION_ID_LENGTH = 60
+
+# Media types that must never be advertised as application/json.
+NON_JSON_PREFIXES = ("audio/", "image/", "video/", "text/event-stream", "application/zip")
+
+# ---------------------------------------------------------------------------
+# Burn-down allowlists — entries here are known-loose, not approved.
+# ---------------------------------------------------------------------------
+
+# Out-of-scope operations returning an untyped JSON object. All are management
+# or analysis surfaces that a generated client will not call.
+ALLOWED_UNTYPED_OPERATIONS = {
+    ("GET", "/"),
+    ("HEAD", "/api/v1/artwork/check/{artist}/{album}"),
+    ("POST", "/api/v1/artwork/queue"),
+    ("POST", "/api/v1/artwork/queue/batch"),
+    ("POST", "/api/v1/artwork/regenerate"),
+    ("POST", "/api/v1/artwork/regenerate-stale"),
+    ("POST", "/api/v1/download/analyses"),
+    ("GET", "/api/v1/download/analyses/{task_id}/download"),
+    ("GET", "/api/v1/download/analyses/{task_id}/status"),
+    ("GET", "/api/v1/download/playlist/{playlist_id}"),
+    ("GET", "/api/v1/download/smart-playlist/{playlist_id}"),
+    ("POST", "/api/v1/download/tracks"),
+    ("POST", "/api/v1/export-import/backup"),
+    ("POST", "/api/v1/export-import/export"),
+    ("POST", "/api/v1/export-import/library/export"),
+    ("POST", "/api/v1/external-albums/{external_album_id}/dismiss"),
+    ("GET", "/api/v1/new-releases"),
+    ("POST", "/api/v1/new-releases/check"),
+    ("POST", "/api/v1/new-releases/check/batch"),
+    ("GET", "/api/v1/new-releases/status"),
+    ("POST", "/api/v1/new-releases/{release_id}/dismiss"),
+    ("DELETE", "/api/v1/outputs/zones/{zone_id}/outputs/{output_id}"),
+    ("POST", "/api/v1/outputs/zones/{zone_id}/outputs/{output_id}"),
+    ("POST", "/api/v1/outputs/zones/{zone_id}/pause"),
+    ("POST", "/api/v1/outputs/zones/{zone_id}/play"),
+    ("POST", "/api/v1/outputs/zones/{zone_id}/stop"),
+    ("POST", "/api/v1/pending-tracks/bulk/approve-all"),
+    ("POST", "/api/v1/pending-tracks/bulk/skip-all"),
+    ("POST", "/api/v1/pending-tracks/bulk/unskip-all"),
+    ("POST", "/api/v1/pending-tracks/group/approve"),
+    ("POST", "/api/v1/pending-tracks/group/metadata"),
+    ("POST", "/api/v1/pending-tracks/group/replace-upgrades"),
+    ("POST", "/api/v1/pending-tracks/group/skip"),
+    ("POST", "/api/v1/pending-tracks/group/skip-downgrades"),
+    ("POST", "/api/v1/pending-tracks/group/unskip"),
+    ("GET", "/api/v1/s3-backup/history"),
+    ("POST", "/api/v1/s3-backup/restore"),
+    ("POST", "/api/v1/s3-backup/restore/check"),
+    ("POST", "/api/v1/s3-backup/restore/download"),
+    ("GET", "/api/v1/s3-backup/restore/status"),
+    ("POST", "/api/v1/s3-backup/run"),
+    ("POST", "/api/v1/tracks/analysis/bulk"),
+    ("GET", "/api/v1/tracks/analysis/bulk/{task_id}"),
+    ("GET", "/api/v1/tracks/analysis/bulk/{task_id}/report"),
+    ("GET", "/api/v1/tracks/{track_id}/analysis"),
+    ("POST", "/api/v1/tracks/{track_id}/analysis"),
+    ("GET", "/api/v1/tracks/{track_id}/analysis/midi"),
+    ("GET", "/api/v1/tracks/{track_id}/analysis/report"),
+    ("GET", "/api/v1/tracks/{track_id}/analysis/similarity.png"),
+    ("GET", "/api/v1/videos/{track_id}/stream"),
+}
+
+# In-scope model fields that are genuinely free-form, with the reason. These are
+# not burn-down candidates — they carry data whose shape the API does not own.
+ALLOWED_LOOSE_FIELDS = {
+    "ChatResponse.tool_calls": "arbitrary LLM tool-call payloads",
+    "ChatResponse.queued_tracks": "shape mirrors whatever the LLM queued",
+    "ChatResponse.playback_action": "open-ended player command from the LLM",
+    "RuleSchema.value": "polymorphic by design — string, number, date, bool or list",
+    "TrackMetadataResponse.user_overrides": "free-form user metadata overrides",
+    "MixTapeResponse.progress": "opaque render-progress JSON read back from Redis",
+    "IdentifyCandidateResponse.features": "third-party AcoustID feature blob",
+    "ImportTrackPreview.incoming_quality": "quality descriptor varies by source format",
+    "ImportTrackPreview.existing_quality": "quality descriptor varies by source format",
+}
+
+# Schema names FastAPI had to fully qualify because two modules declare the same
+# model name. Ugly in a generated client; out of scope to fix here.
+ALLOWED_MANGLED_SCHEMAS = {
+    "app__api__routes__library_import__preview__ImportPreviewResponse",
+    "app__api__routes__export_import__profile__ImportPreviewResponse",
+}
+
+
+def _is_loose(schema: dict[str, Any]) -> bool:
+    """True when a schema fragment generates as ``Any`` in a typed client."""
+    if not schema:
+        return True
+    # dict[str, Any] renders as additionalProperties: true
+    if schema.get("additionalProperties") is True:
+        return True
+    if (
+        schema.get("type") == "object"
+        and "properties" not in schema
+        and "additionalProperties" not in schema
+    ):
+        return True
+    items = schema.get("items")
+    if schema.get("type") == "array":
+        if not items:
+            return True
+        if isinstance(items, dict) and _is_loose(items):
+            return True
+    for key in ("anyOf", "oneOf", "allOf"):
+        for member in schema.get(key, []):
+            # A nullable field is anyOf[T, null]; null alone is not looseness.
+            if isinstance(member, dict) and member.get("type") == "null":
+                continue
+            if isinstance(member, dict) and _is_loose(member):
+                return True
+    return False
+
+
+def _referenced_schemas(node: Any, found: set[str]) -> None:
+    """Collect every component schema name reachable from a fragment."""
+    if isinstance(node, dict):
+        ref = node.get("$ref")
+        if isinstance(ref, str):
+            found.add(ref.rsplit("/", 1)[-1])
+        for value in node.values():
+            _referenced_schemas(value, found)
+    elif isinstance(node, list):
+        for value in node:
+            _referenced_schemas(value, found)
+
+
+def _success_response(operation: dict[str, Any]) -> dict[str, Any] | None:
+    codes = sorted(c for c in operation.get("responses", {}) if c.startswith("2"))
+    return operation["responses"][codes[0]] if codes else None
+
+
+def lint_openapi(schema: dict[str, Any]) -> list[str]:
+    errors: list[str] = []
+    components = schema.get("components", {}).get("schemas", {})
+    seen_operation_ids: dict[str, str] = {}
+    in_scope_schemas: set[str] = set()
+
+    for path, methods in sorted(schema.get("paths", {}).items()):
+        for method, operation in sorted(methods.items()):
+            where = f"{method.upper()} {path}"
+            tags = operation.get("tags") or []
+            in_scope = bool(set(tags) & GENERATED_SURFACE)
+
+            operation_id = operation.get("operationId", "")
+            if operation_id:
+                if operation_id in seen_operation_ids:
+                    errors.append(
+                        f"{where}: duplicate operationId '{operation_id}' "
+                        f"(also {seen_operation_ids[operation_id]}) — breaks client generation"
+                    )
+                seen_operation_ids[operation_id] = where
+                if len(operation_id) > MAX_OPERATION_ID_LENGTH:
+                    errors.append(
+                        f"{where}: operationId is {len(operation_id)} chars "
+                        f"(max {MAX_OPERATION_ID_LENGTH}) — '{operation_id}'"
+                    )
+
+            if not tags and path.startswith("/api/"):
+                errors.append(f"{where}: no tag — generated clients group by tag")
+
+            response = _success_response(operation)
+            if response is None:
+                continue
+            content = response.get("content") or {}
+
+            declared_json = "application/json" in content
+            declared_binary = [
+                ct for ct in content if ct.startswith(NON_JSON_PREFIXES)
+            ]
+            if declared_json and declared_binary:
+                errors.append(
+                    f"{where}: declares application/json alongside {declared_binary} — "
+                    "a generated client would try to JSON-decode it"
+                )
+
+            if not declared_json:
+                continue
+
+            body = content["application/json"].get("schema") or {}
+            if in_scope:
+                _referenced_schemas(body, in_scope_schemas)
+            if _is_loose(body) and (method.upper(), path) not in ALLOWED_UNTYPED_OPERATIONS:
+                scope = "in generated surface" if in_scope else "out of scope"
+                errors.append(
+                    f"{where}: 2xx response generates as untyped object ({scope}). "
+                    "Give it a response_model, or add it to ALLOWED_UNTYPED_OPERATIONS "
+                    "with a reason."
+                )
+
+    # Expand transitively — a typed response whose model has Any fields is still Any.
+    pending = set(in_scope_schemas)
+    while pending:
+        name = pending.pop()
+        nested: set[str] = set()
+        _referenced_schemas(components.get(name, {}), nested)
+        for child in nested - in_scope_schemas:
+            in_scope_schemas.add(child)
+            pending.add(child)
+
+    for name in sorted(in_scope_schemas):
+        for field, field_schema in (components.get(name, {}).get("properties") or {}).items():
+            key = f"{name}.{field}"
+            if _is_loose(field_schema) and key not in ALLOWED_LOOSE_FIELDS:
+                errors.append(
+                    f"{key}: field generates as Any in the generated surface. "
+                    "Type it, or add it to ALLOWED_LOOSE_FIELDS with a reason."
+                )
+
+    for name in sorted(components):
+        if "__" in name and name not in ALLOWED_MANGLED_SCHEMAS:
+            errors.append(
+                f"schema '{name}': name was fully qualified because two modules declare "
+                "the same model name — a generated client uses this verbatim as a type name"
+            )
+
+    return errors
+
+
+def main() -> int:
+    try:
+        from app.main import app
+    except Exception as exc:  # pragma: no cover - import failure is the message
+        print(f"OpenAPI lint FAILED: could not import the app: {exc}")
+        return 1
+
+    schema = app.openapi()
+    errors = lint_openapi(schema)
+
+    if errors:
+        print(f"OpenAPI lint FAILED ({len(errors)} error(s)):\n")
+        for err in errors:
+            print(f"  - {err}")
+        return 1
+
+    operations = sum(len(m) for m in schema.get("paths", {}).values())
+    print(
+        f"OpenAPI lint OK: {operations} operations validated "
+        f"({len(GENERATED_SURFACE)} tags in the generated surface, "
+        f"{len(ALLOWED_UNTYPED_OPERATIONS)} allowlisted for burn-down)"
+    )
+    return 0
+
+
+if __name__ == "__main__":
+    sys.exit(main())

--- a/docs/decisions/ADR-0007-clients-are-generated-from-openapi.md
+++ b/docs/decisions/ADR-0007-clients-are-generated-from-openapi.md
@@ -1,8 +1,23 @@
 # ADR-0007: Clients Are Generated from the OpenAPI Schema
 
-Status: proposed
+Status: accepted
 
 Date: 2026-07-26
+
+Implementation:
+- Decision points 1–4 and 6 were revised before acceptance, after measuring the live schema. The
+  original point 1 said "Swift now, for the `familiar-apple` repo", which contradicts
+  [ADR-0001](ADR-0001-native-apple-clients-supersede-capacitor.md) — that repo begins *after* this
+  ADR is stable. Points 2 and 3 are new; the Context's estimate of four loose handlers was an
+  undercount, as its own follow-up predicted.
+- Phase 1 — schema hardening, operationIds and `scripts/lint_openapi.py`, on branch
+  `feat/adr-0007-openapi-schema`. Longest operationId 95 → 45 characters; seven endpoints stopped
+  advertising `application/json` for audio, images, zips and SSE; two handlers and four model fields
+  typed; `SimilarArtistInfo` de-duplicated into `app/api/schemas/artists.py`. The lint was verified
+  to fail by deliberately adding an untyped in-scope handler.
+- Phase 2 — generating the Swift client — is not started, and waits on `familiar-apple`.
+- Burn-down remaining: 50 out-of-scope untyped operations and one collision-mangled schema name
+  (`ImportPreviewResponse`, declared in two modules), allowlisted in the lint.
 
 Extends [ADR-0001](ADR-0001-native-apple-clients-supersede-capacitor.md).
 
@@ -43,25 +58,51 @@ Authentication imposes no complexity here. There is none — profile selection i
 
 Native clients consume a **generated** API client, not a hand-written one.
 
-1. **Generate from `/openapi.json`.** Swift now, for the `familiar-apple` repo; C# later, from the
-   same schema, if and when Windows happens.
+1. **Generate from `/openapi.json`**, in two phases. Swift for the `familiar-apple` repo, then C#
+   later from the same schema if Windows happens.
 
-2. **Harden the schema first.** Replace bare `dict` returns with Pydantic response models in the
-   handlers listed above. Untyped fields in a generated client are worse than no generation, because
-   they look typed.
+   The original wording said "Swift now", which was not achievable:
+   [ADR-0001](ADR-0001-native-apple-clients-supersede-capacitor.md) places the creation of
+   `familiar-apple` *after* this ADR is stable, so 0007 cannot deliver into a repo it must precede.
+   - **Phase 1 — the schema.** Readable operationIds, honest media types, typed responses across the
+     generated surface, and a lint that stops it regressing. Independently verifiable with no client.
+   - **Phase 2 — the client.** Generation itself, once `familiar-apple` exists and its structure can
+     inform the generator choice.
 
-3. **Add `generate_unique_id_function`** to the FastAPI app so generated method names are readable
+2. **The generated surface is the native v1 listening path, not the whole API** — tags `tracks`,
+   `library`, `playlists`, `smart-playlists`, `profiles`, `favorites`, `chat`, `mixtapes`, `ambient`.
+   Management surfaces stay web-only under
+   [ADR-0002](ADR-0002-web-app-is-the-management-surface.md) and will never need a Swift client,
+   which is fortunate: they are where the untyped responses concentrate.
+
+3. **Non-JSON endpoints must declare their real media type.** Excluding them is not enough. Seven
+   endpoints — audio streaming, artwork, avatars, mixtape downloads and two SSE streams — declared
+   `application/json`, so a generated client would have tried to JSON-decode an MP3. A schema that
+   misdescribes an endpoint is worse than one that leaves it untyped, because it looks correct.
+
+4. **Harden the schema first.** Replace bare `dict` returns with Pydantic response models, and type
+   model fields that would otherwise generate as `Any`. Untyped fields in a generated client are
+   worse than no generation, because they look typed.
+
+   Fields that are genuinely free-form — arbitrary LLM tool-call payloads, opaque render progress
+   read back from Redis, polymorphic smart-playlist rule values — are recorded as exceptions with a
+   reason rather than modelled speculatively.
+
+5. **Add `generate_unique_id_function`** to the FastAPI app so generated method names are readable
    rather than derived from paths.
 
-4. **Generation is a checked-in build step, not a one-time scaffold.** The generated client is
-   regenerated from the schema, and drift between schema and client must fail a build rather than
-   surface at runtime.
+6. **Regressions must fail a build.** Until a client exists there is nothing to diff against, so the
+   check is a schema lint (`backend/scripts/lint_openapi.py`): no new untyped response, no missing
+   tag, no duplicate or over-long operationId, no endpoint claiming JSON while returning binary.
+   Existing out-of-scope looseness is allowlisted as a burn-down list, so adding to it is a visible
+   decision in review. Once the client is generated, the same principle extends to schema-vs-client
+   drift.
 
-5. **The existing TypeScript client is explicitly *not* migrated by this ADR.** It works, it is
+7. **The existing TypeScript client is explicitly *not* migrated by this ADR.** It works, it is
    heavily used, and replacing ~195 call sites is unrelated risk. It may be migrated later on its own
    merits; that is a separate decision.
 
-6. **Handlers deliberately outside the generated client:** audio streaming
+8. **Handlers deliberately outside the generated client:** audio streaming
    (`/tracks/{id}/stream` — range requests, handled by `URLSession` directly), SSE endpoints
    (`/chat`, map streams), and file downloads. Generated clients handle these badly; they are written
    by hand on each platform, which is a small and bounded set.


### PR DESCRIPTION
Phase 1 of [ADR-0007](https://github.com/seethroughlab/familiar/blob/main/docs/decisions/ADR-0007-clients-are-generated-from-openapi.md): make the schema good enough to generate typed clients from. No client is generated yet — that's phase 2, once `familiar-apple` exists.

## The problem, measured

**operationIds were unusable.** FastAPI derives them from function + path + method, up to **95 characters**:

```
get_playlist_external_albums_api_v1_playlists__playlist_id__recommendations_external_albums_get
```

Swift would turn that into a method name nobody can call. `generate_unique_id_function` producing `{tag}_{name}` brings the longest down to **45**, and fixes two schema names for free (FastAPI names multipart body models after the operationId).

**The schema lied about content type on 7 endpoints.** Audio streaming, artwork, avatars, mixtape downloads and both SSE streams all declared `application/json`. **A generated client would have tried to JSON-decode an MP3.** That's worse than an untyped response, because it looks correct — nothing would catch it until runtime on a real device.

**78 responses generated as untyped `object`** — not the four the ADR's Context named, as its own follow-up predicted.

## Scope

The generated client only needs the native v1 listening path (ADR-0001). Management surfaces stay web-only (ADR-0002) — and that's where the looseness concentrates (`pending-tracks` 14, `outputs` 12, `s3-backup`/`download`/`export-import` 15). Scoping by tag cut the job from 78 handlers to 9.

## Changes

- 2 handlers gained response models; 4 model fields that generated as `Any` are now typed
- 7 endpoints declare `audio/*`, `image/*`, `application/zip`, `text/event-stream`
- `SimilarArtistInfo` was declared identically in two modules, so FastAPI emitted one as `app__api__routes__tracks__discovery__SimilarArtistInfo` — a type name Swift would use verbatim. Moved to `app/api/schemas/artists.py`, imported by both.
- `list_tracks` is registered twice on purpose (`/tracks` and `/tracks/`, because the SPA catch-all swallows FastAPI's redirect). They're one API operation, so the alias is `include_in_schema=False` — otherwise a client grows two identical `listTracks` methods. Both paths still route.
- `scripts/lint_openapi.py` fails on any new untyped response, missing tag, duplicate or over-long operationId, or endpoint claiming JSON while returning binary. Wired into `backend-lint`, which already does `uv sync --extra dev` and runs on a bare checkout — a built frontend adds SPA routes under `backend/static/` and changes the schema.

The 50 out-of-scope entries and 9 genuinely free-form fields (LLM tool calls, opaque Redis progress, polymorphic rule values) are allowlisted as a **burn-down list, not an approved state**.

## Two bugs caught on the way

- A `response_model` silently stripped `range` off analysis fields — caught by `test_analysis_fields_have_ranges`. I then checked every nesting level for other dropped keys; there were none.
- `library_missing.relocate` read `track.file_path` *after* overwriting it, so `old_path` and `new_path` came back identical.

## Verified

`1129 passed`; ruff, mypy and all three linters clean. **The lint was verified to actually fail** by adding an untyped in-scope handler — a ratchet that can't fail is decoration.

The 4 remaining failures are pre-existing and unrelated: 3 chat contract tests that assume no Anthropic key is configured (this machine has one), and the `spotify_imports.imported_at` drift that only appears after the migration round-trip tests mutate the local schema — a pristine migrations-only database shows none.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_014P9p2fvFnyiywBxGkv4gfW