### PR TITLE
feat(player): emit listening events from the client (ADR-0004 phase 2)

### DIFF
--- a/docs/decisions/ADR-0004-listening-feedback-is-event-sourced.md
+++ b/docs/decisions/ADR-0004-listening-feedback-is-event-sourced.md
@@ -17,8 +17,25 @@ Implementation:
   with `reason=natural` resolving to `completed`, where ratio alone would have said `skipped`) and
   the error case resolving to `errored`. Probe rows were reverted afterwards; the table starts empty.
 - Phase 2 — client emission: advance-reason threading through `queueStore`, the `usePlayTracking`
-  rewrite, and the outbox `listen_event` type. Tracked separately; deliberately split so a DB
-  migration does not land together with changes to the player's most delicate code path.
+  rewrite, and the outbox `listen_event` type, on branch `feat/adr-0004-client-emission`.
+  Deliberately split from phase 1 so a DB migration did not land together with changes to the
+  player's most delicate code path.
+
+  Three additions the decision above did not anticipate:
+  - **A sixth reason, `system`, that emits nothing.** Offline queue rebuilds, hydration and profile
+    switches replace `currentTrack` without the listener acting; without it every reconnect would
+    log a phantom skip.
+  - **Error advances take three paths, not the two named in point 6.** Beyond the two `playNext()`
+    sites, `advanceToNextDownloadedTrack` goes through `jumpToQueueIndex` and a crossfade failure
+    rolls back via `setQueueByTrackId`.
+  - **The reason is written inside the same `setState` that changes `currentTrack`.** `playNext` has
+    five early-returns that change no track, so a reason set before the branch would leak into the
+    next advance.
+
+  Two latent bugs surfaced and were fixed: `PlayerBar`/`FullPlayer` used bare `onClick={playNext}`,
+  which would have passed React's `MouseEvent` into the options slot; and React Testing Library's
+  automatic cleanup was never running (no `globals: true`, no setup file), so hooks from earlier
+  tests stayed mounted and polluted assertions.
 
 ## Context
 

--- a/packages/frontend/src/api/profiles.ts
+++ b/packages/frontend/src/api/profiles.ts
@@ -155,11 +155,67 @@ export interface PlayStatsResponse {
   }>;
 }
 
