### PR TITLE
fix(observability): make request metrics mean something, and raise the CPU cap

### DIFF
--- a/backend/app/config.py
+++ b/backend/app/config.py
@@ -135,10 +135,57 @@ GENERATIVE_ART_VERSION = 4
 #   v1: CLAP-based mood/genre/instrumentation/energy tags
 MOOD_TAGS_VERSION = 1
 
+# Where the kernel exposes this cgroup's CPU quota. Module-level so tests can point them
+# at synthetic files instead of depending on the host they run on.
+CGROUP_V2_CPU_MAX = Path("/sys/fs/cgroup/cpu.max")
+CGROUP_V1_CPU_QUOTA = Path("/sys/fs/cgroup/cpu/cpu.cfs_quota_us")
+CGROUP_V1_CPU_PERIOD = Path("/sys/fs/cgroup/cpu/cpu.cfs_period_us")
+
+
+def _cgroup_cpu_quota() -> float | None:
+    """This cgroup's CPU quota in cores, or None if unlimited or not in a cgroup."""
+    try:
+        # cgroup v2: "<quota> <period>", where quota may be the literal "max".
+        if CGROUP_V2_CPU_MAX.exists():
+            quota_s, _, period_s = CGROUP_V2_CPU_MAX.read_text().strip().partition(" ")
+            if quota_s and quota_s != "max":
+                period = float(period_s)
+                if period > 0:
+                    return float(quota_s) / period
+
+        # cgroup v1: two files, with -1 meaning unlimited.
+        if CGROUP_V1_CPU_QUOTA.exists() and CGROUP_V1_CPU_PERIOD.exists():
+            quota = float(CGROUP_V1_CPU_QUOTA.read_text().strip())
+            period = float(CGROUP_V1_CPU_PERIOD.read_text().strip())
+            if quota > 0 and period > 0:
+                return quota / period
+    except (OSError, ValueError):
+        # An unreadable or unexpected /sys must not take the process down; the host
+        # count is a safe, if generous, answer.
+        pass
+    return None
+
+
+def available_cpu_count() -> int:
+    """CPUs this process can actually use, honouring the container's CPU quota.
+
+    ``os.cpu_count()`` reports the *host's* CPUs and knows nothing about cgroups. On the
+    NAS that is 8 against a 2.0-CPU container limit, so anything sized off it overshoots
+    by 4x — see ``adaptive_queue_limit``, which was returning its 500 ceiling regardless
+    of the real limit.
+
+    Never returns less than 1, and never more than the host physically has.
+    """
+    host = os.cpu_count() or 2
+    quota = _cgroup_cpu_quota()
+    if quota is None:
+        return max(1, host)
+    return max(1, min(host, int(quota)))
+
+
 def adaptive_queue_limit(base: int = 100) -> int:
-    """Scale queue burst by CPU count, clamped to [50, 500]."""
-    cpus = os.cpu_count() or 2
-    return max(50, min(cpus * base, 500))
+    """Scale queue burst by usable CPU count, clamped to [50, 500]."""
+    return max(50, min(available_cpu_count() * base, 500))
 
 
 # Supported audio formats

--- a/backend/app/main.py
+++ b/backend/app/main.py
@@ -93,13 +93,21 @@ class RequestIDMiddleware:
 
         status_code = 500  # default in case send is never called with response
         response_started = False
+        is_transfer = False
 
         async def send_with_request_id(message: Message) -> None:
-            nonlocal status_code, response_started
+            nonlocal status_code, response_started, is_transfer
             if message["type"] == "http.response.start":
                 status_code = message["status"]
                 response_started = True
                 headers = list(message.get("headers", []))
+                # An audio or video body takes as long as it takes to push the bytes,
+                # and the client reads it at playback speed or hangs up mid-track. That
+                # elapsed time is transfer, not latency — see `MetricsCollector`.
+                for name, value in headers:
+                    if name.lower() == b"content-type":
+                        is_transfer = value.lower().startswith((b"audio/", b"video/"))
+                        break
                 headers.append((b"x-request-id", request_id.encode()))
                 message = {**message, "headers": headers}
             await send(message)
@@ -123,20 +131,25 @@ class RequestIDMiddleware:
         try:
             await self.app(scope, receive, send_with_request_id)
         except BaseException as exc:
-            # `BaseException`, not `Exception`: uvicorn signals a client disconnect with
-            # `CancelledError`, which does not inherit from `Exception`. Without this,
-            # every aborted audio stream — every skipped track — went unrecorded, and the
-            # request log showed only successes. That is not hypothetical: while
-            # diagnosing #13 the absence of non-2xx entries in this very log was read as
-            # evidence the server was healthy.
+            # Catches `BaseException`, not `Exception`, so that `CancelledError` — which
+            # is not an `Exception` — is recorded too. Without any of this, an unhandled
+            # exception propagated straight past the logging below and the request was
+            # never recorded at all: the log showed only successes. That is not
+            # hypothetical. While diagnosing #13 the absence of non-2xx entries in this
+            # very log was read as evidence the server was healthy.
+            #
+            # Note that a *client disconnect* does not arrive here under uvicorn: its
+            # `send` silently no-ops once the socket is gone (`if self.disconnected:
+            # return`), so `FileResponse` reads on to EOF and returns normally. The
+            # disconnect case is handled by classifying transfers instead — see
+            # `is_transfer` above.
             outcome = (
                 OUTCOME_CLIENT_DISCONNECT
                 if isinstance(exc, asyncio.CancelledError)
                 else OUTCOME_ERROR
             )
-            # Only claim a 500 if nothing was sent. A stream aborted 40 s in has already
-            # delivered a 206 and real bytes; relabelling that a server error would
-            # invent a failure that did not happen.
+            # Only claim a 500 if nothing was sent. A response that already delivered a
+            # 206 and real bytes was not a server error.
             if not response_started:
                 status_code = 500
             raise
@@ -163,11 +176,13 @@ class RequestIDMiddleware:
                     "request_id": request_id,
                     "outcome": outcome,
                     "response_started": response_started,
+                    "transfer": is_transfer,
                 },
             )
 
             get_metrics_collector().record_request(
-                method, template, status_code, duration_ms, query_count, outcome=outcome
+                method, template, status_code, duration_ms, query_count,
+                outcome=outcome, transfer=is_transfer,
             )
 
 

--- a/backend/app/main.py
+++ b/backend/app/main.py
@@ -1,5 +1,6 @@
 """Familiar API - Main FastAPI application."""
 
+import asyncio
 import logging
 import multiprocessing
 import time
@@ -91,11 +92,13 @@ class RequestIDMiddleware:
         skip_timing = any(path.startswith(p) for p in self._SKIP_TIMING_PREFIXES)
 
         status_code = 500  # default in case send is never called with response
+        response_started = False
 
         async def send_with_request_id(message: Message) -> None:
-            nonlocal status_code
+            nonlocal status_code, response_started
             if message["type"] == "http.response.start":
                 status_code = message["status"]
+                response_started = True
                 headers = list(message.get("headers", []))
                 headers.append((b"x-request-id", request_id.encode()))
                 message = {**message, "headers": headers}
@@ -105,32 +108,67 @@ class RequestIDMiddleware:
             await self.app(scope, receive, send_with_request_id)
             return
 
-        from app.services.metrics import get_metrics_collector, get_query_count, reset_query_count
+        from app.services.metrics import (
+            OUTCOME_CLIENT_DISCONNECT,
+            OUTCOME_COMPLETED,
+            OUTCOME_ERROR,
+            get_metrics_collector,
+            get_query_count,
+            reset_query_count,
+        )
         reset_query_count()
 
+        outcome = OUTCOME_COMPLETED
         start = time.perf_counter()
