### PR TITLE
fix(streaming): serve audio via Starlette FileResponse

### DIFF
--- a/backend/app/api/routes/tracks/streaming.py
+++ b/backend/app/api/routes/tracks/streaming.py
@@ -8,7 +8,7 @@ from typing import Literal
 from uuid import UUID
 
 from fastapi import APIRouter, Query, Request, UploadFile
-from fastapi.responses import StreamingResponse
+from fastapi.responses import FileResponse, StreamingResponse
 from pydantic import BaseModel
 
 from app.api.deps import DbSession
@@ -67,19 +67,25 @@ class LyricsResponse(BaseModel):
     # Declare the real media type. Without this the schema claims application/json and a
     # generated client would try to JSON-decode audio (ADR-0007). This endpoint is
     # hand-written per platform; the schema only needs to describe it honestly.
-    response_class=StreamingResponse,
+    response_class=FileResponse,
     responses={
         200: {
             "content": {"audio/*": {}},
-            "description": "Audio stream. Supports HTTP range requests for seeking.",
-        }
+            "description": "Whole audio file.",
+        },
+        # The usual response during playback, and previously undeclared.
+        206: {
+            "content": {"audio/*": {}},
+            "description": "Partial content for a Range request (seeking, buffering).",
+        },
+        416: {"description": "Requested range is not satisfiable."},
     },
 )
 async def stream_track(
     db: DbSession,
     track_id: UUID,
     request: Request,
-) -> StreamingResponse:
+) -> FileResponse:
     """Stream audio file with range request support for seeking."""
     from sqlalchemy import select
 