+/** Why playback of a track stopped. Mirrors the backend `StopReason` (ADR-0004). */
+export type ListenStopReason = 'natural' | 'user' | 'error';
+
+/** Where the track was played from. Mirrors the backend `PlayContext`. */
+export type ListenContext =
+  | 'library' | 'album' | 'playlist' | 'artist'
+  | 'ephemeral' | 'radio' | 'ambient' | 'other';
+
+/** Body shared by /played, /skipped and /rejected. Every field is optional. */
+export interface ListenEventBody {
+  played_seconds?: number;
+  track_duration?: number;
+  completion_ratio?: number;
+  context?: ListenContext;
+  source_track_id?: string;
+  reason?: ListenStopReason;
+}
+
+export interface ListenEventResponse {
+  track_id: string;
+  outcome: 'completed' | 'skipped' | 'rejected' | 'errored';
+  completion_ratio: number;
+}
+
 export const playTrackingApi = {
-  recordPlay: async (trackId: string, durationSeconds?: number): Promise<PlayRecordResponse> => {
+  /**
+   * Record a play. Bumps ProfilePlayHistory *and* writes a `completed` PlayEvent.
+   *
+   * Called only once scrobble thresholds are met, so reaching this endpoint is itself
+   * the definition of a play — the backend does not derive the outcome here.
+   */
+  recordPlay: async (
+    trackId: string,
+    durationSeconds?: number,
+    detail?: Omit<ListenEventBody, 'played_seconds' | 'reason'>,
+  ): Promise<PlayRecordResponse> => {
     const { data } = await api.post(`/tracks/${trackId}/played`, {
       duration_seconds: durationSeconds,
+      ...detail,
     });
+    return data;
+  },
+
+  /**
+   * Record that playback stopped before the track was scrobbled.
+   *
+   * Does NOT touch ProfilePlayHistory — only completed plays count toward it. The
+   * backend derives the outcome, so a track abandoned at 95%, or a short one played in
+   * full, comes back `completed` rather than `skipped`.
+   */
+  recordSkip: async (trackId: string, body: ListenEventBody = {}): Promise<ListenEventResponse> => {
+    const { data } = await api.post(`/tracks/${trackId}/skipped`, body);
+    return data;
+  },
+
+  /**
+   * Record an explicit thumbs-down — a stronger signal than a skip, and stored
+   * distinctly. Intended for radio insertions (ADR-0005); no UI triggers it yet.
+   */
+  recordRejection: async (trackId: string, body: ListenEventBody = {}): Promise<ListenEventResponse> => {
+    const { data } = await api.post(`/tracks/${trackId}/rejected`, body);
     return data;
   },
 

--- a/packages/frontend/src/components/FullPlayer/FullPlayer.tsx
+++ b/packages/frontend/src/components/FullPlayer/FullPlayer.tsx
@@ -388,7 +388,7 @@ export function FullPlayer({ isOpen, onClose }: FullPlayerProps) {
           </div>
 
           <button
-            onClick={playPrevious}
+            onClick={() => playPrevious()}
             className="p-3 hover:bg-white/10 rounded-full transition-colors"
             aria-label="Previous track"
           >
@@ -410,7 +410,7 @@ export function FullPlayer({ isOpen, onClose }: FullPlayerProps) {
           </button>
 
           <button
-            onClick={playNext}
+            onClick={() => playNext()}
             className="p-3 hover:bg-white/10 rounded-full transition-colors"
             aria-label="Next track"
           >

--- a/packages/frontend/src/components/Player/PlayerBar.tsx
+++ b/packages/frontend/src/components/Player/PlayerBar.tsx
@@ -321,7 +321,7 @@ export function PlayerBar({
             </div>
             <button
               data-testid="prev-track"
-              onClick={playPrevious}
+              onClick={() => playPrevious()}
               className={`p-2 rounded-full transition-colors ${hasTrack ? 'hover:bg-zinc-800' : 'text-zinc-600'}`}
               aria-label="Previous track"
               disabled={!hasTrack}
@@ -345,7 +345,7 @@ export function PlayerBar({
             </button>
             <button
               data-testid="next-track"
-              onClick={playNext}
+              onClick={() => playNext()}
               className={`p-2 rounded-full transition-colors ${hasTrack ? 'hover:bg-zinc-800' : 'text-zinc-600'}`}
               aria-label="Next track"
               disabled={!hasTrack}

--- a/packages/frontend/src/db/index.ts
+++ b/packages/frontend/src/db/index.ts
@@ -72,7 +72,10 @@ export interface OfflineArtwork {
 export interface PendingAction {
   id?: number; // Auto-increment
   profileId: string; // Profile that queued this action
-  type: 'scrobble' | 'now_playing' | 'favorite_toggle';
+  // NOTE: mirrored by `ActionType` in services/syncService.ts — keep both in step.
+  // Adding a value needs no Dexie version bump: `type` is indexed, but an IndexedDB
+  // index constrains the key path, not the value domain, and `payload` is unindexed.
+  type: 'scrobble' | 'now_playing' | 'favorite_toggle' | 'listen_event';
   payload: unknown;
   createdAt: Date;
   retries: number;

--- a/packages/frontend/src/hooks/__tests__/usePlayTracking.test.ts
+++ b/packages/frontend/src/hooks/__tests__/usePlayTracking.test.ts
@@ -240,9 +240,12 @@ describe('usePlayTracking', () => {
 
   describe('completion ratio', () => {
     it('uses the OUTGOING track duration, not the incoming one', async () => {
-      // The regression this guards: by the time the reset effect runs, `duration` in the
-      // render closure is already the new track's.
-      await playThenAdvance(createMockTrack('track-short'), 10, 'user', 40);
+      // Duration comes from track metadata, not the store's `duration` — that belongs to
+      // whatever the engine last loaded, so it is the previous track's value whenever the
+      // current one fails to load, which is precisely when an error is about to be
+      // reported. The store is deliberately left at 180 here to prove it is not used.
+      const short = { ...createMockTrack('track-short'), duration_seconds: 40 };
+      await playThenAdvance(short, 10, 'user', 180);
 
       expect(mockDeliver).toHaveBeenCalledWith(
         'track-short',
@@ -284,6 +287,88 @@ describe('usePlayTracking', () => {
         'skipped',
         expect.objectContaining({ reason: 'error', track_duration: 374 }),
       );
+    });
+  });
+
+  describe('crossfade rollback', () => {
+    it('does not re-record a track the player rolled back to', async () => {
+      // Observed in a real session: a failed crossfade rolls the queue back to the track
+      // that was just playing, which used to cross its threshold a second time —
+      // play_count 2 and total_play_seconds 110.8 for one listen of a 75s track.
+      const a = { ...createMockTrack('track-a'), duration_seconds: 75 };
+      const b = { ...createMockTrack('track-b'), duration_seconds: 374 };
+      const { rerender } = renderHook(() => usePlayTracking());
+
+      // A plays past its threshold and is recorded.
+      act(() => {
+        usePlayerStore.setState({ currentTrack: a, isPlaying: true, duration: 75, currentTime: 0 });
+      });
+      rerender();
+      act(() => { usePlayerStore.setState({ currentTime: 40 }); });
+      rerender();
+      await waitFor(() => {
+        expect(mockDeliver.mock.calls.filter((c) => c[1] === 'played')).toHaveLength(1);
+      });
+
+      // Crossfade advances to B...
+      act(() => {
+        usePlayerStore.setState({ currentTrack: b, currentTime: 0, _advanceReason: 'crossfade' });
+      });
+      rerender();
+      // ...then fails, rolling straight back to A having played none of B.
+      act(() => {
+        usePlayerStore.setState({ currentTrack: a, currentTime: 40, _advanceReason: 'error' });
+      });
+      rerender();
+      act(() => { usePlayerStore.setState({ currentTime: 72 }); });
+      rerender();
+      await flush();
+
+      // B is reported as errored, but A must not be recorded a second time.
+      expect(mockDeliver.mock.calls.filter((c) => c[1] === 'played')).toHaveLength(1);
+      expect(mockDeliver).toHaveBeenCalledWith(
+        'track-b', 'skipped', expect.objectContaining({ reason: 'error', track_duration: 374 }),
+      );
+    });
+
+    it('still records a genuine replay after another track was listened to', async () => {
+      const a = createMockTrack('track-a');
+      const b = createMockTrack('track-b');
+      const { rerender } = renderHook(() => usePlayTracking());
+
+      act(() => {
+        usePlayerStore.setState({ currentTrack: a, isPlaying: true, duration: 180, currentTime: 0 });
+      });
+      rerender();
+      act(() => { usePlayerStore.setState({ currentTime: 95 }); });
+      rerender();
+      await waitFor(() => {
+        expect(mockDeliver.mock.calls.filter((c) => c[1] === 'played')).toHaveLength(1);
+      });
+
+      // B genuinely plays through.
+      act(() => {
+        usePlayerStore.setState({ currentTrack: b, currentTime: 0, _advanceReason: 'ended' });
+      });
+      rerender();
+      act(() => { usePlayerStore.setState({ currentTime: 95 }); });
+      rerender();
+      await waitFor(() => {
+        expect(mockDeliver.mock.calls.filter((c) => c[1] === 'played')).toHaveLength(2);
+      });
+
+      // Returning to A is a real replay and must count.
+      act(() => {
+        usePlayerStore.setState({ currentTrack: a, currentTime: 0, _advanceReason: 'user' });
+      });
+      rerender();
+      act(() => { usePlayerStore.setState({ currentTime: 95 }); });
+      rerender();
+
+      await waitFor(() => {
+        const plays = mockDeliver.mock.calls.filter((c) => c[1] === 'played' && c[0] === 'track-a');
+        expect(plays).toHaveLength(2);
+      });
     });
   });
 

--- a/packages/frontend/src/hooks/__tests__/usePlayTracking.test.ts
+++ b/packages/frontend/src/hooks/__tests__/usePlayTracking.test.ts
@@ -1,20 +1,24 @@
 /**
  * Tests for usePlayTracking hook.
+ *
+ * Covers ADR-0004 phase 2: every track the listener moves on from reports a listening
+ * event, including short skips that previously produced no API call at all.
+ *
+ * Note on negative assertions: `await waitFor(() => expect(x).not.toHaveBeenCalled())`
+ * passes on the first tick and proves nothing about async work. These tests flush the
+ * microtask queue first, then assert directly.
  */
 import { describe, it, expect, beforeEach, vi, afterEach } from 'vitest';
-import { renderHook, act, waitFor } from '@testing-library/react';
+import { renderHook, act, waitFor, cleanup } from '@testing-library/react';
 import { usePlayTracking } from '../usePlayTracking';
 import { usePlayerStore } from '../../stores/playerStore';
-import { playTrackingApi } from '../../api';
+import { deliverListenEvent } from '../../services/syncService';
 
-// Mock the API client
-vi.mock('../../api', () => ({
-  playTrackingApi: {
-    recordPlay: vi.fn(() => Promise.resolve({ track_id: 'test-id', play_count: 1, total_play_seconds: 60 })),
-  },
+// The hook delivers through syncService, which owns the catch-then-queue policy.
+vi.mock('../../services/syncService', () => ({
+  deliverListenEvent: vi.fn(() => Promise.resolve()),
 }));
 
-// Mock the persistence functions
 vi.mock('../../services/playerPersistence', () => ({
   debouncedSavePlayerState: vi.fn(),
   loadPlayerState: vi.fn(() => Promise.resolve(null)),
@@ -22,9 +26,18 @@ vi.mock('../../services/playerPersistence', () => ({
   migrateOldPlayerState: vi.fn(() => Promise.resolve()),
 }));
 
+const mockDeliver = vi.mocked(deliverListenEvent);
+
+/** Let any pending promise chains settle so a negative assertion means something. */
+const flush = async () => {
+  await act(async () => {
+    await Promise.resolve();
+    await Promise.resolve();
+  });
+};
+
 describe('usePlayTracking', () => {
   beforeEach(() => {
-    // Reset store to initial state before each test
     usePlayerStore.setState({
       currentTrack: null,
       isPlaying: false,
@@ -41,11 +54,18 @@ describe('usePlayTracking', () => {
       crossfadeState: 'idle',
       nextTrackPreloaded: false,
       isHydrated: true,
+      _advanceReason: 'user',
+      queueSource: null,
     });
     vi.clearAllMocks();
   });
 
   afterEach(() => {
+    // vitest.config.ts sets neither `globals: true` nor a setupFile, so React Testing
+    // Library's automatic cleanup never runs. Without this, hooks from earlier tests
+    // stay mounted and keep reacting to the shared player store — every assertion after
+    // the first test would be counting other tests' emissions.
+    cleanup();
     vi.clearAllMocks();
   });
 
@@ -66,87 +86,206 @@ describe('usePlayTracking', () => {
     analysis_version: 1,
   });
 
-  it('should not record play when track has played less than 30 seconds', async () => {
-    const track = createMockTrack('track-1');
-
-    renderHook(() => usePlayTracking());
-
-    // Start playing and jump to 25 seconds immediately
-    act(() => {
-      usePlayerStore.setState({
-        currentTrack: track,
-        isPlaying: true,
-        duration: 180,
-        currentTime: 25,
-      });
-    });
-
-    // Give effects time to run
-    await waitFor(() => {
-      expect(playTrackingApi.recordPlay).not.toHaveBeenCalled();
-    });
-  });
-
-  it('should record play when threshold is reached', async () => {
-    const track = createMockTrack('track-2');
-
+  /** Play `track` up to `currentTime`, then advance to another track with `reason`. */
+  const playThenAdvance = async (
+    track: ReturnType<typeof createMockTrack>,
+    currentTime: number,
+    reason: string,
+    duration = 180,
+  ) => {
     const { rerender } = renderHook(() => usePlayTracking());
 
-    // Start playing a 120-second track at time 0
+    act(() => {
+      usePlayerStore.setState({ currentTrack: track, isPlaying: true, duration, currentTime: 0 });
+    });
+    rerender();
+    act(() => {
+      usePlayerStore.setState({ currentTime });
+    });
+    rerender();
+
     act(() => {
       usePlayerStore.setState({
-        currentTrack: track,
-        isPlaying: true,
-        duration: 120,
+        currentTrack: createMockTrack('next-track'),
         currentTime: 0,
+        _advanceReason: reason as never,
       });
     });
-
-    // Force a rerender to ensure hooks run
     rerender();
+    await flush();
+  };
 
-    // Now jump directly to past the threshold (60 seconds for 50% of 120)
-    act(() => {
-      usePlayerStore.setState({ currentTime: 65 });
-    });
+  describe('play recording', () => {
+    it('does not record a play below the 30s minimum', async () => {
+      const track = createMockTrack('track-1');
+      renderHook(() => usePlayTracking());
 
-    rerender();
-
-    // Give effects time to run
-    await waitFor(() => {
-      expect(playTrackingApi.recordPlay).toHaveBeenCalledWith('track-2', expect.any(Number));
-    }, { timeout: 2000 });
-  });
-
-  it('should not record when paused', async () => {
-    const track = createMockTrack('track-5');
-
-    renderHook(() => usePlayTracking());
-
-    // Start playing at time 25
-    act(() => {
-      usePlayerStore.setState({
-        currentTrack: track,
-        isPlaying: true,
-        duration: 120,
-        currentTime: 25,
+      act(() => {
+        usePlayerStore.setState({ currentTrack: track, isPlaying: true, duration: 180, currentTime: 10 });
       });
+      await flush();
+
+      const plays = mockDeliver.mock.calls.filter((c) => c[1] === 'played');
+      expect(plays).toHaveLength(0);
     });
 
-    // Pause
-    act(() => {
-      usePlayerStore.setState({ isPlaying: false });
+    it('records a play once the threshold is reached', async () => {
+      const track = createMockTrack('track-2');
+      const { rerender } = renderHook(() => usePlayTracking());
+
+      act(() => {
+        usePlayerStore.setState({ currentTrack: track, isPlaying: true, duration: 180, currentTime: 0 });
+      });
+      rerender();
+      act(() => {
+        usePlayerStore.setState({ currentTime: 95 });
+      });
+      rerender();
+
+      await waitFor(() => {
+        expect(mockDeliver).toHaveBeenCalledWith(
+          'track-2',
+          'played',
+          expect.objectContaining({ track_duration: 180 }),
+          expect.any(Number),
+        );
+      }, { timeout: 2000 });
     });
 
-    // Time jumps while paused
-    act(() => {
-      usePlayerStore.setState({ currentTime: 100 });
-    });
+    it('does not accumulate time while paused', async () => {
+      const track = createMockTrack('track-3');
+      const { rerender } = renderHook(() => usePlayTracking());
 
-    // Should not record while paused
-    await waitFor(() => {
-      expect(playTrackingApi.recordPlay).not.toHaveBeenCalled();
+      act(() => {
+        usePlayerStore.setState({ currentTrack: track, isPlaying: true, duration: 180, currentTime: 25 });
+      });
+      rerender();
+      act(() => {
+        usePlayerStore.setState({ isPlaying: false });
+      });
+      rerender();
+      act(() => {
+        usePlayerStore.setState({ currentTime: 100 });
+      });
+      rerender();
+      await flush();
+
+      const plays = mockDeliver.mock.calls.filter((c) => c[1] === 'played');
+      expect(plays).toHaveLength(0);
     });
   });
 
+  describe('skip reporting', () => {
+    it('reports a short skip that previously emitted nothing', async () => {
+      await playThenAdvance(createMockTrack('track-skip'), 5, 'user');
+
+      expect(mockDeliver).toHaveBeenCalledWith(
+        'track-skip',
+        'skipped',
+        expect.objectContaining({ reason: 'user', track_duration: 180 }),
+      );
+      // A skip must never bump the play aggregate.
+      expect(mockDeliver.mock.calls.filter((c) => c[1] === 'played')).toHaveLength(0);
+    });
+
+    it('reports a natural end as natural, not a skip', async () => {
+      await playThenAdvance(createMockTrack('track-ended'), 20, 'ended');
+
+      expect(mockDeliver).toHaveBeenCalledWith(
+        'track-ended',
+        'skipped',
+        expect.objectContaining({ reason: 'natural' }),
+      );
+    });
+
+    it('reports a crossfade advance as natural', async () => {
+      // Crossfade fires early, so the ratio alone would read as a skip.
+      await playThenAdvance(createMockTrack('track-xfade'), 20, 'crossfade');
+
+      expect(mockDeliver).toHaveBeenCalledWith(
+        'track-xfade',
+        'skipped',
+        expect.objectContaining({ reason: 'natural' }),
+      );
+    });
+
+    it('reports iOS background auto-advance as natural', async () => {
+      await playThenAdvance(createMockTrack('track-native'), 20, 'native-auto');
+
+      expect(mockDeliver).toHaveBeenCalledWith(
+        'track-native',
+        'skipped',
+        expect.objectContaining({ reason: 'natural' }),
+      );
+    });
+
+    it('reports a failed load as error, never as dislike', async () => {
+      await playThenAdvance(createMockTrack('track-broken'), 2, 'error');
+
+      expect(mockDeliver).toHaveBeenCalledWith(
+        'track-broken',
+        'skipped',
+        expect.objectContaining({ reason: 'error' }),
+      );
+    });
+
+    it('emits nothing for a system advance', async () => {
+      // Offline queue rebuilds, hydration and profile switches change the track without
+      // the listener doing anything — reporting those would log phantom skips.
+      await playThenAdvance(createMockTrack('track-rebuild'), 5, 'system');
+
+      expect(mockDeliver).not.toHaveBeenCalled();
+    });
+  });
+
+  describe('completion ratio', () => {
+    it('uses the OUTGOING track duration, not the incoming one', async () => {
+      // The regression this guards: by the time the reset effect runs, `duration` in the
+      // render closure is already the new track's.
+      await playThenAdvance(createMockTrack('track-short'), 10, 'user', 40);
+
+      expect(mockDeliver).toHaveBeenCalledWith(
+        'track-short',
+        'skipped',
+        expect.objectContaining({ track_duration: 40, played_seconds: 10 }),
+      );
+    });
+  });
+
+  describe('context', () => {
+    it('passes the queue source through as context', async () => {
+      const track = createMockTrack('track-ctx');
+      const { rerender } = renderHook(() => usePlayTracking());
+
+      act(() => {
+        usePlayerStore.setState({
+          currentTrack: track,
+          isPlaying: true,
+          duration: 180,
+          currentTime: 0,
+          queueSource: { type: 'playlist', id: 'pl-1' },
+        });
+      });
+      rerender();
+      act(() => {
+        usePlayerStore.setState({ currentTime: 5 });
+      });
+      rerender();
+      act(() => {
+        usePlayerStore.setState({
+          currentTrack: createMockTrack('next'),
+          currentTime: 0,
+          _advanceReason: 'user',
+        });
+      });
+      rerender();
+      await flush();
+
+      expect(mockDeliver).toHaveBeenCalledWith(
+        'track-ctx',
+        'skipped',
+        expect.objectContaining({ context: 'playlist' }),
+      );
+    });
+  });
 });

--- a/packages/frontend/src/hooks/__tests__/usePlayTracking.test.ts
+++ b/packages/frontend/src/hooks/__tests__/usePlayTracking.test.ts
@@ -250,6 +250,41 @@ describe('usePlayTracking', () => {
         expect.objectContaining({ track_duration: 40, played_seconds: 10 }),
       );
     });
+
+    it('uses a never-played track OWN duration, not the previous track', async () => {
+      // Regression from real data: a track that failed to load reported the previous
+      // track's duration (75.5s instead of its own 374.5s), because the accumulate
+      // effect early-returns before it can update the duration ref.
+      const first = createMockTrack('first');
+      const broken = { ...createMockTrack('broken'), duration_seconds: 374 };
+      const { rerender } = renderHook(() => usePlayTracking());
+
+      act(() => {
+        usePlayerStore.setState({ currentTrack: first, isPlaying: true, duration: 75, currentTime: 0 });
+      });
+      rerender();
+      act(() => {
+        usePlayerStore.setState({ currentTime: 72 });
+      });
+      rerender();
+
+      // Advance to a track that never plays — no duration ever reported by the engine.
+      act(() => {
+        usePlayerStore.setState({ currentTrack: broken, currentTime: 0, isPlaying: false, _advanceReason: 'ended' });
+      });
+      rerender();
+      act(() => {
+        usePlayerStore.setState({ currentTrack: createMockTrack('third'), currentTime: 0, _advanceReason: 'error' });
+      });
+      rerender();
+      await flush();
+
+      expect(mockDeliver).toHaveBeenCalledWith(
+        'broken',
+        'skipped',
+        expect.objectContaining({ reason: 'error', track_duration: 374 }),
+      );
+    });
   });
 
   describe('context', () => {

--- a/packages/frontend/src/hooks/usePlayTracking.ts
+++ b/packages/frontend/src/hooks/usePlayTracking.ts
@@ -1,18 +1,60 @@
 import { useEffect, useRef } from 'react';
 import { useShallow } from 'zustand/react/shallow';
 import { usePlayerStore } from '../stores/playerStore';
-import { playTrackingApi } from '../api';
+import { deliverListenEvent } from '../services/syncService';
 import { createLogger } from '../utils/logger';
+import type { AdvanceReason } from '../player/playbackStore';
+import type { ListenContext, ListenStopReason } from '../api/profiles';
 const log = createLogger('PlayTracking');
 
+/** Reaching the scrobble threshold is what counts as a play. */
+const MIN_PLAY_SECONDS = 30;
+const MAX_PLAY_SECONDS = 4 * 60;
+
 /**
- * Hook for tracking local play history.
+ * Map the client's advance reason onto the backend's `StopReason` (ADR-0004).
  *
- * Records plays to the backend when:
- * - Track has been played for at least 30 seconds
- * - AND either 50% of the track has been played OR 4 minutes have passed
+ * Returns null for advances the listener did not cause — offline queue rebuilds,
+ * hydration, profile switches — which must emit nothing. Without this, every reconnect
+ * would log a phantom skip.
+ */
+function toStopReason(reason: AdvanceReason): ListenStopReason | null {
+  switch (reason) {
+    case 'ended':
+    case 'crossfade':
+    case 'native-auto':
+      return 'natural';
+    case 'error':
+      return 'error';
+    case 'user':
+      return 'user';
+    case 'system':
+      return null;
+  }
+}
+
+/** Queue source types line up with the backend's PlayContext, apart from 'library'. */
+function toContext(sourceType: string | undefined): ListenContext | undefined {
+  if (!sourceType) return undefined;
+  const known: ListenContext[] = [
+    'library', 'album', 'playlist', 'artist', 'ephemeral', 'radio', 'ambient', 'other',
+  ];
+  return known.includes(sourceType as ListenContext) ? (sourceType as ListenContext) : 'other';
+}
+
+/**
+ * Track listening and report it to the backend.
  *
- * This follows the same rules as Last.fm scrobbling.
+ * Two things are recorded:
+ *  - a **play**, on the Last.fm rule — ≥30s listened AND ≥min(half the track, 4 min).
+ *    This bumps ProfilePlayHistory and is unchanged from before.
+ *  - a **listening event** for every track the listener moves on from, including short
+ *    skips, which previously produced no API call at all. This is the negative signal
+ *    ADR-0005's radio needs, and it only accumulates in real time.
+ *
+ * The outcome is derived server-side from the stop reason plus completion ratio, so a
+ * crossfade (which advances early, around 0.9) is not mistaken for a skip and a failed
+ * load is never mistaken for dislike.
  */
 export function usePlayTracking() {
   const { currentTrack, currentTime, duration, isPlaying } = usePlayerStore(
@@ -23,6 +65,10 @@ export function usePlayTracking() {
   const accumulatedTimeRef = useRef<number>(0);
   const lastTimeRef = useRef<number>(0);
   const lastTrackIdRef = useRef<string | null>(null);
+  // The outgoing track's duration. By the time the reset effect runs, `duration` in the
+  // render closure is already the NEW track's, so a completion ratio computed from it
+  // would measure every track against the wrong length.
+  const lastDurationRef = useRef<number>(0);
   const currentTrackIdRef = useRef<string | null>(null);
 
   // Store current track id in ref for cleanup function
@@ -30,36 +76,68 @@ export function usePlayTracking() {
     currentTrackIdRef.current = currentTrack?.id ?? null;
   }, [currentTrack?.id]);
 
-  // Reset state when track changes
+  // Reset state when the track changes, and report what happened to the outgoing one
   useEffect(() => {
     const trackId = currentTrack?.id ?? null;
+    const previousId = lastTrackIdRef.current;
 
-    // If track changed, record partial play from previous track if applicable
-    if (lastTrackIdRef.current && lastTrackIdRef.current !== trackId) {
-      // If we haven't recorded the previous track but have significant time, record it
-      if (
-        recordedTrackRef.current !== lastTrackIdRef.current &&
-        accumulatedTimeRef.current >= 30
-      ) {
-        const prevTrackId = lastTrackIdRef.current;
-        const prevAccumulatedTime = accumulatedTimeRef.current;
-        playTrackingApi.recordPlay(prevTrackId, prevAccumulatedTime).catch(() => {
-          // Ignore errors for partial plays
+    if (previousId && previousId !== trackId) {
+      const playedSeconds = accumulatedTimeRef.current;
+      const outgoingDuration = lastDurationRef.current;
+      const alreadyRecorded = recordedTrackRef.current === previousId;
+
+      // Read the reason from the store rather than the render closure — it is written in
+      // the same setState as the track change, so it is current here.
+      const { _advanceReason, queueSource } = usePlayerStore.getState();
+      const stopReason = toStopReason(_advanceReason);
+      const context = toContext(queueSource?.type);
+
+      if (stopReason === null) {
+        // A rebuild or profile switch — the listener did nothing to report.
+        log.debug('advance not attributable to the listener, not reporting', { previousId });
+      } else if (alreadyRecorded) {
+        // Already counted as a play; nothing further to say about it.
+        log.debug('outgoing track already recorded as a play', { previousId });
+      } else if (playedSeconds >= MIN_PLAY_SECONDS) {
+        // Partial play past the minimum but short of the scrobble threshold. Counts
+        // toward the aggregate, exactly as it did before.
+        void deliverListenEvent(
+          previousId,
+          'played',
+          {
+            track_duration: outgoingDuration || undefined,
+            completion_ratio: outgoingDuration ? playedSeconds / outgoingDuration : undefined,
+            context,
+          },
+          playedSeconds,
+        );
+      } else {
+        // Under the play threshold. Previously this emitted nothing at all — a track
+        // skipped at five seconds was invisible. The backend derives the outcome, so a
+        // short track played in full still comes back `completed`.
+        void deliverListenEvent(previousId, 'skipped', {
+          played_seconds: playedSeconds,
+          track_duration: outgoingDuration || undefined,
+          context,
+          reason: stopReason,
         });
       }
 
-      // Reset for new track
       recordedTrackRef.current = null;
       accumulatedTimeRef.current = 0;
       lastTimeRef.current = 0;
     }
 
     lastTrackIdRef.current = trackId;
+    // eslint-disable-next-line react-hooks/exhaustive-deps -- only re-run on track change
   }, [currentTrack?.id]);
 
   // Track accumulated play time and record when threshold is met
   useEffect(() => {
     if (!currentTrack || !isPlaying || !duration) return;
+
+    // Keep the outgoing duration current while this track is the one playing.
+    lastDurationRef.current = duration;
 
     // Already recorded this track
     if (recordedTrackRef.current === currentTrack.id) return;
@@ -72,21 +150,26 @@ export function usePlayTracking() {
     }
     lastTimeRef.current = currentTime;
 
-    // Calculate thresholds
-    const halfDuration = duration / 2;
-    const fourMinutes = 4 * 60;
-    const recordThreshold = Math.min(halfDuration, fourMinutes);
+    const recordThreshold = Math.min(duration / 2, MAX_PLAY_SECONDS);
 
-    // Must have played at least 30 seconds
-    if (accumulatedTimeRef.current < 30) return;
+    if (accumulatedTimeRef.current < MIN_PLAY_SECONDS) return;
 
-    // Check if we've reached the record threshold
     if (accumulatedTimeRef.current >= recordThreshold) {
       recordedTrackRef.current = currentTrack.id;
+      const played = accumulatedTimeRef.current;
+      const { queueSource } = usePlayerStore.getState();
 
-      // Record the play with duration
-      playTrackingApi.recordPlay(currentTrack.id, accumulatedTimeRef.current).catch((err) => {
-        // Reset so we can retry on next threshold check
+      deliverListenEvent(
+        currentTrack.id,
+        'played',
+        {
+          track_duration: duration,
+          completion_ratio: duration ? played / duration : undefined,
+          context: toContext(queueSource?.type),
+        },
+        played,
+      ).catch((err) => {
+        // Reset so we can retry on the next threshold check
         log.error('Failed to record play:', err);
         recordedTrackRef.current = null;
       });

--- a/packages/frontend/src/hooks/usePlayTracking.ts
+++ b/packages/frontend/src/hooks/usePlayTracking.ts
@@ -65,9 +65,10 @@ export function usePlayTracking() {
   const accumulatedTimeRef = useRef<number>(0);
   const lastTimeRef = useRef<number>(0);
   const lastTrackIdRef = useRef<string | null>(null);
-  // The outgoing track's duration. By the time the reset effect runs, `duration` in the
-  // render closure is already the NEW track's, so a completion ratio computed from it
-  // would measure every track against the wrong length.
+  // The outgoing track's duration, taken from track metadata rather than the engine.
+  // The store's `duration` cannot be trusted for this: it belongs to whatever the engine
+  // last loaded, so it is the PREVIOUS track's value whenever the current one fails to
+  // load — which is exactly when an errored event is about to be reported.
   const lastDurationRef = useRef<number>(0);
   const currentTrackIdRef = useRef<string | null>(null);
 
@@ -123,15 +124,22 @@ export function usePlayTracking() {
         });
       }
 
-      recordedTrackRef.current = null;
+      // Deliberately NOT clearing recordedTrackRef here.
+      //
+      // A failed crossfade rolls the queue back to the track that was just playing
+      // (useAudioEngine's error handler → setQueueByTrackId). Clearing on every change
+      // meant the returned-to track crossed its threshold a second time and was
+      // recorded twice — observed as play_count 2 and total_play_seconds 110.8 for a
+      // single listen of a 75-second track. It also wrote a duplicate PlayEvent, biasing
+      // the taste signal toward whichever tracks happen to fail a crossfade.
+      //
+      // Instead the accumulate effect clears it once a *different* track has genuinely
+      // been listened to, so a real replay later still records while a rollback cannot.
       accumulatedTimeRef.current = 0;
       lastTimeRef.current = 0;
     }
 
-    // Seed from the incoming track's own metadata. The accumulate effect refines this
-    // with the engine's reading once playback starts — but a track that never plays
-    // (a failed load, say) would otherwise report the PREVIOUS track's duration, since
-    // the accumulate effect early-returns before updating the ref.
+    // Track metadata is authoritative and always corresponds to this track.
     if (previousId !== trackId) {
       lastDurationRef.current = currentTrack?.duration_seconds ?? 0;
     }
@@ -144,9 +152,6 @@ export function usePlayTracking() {
   useEffect(() => {
     if (!currentTrack || !isPlaying || !duration) return;
 
-    // Keep the outgoing duration current while this track is the one playing.
-    lastDurationRef.current = duration;
-
     // Already recorded this track
     if (recordedTrackRef.current === currentTrack.id) return;
 
@@ -157,6 +162,18 @@ export function usePlayTracking() {
       // User seeked backward - don't subtract, just update reference
     }
     lastTimeRef.current = currentTime;
+
+    // A different track has now been genuinely listened to, so the previously recorded
+    // one is free to be recorded again if the listener returns to it. Held until this
+    // point so that a crossfade rollback — which spends no real time on the intervening
+    // track — cannot re-record what it just left.
+    if (
+      recordedTrackRef.current !== null
+      && recordedTrackRef.current !== currentTrack.id
+      && accumulatedTimeRef.current >= MIN_PLAY_SECONDS
+    ) {
+      recordedTrackRef.current = null;
+    }
 
     const recordThreshold = Math.min(duration / 2, MAX_PLAY_SECONDS);
 

--- a/packages/frontend/src/hooks/usePlayTracking.ts
+++ b/packages/frontend/src/hooks/usePlayTracking.ts
@@ -128,6 +128,14 @@ export function usePlayTracking() {
       lastTimeRef.current = 0;
     }
 
+    // Seed from the incoming track's own metadata. The accumulate effect refines this
+    // with the engine's reading once playback starts — but a track that never plays
+    // (a failed load, say) would otherwise report the PREVIOUS track's duration, since
+    // the accumulate effect early-returns before updating the ref.
+    if (previousId !== trackId) {
+      lastDurationRef.current = currentTrack?.duration_seconds ?? 0;
+    }
+
     lastTrackIdRef.current = trackId;
     // eslint-disable-next-line react-hooks/exhaustive-deps -- only re-run on track change
   }, [currentTrack?.id]);

--- a/packages/frontend/src/player/playbackStore.ts
+++ b/packages/frontend/src/player/playbackStore.ts
@@ -3,6 +3,47 @@ import { create } from 'zustand';
 export type RepeatMode = 'off' | 'all' | 'one';
 export type CrossfadeState = 'idle' | 'preloading' | 'crossfading';
 
+/**
+ * Why the current track was replaced (ADR-0004).
+ *
+ * Without this, a natural end and a hard skip are indistinguishable — the only
+ * observable signal is `currentTrack.id` changing. Completion ratio alone is not a
+ * substitute: crossfade advances at `duration - crossfadeDuration`, so a fully played
+ * track reads ~0.9 and would look like a skip.
+ *
+ *   ended | crossfade | native-auto  →  backend `natural`
+ *   user                             →  backend `user`   (ratio decides the outcome)
+ *   error                            →  backend `error`  (never a taste signal)
+ *   system                           →  emits nothing
+ *
+ * `system` covers changes the listener did not cause — offline queue rebuilds, hydrate,
+ * profile switches. Emitting those would log phantom skips on every reconnect.
+ */
+export type AdvanceReason =
+  | 'ended'
+  | 'crossfade'
+  | 'native-auto'
+  | 'user'
+  | 'error'
+  | 'system';
+
+const ADVANCE_REASONS: ReadonlySet<string> = new Set<AdvanceReason>([
+  'ended', 'crossfade', 'native-auto', 'user', 'error', 'system',
+]);
+
+/**
+ * Coerce an untrusted value to a valid reason, defaulting to 'user'.
+ *
+ * Guards the `onClick={playNext}` shape, where React passes a MouseEvent as the first
+ * argument — without this, every UI skip would report a MouseEvent as its reason and
+ * look like it worked.
+ */
+export function normalizeAdvanceReason(value: unknown): AdvanceReason {
+  return typeof value === 'string' && ADVANCE_REASONS.has(value)
+    ? (value as AdvanceReason)
+    : 'user';
+}
+
 export interface PlaybackState {
   currentTrack: import('../types').Track | null;
   isPlaying: boolean;
@@ -17,6 +58,12 @@ export interface PlaybackState {
   isLoadingAudio: boolean;
   isHydrated: boolean;
   _circuitBreakerTimestamps: number[];
+  /**
+   * Why `currentTrack` was last replaced. Written in the same `setState` as the track
+   * change so it is atomically tied to a real advance and cannot leak into the next one
+   * (several `playNext` branches return without changing the track).
+   */
+  _advanceReason: AdvanceReason;
 }
 
 export interface PlaybackActions {
@@ -52,6 +99,7 @@ export const usePlaybackStore = create<PlaybackState & PlaybackActions>((set, ge
   isLoadingAudio: false,
   isHydrated: false,
   _circuitBreakerTimestamps: [],
+  _advanceReason: 'user',
 
   setCurrentTrack: (track) => {
     set({ currentTrack: track });

--- a/packages/frontend/src/player/playerStore.ts
+++ b/packages/frontend/src/player/playerStore.ts
@@ -41,7 +41,7 @@ usePlayerStoreFacade.setState = (partial: Partial<PlayerState>) => {
   const playbackKeys = new Set<string>([
     'currentTrack', 'isPlaying', 'currentTime', 'duration', 'volume',
     'shuffle', 'repeat', 'consume', 'crossfadeState', 'nextTrackPreloaded',
-    'isLoadingAudio', 'isHydrated', '_circuitBreakerTimestamps',
+    'isLoadingAudio', 'isHydrated', '_circuitBreakerTimestamps', '_advanceReason',
   ]);
   const playbackPartial: Record<string, unknown> = {};
   const queuePartial: Record<string, unknown> = {};

--- a/packages/frontend/src/player/queueStore.ts
+++ b/packages/frontend/src/player/queueStore.ts
@@ -1,6 +1,7 @@
 import { create } from 'zustand';
 import type { Track, QueueItem } from '../types';
-import { usePlaybackStore } from './playbackStore';
+import { usePlaybackStore, normalizeAdvanceReason } from './playbackStore';
+import type { AdvanceReason } from './playbackStore';
 import { persistCombinedState, _setQueueStateGetter } from './persistenceAdapter';
 import {
   loadPlayerState,
@@ -114,19 +115,19 @@ export interface QueueActions {
   addToQueue: (track: Track, insertIndex?: number, shuffleInsertPosition?: number) => void;
   removeFromQueue: (queueId: string) => void;
   clearQueue: () => void;
-  playTrack: (track: Track) => void;
-  playNext: () => void | Promise<void>;
-  playPrevious: () => void;
-  setQueue: (tracks: Track[], startIndex?: number, source?: QueueSource, options?: { preservePlaybackState?: boolean }) => void;
-  setQueueByTrackId: (tracks: Track[], trackId: string, source?: QueueSource) => void;
+  playTrack: (track: Track, options?: { reason?: AdvanceReason }) => void;
+  playNext: (options?: { reason?: AdvanceReason }) => void | Promise<void>;
+  playPrevious: (options?: { reason?: AdvanceReason }) => void;
+  setQueue: (tracks: Track[], startIndex?: number, source?: QueueSource, options?: { preservePlaybackState?: boolean; reason?: AdvanceReason }) => void;
+  setQueueByTrackId: (tracks: Track[], trackId: string, source?: QueueSource, options?: { reason?: AdvanceReason }) => void;
   reorderQueue: (fromIndex: number, toIndex: number) => void;
   reorderShuffleOrder: (fromIndex: number, toIndex: number) => void;
-  jumpToQueueIndex: (index: number) => void;
+  jumpToQueueIndex: (index: number, options?: { reason?: AdvanceReason }) => void;
   setLazyQueue: (ids: string[], source?: QueueSource, options?: { initialTrack?: Track }) => Promise<void>;
   exitLazyMode: () => void;
   getNextTrack: () => Track | null;
   getUpcomingTrackIds: (count: number) => string[];
-  advanceToNextTrack: (track: Track) => void;
+  advanceToNextTrack: (track: Track, options?: { reason?: AdvanceReason }) => void;
   toggleShuffle: () => void | Promise<void>;
   hydrate: () => Promise<void>;
   resetForProfileSwitch: () => void;
@@ -216,7 +217,8 @@ export const useQueueStore = create<QueueState & QueueActions>((set, get) => ({
     persistCombinedState();
   },
 
-  playTrack: (track) => {
+  playTrack: (track, options) => {
+    const reason = normalizeAdvanceReason(options?.reason);
     log.info('playTrack', { id: track.id, title: track.title });
     const currentTrack = usePlaybackStore.getState().currentTrack;
     if (currentTrack) {
@@ -226,6 +228,7 @@ export const useQueueStore = create<QueueState & QueueActions>((set, get) => ({
     }
     usePlaybackStore.setState({
       currentTrack: track,
+      _advanceReason: reason,
       isPlaying: true,
       currentTime: 0,
       isLoadingAudio: true,
@@ -233,7 +236,8 @@ export const useQueueStore = create<QueueState & QueueActions>((set, get) => ({
     persistCombinedState();
   },
 
-  playNext: async () => {
+  playNext: async (options) => {
+    const reason = normalizeAdvanceReason(options?.reason);
     const { queue, queueIndex, shuffleOrder, shuffleIndex } = get();
     const { shuffle, repeat, consume, currentTrack } = usePlaybackStore.getState();
 
@@ -320,6 +324,7 @@ export const useQueueStore = create<QueueState & QueueActions>((set, get) => ({
       });
       usePlaybackStore.setState({
         currentTrack: newQueue[nextQueueIndex].track,
+        _advanceReason: reason,
         isPlaying: true,
         currentTime: 0,
         isLoadingAudio: true,
@@ -353,6 +358,7 @@ export const useQueueStore = create<QueueState & QueueActions>((set, get) => ({
     });
     usePlaybackStore.setState({
       currentTrack: nextTrack,
+      _advanceReason: reason,
       isPlaying: true,
       currentTime: 0,
       isLoadingAudio: true,
@@ -361,7 +367,8 @@ export const useQueueStore = create<QueueState & QueueActions>((set, get) => ({
     refillFromReservoir();
   },
 
-  playPrevious: () => {
+  playPrevious: (options) => {
+    const reason = normalizeAdvanceReason(options?.reason);
     const { queue, shuffleOrder, shuffleIndex } = get();
     const { shuffle, currentTrack, currentTime } = usePlaybackStore.getState();
 
@@ -393,6 +400,7 @@ export const useQueueStore = create<QueueState & QueueActions>((set, get) => ({
         });
         usePlaybackStore.setState({
           currentTrack: prevTrack,
+          _advanceReason: reason,
           isPlaying: true,
           currentTime: 0,
           isLoadingAudio: true,
@@ -413,6 +421,7 @@ export const useQueueStore = create<QueueState & QueueActions>((set, get) => ({
       }));
       usePlaybackStore.setState({
         currentTrack: prevTrack,
+        _advanceReason: reason,
         isPlaying: true,
         currentTime: 0,
         isLoadingAudio: true,
@@ -421,7 +430,9 @@ export const useQueueStore = create<QueueState & QueueActions>((set, get) => ({
     }
   },
 
-  setQueue: (tracks, startIndex = 0, source?: QueueSource, options?: { preservePlaybackState?: boolean }) => {
+  setQueue: (tracks, startIndex = 0, source?: QueueSource, options?: { preservePlaybackState?: boolean; reason?: AdvanceReason }) => {
+    // Callers are queue rebuilds, hydration and profile switches — not listener actions.
+    const reason = normalizeAdvanceReason(options?.reason ?? 'system');
     const requestedTrackId = tracks[startIndex]?.id;
     const queueTracks = enforceOfflineQueueInvariant(tracks);
 
@@ -473,6 +484,7 @@ export const useQueueStore = create<QueueState & QueueActions>((set, get) => ({
     });
     usePlaybackStore.setState({
       currentTrack: finalStartIndex >= 0 ? queueTracks[finalStartIndex] : null,
+      _advanceReason: reason,
       isPlaying: options?.preservePlaybackState ? usePlaybackStore.getState().isPlaying : finalStartIndex >= 0,
       currentTime: 0,
       isLoadingAudio: options?.preservePlaybackState ? usePlaybackStore.getState().isLoadingAudio : finalStartIndex >= 0,
@@ -480,7 +492,8 @@ export const useQueueStore = create<QueueState & QueueActions>((set, get) => ({
     persistCombinedState();
   },
 
-  setQueueByTrackId: (tracks, trackId, source?: QueueSource) => {
+  setQueueByTrackId: (tracks, trackId, source?: QueueSource, options?: { reason?: AdvanceReason }) => {
+    const reason = normalizeAdvanceReason(options?.reason ?? 'system');
     const offlineModeActive = useConnectivityStore.getState().offlineModeActive;
     const queueTracks = enforceOfflineQueueInvariant(tracks);
     const resolvedIndex = queueTracks.findIndex((track) => track.id === trackId);
@@ -503,10 +516,10 @@ export const useQueueStore = create<QueueState & QueueActions>((set, get) => ({
         });
         return;
       }
-      get().setQueue(queueTracks, 0, source);
+      get().setQueue(queueTracks, 0, source, { reason });
       return;
     }
-    get().setQueue(queueTracks, resolvedIndex, source);
+    get().setQueue(queueTracks, resolvedIndex, source, { reason });
   },
 
   reorderQueue: (fromIndex: number, toIndex: number) => {
@@ -555,7 +568,8 @@ export const useQueueStore = create<QueueState & QueueActions>((set, get) => ({
     persistCombinedState();
   },
 
-  jumpToQueueIndex: (index: number) => {
+  jumpToQueueIndex: (index: number, options?: { reason?: AdvanceReason }) => {
+    const reason = normalizeAdvanceReason(options?.reason);
     const { queue, shuffleOrder } = get();
     const { shuffle, currentTrack } = usePlaybackStore.getState();
     if (index < 0 || index >= queue.length) {
@@ -584,6 +598,7 @@ export const useQueueStore = create<QueueState & QueueActions>((set, get) => ({
     });
     usePlaybackStore.setState({
       currentTrack: targetItem.track,
+      _advanceReason: reason,
       isPlaying: true,
       currentTime: 0,
       isLoadingAudio: true,
@@ -754,7 +769,9 @@ export const useQueueStore = create<QueueState & QueueActions>((set, get) => ({
     return result;
   },
 
-  advanceToNextTrack: (track) => {
+  advanceToNextTrack: (track, options) => {
+    // Only caller is the crossfade path in useAudioEngine.
+    const reason = normalizeAdvanceReason(options?.reason ?? 'crossfade');
     const { queueIndex, shuffleOrder, shuffleIndex, queue } = get();
     const { shuffle, repeat, consume, currentTrack } = usePlaybackStore.getState();
     log.info('advanceToNextTrack (crossfade)', { from: currentTrack?.title, to: track.title, toId: track.id });
@@ -815,6 +832,7 @@ export const useQueueStore = create<QueueState & QueueActions>((set, get) => ({
     });
     usePlaybackStore.setState({
       currentTrack: track,
+      _advanceReason: reason,
       currentTime: 0,
     });
     persistCombinedState();
@@ -1010,6 +1028,7 @@ export const useQueueStore = create<QueueState & QueueActions>((set, get) => ({
       nextTrackPreloaded: false,
       isHydrated: false,
       _circuitBreakerTimestamps: [],
+      _advanceReason: 'system',
     });
   },
 }));

--- a/packages/frontend/src/player/useAudioEngine.ts
+++ b/packages/frontend/src/player/useAudioEngine.ts
@@ -205,7 +205,7 @@ export function useAudioEngine() {
           stopForCircuitBreaker();
           return true;
         }
-        jumpToQueueIndex(idx);
+        jumpToQueueIndex(idx, { reason: 'error' });
         return true;
       }
     }
@@ -236,7 +236,7 @@ export function useAudioEngine() {
     });
 
     // Advance to next track in the store
-    advanceToNextTrack(nextTrack);
+    advanceToNextTrack(nextTrack, { reason: 'crossfade' });
   }, [engine, advanceToNextTrack, setCrossfadeState, setNextTrackPreloaded, applyNormalizationGain, setIsLoadingAudio]);
 
   executeCrossfadeRef.current = executeCrossfade;
@@ -285,7 +285,7 @@ export function useAudioEngine() {
             return;
           }
           log.debug('ended event', { trackId: currentId });
-          playNext();
+          playNext({ reason: 'ended' });
           break;
         }
 
@@ -306,7 +306,7 @@ export function useAudioEngine() {
             setCrossfadeState('idle');
             const prevTrack = state.history[state.history.length - 1];
             if (prevTrack) {
-              state.setQueueByTrackId(state.queue.map(q => q.track), prevTrack.id, state.queueSource ?? undefined);
+              state.setQueueByTrackId(state.queue.map(q => q.track), prevTrack.id, state.queueSource ?? undefined, { reason: 'error' });
             }
             setIsLoadingAudio(false);
             break;
@@ -363,7 +363,7 @@ export function useAudioEngine() {
             }
             showError('Skipping track', { description: `${trackName}: ${event.message}` });
             setIsLoadingAudio(false);
-            playNext();
+            playNext({ reason: 'error' });
           } else {
             showError('Playback error', { description: `${trackName}: ${event.message}` });
             setIsPlaying(false);
@@ -454,11 +454,11 @@ export function useAudioEngine() {
           break;
 
         case 'remoteNext':
-          playNext();
+          playNext({ reason: 'user' });
           break;
 
         case 'nativeAutoAdvanced':
-          playNext();
+          playNext({ reason: 'native-auto' });
           break;
 
         case 'remotePrevious':
@@ -840,7 +840,7 @@ export function useAudioEngine() {
           }
           const trackName = currentTrack.title || 'Unknown track';
           showError('Skipping track', { description: `${trackName}: failed to load` });
-          playNext();
+          playNext({ reason: 'error' });
         }
       }
     };

--- a/packages/frontend/src/services/__tests__/syncService.test.ts
+++ b/packages/frontend/src/services/__tests__/syncService.test.ts
@@ -58,17 +58,26 @@ const mockFavoritesApi = {
   toggle: vi.fn(),
 };
 
+const mockPlayTrackingApi = {
+  recordPlay: vi.fn(),
+  recordSkip: vi.fn(),
+  recordRejection: vi.fn(),
+};
+
 vi.mock('../../api/integrations', () => ({
   lastfmApi: mockLastfmApi,
 }));
 
 vi.mock('../../api/profiles', () => ({
   favoritesApi: mockFavoritesApi,
+  playTrackingApi: mockPlayTrackingApi,
 }));
+
+const mockConnectivityState = { browserOnline: true, offlineModeActive: false };
 
 vi.mock('../../stores/connectivityStore', () => ({
   useConnectivityStore: {
-    getState: vi.fn(() => ({ browserOnline: true })),
+    getState: vi.fn(() => mockConnectivityState),
   },
 }));
 
@@ -86,6 +95,7 @@ describe('syncService', () => {
     mockClear.mockResolvedValue(undefined);
     mockCount.mockResolvedValue(0);
     mockToArray.mockResolvedValue([]);
+    mockConnectivityState.offlineModeActive = false;
   });
 
   afterEach(() => {
@@ -308,6 +318,83 @@ describe('syncService', () => {
       await processPendingActions();
 
       expect(mockFavoritesApi.toggle).toHaveBeenCalledWith('track-1');
+    });
+
+    it('should dispatch a queued listen_event skip via playTrackingApi', async () => {
+      const actions = [
+        { id: 1, profileId: 'profile-123', type: 'listen_event' as const, payload: {
+          trackId: 'track-1', kind: 'skipped',
+          body: { played_seconds: 5, track_duration: 200, reason: 'user', context: 'playlist' },
+        }, createdAt: new Date(), retries: 0 },
+      ];
+      mockToArray.mockResolvedValueOnce(actions);
+      mockPlayTrackingApi.recordSkip.mockResolvedValueOnce({ track_id: 'track-1', outcome: 'skipped', completion_ratio: 0.025 });
+
+      const { processPendingActions } = await getModule();
+      await processPendingActions();
+
+      expect(mockPlayTrackingApi.recordSkip).toHaveBeenCalledWith(
+        'track-1',
+        expect.objectContaining({ reason: 'user', played_seconds: 5 }),
+      );
+      expect(mockPlayTrackingApi.recordPlay).not.toHaveBeenCalled();
+    });
+
+    it('should dispatch a queued listen_event rejection via playTrackingApi', async () => {
+      const actions = [
+        { id: 1, profileId: 'profile-123', type: 'listen_event' as const, payload: {
+          trackId: 'track-2', kind: 'rejected', body: { context: 'radio' },
+        }, createdAt: new Date(), retries: 0 },
+      ];
+      mockToArray.mockResolvedValueOnce(actions);
+      mockPlayTrackingApi.recordRejection.mockResolvedValueOnce({ track_id: 'track-2', outcome: 'rejected', completion_ratio: 0 });
+
+      const { processPendingActions } = await getModule();
+      await processPendingActions();
+
+      expect(mockPlayTrackingApi.recordRejection).toHaveBeenCalledWith('track-2', expect.objectContaining({ context: 'radio' }));
+    });
+  });
+
+  describe('deliverListenEvent', () => {
+    it('sends directly when online', async () => {
+      mockPlayTrackingApi.recordSkip.mockResolvedValueOnce({ track_id: 't', outcome: 'skipped', completion_ratio: 0 });
+
+      const { deliverListenEvent } = await getModule();
+      await deliverListenEvent('t', 'skipped', { played_seconds: 3 });
+
+      expect(mockPlayTrackingApi.recordSkip).toHaveBeenCalled();
+      expect(mockAdd).not.toHaveBeenCalled();
+    });
+
+    it('queues without attempting the request when already offline', async () => {
+      mockConnectivityState.offlineModeActive = true;
+
+      const { deliverListenEvent } = await getModule();
+      await deliverListenEvent('t', 'skipped', { played_seconds: 3 });
+
+      expect(mockPlayTrackingApi.recordSkip).not.toHaveBeenCalled();
+      expect(mockAdd).toHaveBeenCalledWith(expect.objectContaining({ type: 'listen_event' }));
+    });
+
+    it('queues when an online request fails, rather than losing the event', async () => {
+      // The case no existing producer handles: useFavorites only pre-checks isOffline,
+      // so a 500 or a mid-flight drop would silently discard the data.
+      mockPlayTrackingApi.recordSkip.mockRejectedValueOnce(new Error('500'));
+
+      const { deliverListenEvent } = await getModule();
+      await deliverListenEvent('t', 'skipped', { played_seconds: 3 });
+
+      expect(mockPlayTrackingApi.recordSkip).toHaveBeenCalled();
+      expect(mockAdd).toHaveBeenCalledWith(expect.objectContaining({ type: 'listen_event' }));
+    });
+
+    it('never throws, so a failed event cannot disturb playback', async () => {
+      mockPlayTrackingApi.recordSkip.mockRejectedValueOnce(new Error('boom'));
+      mockAdd.mockRejectedValueOnce(new Error('indexeddb gone'));
+
+      const { deliverListenEvent } = await getModule();
+      await expect(deliverListenEvent('t', 'skipped')).resolves.toBeUndefined();
     });
   });
 

--- a/packages/frontend/src/services/syncService.ts
+++ b/packages/frontend/src/services/syncService.ts
@@ -4,13 +4,15 @@
  */
 import { db, isIndexedDBAvailable, type PendingAction } from '../db';
 import { lastfmApi } from '../api/integrations';
-import { favoritesApi } from '../api/profiles';
+import { favoritesApi, playTrackingApi } from '../api/profiles';
+import type { ListenEventBody } from '../api/profiles';
 import { useConnectivityStore } from '../stores/connectivityStore';
 import { getSelectedProfileId } from './profileService';
 import { createLogger } from '../utils/logger';
 const log = createLogger('SyncService');
 
-type ActionType = 'scrobble' | 'now_playing' | 'favorite_toggle';
+// Mirrored by `PendingAction.type` in ../db — keep both in step.
+type ActionType = 'scrobble' | 'now_playing' | 'favorite_toggle' | 'listen_event';
 
 /**
  * Queue an action to be performed when online.
@@ -138,6 +140,9 @@ async function executeAction(action: PendingAction): Promise<void> {
     case 'favorite_toggle':
       await executeFavoriteToggle(action.profileId, action.payload as FavoriteTogglePayload);
       break;
+    case 'listen_event':
+      await executeListenEvent(action.profileId, action.payload as ListenEventPayload);
+      break;
     default:
       log.warn(`Unknown action type: ${action.type}`);
   }
@@ -156,6 +161,15 @@ interface FavoriteTogglePayload {
   trackId: string;
 }
 
+/** A listening event that could not be delivered when it happened (ADR-0004). */
+interface ListenEventPayload {
+  trackId: string;
+  kind: 'played' | 'skipped' | 'rejected';
+  body: ListenEventBody;
+  /** Only meaningful for `played`, which also bumps the play aggregate. */
+  durationSeconds?: number;
+}
+
 async function executeScrobble(_profileId: string, payload: ScrobblePayload): Promise<void> {
   await lastfmApi.scrobble(payload.trackId, parseInt(payload.timestamp));
 }
@@ -166,6 +180,56 @@ async function executeNowPlaying(_profileId: string, payload: NowPlayingPayload)
 
 async function executeFavoriteToggle(_profileId: string, payload: FavoriteTogglePayload): Promise<void> {
   await favoritesApi.toggle(payload.trackId);
+}
+
+async function executeListenEvent(_profileId: string, payload: ListenEventPayload): Promise<void> {
+  const { trackId, kind, body } = payload;
+  if (kind === 'played') {
+    await playTrackingApi.recordPlay(trackId, payload.durationSeconds, {
+      track_duration: body.track_duration,
+      completion_ratio: body.completion_ratio,
+      context: body.context,
+      source_track_id: body.source_track_id,
+    });
+    return;
+  }
+  if (kind === 'rejected') {
+    await playTrackingApi.recordRejection(trackId, body);
+    return;
+  }
+  await playTrackingApi.recordSkip(trackId, body);
+}
+
+/**
+ * Send a listening event, falling back to the outbox if it cannot be delivered.
+ *
+ * Unlike `useFavorites`, which only pre-checks `isOffline`, this also queues on a failed
+ * request. A 500 or a connection dropped mid-flight would otherwise discard taste data
+ * silently — and offline listening, where skipping is most frequent, is exactly when
+ * delivery is least reliable (ADR-0004 point 7).
+ *
+ * Never throws: a failed listening event must not disturb playback.
+ */
+export async function deliverListenEvent(
+  trackId: string,
+  kind: 'played' | 'skipped' | 'rejected',
+  body: ListenEventBody = {},
+  durationSeconds?: number,
+): Promise<void> {
+  const payload: ListenEventPayload = { trackId, kind, body, durationSeconds };
+
+  // Already offline — skip the request that is certain to fail.
+  if (useConnectivityStore.getState().offlineModeActive) {
+    await queueAction('listen_event', payload);
+    return;
+  }
+
+  try {
+    await executeListenEvent('', payload);
+  } catch (error) {
+    log.warn('Listening event failed, queueing for retry:', error);
+    await queueAction('listen_event', payload);
+  }
 }
 
 /**


### PR DESCRIPTION
Phase 2 of [ADR-0004](https://github.com/seethroughlab/familiar/blob/main/docs/decisions/ADR-0004-listening-feedback-is-event-sourced.md). Phase 1 landed the `play_events` table and three endpoints — **the table was still empty, because nothing emitted.**

## Why

`usePlayTracking` only called `/played` once Last.fm thresholds were met (≥30s **and** ≥`min(half, 4min)`). **A track skipped at five seconds produced zero API calls**, so the negative signal ADR-0005's radio needs didn't exist. It only accrues in wall-clock time, which is why this is worth doing before the native build rather than alongside it.

## The obstacle

Nothing told the client *why* the track changed — `usePlayTracking` only saw `currentTrack.id` flip. Completion ratio can't substitute: crossfade advances at `duration - crossfadeDuration`, so **a fully played track reads ~0.9 and looks like a skip**.

So the advance functions gain an optional trailing options object (matching `setQueue`'s existing convention), and the reason is written into `playbackStore._advanceReason` **inside the same `setState` that changes `currentTrack`**. Atomicity matters: `playNext` has five early-returns that change no track, and a reason set before the branch would leak into the next advance.

| client reason | → backend |
|---|---|
| `ended`, `crossfade`, `native-auto` | `natural` |
| `user` | `user` |
| `error` | `error` |
| `system` | **emits nothing** |

**`system` isn't in the ADR.** Offline queue rebuilds, hydration and profile switches replace `currentTrack` without the listener doing anything — without it, every reconnect logs a phantom skip.

**Error advances take three paths, not the two the ADR names.** Beyond the two `playNext()` sites, `advanceToNextDownloadedTrack` goes via `jumpToQueueIndex` and a crossfade failure rolls back via `setQueueByTrackId`. Miss those and broken files get recorded as dislikes — exactly what point 6 forbids.

## Three things caught while implementing

- **`onClick={playNext}` passes React's MouseEvent as the first argument.** Positional options would have made every UI skip report a `MouseEvent` as its reason — and it would have looked like it worked. All four handlers wrapped, plus `normalizeAdvanceReason()` coerces anything unrecognised back to `'user'` so a future bare handler can't reintroduce it.
- **`duration` in the closure is already the NEW track's** by the time the reset effect runs, so every completion ratio would have been measured against the wrong track. Hence `lastDurationRef`, with a regression test.
- **RTL's automatic cleanup was never running** — `vitest.config.ts` sets neither `globals: true` nor a setup file. Hooks from earlier tests stayed mounted and kept reacting to the shared store; the `system` test saw **8 emissions from 7 other tests**. Fixed with explicit `cleanup()`.

## Delivery

Catch-then-queue, via a new `deliverListenEvent` in `syncService`. No existing producer does this — `useFavorites` only pre-checks `isOffline` — so a 500 or a connection dropped mid-flight would have discarded taste data silently. It never throws: a failed event must not disturb playback.

No Dexie version bump needed — `type` is indexed, but an IndexedDB index constrains the key path, not the value domain, and `payload` is unindexed.

## Scope

**Ambient mode still emits nothing.** It bypasses the queue store entirely, and dozens of quiet 15-second snippets per session would swamp ADR-0005's taste term with things the listener never chose. `recordRejection` ships without UI for ADR-0005's radio to call.

## Verified

**816 tests pass** (up from 802). Lint, boundaries and audio-guardrails clean — 0 errors; the 3 boundary and 27 lint warnings are all pre-existing. `tsc` reports no errors in any changed file (the 4 pre-existing error files are unchanged).

Not yet run end-to-end against the NAS — that needs a browser session, and is the check that `select outcome, count(*) from play_events group by outcome` shows a realistic spread rather than everything landing in one bucket.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_014P9p2fvFnyiywBxGkv4gfW