-        await self.app(scope, receive, send_with_request_id)
-        duration_ms = (time.perf_counter() - start) * 1000
+        try:
+            await self.app(scope, receive, send_with_request_id)
+        except BaseException as exc:
+            # `BaseException`, not `Exception`: uvicorn signals a client disconnect with
+            # `CancelledError`, which does not inherit from `Exception`. Without this,
+            # every aborted audio stream — every skipped track — went unrecorded, and the
+            # request log showed only successes. That is not hypothetical: while
+            # diagnosing #13 the absence of non-2xx entries in this very log was read as
+            # evidence the server was healthy.
+            outcome = (
+                OUTCOME_CLIENT_DISCONNECT
+                if isinstance(exc, asyncio.CancelledError)
+                else OUTCOME_ERROR
+            )
+            # Only claim a 500 if nothing was sent. A stream aborted 40 s in has already
+            # delivered a 206 and real bytes; relabelling that a server error would
+            # invent a failure that did not happen.
+            if not response_started:
+                status_code = 500
+            raise
+        finally:
+            # Never swallow: `CancelledError` must reach uvicorn for connection teardown,
+            # and an unhandled exception must reach `ServerErrorMiddleware`, which is what
+            # actually produces the 500 body.
+            duration_ms = (time.perf_counter() - start) * 1000
+            query_count = get_query_count()
 
-        query_count = get_query_count()
+            route = scope.get("route")
+            template = route.path if route else path
+            method = scope.get("method", "?")
 
-        route = scope.get("route")
-        template = route.path if route else path
-        method = scope.get("method", "?")
+            log_at = logger.warning if outcome == OUTCOME_ERROR else logger.info
+            log_at(
+                "request_completed",
+                extra={
+                    "method": method,
+                    "route": template,
+                    "status_code": status_code,
+                    "duration_ms": round(duration_ms, 2),
+                    "query_count": query_count,
+                    "request_id": request_id,
+                    "outcome": outcome,
+                    "response_started": response_started,
+                },
+            )
 
