### PR TITLE
fix(player): restore loadedTrackId when a crossfade is cancelled

### DIFF
--- a/packages/frontend/src/player/audio/__tests__/crossfadeCancel.test.ts
+++ b/packages/frontend/src/player/audio/__tests__/crossfadeCancel.test.ts
@@ -1,0 +1,86 @@
+/**
+ * Regression test for a silent playback-killing bug in the crossfade path.
+ *
+ * `executeCrossfade` optimistically sets `loadedTrackId` to the next track, because a
+ * crossfade normally completes. When it is cancelled instead — a media error on either
+ * element rolls it back — the element still playing is the *current* one, but
+ * `cancelCrossfade` used to leave `loadedTrackId` pointing at the next track.
+ *
+ * That desync is permanent and fatal. `useAudioEngine`'s 'ended' handler discards the
+ * event whenever `engine.getLoadedTrackId() !== store.currentTrack.id`, so once the two
+ * disagree the queue never advances again and playback dies with no error shown.
+ *
+ * Observed live: after a failed crossfade the logs showed
+ * `ended ignored: queue already advanced {currentId: <rolled-back track>, loadedId: <next track>}`
+ * on every subsequent track end.
+ */
+import { describe, expect, it } from 'vitest';
+import { WebAudioEngine } from '../../../../../web/src/WebAudioEngine';
+
+/** Minimal harness — cancelCrossfade only touches elements, gains and URL state. */
+function makeEngineMidCrossfade() {
+  const engine = new WebAudioEngine();
+  const internals = engine as unknown as {
+    elementA: HTMLAudioElement | null;
+    elementB: HTMLAudioElement | null;
+    currentIsA: boolean;
+    crossfadeActive: boolean;
+    loadedTrackId: string | null;
+    preloadingTrackId: string | null;
+  };
+
+  const current = document.createElement('audio');
+  current.setAttribute('data-track-id', 'current-track');
+  const next = document.createElement('audio');
+  next.setAttribute('data-track-id', 'next-track');
+
+  internals.elementA = current;
+  internals.elementB = next;
+  internals.currentIsA = true;
+  internals.crossfadeActive = true;
+  // What executeCrossfade leaves behind: pointing at the track that has not taken over.
+  internals.loadedTrackId = 'next-track';
+  internals.preloadingTrackId = 'next-track';
+
+  return { engine, internals };
+}
+
+describe('WebAudioEngine.cancelCrossfade', () => {
+  it('restores loadedTrackId to the track that is actually playing', () => {
+    const { engine } = makeEngineMidCrossfade();
+    expect(engine.getLoadedTrackId()).toBe('next-track');
+
+    engine.cancelCrossfade();
+
+    // Must match the element still playing, or the 'ended' guard silently kills the queue.
+    expect(engine.getLoadedTrackId()).toBe('current-track');
+  });
+
+  it('clears crossfade state so a later crossfade can run', () => {
+    const { engine, internals } = makeEngineMidCrossfade();
+
+    engine.cancelCrossfade();
+
+    expect(engine.isCrossfading()).toBe(false);
+    expect(internals.preloadingTrackId).toBeNull();
+  });
+
+  it('is a no-op when no crossfade is active', () => {
+    const { engine, internals } = makeEngineMidCrossfade();
+    internals.crossfadeActive = false;
+    internals.loadedTrackId = 'something-else';
+
+    engine.cancelCrossfade();
+
+    // Nothing in flight to roll back — must not clobber the loaded track.
+    expect(engine.getLoadedTrackId()).toBe('something-else');
+  });
+
+  it('handles a missing current element without throwing', () => {
+    const { engine, internals } = makeEngineMidCrossfade();
+    internals.elementA = null;
+
+    expect(() => engine.cancelCrossfade()).not.toThrow();
+    expect(engine.getLoadedTrackId()).toBeNull();
+  });
+});