@@ -114,7 +120,7 @@ async def stream_track(
     return await stream_file(file_path, request, mime_type)
 
 
-async def _get_or_transcode(track_id: UUID, file_path: Path, request: Request) -> StreamingResponse:
+async def _get_or_transcode(track_id: UUID, file_path: Path, request: Request) -> FileResponse:
     """Transcode audio to FLAC (cached to disk), then serve via stream_file().
 
     Caching to disk ensures the served file has complete FLAC headers (streaminfo +

--- a/backend/app/api/streaming.py
+++ b/backend/app/api/streaming.py
@@ -1,80 +1,54 @@
 """Shared streaming utilities for serving audio files with range request support."""
 
 import logging
-from collections.abc import AsyncIterator
 from pathlib import Path
 
 from fastapi import Request
-from starlette.responses import StreamingResponse
+from starlette.responses import FileResponse
 
 logger = logging.getLogger(__name__)
 
 
-async def stream_file(file_path: Path, request: Request, mime_type: str) -> StreamingResponse:
-    """Stream a file with HTTP range request support.
+async def stream_file(file_path: Path, request: Request, mime_type: str) -> FileResponse:
+    """Serve a file with HTTP range support.
 
-    Used by the main tracks API.
+    Delegates to Starlette's ``FileResponse``, which reads the ``Range`` header off the
+    ASGI scope itself and handles 206, 416, multipart ranges, ``ETag`` and
+    ``Last-Modified``.
+
+    This replaced a hand-rolled implementation that caused issue #13 — playback dying
+    with ``PIPELINE_ERROR_READ: FFmpegDemuxer: data source error`` a couple of times per
+    seven minutes of listening. Five defects, in rough order of how much they hurt:
+
+    1. **Blocking I/O on the event loop.** ``open``/``seek``/``read`` ran inline in an
+       async generator, 64 KiB at a time. Uvicorn runs ``--workers 1`` (CLAP needs
+       ~1.5 GB, so more workers would OOM) and library sync plus background analysis
+       share that process, so a sync would stall the loop — p95 latency was measured at
+       990 ms and 1036 ms during sync, against ~50 ms idle. A starved media element
+       reports a read failure. ``FileResponse`` uses ``anyio`` for both ``stat`` and the
+       reads, so file I/O no longer blocks the loop.
+    2. **Silent truncation.** ``except OSError`` logged and returned *without*
+       re-raising, and a short read hit ``break`` — but the response had already sent
+       ``Content-Length: N``. The body then ended early while the header still claimed
+       N bytes, which a demuxer cannot tell apart from corruption.
+    3. **No ``ETag``/``Last-Modified``**, while still sending
+       ``Cache-Control: private, max-age=3600``. With no validator the browser cannot
+       revalidate or resume — only refetch blind.
+    4. **Suffix ranges served the wrong bytes.** ``bytes=-100`` means the *last* 100
+       bytes; splitting on ``-`` gave an empty first field, so it returned bytes 0-100
+       with a ``Content-Range`` contradicting the request, under a 206. Demuxers use
+       suffix ranges to read trailers.
+    5. **No 416, and multipart ranges 500'd.** An unsatisfiable range was clamped into
+       the file and served as a bogus single-byte 206; ``bytes=0-10,20-30`` raised
+       ``ValueError`` from ``int("100,200")``.
+
+    ``request`` is retained for call-site compatibility and is no longer read here —
+    ``FileResponse`` takes the range from the scope.
     """
-    file_size = file_path.stat().st_size
-    range_header = request.headers.get("range")
-
-    if range_header:
-        range_spec = range_header.replace("bytes=", "")
-        range_parts = range_spec.split("-")
-        start = int(range_parts[0]) if range_parts[0] else 0
-        end = int(range_parts[1]) if range_parts[1] else file_size - 1
-
-        start = max(0, min(start, file_size - 1))
-        end = max(start, min(end, file_size - 1))
-        content_length = end - start + 1
-
-        logger.debug("Range request: %s bytes=%d-%d (%d bytes)", file_path.name, start, end, content_length)
-
-        async def stream_range() -> AsyncIterator[bytes]:
-            try:
-                with open(file_path, "rb") as f:
-                    f.seek(start)
-                    remaining = content_length
-                    chunk_size = 64 * 1024
-                    while remaining > 0:
-                        read_size = min(chunk_size, remaining)
-                        data = f.read(read_size)
-                        if not data:
-                            break
-                        remaining -= len(data)
-                        yield data
-            except OSError:
-                logger.exception("IO error streaming range for %s", file_path)
-
-        return StreamingResponse(
-            stream_range(),
-            status_code=206,
-            media_type=mime_type,
-            headers={
-                "Content-Range": f"bytes {start}-{end}/{file_size}",
-                "Accept-Ranges": "bytes",
-                "Content-Length": str(content_length),
-                "Cache-Control": "private, max-age=3600",
-            },
-        )
-    else:
-        logger.debug("Full file request: %s (%d bytes)", file_path.name, file_size)
-
-        async def stream_full() -> AsyncIterator[bytes]:
-            try:
-                with open(file_path, "rb") as f:
-                    chunk_size = 64 * 1024
-                    while chunk := f.read(chunk_size):
-                        yield chunk
-            except OSError:
-                logger.exception("IO error streaming full file %s", file_path)
-
-        return StreamingResponse(
-            stream_full(),
-            media_type=mime_type,
-            headers={
-                "Accept-Ranges": "bytes",
-                "Content-Length": str(file_size),
-                "Cache-Control": "private, max-age=3600",
-            },
-        )
+    return FileResponse(
+        path=file_path,
+        media_type=mime_type,
+        # Preserved from the previous implementation, and only now actually useful:
+        # FileResponse supplies the validators that make revalidation possible.
+        headers={"Cache-Control": "private, max-age=3600"},
+    )

--- a/backend/tests/test_streaming.py
+++ b/backend/tests/test_streaming.py
@@ -1,0 +1,188 @@
+"""Tests for audio range-request streaming.
+
+`app.api.streaming.stream_file` had no test coverage at all.
+`test_stream_concurrency.py` looks like it covers this but does not: all three of its
+tests use a random `uuid4()` that 404s before `stream_file` is ever reached, and they
+assert `status_code in (200, 206, 404, 500)` — so even an unhandled exception passes.
+Its `temp_audio_file` fixture is defined and never used by anything.
+
+These drive the real endpoint against a real file on disk, so a byte returned wrong is
+a byte that fails a test.
+
+Several of these are expected to FAIL against the hand-rolled implementation and to pass
+once it is replaced with Starlette's `FileResponse` (issue #13). They are written first
+deliberately: a bug that cannot be demonstrated is a bug that has not been established.
+"""
+
+import tempfile
+from pathlib import Path
+
+import pytest
+
+from tests.factories import insert_test_track
+
+# Deterministic, and large enough that ranges are meaningful.
+CONTENT = bytes(range(256)) * 64  # 16 KiB
+CONTENT_LEN = len(CONTENT)
+
+
+@pytest.fixture()
+def audio_file():
+    """A real file on disk for a track row to point at."""
+    with tempfile.NamedTemporaryFile(suffix=".mp3", delete=False) as f:
+        f.write(CONTENT)
+        f.flush()
+        path = Path(f.name)
+    yield path
+    path.unlink(missing_ok=True)
+
+
+@pytest.fixture()
+async def streamable_track(async_db, audio_file):
+    """A track whose file_path points at a real, readable file."""
+    track = await insert_test_track(async_db, title="Streamable", file_path=str(audio_file))
+    await async_db.commit()
+    return track
+
+
+class TestFullRequest:
+    @pytest.mark.asyncio
+    async def test_serves_the_whole_file(self, streamable_track, client):
+        r = client.get(f"/api/v1/tracks/{streamable_track.id}/stream")
+        assert r.status_code == 200
+        assert r.content == CONTENT
+        assert int(r.headers["content-length"]) == CONTENT_LEN
+
+    @pytest.mark.asyncio
+    async def test_advertises_range_support(self, streamable_track, client):
+        r = client.get(f"/api/v1/tracks/{streamable_track.id}/stream")
+        assert r.headers.get("accept-ranges") == "bytes"
+
+
+class TestRanges:
+    @pytest.mark.asyncio
+    async def test_closed_range(self, streamable_track, client):
+        r = client.get(f"/api/v1/tracks/{streamable_track.id}/stream",
+                       headers={"Range": "bytes=0-99"})
+        assert r.status_code == 206
+        assert r.content == CONTENT[0:100]
+        assert r.headers["content-range"] == f"bytes 0-99/{CONTENT_LEN}"
+        assert int(r.headers["content-length"]) == 100
+
+    @pytest.mark.asyncio
+    async def test_mid_file_range(self, streamable_track, client):
+        r = client.get(f"/api/v1/tracks/{streamable_track.id}/stream",
+                       headers={"Range": "bytes=1000-1999"})
+        assert r.status_code == 206
+        assert r.content == CONTENT[1000:2000]
+
+    @pytest.mark.asyncio
+    async def test_open_ended_range_runs_to_eof(self, streamable_track, client):
+        start = CONTENT_LEN - 500
+        r = client.get(f"/api/v1/tracks/{streamable_track.id}/stream",
+                       headers={"Range": f"bytes={start}-"})
+        assert r.status_code == 206
+        assert r.content == CONTENT[start:]
+
+    @pytest.mark.asyncio
+    async def test_suffix_range_returns_the_LAST_bytes(self, streamable_track, client):
+        """`bytes=-100` means the final 100 bytes (RFC 9110 §14.1.2).
+
+        The hand-rolled parser splits on '-', sees an empty first field, and serves
+        bytes 0-100 instead — the wrong end of the file, with a Content-Range that
+        contradicts the request. Demuxers use suffix ranges to read trailers, so this
+        hands them the wrong data while reporting success.
+        """
+        r = client.get(f"/api/v1/tracks/{streamable_track.id}/stream",
+                       headers={"Range": "bytes=-100"})
+        assert r.status_code == 206
+        assert r.content == CONTENT[-100:]
+
+    @pytest.mark.asyncio
+    async def test_unsatisfiable_range_is_416(self, streamable_track, client):
+        """A range starting past EOF must be 416, not a clamped 206.
+
+        The hand-rolled version clamps start/end into the file and returns a bogus
+        single-byte 206, so a client seeking past the end is told it succeeded.
+        """
+        r = client.get(f"/api/v1/tracks/{streamable_track.id}/stream",
+                       headers={"Range": f"bytes={CONTENT_LEN + 5000}-"})
+        assert r.status_code == 416
+
+    @pytest.mark.asyncio
+    async def test_multiple_ranges_do_not_500(self, streamable_track, client):
+        """`int("100,200")` raises ValueError in the hand-rolled parser."""
+        r = client.get(f"/api/v1/tracks/{streamable_track.id}/stream",
+                       headers={"Range": "bytes=0-10,20-30"})
+        assert r.status_code in (206, 416)
+        assert r.status_code != 500
+
+    @pytest.mark.asyncio
+    async def test_malformed_range_does_not_500(self, streamable_track, client):
+        r = client.get(f"/api/v1/tracks/{streamable_track.id}/stream",
+                       headers={"Range": "bytes=abc-def"})
+        assert r.status_code != 500
+
+
+class TestValidators:
+    @pytest.mark.asyncio
+    async def test_sends_cache_validators(self, streamable_track, client):
+        """Without ETag or Last-Modified the browser cannot revalidate.
+
+        Combined with `Cache-Control: private, max-age=3600` that means a blind refetch
+        is the only option — it cannot resume or confirm what it already holds.
+        """
+        r = client.get(f"/api/v1/tracks/{streamable_track.id}/stream")
+        assert "etag" in r.headers or "last-modified" in r.headers
+
+    @pytest.mark.asyncio
+    async def test_preserves_cache_control(self, streamable_track, client):
+        r = client.get(f"/api/v1/tracks/{streamable_track.id}/stream")
+        assert "private" in r.headers.get("cache-control", "")
+
+    @pytest.mark.asyncio
+    async def test_preserves_audio_media_type(self, streamable_track, client):
+        r = client.get(f"/api/v1/tracks/{streamable_track.id}/stream")
+        assert r.headers["content-type"].startswith("audio/")
+
+
+class TestBodyIntegrity:
+    @pytest.mark.asyncio
+    async def test_body_length_always_matches_declared_length(self, streamable_track, client):
+        """The failure mode behind issue #13.
+
+        The hand-rolled generator swallows OSError and breaks on a short read *after*
+        the response has already declared Content-Length. The body then ends early with
+        a header claiming otherwise, which a demuxer cannot distinguish from corruption
+        — it surfaces as PIPELINE_ERROR_READ rather than a clean error.
+        """
+        for header in (None, "bytes=0-99", "bytes=500-", "bytes=-100"):
+            headers = {"Range": header} if header else {}
+            r = client.get(f"/api/v1/tracks/{streamable_track.id}/stream", headers=headers)
+            if r.status_code in (200, 206):
+                assert len(r.content) == int(r.headers["content-length"]), (
+                    f"body/Content-Length mismatch for Range={header!r}"
+                )
+
+    @pytest.mark.asyncio
+    async def test_ranges_reassemble_into_the_original(self, streamable_track, client):
+        """Fetch the file in chunks the way a media element does, and rebuild it."""
+        chunk = 4096
+        rebuilt = b""
+        for start in range(0, CONTENT_LEN, chunk):
+            end = min(start + chunk - 1, CONTENT_LEN - 1)
+            r = client.get(f"/api/v1/tracks/{streamable_track.id}/stream",
+                           headers={"Range": f"bytes={start}-{end}"})
+            assert r.status_code == 206
+            rebuilt += r.content
+        assert rebuilt == CONTENT
+
+
+class TestMissing:
+    @pytest.mark.asyncio
+    async def test_missing_file_is_404_not_500(self, async_db, client):
+        track = await insert_test_track(async_db, title="Gone",
+                                        file_path="/nonexistent/definitely/not/here.mp3")
+        await async_db.commit()
+        r = client.get(f"/api/v1/tracks/{track.id}/stream")
+        assert r.status_code == 404


### PR DESCRIPTION
Fixes #13 — playback dying with `PIPELINE_ERROR_READ: FFmpegDemuxer: data source error`, roughly twice per seven minutes of listening.

## The cause is contention, not the range logic

`stream_file` did blocking `open`/`seek`/`read` **directly on the asyncio event loop**, 64 KiB at a time. Uvicorn runs `--workers 1` (deliberately — CLAP needs ~1.5 GB), and library sync plus background analysis run in that same process.

From `metrics_summary` on the NAS, spanning both observed failures:

| time | sync | p95 |
|---|---|---|
| 01:57:21 | False | 364 ms |
| **02:02:21** | **True** | 160 ms ← crossfade failed 02:02:27 |
| **02:07:21** | **True** | **990 ms** |
| 02:12:21 | False | 49 ms |
| 02:22:21 | False | **1036 ms** |

Idle p95 is ~50 ms. A media element whose reads stall for a second reports a read failure.

## Why replacing rather than patching

Starlette 0.50's `FileResponse` already implements all of this, tested, using `anyio` for both `stat` and the reads — so file I/O leaves the event loop. This **deletes** 81 lines of hand-rolled HTTP and fixes five defects at once.

**Tests were written first**, and these five failed against the old implementation:

| test | before | after |
|---|---|---|
| suffix range returns LAST bytes | FAIL | pass |
| unsatisfiable range → 416 | FAIL | pass |
| multiple ranges don't 500 | FAIL | pass |
| malformed range doesn't 500 | FAIL | pass |
| sends cache validators | FAIL | pass |

## The defect that mattered most isn't in that table

It can't be triggered on demand. `except OSError` logged and returned **without re-raising**, and a short read hit `break` — *after* `Content-Length` had already been sent. The body then ended early while the header still claimed N bytes.

**A truncated body with a valid `Content-Length` is indistinguishable from corruption to a demuxer.** That is what turned a transient stall into a hard playback failure instead of a clean, recoverable error.

Also: `bytes=-100` means the *last* 100 bytes. Splitting on `-` gave an empty first field, so it served bytes 0–100 with a `Content-Range` contradicting the request, under a 206. Demuxers use suffix ranges to read trailers — so it handed them the wrong data while reporting success.

## Test coverage

`test_streaming.py` is new. `stream_file` had **zero** coverage: `test_stream_concurrency.py` looks like it covers this, but every test uses a random `uuid4()` that 404s before `stream_file` is reached, and asserts `status_code in (200, 206, 404, 500)` — so even an unhandled exception passed. Its `temp_audio_file` fixture was defined and never used.

The route now also declares **206** and **416** in its OpenAPI responses; 206 is the usual response during playback and was previously undeclared.

## Honest limitation

This will make the failures **rarer, not necessarily zero**. The underlying contention persists until background work moves out of the request process — filed as #15, along with #16 for `RequestIDMiddleware` lacking a `try/finally`, which is why aborted streams never logged and the server looked healthy throughout.

## Verified

15 new tests pass; 1144 total. The 4 remaining failures are pre-existing and unrelated — 3 chat contract tests that assume no Anthropic key is configured, and the `spotify_imports` drift that only appears after the migration round-trip tests mutate the local schema.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_014P9p2fvFnyiywBxGkv4gfW