-        logger.info(
-            "request_completed",
-            extra={
-                "method": method,
-                "route": template,
-                "status_code": status_code,
-                "duration_ms": round(duration_ms, 2),
-                "query_count": query_count,
-                "request_id": request_id,
-            },
-        )
-
-        get_metrics_collector().record_request(method, template, status_code, duration_ms, query_count)
+            get_metrics_collector().record_request(
+                method, template, status_code, duration_ms, query_count, outcome=outcome
+            )
 
 
 def create_error_response(
@@ -149,7 +187,12 @@ def create_error_response(
         content["detail"] = detail
     if request_id:
         content["request_id"] = request_id
-    return JSONResponse(status_code=status_code, content=content)
+    # Also as a header. Starlette hoists the `@app.exception_handler(Exception)` catch-all
+    # into `ServerErrorMiddleware`, which sits *outside* `RequestIDMiddleware` — so the
+    # 500 it emits never passes through `send_with_request_id` and would otherwise be the
+    # one response with no `x-request-id` to correlate against the log.
+    headers = {"x-request-id": request_id} if request_id else None
+    return JSONResponse(status_code=status_code, content=content, headers=headers)
 
 
 def validate_library_path() -> None:

--- a/backend/app/services/background/manager.py
+++ b/backend/app/services/background/manager.py
@@ -155,6 +155,7 @@ class BackgroundManager(ExecutorMixin, AnalysisMixin, SyncMixin, BackupMixin):
                 "metrics_summary",
                 extra={
                     "requests_5m": req["total_requests"],
+                    "client_disconnects": req["client_disconnects"],
                     "error_rate": req["error_rate"],
                     "p50_ms": req["duration_p50_ms"],
                     "p95_ms": req["duration_p95_ms"],

--- a/backend/app/services/background/manager.py
+++ b/backend/app/services/background/manager.py
@@ -157,8 +157,13 @@ class BackgroundManager(ExecutorMixin, AnalysisMixin, SyncMixin, BackupMixin):
                     "requests_5m": req["total_requests"],
                     "client_disconnects": req["client_disconnects"],
                     "error_rate": req["error_rate"],
+                    # API latency only. `transfer_*` covers audio/video bodies, whose
+                    # elapsed time is byte-movement — a single skipped track used to set
+                    # p95 for the whole window.
                     "p50_ms": req["duration_p50_ms"],
                     "p95_ms": req["duration_p95_ms"],
+                    "transfers": req["transfer_requests"],
+                    "transfer_p95_ms": req["transfer_p95_ms"],
                     "analysis_queue": bg.get("analysis_queue_depth", 0),
                     "sync_running": bg.get("sync_running", False),
                     "current_phase": bg.get("current_phase"),

--- a/backend/app/services/metrics.py
+++ b/backend/app/services/metrics.py
@@ -28,6 +28,15 @@ def get_query_count() -> int:
     return _request_query_count.get()
 
 
+# How a request ended. `RequestIDMiddleware` supplies this.
+#   completed         — the response was fully sent
+#   client_disconnect — the client went away mid-response (a skipped track, a closed tab)
+#   error             — an exception escaped to ServerErrorMiddleware
+OUTCOME_COMPLETED = "completed"
+OUTCOME_CLIENT_DISCONNECT = "client_disconnect"
+OUTCOME_ERROR = "error"
+
+
 class MetricsCollector:
     """Collects request metrics and background gauges.
 
@@ -35,14 +44,29 @@ class MetricsCollector:
     """
 
     def __init__(self, max_requests: int = 2000):
-        self._requests: deque[tuple[float, str, str, int, float, int]] = deque(maxlen=max_requests)
+        self._requests: deque[tuple[float, str, str, int, float, int, str]] = deque(maxlen=max_requests)
         self._gauges: dict[str, Any] = {}
         self._lock = threading.Lock()
 
-    def record_request(self, method: str, route: str, status_code: int, duration_ms: float, query_count: int = 0) -> None:
-        """Record a completed HTTP request."""
+    def record_request(
+        self,
+        method: str,
+        route: str,
+        status_code: int,
+        duration_ms: float,
+        query_count: int = 0,
+        outcome: str = OUTCOME_COMPLETED,
+    ) -> None:
+        """Record an HTTP request that has finished, however it finished.
+
+        ``outcome`` defaults to ``completed`` so existing positional call sites are
+        unaffected. It exists because a disconnect and a completion are not comparable
+        measurements: a client that aborts a stream after 40 seconds of listening
+        produces a 40000 ms "duration" that is listening time, not latency. Folding
+        those into the percentiles would make p95 meaningless — see ``get_snapshot``.
+        """
         with self._lock:
-            self._requests.append((time.time(), method, route, status_code, duration_ms, query_count))
+            self._requests.append((time.time(), method, route, status_code, duration_ms, query_count, outcome))
 
     def set_gauge(self, name: str, value: Any) -> None:
         """Set a named gauge value."""
@@ -50,52 +74,79 @@ class MetricsCollector:
             self._gauges[name] = value
 
     def get_snapshot(self, window_seconds: int = 300) -> dict[str, Any]:
-        """Get metrics snapshot for the given time window."""
+        """Get metrics snapshot for the given time window.
+
+        Client disconnects are counted (``client_disconnects``) but excluded from both
+        the latency percentiles and the error rate:
+
+        - **Percentiles.** A disconnect's duration is how long the client stayed
+          connected, not how long the server took. Streams dominate that population, so
+          including them would swamp p95 with listening time.
+        - **Error rate.** Skipping a track aborts its stream. That is normal use, and
+          counting it as a server error makes the rate — and the alarm built on it in
+          ``check_pressure_alarms`` — mean nothing.
+        """
         cutoff = time.time() - window_seconds
         with self._lock:
-            recent = [(ts, method, route, status, dur, qc) for ts, method, route, status, dur, qc in self._requests if ts >= cutoff]
+            recent = [r for r in self._requests if r[0] >= cutoff]
             gauges = dict(self._gauges)
 
+        empty = {
+            "window_seconds": window_seconds,
+            "total_requests": 0,
+            "client_disconnects": 0,
+            "error_rate": 0.0,
+            "duration_p50_ms": 0.0,
+            "duration_p95_ms": 0.0,
+            "duration_p99_ms": 0.0,
+            "avg_queries_per_request": 0.0,
+            "max_queries_per_request": 0,
+            "top_routes": [],
+        }
         if not recent:
-            return {
-                "request_metrics": {
-                    "window_seconds": window_seconds,
-                    "total_requests": 0,
-                    "error_rate": 0.0,
-                    "duration_p50_ms": 0.0,
-                    "duration_p95_ms": 0.0,
-                    "duration_p99_ms": 0.0,
-                    "avg_queries_per_request": 0.0,
-                    "max_queries_per_request": 0,
-                    "top_routes": [],
-                },
-                "background_gauges": gauges,
-            }
+            return {"request_metrics": empty, "background_gauges": gauges}
 
-        durations = [dur for _, _, _, _, dur, _ in recent]
-        query_counts = [qc for _, _, _, _, _, qc in recent]
-        error_count = sum(1 for _, _, _, status, _, _ in recent if status >= 500)
+        disconnects = [r for r in recent if r[6] == OUTCOME_CLIENT_DISCONNECT]
+        served = [r for r in recent if r[6] != OUTCOME_CLIENT_DISCONNECT]
 
-        # Count requests per route
+        query_counts = [qc for _, _, _, _, _, qc, _ in recent]
+
+        # Count requests per route — over everything, since a route that only ever gets
+        # disconnected on is exactly what we want to see.
         route_counts: dict[str, int] = {}
-        for _, _, route, _, _, _ in recent:
+        for _, _, route, _, _, _, _ in recent:
             route_counts[route] = route_counts.get(route, 0) + 1
         top_routes = sorted(route_counts.items(), key=lambda x: -x[1])[:10]
 
-        durations_sorted = sorted(durations)
+        total = len(recent)
+        common = {
+            "window_seconds": window_seconds,
+            "total_requests": total,
+            "client_disconnects": len(disconnects),
+            "avg_queries_per_request": round(sum(query_counts) / total, 2),
+            "max_queries_per_request": max(query_counts) if query_counts else 0,
+            "top_routes": [{"route": r, "count": c} for r, c in top_routes],
+        }
+
+        if not served:
+            # Everything in the window was a disconnect. There is no latency or error
+            # rate to report, but the disconnect count above is the interesting part.
+            return {
+                "request_metrics": {**empty, **common},
+                "background_gauges": gauges,
+            }
+
+        durations_sorted = sorted(dur for _, _, _, _, dur, _, _ in served)
         n = len(durations_sorted)
+        error_count = sum(1 for _, _, _, status, _, _, _ in served if status >= 500)
 
         return {
             "request_metrics": {
-                "window_seconds": window_seconds,
-                "total_requests": n,
-                "error_rate": round(error_count / n, 4) if n else 0.0,
+                **common,
+                "error_rate": round(error_count / n, 4),
                 "duration_p50_ms": round(durations_sorted[n // 2], 2),
                 "duration_p95_ms": round(durations_sorted[int(n * 0.95)], 2) if n > 1 else round(durations_sorted[0], 2),
                 "duration_p99_ms": round(durations_sorted[int(n * 0.99)], 2) if n > 1 else round(durations_sorted[0], 2),
-                "avg_queries_per_request": round(sum(query_counts) / n, 2) if n else 0.0,
-                "max_queries_per_request": max(query_counts) if query_counts else 0,
-                "top_routes": [{"route": r, "count": c} for r, c in top_routes],
             },
             "background_gauges": gauges,
         }

--- a/backend/app/services/metrics.py
+++ b/backend/app/services/metrics.py
@@ -44,7 +44,7 @@ class MetricsCollector:
     """
 
     def __init__(self, max_requests: int = 2000):
-        self._requests: deque[tuple[float, str, str, int, float, int, str]] = deque(maxlen=max_requests)
+        self._requests: deque[tuple[float, str, str, int, float, int, str, bool]] = deque(maxlen=max_requests)
         self._gauges: dict[str, Any] = {}
         self._lock = threading.Lock()
 
@@ -56,35 +56,60 @@ class MetricsCollector:
         duration_ms: float,
         query_count: int = 0,
         outcome: str = OUTCOME_COMPLETED,
+        transfer: bool = False,
     ) -> None:
         """Record an HTTP request that has finished, however it finished.
 
-        ``outcome`` defaults to ``completed`` so existing positional call sites are
-        unaffected. It exists because a disconnect and a completion are not comparable
-        measurements: a client that aborts a stream after 40 seconds of listening
-        produces a 40000 ms "duration" that is listening time, not latency. Folding
-        those into the percentiles would make p95 meaningless — see ``get_snapshot``.
+        Both keyword arguments default to today's behaviour so existing positional call
+        sites are unaffected.
+
+        ``transfer`` marks a response whose body is audio or video. Its elapsed time is
+        how long the bytes took to move, not how long the server took to think — the
+        client reads at playback speed, or hangs up mid-track. Mixing that into the
+        latency percentiles makes them meaningless; see ``get_snapshot``.
         """
         with self._lock:
-            self._requests.append((time.time(), method, route, status_code, duration_ms, query_count, outcome))
+            self._requests.append(
+                (time.time(), method, route, status_code, duration_ms, query_count, outcome, transfer)
+            )
 
     def set_gauge(self, name: str, value: Any) -> None:
         """Set a named gauge value."""
         with self._lock:
             self._gauges[name] = value
 
+    @staticmethod
+    def _percentiles(durations: list[float]) -> tuple[float, float, float]:
+        """(p50, p95, p99) over a duration list, or zeroes if it is empty."""
+        if not durations:
+            return 0.0, 0.0, 0.0
+        s = sorted(durations)
+        n = len(s)
+        if n == 1:
+            return round(s[0], 2), round(s[0], 2), round(s[0], 2)
+        return (
+            round(s[n // 2], 2),
+            round(s[int(n * 0.95)], 2),
+            round(s[int(n * 0.99)], 2),
+        )
+
     def get_snapshot(self, window_seconds: int = 300) -> dict[str, Any]:
         """Get metrics snapshot for the given time window.
 
-        Client disconnects are counted (``client_disconnects``) but excluded from both
-        the latency percentiles and the error rate:
+        Two populations are kept apart, because folding them together produced a p95
+        that measured nothing:
 
-        - **Percentiles.** A disconnect's duration is how long the client stayed
-          connected, not how long the server took. Streams dominate that population, so
-          including them would swamp p95 with listening time.
-        - **Error rate.** Skipping a track aborts its stream. That is normal use, and
-          counting it as a server error makes the rate — and the alarm built on it in
-          ``check_pressure_alarms`` — mean nothing.
+        - **Transfers** (``audio/*``, ``video/*``) are reported under ``transfer_*``.
+          Their elapsed time is byte-movement, and a client that skips a track hangs up
+          mid-response — uvicorn's ``send`` then silently no-ops, so the request still
+          records as a clean 200 whose duration is simply how long the listener stayed.
+          One skipped track was enough to define ``duration_p95_ms`` for a whole
+          five-minute window. ``duration_*`` now covers API responses only and means
+          "how quickly does the server answer".
+        - **Client disconnects** are counted in ``client_disconnects`` and excluded from
+          the percentiles and the error rate. Skipping a track is normal use; counting it
+          as a server error would make the rate — and the alarm built on it in
+          ``check_pressure_alarms`` — meaningless.
         """
         cutoff = time.time() - window_seconds
         with self._lock:
@@ -95,10 +120,13 @@ class MetricsCollector:
             "window_seconds": window_seconds,
             "total_requests": 0,
             "client_disconnects": 0,
+            "transfer_requests": 0,
             "error_rate": 0.0,
             "duration_p50_ms": 0.0,
             "duration_p95_ms": 0.0,
             "duration_p99_ms": 0.0,
+            "transfer_p50_ms": 0.0,
+            "transfer_p95_ms": 0.0,
             "avg_queries_per_request": 0.0,
             "max_queries_per_request": 0,
             "top_routes": [],
@@ -108,45 +136,41 @@ class MetricsCollector:
 
         disconnects = [r for r in recent if r[6] == OUTCOME_CLIENT_DISCONNECT]
         served = [r for r in recent if r[6] != OUTCOME_CLIENT_DISCONNECT]
+        api = [r for r in served if not r[7]]
+        transfers = [r for r in served if r[7]]
 
-        query_counts = [qc for _, _, _, _, _, qc, _ in recent]
+        query_counts = [r[5] for r in recent]
 
-        # Count requests per route — over everything, since a route that only ever gets
-        # disconnected on is exactly what we want to see.
+        # Route counts cover everything — a route that only ever gets disconnected on is
+        # exactly what we want to see.
         route_counts: dict[str, int] = {}
-        for _, _, route, _, _, _, _ in recent:
-            route_counts[route] = route_counts.get(route, 0) + 1
+        for r in recent:
+            route_counts[r[2]] = route_counts.get(r[2], 0) + 1
         top_routes = sorted(route_counts.items(), key=lambda x: -x[1])[:10]
 
-        total = len(recent)
-        common = {
-            "window_seconds": window_seconds,
-            "total_requests": total,
-            "client_disconnects": len(disconnects),
-            "avg_queries_per_request": round(sum(query_counts) / total, 2),
-            "max_queries_per_request": max(query_counts) if query_counts else 0,
-            "top_routes": [{"route": r, "count": c} for r, c in top_routes],
-        }
+        api_p50, api_p95, api_p99 = self._percentiles([r[4] for r in api])
+        tx_p50, tx_p95, _ = self._percentiles([r[4] for r in transfers])
 
-        if not served:
-            # Everything in the window was a disconnect. There is no latency or error
-            # rate to report, but the disconnect count above is the interesting part.
-            return {
-                "request_metrics": {**empty, **common},
-                "background_gauges": gauges,
-            }
-
-        durations_sorted = sorted(dur for _, _, _, _, dur, _, _ in served)
-        n = len(durations_sorted)
-        error_count = sum(1 for _, _, _, status, _, _, _ in served if status >= 500)
+        # Error rate over served API requests. Transfers are excluded for the same
+        # reason as their durations: a 200 that the client walked away from is not a
+        # server outcome we can reason about.
+        error_count = sum(1 for r in api if r[3] >= 500)
 
         return {
             "request_metrics": {
-                **common,
-                "error_rate": round(error_count / n, 4),
-                "duration_p50_ms": round(durations_sorted[n // 2], 2),
-                "duration_p95_ms": round(durations_sorted[int(n * 0.95)], 2) if n > 1 else round(durations_sorted[0], 2),
-                "duration_p99_ms": round(durations_sorted[int(n * 0.99)], 2) if n > 1 else round(durations_sorted[0], 2),
+                "window_seconds": window_seconds,
+                "total_requests": len(recent),
+                "client_disconnects": len(disconnects),
+                "transfer_requests": len(transfers),
+                "error_rate": round(error_count / len(api), 4) if api else 0.0,
+                "duration_p50_ms": api_p50,
+                "duration_p95_ms": api_p95,
+                "duration_p99_ms": api_p99,
+                "transfer_p50_ms": tx_p50,
+                "transfer_p95_ms": tx_p95,
+                "avg_queries_per_request": round(sum(query_counts) / len(recent), 2),
+                "max_queries_per_request": max(query_counts) if query_counts else 0,
+                "top_routes": [{"route": r, "count": c} for r, c in top_routes],
             },
             "background_gauges": gauges,
         }

--- a/backend/tests/test_cpu_limits.py
+++ b/backend/tests/test_cpu_limits.py
@@ -1,0 +1,126 @@
+"""Tests for cgroup-aware CPU counting.
+
+`os.cpu_count()` reports the **host's** CPUs, not the container's quota. On the NAS that
+is 8 against a cgroup limit of 2, so anything sizing work off `os.cpu_count()` overshoots
+by 4x — it thinks it has cores it will never be scheduled on.
+
+The concrete case is `adaptive_queue_limit`, which multiplies the count by 100 and clamps
+to 500: at a reported 8 it returns the ceiling regardless of the real limit.
+
+These drive the parsers against synthetic cgroup files rather than whatever the machine
+running the tests happens to have, so they mean the same thing on macOS, on a bare Linux
+runner, and inside a container.
+"""
+
+from pathlib import Path
+
+import pytest
+
+from app.config import adaptive_queue_limit, available_cpu_count
+
+
+@pytest.fixture()
+def cgroup(tmp_path, monkeypatch):
+    """Point the cgroup readers at a temp directory and hand back writers for each file."""
+
+    v2 = tmp_path / "cpu.max"
+    v1_quota = tmp_path / "cpu.cfs_quota_us"
+    v1_period = tmp_path / "cpu.cfs_period_us"
+
+    monkeypatch.setattr("app.config.CGROUP_V2_CPU_MAX", v2)
+    monkeypatch.setattr("app.config.CGROUP_V1_CPU_QUOTA", v1_quota)
+    monkeypatch.setattr("app.config.CGROUP_V1_CPU_PERIOD", v1_period)
+    monkeypatch.setattr("os.cpu_count", lambda: 8)
+
+    class Cgroup:
+        def v2(self, contents: str) -> None:
+            v2.write_text(contents)
+
+        def v1(self, quota: str, period: str) -> None:
+            v1_quota.write_text(quota)
+            v1_period.write_text(period)
+
+    return Cgroup()
+
+
+class TestCgroupV2:
+    def test_reads_the_quota(self, cgroup):
+        cgroup.v2("200000 100000")  # 2.0 CPUs — the NAS's actual setting
+        assert available_cpu_count() == 2
+
+    def test_unlimited_falls_back_to_the_host_count(self, cgroup):
+        cgroup.v2("max 100000")
+        assert available_cpu_count() == 8
+
+    def test_fractional_quota_rounds_down_but_never_to_zero(self, cgroup):
+        cgroup.v2("50000 100000")  # 0.5 CPUs
+        assert available_cpu_count() == 1
+
+    def test_quota_above_the_host_count_is_capped(self, cgroup):
+        """A quota can exceed the cores that physically exist; the cores cannot."""
+        cgroup.v2("1600000 100000")  # 16.0 CPUs on an 8-core host
+        assert available_cpu_count() == 8
+
+    def test_malformed_contents_fall_back(self, cgroup):
+        cgroup.v2("nonsense")
+        assert available_cpu_count() == 8
+
+    def test_empty_file_falls_back(self, cgroup):
+        cgroup.v2("")
+        assert available_cpu_count() == 8
+
+
+class TestCgroupV1:
+    def test_reads_quota_and_period(self, cgroup):
+        cgroup.v1("200000", "100000")
+        assert available_cpu_count() == 2
+
+    def test_negative_quota_means_unlimited(self, cgroup):
+        cgroup.v1("-1", "100000")
+        assert available_cpu_count() == 8
+
+    def test_zero_period_does_not_divide_by_zero(self, cgroup):
+        cgroup.v1("200000", "0")
+        assert available_cpu_count() == 8
+
+    def test_v2_wins_when_both_are_present(self, cgroup):
+        cgroup.v2("400000 100000")  # 4.0
+        cgroup.v1("100000", "100000")  # 1.0
+        assert available_cpu_count() == 4
+
+
+class TestNoCgroup:
+    def test_missing_files_fall_back_to_os_cpu_count(self, cgroup):
+        # The fixture creates no files.
+        assert available_cpu_count() == 8
+
+    def test_unreadable_file_falls_back(self, cgroup, monkeypatch):
+        """A sandboxed or restricted /sys must not take the process down."""
+        def boom(*args, **kwargs):
+            raise PermissionError("nope")
+
+        monkeypatch.setattr(Path, "read_text", boom)
+        assert available_cpu_count() == 8
+
+    def test_os_cpu_count_none_falls_back_to_two(self, cgroup, monkeypatch):
+        monkeypatch.setattr("os.cpu_count", lambda: None)
+        assert available_cpu_count() == 2
+
+    def test_always_at_least_one(self, cgroup, monkeypatch):
+        monkeypatch.setattr("os.cpu_count", lambda: 0)
+        assert available_cpu_count() >= 1
+
+
+class TestAdaptiveQueueLimitUsesTheRealCount:
+    """The reason the helper exists."""
+
+    def test_capped_container_no_longer_reports_the_ceiling(self, cgroup):
+        cgroup.v2("200000 100000")  # 2.0 CPUs on an 8-core host — the NAS
+        assert adaptive_queue_limit() == 200, (
+            "with os.cpu_count() this returned the 500 clamp, sizing analysis batches "
+            "for four times the cores the container can actually use"
+        )
+
+    def test_uncapped_host_is_unchanged(self, cgroup):
+        cgroup.v2("max 100000")
+        assert adaptive_queue_limit() == 500  # 8 * 100, clamped

--- a/backend/tests/test_metrics.py
+++ b/backend/tests/test_metrics.py
@@ -191,7 +191,14 @@ class TestCheckPressureAlarms:
 
 
 class TestAdaptiveQueueLimit:
-    """Test CPU-adaptive queue burst sizing."""
+    """Test CPU-adaptive queue burst sizing.
+
+    These patch `app.config.available_cpu_count`, not `os.cpu_count`. The count is now
+    cgroup-aware (see `test_cpu_limits.py`), so patching `os.cpu_count` would no longer
+    determine the answer on a host that has a CPU quota — these tests would start
+    depending on the machine running them. The scaling behaviour asserted here is
+    unchanged; only the seam moved.
+    """
 
     def test_default_returns_int_in_range(self):
         """Default call returns an int clamped to [50, 500]."""
@@ -199,7 +206,7 @@ class TestAdaptiveQueueLimit:
         assert isinstance(result, int)
         assert 50 <= result <= 500
 
-    @patch("os.cpu_count")
+    @patch("app.config.available_cpu_count")
     def test_scales_with_cpu_count(self, mock_cpus):
         """Limit scales linearly with CPU count."""
         mock_cpus.return_value = 1
@@ -211,21 +218,13 @@ class TestAdaptiveQueueLimit:
         mock_cpus.return_value = 8
         assert adaptive_queue_limit() == 500  # 8 * 100 = 800 → clamped to 500
 
-    @patch("os.cpu_count")
-    def test_none_cpus_fallback(self, mock_cpus):
-        """os.cpu_count() returning None should still produce a valid result."""
-        mock_cpus.return_value = None
-        result = adaptive_queue_limit()
-        assert isinstance(result, int)
-        assert result == 200  # fallback: 2 * 100
-
-    @patch("os.cpu_count")
+    @patch("app.config.available_cpu_count")
     def test_custom_base(self, mock_cpus):
         """Custom base value scales correctly."""
         mock_cpus.return_value = 4
         assert adaptive_queue_limit(base=50) == 200  # 4 * 50
 
-    @patch("os.cpu_count")
+    @patch("app.config.available_cpu_count")
     def test_clamp_floor(self, mock_cpus):
         """Very low CPU * base is clamped to 50."""
         mock_cpus.return_value = 1

--- a/backend/tests/test_request_middleware.py
+++ b/backend/tests/test_request_middleware.py
@@ -1,0 +1,275 @@
+"""Tests for `RequestIDMiddleware` — specifically, the requests it cannot see.
+
+`main.py` awaited the downstream app with no `try`/`finally`, so the logging and
+`record_request` calls that follow it were skipped whenever the request did not return
+normally. Two ways that happens:
+
+- **Client disconnect.** Uvicorn raises `CancelledError` into the task when the socket
+  goes away. Every aborted audio stream — every skipped track — took this path.
+- **Unhandled exception.** Starlette hoists the `@app.exception_handler(Exception)`
+  catch-all into `ServerErrorMiddleware`, which sits *outside* `RequestIDMiddleware`, so
+  the exception propagates through the middleware before anything catches it.
+
+The result was that `metrics_summary` and the request log recorded only successes. That
+is not a cosmetic gap: while diagnosing issue #13 I read "586 stream requests, zero
+non-2xx" off those logs and concluded the server was healthy. The logs could not have
+shown otherwise. **These are the regression tests for that wrong conclusion.**
+
+They drive the ASGI callable directly rather than through `TestClient`, because
+`TestClient` completes every request it starts — it cannot abort mid-body, which is the
+case that matters most.
+
+The trap in the obvious fix has its own tests below (`TestDoesNotPoisonMetrics`): a bare
+`try`/`finally` would record an aborted 40-second stream as a *successful* 206 that took
+40000 ms, because `status_code` is set as soon as the response *starts*. That inflates
+p95 with what is really listening time and reports failures as successes — worse than
+recording nothing, since #15 depends on that p95 being trustworthy.
+"""
+
+import asyncio
+
+import pytest
+
+from app.main import RequestIDMiddleware, create_error_response
+from app.services.metrics import MetricsCollector
+
+
+class RecordingCollector(MetricsCollector):
+    """A real collector that also keeps the calls, so assertions can read them back."""
+
+    def __init__(self) -> None:
+        super().__init__()
+        self.calls: list[dict] = []
+
+    def record_request(self, method, route, status_code, duration_ms, query_count=0, outcome="completed"):  # type: ignore[override]
+        self.calls.append({
+            "method": method,
+            "route": route,
+            "status_code": status_code,
+            "duration_ms": duration_ms,
+            "query_count": query_count,
+            "outcome": outcome,
+        })
+        super().record_request(method, route, status_code, duration_ms, query_count, outcome=outcome)
+
+
+@pytest.fixture()
+def collector(monkeypatch):
+    """Swap the singleton for a recording one, for the duration of a test."""
+    rec = RecordingCollector()
+    monkeypatch.setattr("app.services.metrics.get_metrics_collector", lambda: rec)
+    return rec
+
+
+def make_scope(path: str = "/api/v1/thing", method: str = "GET") -> dict:
+    return {
+        "type": "http",
+        "asgi": {"version": "3.0"},
+        "http_version": "1.1",
+        "method": method,
+        "scheme": "http",
+        "path": path,
+        "raw_path": path.encode(),
+        "query_string": b"",
+        "root_path": "",
+        "headers": [],
+        "client": ("127.0.0.1", 54321),
+        "server": ("127.0.0.1", 8000),
+    }
+
+
+async def empty_receive() -> dict:
+    return {"type": "http.disconnect"}
+
+
+def make_send():
+    """A `send` that records the messages it is given."""
+    messages: list[dict] = []
+
+    async def send(message):
+        messages.append(message)
+
+    return send, messages
+
+
+async def drive(downstream, path="/api/v1/thing"):
+    """Run `downstream` under the middleware. Returns (sent_messages, raised_or_None)."""
+    send, messages = make_send()
+    middleware = RequestIDMiddleware(downstream)
+    raised = None
+    try:
+        await middleware(make_scope(path), empty_receive, send)
+    except BaseException as exc:  # noqa: BLE001 — the point is to capture whatever escapes
+        raised = exc
+    return messages, raised
+
+
+# --- downstream apps ------------------------------------------------------------------
+
+async def ok_app(scope, receive, send):
+    await send({"type": "http.response.start", "status": 200, "headers": []})
+    await send({"type": "http.response.body", "body": b"fine"})
+
+
+async def raising_app(scope, receive, send):
+    raise RuntimeError("handler blew up")
+
+
+async def stream_then_disconnect_app(scope, receive, send):
+    """A range response that starts, sends some body, then the client goes away."""
+    await send({"type": "http.response.start", "status": 206, "headers": []})
+    await send({"type": "http.response.body", "body": b"audio", "more_body": True})
+    raise asyncio.CancelledError()
+
+
+async def disconnect_before_response_app(scope, receive, send):
+    raise asyncio.CancelledError()
+
+
+# --- tests ----------------------------------------------------------------------------
+
+
+class TestNormalRequests:
+    async def test_records_a_completed_request(self, collector):
+        messages, raised = await drive(ok_app)
+
+        assert raised is None
+        assert len(collector.calls) == 1
+        call = collector.calls[0]
+        assert call["outcome"] == "completed"
+        assert call["status_code"] == 200
+
+    async def test_still_adds_the_request_id_header(self, collector):
+        messages, _ = await drive(ok_app)
+
+        start = next(m for m in messages if m["type"] == "http.response.start")
+        header_names = [k for k, _ in start["headers"]]
+        assert b"x-request-id" in header_names
+
+    async def test_skipped_paths_are_not_recorded(self, collector):
+        """`/health` and static assets bypass timing entirely — unchanged behaviour."""
+        await drive(ok_app, path="/health")
+        assert collector.calls == []
+
+
+class TestClientDisconnect:
+    """The case that made every aborted audio stream invisible."""
+
+    async def test_disconnect_mid_body_is_recorded(self, collector):
+        _, raised = await drive(stream_then_disconnect_app)
+
+        assert isinstance(raised, asyncio.CancelledError), "CancelledError must propagate"
+        assert len(collector.calls) == 1, "an aborted stream must still be recorded"
+        assert collector.calls[0]["outcome"] == "client_disconnect"
+
+    async def test_disconnect_keeps_the_status_already_sent(self, collector):
+        """Not 500.
+
+        The response *started* — the client received a 206 and some audio. Reporting it
+        as a 500 would invent a server error that never happened.
+        """
+        await drive(stream_then_disconnect_app)
+        assert collector.calls[0]["status_code"] == 206
+
+    async def test_disconnect_before_response_is_500(self, collector):
+        """Distinguishable from the above: the server never got to respond at all."""
+        _, raised = await drive(disconnect_before_response_app)
+
+        assert isinstance(raised, asyncio.CancelledError)
+        assert collector.calls[0]["outcome"] == "client_disconnect"
+        assert collector.calls[0]["status_code"] == 500
+
+
+class TestUnhandledException:
+    async def test_error_is_recorded_and_propagates(self, collector):
+        """It must reach `ServerErrorMiddleware`, which is what produces the 500 body."""
+        _, raised = await drive(raising_app)
+
+        assert isinstance(raised, RuntimeError)
+        assert len(collector.calls) == 1
+        assert collector.calls[0]["outcome"] == "error"
+        assert collector.calls[0]["status_code"] == 500
+
+    async def test_recorded_exactly_once(self, collector):
+        """A `finally` that also ran on the exception path would double-count."""
+        await drive(raising_app)
+        assert len(collector.calls) == 1
+
+
+class TestDoesNotPoisonMetrics:
+    """A bare try/finally would be worse than the bug. These pin down why."""
+
+    def test_disconnects_are_excluded_from_percentiles(self):
+        c = MetricsCollector()
+        for _ in range(9):
+            c.record_request("GET", "/api/v1/thing", 200, 50.0)
+        # One aborted stream that the user listened to for 40 seconds.
+        c.record_request("GET", "/api/v1/stream", 206, 40000.0, outcome="client_disconnect")
+
+        req = c.get_snapshot()["request_metrics"]
+
+        assert req["duration_p95_ms"] < 100, (
+            "a 40s listen recorded as latency would put p95 at 40000ms and make the "
+            "measurement for #15 meaningless"
+        )
+
+    def test_disconnects_do_not_count_as_errors(self):
+        """Skipping a track is normal use, not a server error."""
+        c = MetricsCollector()
+        for _ in range(9):
+            c.record_request("GET", "/api/v1/thing", 200, 10.0)
+        c.record_request("GET", "/api/v1/stream", 206, 5000.0, outcome="client_disconnect")
+
+        assert c.get_snapshot()["request_metrics"]["error_rate"] == 0.0
+
+    def test_disconnects_are_counted_separately(self):
+        """Excluded from the error rate, but not thrown away — this is the #13 signal."""
+        c = MetricsCollector()
+        c.record_request("GET", "/api/v1/thing", 200, 10.0)
+        c.record_request("GET", "/api/v1/stream", 206, 5000.0, outcome="client_disconnect")
+        c.record_request("GET", "/api/v1/stream", 206, 5000.0, outcome="client_disconnect")
+
+        req = c.get_snapshot()["request_metrics"]
+        assert req["client_disconnects"] == 2
+        assert req["total_requests"] == 3
+
+    def test_real_errors_still_count(self):
+        c = MetricsCollector()
+        for _ in range(9):
+            c.record_request("GET", "/api/v1/thing", 200, 10.0)
+        c.record_request("GET", "/api/v1/thing", 500, 10.0, outcome="error")
+
+        assert c.get_snapshot()["request_metrics"]["error_rate"] == 0.1
+
+    def test_snapshot_with_only_disconnects_does_not_divide_by_zero(self):
+        c = MetricsCollector()
+        c.record_request("GET", "/api/v1/stream", 206, 5000.0, outcome="client_disconnect")
+
+        req = c.get_snapshot()["request_metrics"]
+        assert req["error_rate"] == 0.0
+        assert req["duration_p95_ms"] == 0.0
+        assert req["client_disconnects"] == 1
+
+    def test_outcome_defaults_to_completed(self):
+        """Existing call sites pass five positional args and must keep working."""
+        c = MetricsCollector()
+        c.record_request("GET", "/api/v1/thing", 200, 10.0, 3)
+        assert c.get_snapshot()["request_metrics"]["total_requests"] == 1
+
+
+class TestErrorResponsesCarryTheRequestID:
+    """`ServerErrorMiddleware` is outside `RequestIDMiddleware`, so the 500 it emits never
+    passes through `send_with_request_id` and got no `x-request-id` header — on exactly
+    the responses you most want to correlate with a log line."""
+
+    def test_header_is_set_when_a_request_id_is_known(self):
+        response = create_error_response(500, "Internal server error", request_id="abc12345")
+        assert response.headers.get("x-request-id") == "abc12345"
+
+    def test_body_still_carries_it_too(self):
+        response = create_error_response(500, "Internal server error", request_id="abc12345")
+        assert b"abc12345" in response.body
+
+    def test_no_header_without_a_request_id(self):
+        response = create_error_response(404, "Not found")
+        assert "x-request-id" not in response.headers

--- a/backend/tests/test_request_middleware.py
+++ b/backend/tests/test_request_middleware.py
@@ -1,29 +1,31 @@
 """Tests for `RequestIDMiddleware` — specifically, the requests it cannot see.
 
 `main.py` awaited the downstream app with no `try`/`finally`, so the logging and
-`record_request` calls that follow it were skipped whenever the request did not return
-normally. Two ways that happens:
+`record_request` calls that follow it were skipped whenever an exception propagated.
+Starlette hoists the `@app.exception_handler(Exception)` catch-all into
+`ServerErrorMiddleware`, which sits *outside* `RequestIDMiddleware` — so unhandled
+exceptions went past it and were never recorded at all. The request log showed only
+successes. That is not a cosmetic gap: while diagnosing issue #13 I read "586 stream
+requests, zero non-2xx" off those logs and concluded the server was healthy. The logs
+could not have shown otherwise.
 
-- **Client disconnect.** Uvicorn raises `CancelledError` into the task when the socket
-  goes away. Every aborted audio stream — every skipped track — took this path.
-- **Unhandled exception.** Starlette hoists the `@app.exception_handler(Exception)`
-  catch-all into `ServerErrorMiddleware`, which sits *outside* `RequestIDMiddleware`, so
-  the exception propagates through the middleware before anything catches it.
+**A client disconnect does not take that path**, which is worth being explicit about
+because I first assumed it did. Uvicorn's `send` is:
 
-The result was that `metrics_summary` and the request log recorded only successes. That
-is not a cosmetic gap: while diagnosing issue #13 I read "586 stream requests, zero
-non-2xx" off those logs and concluded the server was healthy. The logs could not have
-shown otherwise. **These are the regression tests for that wrong conclusion.**
+    if self.disconnected:
+        return
 
-They drive the ASGI callable directly rather than through `TestClient`, because
-`TestClient` completes every request it starts — it cannot abort mid-body, which is the
-case that matters most.
+— a silent no-op. It raises nothing. `FileResponse` reads on to EOF, sending into a
+closed socket, and returns normally. So an aborted stream *is* recorded, as a clean 200
+whose duration is however long the listener stayed before skipping.
 
-The trap in the obvious fix has its own tests below (`TestDoesNotPoisonMetrics`): a bare
-`try`/`finally` would record an aborted 40-second stream as a *successful* 206 that took
-40000 ms, because `status_code` is set as soon as the response *starts*. That inflates
-p95 with what is really listening time and reports failures as successes — worse than
-recording nothing, since #15 depends on that p95 being trustworthy.
+That turned out to be the more damaging problem, and it is measured, not theorised: one
+aborted stream on the NAS logged `duration_ms: 1424.56`, and the p95 for the whole
+five-minute window was `1424.56`. **A single skipped track defined p95 for every other
+request.** Hence the transfer/API split in `TestTransfersDoNotDefinePercentiles`.
+
+These drive the ASGI callable directly rather than through `TestClient`, which completes
+every request it starts and so cannot express any of these cases.
 """
 
 import asyncio
@@ -41,7 +43,7 @@ class RecordingCollector(MetricsCollector):
         super().__init__()
         self.calls: list[dict] = []
 
-    def record_request(self, method, route, status_code, duration_ms, query_count=0, outcome="completed"):  # type: ignore[override]
+    def record_request(self, method, route, status_code, duration_ms, query_count=0, outcome="completed", transfer=False):  # type: ignore[override]
         self.calls.append({
             "method": method,
             "route": route,
@@ -49,8 +51,11 @@ class RecordingCollector(MetricsCollector):
             "duration_ms": duration_ms,
             "query_count": query_count,
             "outcome": outcome,
+            "transfer": transfer,
         })
-        super().record_request(method, route, status_code, duration_ms, query_count, outcome=outcome)
+        super().record_request(
+            method, route, status_code, duration_ms, query_count, outcome=outcome, transfer=transfer
+        )
 
 
 @pytest.fixture()
@@ -107,8 +112,22 @@ async def drive(downstream, path="/api/v1/thing"):
 # --- downstream apps ------------------------------------------------------------------
 
 async def ok_app(scope, receive, send):
-    await send({"type": "http.response.start", "status": 200, "headers": []})
+    await send({
+        "type": "http.response.start",
+        "status": 200,
+        "headers": [(b"content-type", b"application/json")],
+    })
     await send({"type": "http.response.body", "body": b"fine"})
+
+
+async def audio_app(scope, receive, send):
+    """What the client actually walks away from."""
+    await send({
+        "type": "http.response.start",
+        "status": 206,
+        "headers": [(b"content-type", b"audio/mpeg")],
+    })
+    await send({"type": "http.response.body", "body": b"...."})
 
 
 async def raising_app(scope, receive, send):
@@ -196,38 +215,109 @@ class TestUnhandledException:
         assert len(collector.calls) == 1
 
 
-class TestDoesNotPoisonMetrics:
-    """A bare try/finally would be worse than the bug. These pin down why."""
+class TestTransferClassification:
+    async def test_audio_response_is_marked_as_a_transfer(self, collector):
+        await drive(audio_app)
+        assert collector.calls[0]["transfer"] is True
 
+    async def test_json_response_is_not(self, collector):
+        await drive(ok_app)
+        assert collector.calls[0]["transfer"] is False
+
+    async def test_content_type_with_parameters_still_matches(self, collector):
+        async def app(scope, receive, send):
+            await send({
+                "type": "http.response.start",
+                "status": 200,
+                "headers": [(b"Content-Type", b"audio/mpeg; charset=binary")],
+            })
+            await send({"type": "http.response.body", "body": b""})
+
+        await drive(app)
+        assert collector.calls[0]["transfer"] is True
+
+    async def test_response_with_no_content_type_is_not_a_transfer(self, collector):
+        async def app(scope, receive, send):
+            await send({"type": "http.response.start", "status": 204, "headers": []})
+            await send({"type": "http.response.body", "body": b""})
+
+        await drive(app)
+        assert collector.calls[0]["transfer"] is False
+
+
+class TestTransfersDoNotDefinePercentiles:
+    """Measured, not theorised.
+
+    One stream aborted after ~1.4s on the NAS logged `duration_ms: 1424.56`, and the
+    p95 for the entire five-minute window came back as `1424.56` — a single skipped
+    track setting the latency figure for every other request in the window. Since #15
+    is judged on that p95 during a library sync, it has to mean something first.
+    """
+
+    def test_one_aborted_stream_does_not_set_p95(self):
+        c = MetricsCollector()
+        for _ in range(9):
+            c.record_request("GET", "/api/v1/thing", 200, 50.0)
+        # A listener who played 40s of a track and skipped: a clean 200, 40s elapsed.
+        c.record_request("GET", "/api/v1/tracks/{id}/stream", 200, 40000.0, transfer=True)
+
+        req = c.get_snapshot()["request_metrics"]
+
+        assert req["duration_p95_ms"] < 100, "listening time is not API latency"
+        assert req["transfer_p95_ms"] == 40000.0, "but it is still reported"
+        assert req["transfer_requests"] == 1
+
+    def test_transfers_do_not_move_the_error_rate(self):
+        c = MetricsCollector()
+        for _ in range(9):
+            c.record_request("GET", "/api/v1/thing", 200, 10.0)
+        c.record_request("GET", "/api/v1/tracks/{id}/stream", 200, 9000.0, transfer=True)
+
+        assert c.get_snapshot()["request_metrics"]["error_rate"] == 0.0
+
+    def test_a_window_of_only_transfers_reports_no_api_latency(self):
+        c = MetricsCollector()
+        c.record_request("GET", "/api/v1/tracks/{id}/stream", 200, 9000.0, transfer=True)
+
+        req = c.get_snapshot()["request_metrics"]
+        assert req["duration_p95_ms"] == 0.0
+        assert req["error_rate"] == 0.0
+        assert req["transfer_requests"] == 1
+        assert req["total_requests"] == 1
+
+    def test_transfers_still_appear_in_top_routes(self):
+        """Excluded from the percentiles, not hidden."""
+        c = MetricsCollector()
+        c.record_request("GET", "/api/v1/tracks/{id}/stream", 200, 9000.0, transfer=True)
+
+        routes = [r["route"] for r in c.get_snapshot()["request_metrics"]["top_routes"]]
+        assert "/api/v1/tracks/{id}/stream" in routes
+
+
+class TestDoesNotPoisonMetrics:
     def test_disconnects_are_excluded_from_percentiles(self):
         c = MetricsCollector()
         for _ in range(9):
             c.record_request("GET", "/api/v1/thing", 200, 50.0)
-        # One aborted stream that the user listened to for 40 seconds.
-        c.record_request("GET", "/api/v1/stream", 206, 40000.0, outcome="client_disconnect")
+        c.record_request("GET", "/api/v1/thing", 500, 40000.0, outcome="client_disconnect")
 
-        req = c.get_snapshot()["request_metrics"]
-
-        assert req["duration_p95_ms"] < 100, (
-            "a 40s listen recorded as latency would put p95 at 40000ms and make the "
-            "measurement for #15 meaningless"
-        )
+        assert c.get_snapshot()["request_metrics"]["duration_p95_ms"] < 100
 
     def test_disconnects_do_not_count_as_errors(self):
         """Skipping a track is normal use, not a server error."""
         c = MetricsCollector()
         for _ in range(9):
             c.record_request("GET", "/api/v1/thing", 200, 10.0)
-        c.record_request("GET", "/api/v1/stream", 206, 5000.0, outcome="client_disconnect")
+        c.record_request("GET", "/api/v1/thing", 500, 5000.0, outcome="client_disconnect")
 
         assert c.get_snapshot()["request_metrics"]["error_rate"] == 0.0
 
     def test_disconnects_are_counted_separately(self):
-        """Excluded from the error rate, but not thrown away — this is the #13 signal."""
+        """Excluded from the error rate, but not thrown away."""
         c = MetricsCollector()
         c.record_request("GET", "/api/v1/thing", 200, 10.0)
-        c.record_request("GET", "/api/v1/stream", 206, 5000.0, outcome="client_disconnect")
-        c.record_request("GET", "/api/v1/stream", 206, 5000.0, outcome="client_disconnect")
+        c.record_request("GET", "/api/v1/thing", 500, 5000.0, outcome="client_disconnect")
+        c.record_request("GET", "/api/v1/thing", 500, 5000.0, outcome="client_disconnect")
 
         req = c.get_snapshot()["request_metrics"]
         assert req["client_disconnects"] == 2
@@ -243,18 +333,22 @@ class TestDoesNotPoisonMetrics:
 
     def test_snapshot_with_only_disconnects_does_not_divide_by_zero(self):
         c = MetricsCollector()
-        c.record_request("GET", "/api/v1/stream", 206, 5000.0, outcome="client_disconnect")
+        c.record_request("GET", "/api/v1/thing", 500, 5000.0, outcome="client_disconnect")
 
         req = c.get_snapshot()["request_metrics"]
         assert req["error_rate"] == 0.0
         assert req["duration_p95_ms"] == 0.0
         assert req["client_disconnects"] == 1
 
-    def test_outcome_defaults_to_completed(self):
+    def test_keyword_args_default_to_todays_behaviour(self):
         """Existing call sites pass five positional args and must keep working."""
         c = MetricsCollector()
         c.record_request("GET", "/api/v1/thing", 200, 10.0, 3)
-        assert c.get_snapshot()["request_metrics"]["total_requests"] == 1
+
+        req = c.get_snapshot()["request_metrics"]
+        assert req["total_requests"] == 1
+        assert req["duration_p95_ms"] == 10.0  # counted as an API request
+        assert req["transfer_requests"] == 0
 
 
 class TestErrorResponsesCarryTheRequestID:

--- a/docker/docker-compose.prod.yml
+++ b/docker/docker-compose.prod.yml
@@ -66,10 +66,21 @@ services:
     # Resource limits to prevent system overload during analysis
     # Note: CLAP embedding model requires ~4GB peak memory, so 6GB limit
     # provides headroom to prevent OOM kills during analysis
+    #
+    # The CPU limit covers three processes, not one: the API worker, the library-scan
+    # subprocess, and the analysis subprocess (both spawned via ProcessPoolExecutor).
+    # At 2.0 they contended with each other and with Postgres, and audio-stream p95
+    # went from ~50ms idle to ~1000ms during a sync (issue #13). Memory is not the
+    # constraint here — the 6G limit sits against ~650MB in use.
+    #
+    # NOTE: `scripts/deploy-dev.sh` does `docker cp` + `docker restart`, which preserves
+    # the container's existing HostConfig — it will NOT apply a change made here. To
+    # apply it to a running container without recreating it (and without disturbing the
+    # database):  docker update --cpus=6 familiar-api
     deploy:
       resources:
         limits:
-          cpus: '2.0'    # Max 2 CPU cores
+          cpus: '6.0'    # Max 6 CPU cores, leaving 2 for Postgres, Redis and the OS
           memory: 6G     # Max 6GB RAM (CLAP model needs ~4GB peak)
         reservations:
           cpus: '0.5'    # Guaranteed 0.5 cores


### PR DESCRIPTION
Closes #16. Refs #15.

## What was wrong

Two separate defects, both of which made the request metrics unusable for diagnosing #13.

**1. Unhandled exceptions were never recorded.** `RequestIDMiddleware` awaited the downstream app with no `try`/`finally`. Starlette hoists the `@app.exception_handler(Exception)` catch-all into `ServerErrorMiddleware`, which sits *outside* this middleware, so unhandled exceptions propagated past the logging and `record_request` calls entirely. The log showed only successes — which is why, while diagnosing #13, "586 stream requests, zero non-2xx" was read as evidence the server was healthy. It could not have shown otherwise.

**2. A single skipped track defined p95 for a whole five-minute window.** This one is measured, not theorised.

I initially assumed a client disconnect raised `CancelledError` into the app. **It does not.** Uvicorn's `send` is:

```python
if self.disconnected:
    return
```

a silent no-op. `FileResponse` reads on to EOF into a closed socket and returns normally, so an aborted stream *was* already being recorded — as a clean 200 whose duration is however long the listener stayed before skipping.

On the NAS, one stream aborted after ~1.4s logged `duration_ms: 1424.56`, and the window's `duration_p95_ms` came back as `1424.56`.

**This makes the #13 evidence suspect.** The 990ms and 1036ms p95 readings taken during a library sync may have been transfer time, not slow responses.

## What changed

- `try`/`except BaseException`/`finally` around the downstream call, always re-raising. `CancelledError` must reach uvicorn for connection teardown; an unhandled exception must reach `ServerErrorMiddleware`, which is what produces the 500 body.
- `response_started` is tracked separately from `status_code`, so a response that already sent a 206 and real bytes is not relabelled a 500.
- Responses with an `audio/*` or `video/*` content-type are marked as **transfers**. Their elapsed time is byte-movement, so they are reported under `transfer_p50_ms`/`transfer_p95_ms` and kept out of `duration_*` and `error_rate`. `duration_*` now means "how quickly does the server answer". Classification is on content-type rather than a route list, so it needs no maintenance.
- Error responses carry `x-request-id` as a header. `ServerErrorMiddleware`'s 500s never passed through `send_with_request_id` and were the one response with nothing to correlate against the log.
- `metrics_summary` gains `client_disconnects`, `transfers` and `transfer_p95_ms`.

### Also in here: #15

The 2.0-CPU container limit covers three processes, not one — the API worker plus the scan and analysis subprocesses. Raised to 6.0 on the 8-core NAS, leaving 2 for Postgres, Redis and the OS. Memory was never the constraint (6G limit against ~650MB in use).

This corrects an earlier diagnosis of mine: I claimed the scan threads contended with the API event loop through the GIL. They do not — `_run_scan_in_process` goes to a spawn-context `ProcessPoolExecutor` and `LibraryScanner` is imported inside the subprocess. There is no shared interpreter. The cgroup cap, not the GIL, was the contention.

`os.cpu_count()` reports the host's CPUs and knows nothing about cgroups, so `adaptive_queue_limit` saw 8 where the container had 2. Adds `available_cpu_count()`, reading cgroup v2 `cpu.max` with fallbacks to v1 quota/period and then `os.cpu_count()`.

Note `deploy-dev.sh` does `docker cp` + `docker restart`, which preserves the existing `HostConfig` and will **not** apply the compose change. Recorded in the compose file alongside the `docker update --cpus=6` that applies it live.

## Verification

Deployed to the NAS and measured there.

Before the split, one aborted stream set p95 for everything. After:

```
transfer_requests      1
duration_p95_ms        90.09      <- API latency
transfer_p95_ms        2108.88    <- the aborted stream, still reported
```

The log line now carries the classification:

```json
{"message": "request_completed", "duration_ms": 2108.88, "outcome": "completed",
 "transfer": true, "route": "/api/v1/tracks/{track_id}/stream", "status_code": 200}
```

CPU limit applied live with `docker update` (no recreation, container stayed healthy):

```
NanoCpus=6000000000  Memory=6442450944   Up 53 seconds (healthy)
```

And inside the container, the helper reads the real cgroup rather than the host:

```
/sys/fs/cgroup/cpu.max -> 600000 100000
available_cpu_count()  -> 6      (host has 8)
adaptive_queue_limit() -> 500
```

Library intact: 26,462 tracks, 26,437 analyzed.

## Tests

41 new (`test_request_middleware.py`, `test_cpu_limits.py`), driving the ASGI callable directly — `TestClient` completes every request it starts and cannot express any of these cases. Full core suite passes.

`TestAdaptiveQueueLimit` in `test_metrics.py` previously patched `os.cpu_count`, which no longer determines the answer on a host with a CPU quota; on a Linux CI runner those tests would have started depending on the machine. They now patch `available_cpu_count`. The scaling behaviour they assert is unchanged.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_014P9p2fvFnyiywBxGkv4gfW