--- a/packages/frontend/src/player/useAudioEngine.ts
+++ b/packages/frontend/src/player/useAudioEngine.ts
@@ -294,7 +294,15 @@ export function useAudioEngine() {
 
           // If error during crossfade, roll back the store to the previous track
           if (state.crossfadeState === 'crossfading') {
-            log.warn('Crossfade failed, rolling back to previous track');
+            // Log the underlying reason — this branch returns before the general
+            // error logging below, so the actual media error used to be discarded and
+            // "Crossfade failed" was all that reached the logs.
+            log.warn('Crossfade failed, rolling back to previous track', {
+              reason: event.message,
+              code: event.code,
+              fromTrack: state.currentTrack?.title,
+              rollbackTo: state.history[state.history.length - 1]?.title,
+            });
             setCrossfadeState('idle');
             const prevTrack = state.history[state.history.length - 1];
             if (prevTrack) {

--- a/packages/web/src/WebAudioEngine.ts
+++ b/packages/web/src/WebAudioEngine.ts
@@ -513,7 +513,17 @@ export class WebAudioEngine implements AudioEngine {
   cancelCrossfade(): void {
     if (!this.crossfadeActive) return;
 
-    log.debug('cancelCrossfade');
+    // executeCrossfade optimistically points loadedTrackId at the next track, because
+    // the crossfade normally completes. When it is cancelled instead, the element still
+    // playing is the current one — so leaving loadedTrackId on the next track makes the
+    // engine claim a track it is not playing.
+    //
+    // That desync is permanent and fatal: the hook's 'ended' handler discards the event
+    // whenever engine.getLoadedTrackId() !== store.currentTrack.id, so the queue never
+    // advances again and playback dies silently until the listener picks a track by hand.
+    const currentTrackId = this.getCurrentElement()?.getAttribute('data-track-id') ?? null;
+    log.debug('cancelCrossfade', { restoringLoadedTrackId: currentTrackId });
+    this.loadedTrackId = currentTrackId;
 
     const currentGain = this.getCurrentGain();
     const nextGain = this.getNextGain();


### PR DESCRIPTION
Fixes #11. **A failed crossfade permanently killed queue advancement** — playback stopped after the current track and never resumed until a track was picked by hand, with no error shown.

## Cause

`executeCrossfade` optimistically sets `loadedTrackId` to the next track ([`WebAudioEngine.ts:510`](https://github.com/seethroughlab/familiar/blob/main/packages/web/src/WebAudioEngine.ts#L510)), because a crossfade normally completes. When a media error cancels it instead, the element still playing is the **current** one — but `cancelCrossfade` restored gains, elements, blob URLs and timers, and never touched `loadedTrackId`.

The engine was then permanently claiming a track it wasn't playing. `useAudioEngine`'s `ended` handler discards the event whenever `engine.getLoadedTrackId() !== store.currentTrack.id`, so **every subsequent track end was silently ignored**.

## Evidence

From `frontend_logs` during ADR-0004 browser testing:

```
01:34:03.801  executeCrossfade {"duration":2.26,"nextTrackId":"2d2fd439-…"}
01:34:03.836  Crossfade failed, rolling back to previous track
01:34:03.869  loadTrack "Canticle Drawl"
01:34:06.578  ended ignored: queue already advanced
              {currentId: 6d8f235b (Canticle Drawl), loadedId: 2d2fd439 (marram)}
```

The same pattern appeared in two separate sessions, on different tracks.

## Also: the cause is now diagnosable

The crossfade branch `return`s before the general error logging below it, so the underlying media error was thrown away and `"Crossfade failed"` was all that reached the logs — which is why we still don't know *why* it fails. The message, code and both track titles are now recorded, so the next occurrence tells us.

## Not a bug: the crossfade setting

Worth recording since it was suspected. `getEffectiveCrossfadeDuration` returns 0 when disabled, and `getCrossfadeTrigger` can never return `'crossfade'` at 0. The gating is correct; the failing session simply had a 2.26s duration configured.

## Tests

`crossfadeCancel.test.ts` drives `cancelCrossfade` directly and asserts:

- `loadedTrackId` matches the element still playing — the actual regression
- crossfade state clears so a later crossfade can run
- it stays a no-op when nothing is in flight (must not clobber `loadedTrackId`)
- a missing current element doesn't throw

806 tests pass, lint/boundaries unchanged (0 errors), web build succeeds.

## Why this mattered beyond itself

It was blocking verification of [ADR-0004 phase 2](https://github.com/seethroughlab/familiar/pull/10) — every natural transition in testing went through crossfade, failed, and stalled, so the `ended` path could never be exercised. It's also a concrete instance of the "playback glitches" symptom that motivated ADR-0001.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_014P9p2fvFnyiywBxGkv4gfW