### PR TITLE
fix(player): persist queueSource and the lazy reservoir across reloads

### DIFF
--- a/packages/frontend/src/db/index.ts
+++ b/packages/frontend/src/db/index.ts
@@ -5,6 +5,7 @@
  */
 import Dexie, { type Table } from 'dexie';
 import { createLogger } from '../utils/logger';
+import type { QueueSource } from '../player/playerStore.types';
 
 const log = createLogger('DB');
 
@@ -179,8 +180,29 @@ export interface PersistedPlayerState {
   shuffleIndex: number; // Current position in shuffleOrder (-1 when off)
   currentTime: number; // Playback position in seconds
   consume?: boolean; // Remove tracks from queue after playing
+
+  // Where the queue came from — needed so listening events keep their context across a
+  // reload, and so `toggleShuffle` can still take its server-side branch.
+  queueSource?: PersistedQueueSource | null;
+
+  // The lazy reservoir. `queueTrackIds` above holds only the ~50-track materialised
+  // window; without these the rest of the queue is lost on reload and playback simply
+  // stops at the end of the window. Optional so records written before this existed load
+  // as `undefined` and fall back to non-lazy mode — no Dexie version bump needed.
+  lazyQueueIds?: string[] | null;
+  lazyQueueIndex?: number;
+
   updatedAt: Date;
 }
+
+/**
+ * What gets persisted for `queueSource`.
+ *
+ * Aliased to the player's own `QueueSource` rather than restated structurally, so the two
+ * cannot drift. `playerStore.types` has no runtime imports and this is a type-only
+ * import, so it is erased at build time — `db/` gains no dependency on `player/`.
+ */
+export type PersistedQueueSource = QueueSource;
 
 // Track IndexedDB availability (can be disabled on iOS private browsing)
 let indexedDBAvailable: boolean | null = null;

--- a/packages/frontend/src/player/__tests__/persistence.test.ts
+++ b/packages/frontend/src/player/__tests__/persistence.test.ts
@@ -1,0 +1,177 @@
+/**
+ * Tests for the persistence layer's storage shape.
+ *
+ * The lazy reservoir is the one persisted field that is both large and rarely changing:
+ * ~26k UUIDs (~1 MB) for a full library, changed only by `setLazyQueue`, `toggleShuffle`
+ * and refills. But `setCurrentTime` persists on every tick, throttled to 500ms, so a
+ * reservoir kept in the main record would be rewritten twice a second for the whole of
+ * playback — ~2 MB/s of flash writes to save a value that did not change.
+ *
+ * It therefore lives in its own row, written only when it actually differs. These tests
+ * pin that down, because it is invisible from the store's point of view: `loadPlayerState`
+ * stitches the two rows back together, so nothing upstream can tell the difference except
+ * by counting writes.
+ */
+import { describe, it, expect, beforeEach, vi } from 'vitest';
+
+/* eslint-disable @typescript-eslint/no-explicit-any */
+const { mockPut, mockGet, mockDelete, mockBulkDelete } = vi.hoisted(() => ({
+  mockPut: vi.fn(() => Promise.resolve()) as any,
+  mockGet: vi.fn() as any,
+  mockDelete: vi.fn(() => Promise.resolve()) as any,
+  mockBulkDelete: vi.fn(() => Promise.resolve()) as any,
+}));
+
+vi.mock('../../db', () => ({
+  db: {
+    playerState: {
+      put: mockPut,
+      get: mockGet,
+      delete: mockDelete,
+      bulkDelete: mockBulkDelete,
+    },
+  },
+  isIndexedDBAvailable: () => Promise.resolve(true),
+}));
+
+vi.mock('../../services/profileService', () => ({
+  getSelectedProfileId: () => Promise.resolve('profile-1'),
+}));
+
+vi.mock('../../api', () => ({ tracksApi: { getBatch: vi.fn() } }));
+
+import { savePlayerState, loadPlayerState, clearPlayerState } from '../persistence';
+
+const RESERVOIR_KEY = 'profile-1::reservoir';
+
+const baseState = {
+  volume: 1,
+  shuffle: false,
+  repeat: 'off' as const,
+  consume: false,
+  queue: [],
+  queueIndex: -1,
+  currentTrack: null,
+  shuffleOrder: [],
+  shuffleIndex: -1,
+  currentTime: 0,
+};
+
+const putFor = (id: string): Record<string, unknown>[] =>
+  mockPut.mock.calls
+    .map((c: unknown[]) => c[0] as Record<string, unknown>)
+    .filter((r: Record<string, unknown>) => r.id === id);
+
+beforeEach(() => {
+  mockPut.mockClear();
+  mockGet.mockReset();
+  mockGet.mockResolvedValue(undefined);
+  mockDelete.mockClear();
+  mockBulkDelete.mockClear();
+});
+
+describe('reservoir storage', () => {
+  it('writes the reservoir to its own row', async () => {
+    const ids = ['a', 'b', 'c'];
+    await savePlayerState({ ...baseState, lazyQueueIds: ids, lazyQueueIndex: 2 });
+
+    const rows = putFor(RESERVOIR_KEY);
+    expect(rows).toHaveLength(1);
+    expect(rows[0].lazyQueueIds).toEqual(ids);
+  });
+
+  it('keeps the bulk out of the main record', async () => {
+    const ids = ['a', 'b', 'c'];
+    await savePlayerState({ ...baseState, lazyQueueIds: ids, lazyQueueIndex: 2 });
+
+    const main = putFor('profile-1')[0];
+    expect(main.lazyQueueIds).toBeUndefined();
+    // The cursor is small and tracks the queue, so it stays with the main record.
+    expect(main.lazyQueueIndex).toBe(2);
+  });
+
+  it('does not rewrite an unchanged reservoir', async () => {
+    const ids = ['a', 'b', 'c'];
+    await savePlayerState({ ...baseState, lazyQueueIds: ids, lazyQueueIndex: 2 });
+    mockPut.mockClear();
+
+    // What playback does twice a second: same queue, later position.
+    for (let t = 1; t <= 5; t++) {
+      await savePlayerState({ ...baseState, currentTime: t, lazyQueueIds: ids, lazyQueueIndex: 2 });
+    }
+
+    expect(putFor('profile-1')).toHaveLength(5);
+    expect(putFor(RESERVOIR_KEY)).toHaveLength(0);
+  });
+
+  it('rewrites when the reservoir actually changes', async () => {
+    await savePlayerState({ ...baseState, lazyQueueIds: ['a'], lazyQueueIndex: 1 });
+    mockPut.mockClear();
+
+    await savePlayerState({ ...baseState, lazyQueueIds: ['x', 'y'], lazyQueueIndex: 2 });
+
+    expect(putFor(RESERVOIR_KEY)).toHaveLength(1);
+  });
+
+  it('deletes the row when lazy mode ends', async () => {
+    await savePlayerState({ ...baseState, lazyQueueIds: ['a'], lazyQueueIndex: 1 });
+    mockDelete.mockClear();
+
+    await savePlayerState({ ...baseState, lazyQueueIds: null, lazyQueueIndex: -1 });
+
+    expect(mockDelete).toHaveBeenCalledWith(RESERVOIR_KEY);
+  });
+});
+
+describe('loading stitches the rows back together', () => {
+  it('returns the reservoir alongside the main record', async () => {
+    mockGet.mockImplementation((key: string) =>
+      Promise.resolve(
+        key === RESERVOIR_KEY
+          ? { id: key, lazyQueueIds: ['a', 'b'], lazyQueueIndex: 2 }
+          : { id: 'profile-1', queueTrackIds: [], lazyQueueIndex: 2 }
+      )
+    );
+
+    const loaded = await loadPlayerState();
+
+    expect(loaded?.lazyQueueIds).toEqual(['a', 'b']);
+    expect(loaded?.lazyQueueIndex).toBe(2);
+  });
+
+  it('reads a record written before the reservoir row existed', async () => {
+    mockGet.mockImplementation((key: string) =>
+      Promise.resolve(key === RESERVOIR_KEY ? undefined : { id: 'profile-1', queueTrackIds: ['t1'] })
+    );
+
+    const loaded = await loadPlayerState();
+
+    expect(loaded?.queueTrackIds).toEqual(['t1']);
+    expect(loaded?.lazyQueueIds).toBeNull();
+  });
+
+  it('returns null when there is no state at all', async () => {
+    mockGet.mockResolvedValue(undefined);
+    expect(await loadPlayerState()).toBeNull();
+  });
+});
+
+describe('clearing', () => {
+  it('removes both rows, so the reservoir cannot outlive its state', async () => {
+    await clearPlayerState();
+    expect(mockBulkDelete).toHaveBeenCalledWith(['profile-1', RESERVOIR_KEY]);
+  });
+
+  it('lets a later save rewrite the reservoir it had already written', async () => {
+    const ids = ['a', 'b'];
+    await savePlayerState({ ...baseState, lazyQueueIds: ids, lazyQueueIndex: 2 });
+    await clearPlayerState();
+    mockPut.mockClear();
+
+    // Same array reference as before the clear — the skip-if-unchanged cache must not
+    // suppress this, or the cleared row would never come back.
+    await savePlayerState({ ...baseState, lazyQueueIds: ids, lazyQueueIndex: 2 });
+
+    expect(putFor(RESERVOIR_KEY)).toHaveLength(1);
+  });
+});

--- a/packages/frontend/src/player/__tests__/queuePersistence.test.ts
+++ b/packages/frontend/src/player/__tests__/queuePersistence.test.ts
@@ -1,0 +1,278 @@
+/**
+ * Tests for what survives a page reload.
+ *
+ * `savePlayerState` wrote twelve fields, and neither `queueSource` nor the lazy
+ * reservoir (`lazyQueueIds` / `lazyQueueIndex`) was among them. `hydrate()` restored
+ * neither. The consequences are not cosmetic:
+ *
+ * - **Playback silently stops after 50 tracks.** `setLazyQueue` keeps the full ID list
+ *   in `lazyQueueIds` and materialises only the first `WINDOW_SIZE = 50` into `queue`.
+ *   After a reload `lazyQueueIds` is back to its `null` default, so
+ *   `refillFromReservoir` returns immediately and the queue never grows again. The user
+ *   sees playback end mid-library with no error.
+ * - **Shuffle quietly stops using the server.** `toggleShuffle`'s lazy branch requires
+ *   both `lazyQueueIds` and `queueSource?.type === 'library'`. With both gone it falls
+ *   through to the standard branch and permutes only the 50 loaded tracks, bypassing the
+ *   server-side weighted preset entirely.
+ * - **Listening events lose their context**, which is what the issue was filed about and
+ *   what ADR-0005 needs.
+ *
+ * The first of those is the one a user would report, so it gets the most direct test.
+ */
+import { describe, it, expect, beforeEach, vi } from 'vitest';
+import { createMockTrack, mockConnectivityState } from './testHelpers';
+
+// `vi.hoisted`, not plain consts. `vi.mock` is hoisted above const declarations, and a
+// factory that *dereferences* an outer const at factory-call time (as `loadPlayerState:
+// mockLoadPlayerState` does) hits the temporal dead zone. Vitest swallows that and falls
+// back to the real module, so the mocks appear to do nothing and every test fails for a
+// reason unrelated to what it is testing.
+const { mockLoadPlayerState, mockSave } = vi.hoisted(() => ({
+  mockLoadPlayerState: vi.fn(() => Promise.resolve(null as unknown)),
+  mockSave: vi.fn(),
+}));
+
+vi.mock('../persistence', () => ({
+  debouncedSavePlayerState: mockSave,
+  loadPlayerState: mockLoadPlayerState,
+  fetchTracksBatched: (ids: string[]) =>
+    Promise.resolve(ids.map((id) => ({
+      id,
+      title: `Track ${id}`,
+      artist: 'Test Artist',
+      album: 'Test Album',
+      duration_seconds: 180,
+      file_path: `/music/${id}.mp3`,
+    }))),
+  migrateOldPlayerState: vi.fn(() => Promise.resolve()),
+}));
+
+vi.mock('../audio/engineInstance', () => ({
+  getEngine: () => ({ seek: vi.fn(), cancelCrossfade: vi.fn() }),
+}));
+
+vi.mock('../../stores/connectivityStore', () => ({
+  useConnectivityStore: Object.assign(
+    (selector: (state: typeof mockConnectivityState) => unknown) => selector(mockConnectivityState),
+    { getState: () => mockConnectivityState }
+  ),
+}));
+
+const { mockGetBatch, mockGetIds } = vi.hoisted(() => ({
+  mockGetBatch: vi.fn(),
+  mockGetIds: vi.fn(),
+}));
+
+vi.mock('../../api', () => ({
+  tracksApi: {
+    getBatch: (ids: string[]) => mockGetBatch(ids),
+    getIds: (params: unknown) => mockGetIds(params as never),
+  },
+}));
+
+import { useQueueStore } from '../queueStore';
+import { usePlaybackStore } from '../playbackStore';
+
+const ids = (n: number, prefix = 't') =>
+  Array.from({ length: n }, (_, i) => `${prefix}${i}`);
+
+/** A persisted record as it would exist after playing the library. */
+function persistedLazyQueue(total = 200, window = 50) {
+  const all = ids(total);
+  return {
+    id: 'profile-1',
+    volume: 1,
+    shuffle: false,
+    repeat: 'off' as const,
+    consume: false,
+    queueTrackIds: all.slice(0, window),
+    queueIndex: 0,
+    currentTrackId: all[0],
+    shuffleOrder: [],
+    shuffleIndex: -1,
+    currentTime: 0,
+    queueSource: { type: 'library' as const, filters: { genre: 'jazz' } },
+    lazyQueueIds: all,
+    lazyQueueIndex: window,
+    updatedAt: new Date(),
+  };
+}
+
+function resetStores() {
+  usePlaybackStore.setState({
+    currentTrack: null,
+    isPlaying: false,
+    currentTime: 0,
+    duration: 0,
+    volume: 1,
+    shuffle: false,
+    repeat: 'off',
+    consume: false,
+    crossfadeState: 'idle',
+    nextTrackPreloaded: false,
+    isLoadingAudio: false,
+    isHydrated: false,
+    _circuitBreakerTimestamps: [],
+  });
+  useQueueStore.setState({
+    queue: [],
+    queueIndex: -1,
+    history: [],
+    shuffleOrder: [],
+    shuffleIndex: -1,
+    lazyQueueIds: null,
+    lazyQueueIndex: -1,
+    queueSource: null,
+    isQueueHydrating: false,
+  });
+  mockConnectivityState.offlineModeActive = false;
+  mockConnectivityState.offlineTrackIds = new Set<string>();
+}
+
+beforeEach(() => {
+  resetStores();
+  mockSave.mockClear();
+  mockGetBatch.mockReset();
+  mockGetBatch.mockImplementation((batchIds: string[]) =>
+    Promise.resolve(batchIds.map((id) => createMockTrack(id)))
+  );
+  mockGetIds.mockReset();
+  mockGetIds.mockResolvedValue({ ids: [] });
+  mockLoadPlayerState.mockResolvedValue(null);
+});
+
+describe('saving', () => {
+  it('writes queueSource so listening events keep their context', async () => {
+    const source = { type: 'playlist' as const, id: 'p1' };
+    useQueueStore.getState().setQueue([createMockTrack('a')], 0, source);
+
+    expect(mockSave).toHaveBeenCalled();
+    expect(mockSave.mock.calls.at(-1)![0]).toMatchObject({ queueSource: source });
+  });
+
+  it('writes the lazy reservoir', async () => {
+    await useQueueStore.getState().setLazyQueue(ids(200), { type: 'library' });
+
+    const saved = mockSave.mock.calls.at(-1)![0];
+    expect(saved.lazyQueueIds).toHaveLength(200);
+    expect(saved.lazyQueueIndex).toBe(50);
+  });
+
+  it('writes the advanced reservoir index after a refill', async () => {
+    await useQueueStore.getState().setLazyQueue(ids(200), { type: 'library' });
+    // Sit near the end of the loaded window so a refill is due.
+    useQueueStore.setState({ queueIndex: 45 });
+    mockSave.mockClear();
+
+    await useQueueStore.getState().playNext();
+    await vi.waitFor(() => expect(mockSave).toHaveBeenCalled());
+
+    const saved = mockSave.mock.calls.at(-1)![0];
+    expect(saved.lazyQueueIndex).toBeGreaterThan(50);
+  });
+});
+
+describe('hydrating', () => {
+  it('restores queueSource', async () => {
+    mockLoadPlayerState.mockResolvedValue(persistedLazyQueue());
+
+    await useQueueStore.getState().hydrate();
+
+    expect(useQueueStore.getState().queueSource).toEqual({
+      type: 'library',
+      filters: { genre: 'jazz' },
+    });
+  });
+
+  it('restores the full reservoir, not just the loaded window', async () => {
+    mockLoadPlayerState.mockResolvedValue(persistedLazyQueue(200, 50));
+
+    await useQueueStore.getState().hydrate();
+
+    const s = useQueueStore.getState();
+    expect(s.queue).toHaveLength(50);
+    expect(s.lazyQueueIds).toHaveLength(200);
+    expect(s.lazyQueueIndex).toBe(50);
+  });
+
+  it('keeps playing past the 50-track window after a reload', async () => {
+    // The bug a user would actually report: playback just ends mid-library.
+    mockLoadPlayerState.mockResolvedValue(persistedLazyQueue(200, 50));
+    await useQueueStore.getState().hydrate();
+
+    // Advance to the end of the loaded window, which should trigger a refill.
+    useQueueStore.setState({ queueIndex: 45 });
+    await useQueueStore.getState().playNext();
+
+    await vi.waitFor(() => {
+      expect(useQueueStore.getState().queue.length).toBeGreaterThan(50);
+    });
+  });
+
+  it('takes the server-side lazy branch on toggleShuffle after a reload', async () => {
+    mockLoadPlayerState.mockResolvedValue(persistedLazyQueue(200, 50));
+    mockGetIds.mockResolvedValue({ ids: ids(200).reverse() });
+    await useQueueStore.getState().hydrate();
+
+    await useQueueStore.getState().toggleShuffle();
+
+    expect(mockGetIds).toHaveBeenCalled();
+    // The library filters have to survive too, or the reshuffle spans the wrong set.
+    expect(mockGetIds.mock.calls[0][0]).toMatchObject({ genre: 'jazz' });
+  });
+});
+
+describe('hydrating defensively', () => {
+  it('reads a record saved before these fields existed', async () => {
+    const legacy = persistedLazyQueue();
+    delete (legacy as Record<string, unknown>).queueSource;
+    delete (legacy as Record<string, unknown>).lazyQueueIds;
+    delete (legacy as Record<string, unknown>).lazyQueueIndex;
+    mockLoadPlayerState.mockResolvedValue(legacy);
+
+    await useQueueStore.getState().hydrate();
+
+    const s = useQueueStore.getState();
+    expect(s.lazyQueueIds).toBeNull();
+    expect(s.lazyQueueIndex).toBe(-1);
+    expect(s.queueSource).toBeNull();
+    expect(s.queue).toHaveLength(50); // still hydrates the queue itself
+  });
+
+  it('ignores a reservoir index past the end of the list', async () => {
+    mockLoadPlayerState.mockResolvedValue({
+      ...persistedLazyQueue(200, 50),
+      lazyQueueIndex: 9999,
+    });
+
+    await useQueueStore.getState().hydrate();
+
+    // Falling back to non-lazy mode is correct: an index past the end can only
+    // produce an empty refill batch forever.
+    expect(useQueueStore.getState().lazyQueueIds).toBeNull();
+  });
+
+  it('ignores an empty reservoir', async () => {
+    mockLoadPlayerState.mockResolvedValue({
+      ...persistedLazyQueue(200, 50),
+      lazyQueueIds: [],
+    });
+
+    await useQueueStore.getState().hydrate();
+
+    expect(useQueueStore.getState().lazyQueueIds).toBeNull();
+  });
+
+  it('does not enter lazy mode from a non-lazy record', async () => {
+    const plain = persistedLazyQueue();
+    delete (plain as Record<string, unknown>).lazyQueueIds;
+    plain.queueSource = { type: 'playlist', id: 'p1' } as never;
+    mockLoadPlayerState.mockResolvedValue(plain);
+
+    await useQueueStore.getState().hydrate();
+
+    const s = useQueueStore.getState();
+    expect(s.lazyQueueIds).toBeNull();
+    expect(s.queueSource).toEqual({ type: 'playlist', id: 'p1' });
+  });
+});

--- a/packages/frontend/src/player/__tests__/testHelpers.ts
+++ b/packages/frontend/src/player/__tests__/testHelpers.ts
@@ -1,4 +1,18 @@
-import { vi } from 'vitest';
+/**
+ * Shared fixtures for player tests.
+ *
+ * Deliberately contains **no `vi.mock` calls**. Vitest hoists `vi.mock` to the top of the
+ * module it appears in, even from inside a function body — so a helper module that merely
+ * *defines* mocks registers them for every test file that imports anything from it, and
+ * those hoisted mocks win over the importing file's own. This module previously exported
+ * an unused `setupStandardMocks()` doing exactly that, which silently replaced
+ * `../persistence` with inert spies in any test that imported `createMockTrack`. Tests
+ * needing a controllable mock got the inert one and failed for reasons unrelated to what
+ * they were testing.
+ *
+ * Each test file declares its own mocks, using `vi.hoisted()` for any spy the factory
+ * dereferences at factory-call time.
+ */
 import type { Track } from '../../types';
 
 export const createMockTrack = (id: string, title = 'Test Track'): Track => ({
@@ -23,26 +37,3 @@ export const mockConnectivityState = {
   offlineTrackIds: new Set<string>(),
 };
 
-/**
- * Standard mock setup for playerStore tests.
- * Call vi.mock() with these in your test file's top-level scope.
- */
-export function setupStandardMocks() {
-  vi.mock('../persistence', () => ({
-    debouncedSavePlayerState: vi.fn(),
-    loadPlayerState: vi.fn(() => Promise.resolve(null)),
-    fetchTracksBatched: vi.fn(() => Promise.resolve([])),
-    migrateOldPlayerState: vi.fn(() => Promise.resolve()),
-  }));
-
-  vi.mock('../audio/engineInstance', () => ({
-    getEngine: () => ({ seek: vi.fn(), cancelCrossfade: vi.fn() }),
-  }));
-
-  vi.mock('../../stores/connectivityStore', () => ({
-    useConnectivityStore: Object.assign(
-      (selector: (state: typeof mockConnectivityState) => unknown) => selector(mockConnectivityState),
-      { getState: () => mockConnectivityState }
-    ),
-  }));
-}

--- a/packages/frontend/src/player/persistence.ts
+++ b/packages/frontend/src/player/persistence.ts
@@ -3,7 +3,12 @@
  * Saves and loads player state from IndexedDB per profile.
  * All operations silently fail if IndexedDB isn't available (iOS private browsing).
  */
-import { db, isIndexedDBAvailable, type PersistedPlayerState } from '../db';
+import {
+  db,
+  isIndexedDBAvailable,
+  type PersistedPlayerState,
+  type PersistedQueueSource,
+} from '../db';
 import { getSelectedProfileId } from '../services/profileService';
 import type { Track, QueueItem } from '../types';
 import { tracksApi } from '../api';
@@ -11,10 +16,8 @@ import { createLogger } from '../utils/logger';
 
 const log = createLogger('PlayerPersistence');
 
-/**
- * Save player state to IndexedDB for the current profile.
- */
-export async function savePlayerState(state: {
+/** The shape both `savePlayerState` and its throttled wrapper accept. */
+export interface PersistablePlayerState {
   volume: number;
   shuffle: boolean;
   repeat: 'off' | 'all' | 'one';
@@ -25,7 +28,66 @@ export async function savePlayerState(state: {
   shuffleOrder: number[];
   shuffleIndex: number;
   currentTime: number;
-}): Promise<void> {
+  queueSource?: PersistedQueueSource | null;
+  lazyQueueIds?: string[] | null;
+  lazyQueueIndex?: number;
+}
+
+/**
+ * Key for a profile's lazy reservoir, stored as its own row in the same table.
+ *
+ * The reservoir is the one field here that is both large and rarely changing. For a full
+ * library it is ~26k UUIDs (~1 MB), but it only changes on `setLazyQueue`, `toggleShuffle`
+ * and a refill. Meanwhile `setCurrentTime` persists on every tick, throttled to 500ms —
+ * so keeping the reservoir in the main record would rewrite that megabyte twice a second
+ * for the whole of playback. The clone cost is negligible (~0.9ms measured), but the
+ * sustained ~2 MB/s of flash writes is not, particularly on iOS.
+ *
+ * `playerState` is keyed on `id` alone, so a second row costs no schema change.
+ */
+const reservoirKey = (profileId: string) => `${profileId}::reservoir`;
+
+interface ReservoirRecord {
+  id: string;
+  lazyQueueIds: string[] | null;
+  lazyQueueIndex: number;
+  updatedAt: Date;
+}
+
+// Last reservoir written, per profile, so unchanged ones can be skipped. Compared by
+// reference: the store replaces the array wholesale whenever it changes.
+const lastWrittenReservoir = new Map<string, string[] | null>();
+
+async function saveReservoir(
+  profileId: string,
+  ids: string[] | null,
+  index: number
+): Promise<void> {
+  if (lastWrittenReservoir.get(profileId) === ids) return;
+  lastWrittenReservoir.set(profileId, ids);
+
+  const key = reservoirKey(profileId);
+  if (!ids || ids.length === 0) {
+    await db.playerState.delete(key);
+    return;
+  }
+  await db.playerState.put({
+    id: key,
+    lazyQueueIds: ids,
+    lazyQueueIndex: index,
+    updatedAt: new Date(),
+  } as unknown as PersistedPlayerState);
+}
+
+async function loadReservoir(profileId: string): Promise<ReservoirRecord | null> {
+  const row = await db.playerState.get(reservoirKey(profileId));
+  return (row as unknown as ReservoirRecord) ?? null;
+}
+
+/**
+ * Save player state to IndexedDB for the current profile.
+ */
+export async function savePlayerState(state: PersistablePlayerState): Promise<void> {
   const idbAvailable = await isIndexedDBAvailable();
   if (!idbAvailable) return;
 
@@ -47,13 +109,25 @@ export async function savePlayerState(state: {
       shuffleOrder: state.shuffleOrder,
       shuffleIndex: state.shuffleIndex,
       currentTime: state.currentTime,
+      queueSource: state.queueSource ?? null,
+      // The reservoir itself lives in its own row; the cursor into it is small and
+      // changes with the queue, so it stays here.
+      lazyQueueIndex: state.lazyQueueIndex ?? -1,
       updatedAt: new Date(),
     };
 
     await db.playerState.put(persistedState);
+    await saveReservoir(profileId, state.lazyQueueIds ?? null, state.lazyQueueIndex ?? -1);
   } catch (error) {
     log.warn('Failed to save player state:', error);
   }
+}
+
+async function readPlayerState(profileId: string): Promise<PersistedPlayerState | null> {
+  const state = await db.playerState.get(profileId);
+  if (!state) return null;
+  const reservoir = await loadReservoir(profileId);
+  return { ...state, lazyQueueIds: reservoir?.lazyQueueIds ?? null };
 }
 
 /**
@@ -69,8 +143,7 @@ export async function loadPlayerState(): Promise<PersistedPlayerState | null> {
   }
 
   try {
-    const state = await db.playerState.get(profileId);
-    return state || null;
+    return await readPlayerState(profileId);
   } catch (error) {
     log.warn('Failed to load player state:', error);
     return null;
@@ -85,8 +158,7 @@ export async function loadPlayerStateForProfile(profileId: string): Promise<Pers
   if (!idbAvailable) return null;
 
   try {
-    const state = await db.playerState.get(profileId);
-    return state || null;
+    return await readPlayerState(profileId);
   } catch (error) {
     log.warn('Failed to load player state for profile:', error);
     return null;
@@ -155,7 +227,9 @@ export async function clearPlayerState(): Promise<void> {
   }
 
   try {
-    await db.playerState.delete(profileId);
+    // Both rows, or the reservoir outlives the state that referenced it.
+    await db.playerState.bulkDelete([profileId, reservoirKey(profileId)]);
+    lastWrittenReservoir.delete(profileId);
   } catch (error) {
     log.warn('Failed to clear player state:', error);
   }
@@ -204,18 +278,7 @@ export async function migrateOldPlayerState(): Promise<void> {
 let saveTimeout: ReturnType<typeof setTimeout> | null = null;
 let lastSaveTime = 0;
 
-export function debouncedSavePlayerState(state: {
-  volume: number;
-  shuffle: boolean;
-  repeat: 'off' | 'all' | 'one';
-  consume: boolean;
-  queue: QueueItem[];
-  queueIndex: number;
-  currentTrack: Track | null;
-  shuffleOrder: number[];
-  shuffleIndex: number;
-  currentTime: number;
-}): void {
+export function debouncedSavePlayerState(state: PersistablePlayerState): void {
   const now = Date.now();
 
   if (saveTimeout) {

--- a/packages/frontend/src/player/persistenceAdapter.ts
+++ b/packages/frontend/src/player/persistenceAdapter.ts
@@ -2,15 +2,36 @@ import { usePlaybackStore, _setPersistHook } from './playbackStore';
 import { debouncedSavePlayerState } from './persistence';
 
 // Late-bound import to avoid circular dependency (queueStore imports playbackStore)
-let getQueueState: (() => { queue: import('../types').QueueItem[]; queueIndex: number; shuffleOrder: number[]; shuffleIndex: number }) | null = null;
+interface PersistableQueueState {
+  queue: import('../types').QueueItem[];
+  queueIndex: number;
+  shuffleOrder: number[];
+  shuffleIndex: number;
+  queueSource: import('../db').PersistedQueueSource | null;
+  lazyQueueIds: string[] | null;
+  lazyQueueIndex: number;
+}
+
+let getQueueState: (() => PersistableQueueState) | null = null;
+
+const EMPTY_QUEUE_STATE: PersistableQueueState = {
+  queue: [],
+  queueIndex: -1,
+  shuffleOrder: [],
+  shuffleIndex: -1,
+  queueSource: null,
+  lazyQueueIds: null,
+  lazyQueueIndex: -1,
+};
 
 export function _setQueueStateGetter(fn: typeof getQueueState) {
   getQueueState = fn;
 }
 
+// Every caller persists through here, so widening the payload once covers all of them.
 export function persistCombinedState() {
   const playback = usePlaybackStore.getState();
-  const queue = getQueueState?.() ?? { queue: [], queueIndex: -1, shuffleOrder: [], shuffleIndex: -1 };
+  const queue = getQueueState?.() ?? EMPTY_QUEUE_STATE;
   debouncedSavePlayerState({
     volume: playback.volume,
     shuffle: playback.shuffle,
@@ -22,6 +43,9 @@ export function persistCombinedState() {
     queueIndex: queue.queueIndex,
     shuffleOrder: queue.shuffleOrder,
     shuffleIndex: queue.shuffleIndex,
+    queueSource: queue.queueSource,
+    lazyQueueIds: queue.lazyQueueIds,
+    lazyQueueIndex: queue.lazyQueueIndex,
   });
 }
 

--- a/packages/frontend/src/player/queueStore.ts
+++ b/packages/frontend/src/player/queueStore.ts
@@ -48,6 +48,25 @@ const REFILL_BATCH = 20;
 let isRefilling = false;
 let hydrationVersion = 0;
 
+/**
+ * Validate a persisted lazy reservoir before trusting it.
+ *
+ * Falls back to non-lazy mode rather than restoring something unusable: an index at or
+ * past the end of the list can only ever produce an empty refill batch, so lazy mode
+ * would stay on while never delivering another track — the same silent stall the missing
+ * persistence caused, just from the other direction.
+ */
+function restoreReservoir(
+  ids: string[] | null | undefined,
+  index: number | undefined
+): { lazyQueueIds: string[] | null; lazyQueueIndex: number } {
+  if (!ids || ids.length === 0) return { lazyQueueIds: null, lazyQueueIndex: -1 };
+  if (typeof index !== 'number' || index < 0 || index > ids.length) {
+    return { lazyQueueIds: null, lazyQueueIndex: -1 };
+  }
+  return { lazyQueueIds: ids, lazyQueueIndex: index };
+}
+
 const refillFromReservoir = async () => {
   if (isRefilling) return;
 
@@ -948,8 +967,16 @@ export const useQueueStore = create<QueueState & QueueActions>((set, get) => ({
         isPlaying: false,
         isHydrated: true,
       });
+      // Restore the queue's provenance before anything can read it. Without
+      // `queueSource`, listening events lose their context and `toggleShuffle` falls
+      // through to the standard branch, bypassing the server-side weighted preset.
+      // Without the reservoir, `refillFromReservoir` bails at its first guard and the
+      // queue never grows past the materialised window — playback just stops at track
+      // ~50 with no error. Both were dropped on every reload.
       set({
         isQueueHydrating: persisted.queueTrackIds.length > 0,
+        queueSource: persisted.queueSource ?? null,
+        ...restoreReservoir(persisted.lazyQueueIds, persisted.lazyQueueIndex),
       });
 
       if (persisted.queueTrackIds.length === 0) return;
@@ -1036,5 +1063,13 @@ export const useQueueStore = create<QueueState & QueueActions>((set, get) => ({
 // Wire the queue state getter for persistenceAdapter
 _setQueueStateGetter(() => {
   const s = useQueueStore.getState();
-  return { queue: s.queue, queueIndex: s.queueIndex, shuffleOrder: s.shuffleOrder, shuffleIndex: s.shuffleIndex };
+  return {
+    queue: s.queue,
+    queueIndex: s.queueIndex,
+    shuffleOrder: s.shuffleOrder,
+    shuffleIndex: s.shuffleIndex,
+    queueSource: s.queueSource,
+    lazyQueueIds: s.lazyQueueIds,
+    lazyQueueIndex: s.lazyQueueIndex,
+  };
 });

--- a/packages/frontend/src/services/__tests__/playerPersistence.test.ts
+++ b/packages/frontend/src/services/__tests__/playerPersistence.test.ts
@@ -10,6 +10,10 @@ const { mockPlayerState } = vi.hoisted(() => ({
     get: vi.fn() as any,
     put: vi.fn(() => Promise.resolve()) as any,
     delete: vi.fn(() => Promise.resolve()) as any,
+    // The lazy reservoir lives in its own row (`<profileId>::reservoir`) so that a ~1 MB
+    // ID list is not rewritten twice a second by the `setCurrentTime` throttle. Loads
+    // read both rows; clears delete both.
+    bulkDelete: vi.fn(() => Promise.resolve()) as any,
   },
 }));
 
@@ -196,8 +200,10 @@ describe('playerPersistence', () => {
 
       const result = await loadPlayerState();
 
-      expect(result).toEqual(persisted);
+      // `lazyQueueIds` is stitched in from the reservoir row, which is absent here.
+      expect(result).toEqual({ ...persisted, lazyQueueIds: null });
       expect(mockPlayerState.get).toHaveBeenCalledWith('profile-123');
+      expect(mockPlayerState.get).toHaveBeenCalledWith('profile-123::reservoir');
     });
 
     it('should return null when no saved state', async () => {
@@ -249,8 +255,9 @@ describe('playerPersistence', () => {
 
       const result = await loadPlayerStateForProfile('other-profile');
 
-      expect(result).toEqual(persisted);
+      expect(result).toEqual({ ...persisted, lazyQueueIds: null });
       expect(mockPlayerState.get).toHaveBeenCalledWith('other-profile');
+      expect(mockPlayerState.get).toHaveBeenCalledWith('other-profile::reservoir');
     });
 
     it('should return null when IndexedDB unavailable', async () => {
@@ -269,28 +276,32 @@ describe('playerPersistence', () => {
   });
 
   describe('clearPlayerState', () => {
-    it('should delete state for current profile', async () => {
+    it('should delete both rows for current profile', async () => {
       await clearPlayerState();
 
-      expect(mockPlayerState.delete).toHaveBeenCalledWith('profile-123');
+      // Including the reservoir, or a ~1 MB ID list outlives the state referencing it.
+      expect(mockPlayerState.bulkDelete).toHaveBeenCalledWith([
+        'profile-123',
+        'profile-123::reservoir',
+      ]);
     });
 
     it('should not delete when IndexedDB unavailable', async () => {
       vi.mocked(isIndexedDBAvailable).mockResolvedValueOnce(false);
 
       await clearPlayerState();
-      expect(mockPlayerState.delete).not.toHaveBeenCalled();
+      expect(mockPlayerState.bulkDelete).not.toHaveBeenCalled();
     });
 
     it('should not delete when no profile selected', async () => {
       vi.mocked(getSelectedProfileId).mockResolvedValueOnce(null);
 
       await clearPlayerState();
-      expect(mockPlayerState.delete).not.toHaveBeenCalled();
+      expect(mockPlayerState.bulkDelete).not.toHaveBeenCalled();
     });
 
     it('should silently handle errors', async () => {
-      mockPlayerState.delete.mockRejectedValueOnce(new Error('delete failed'));
+      mockPlayerState.bulkDelete.mockRejectedValueOnce(new Error('delete failed'));
 
       // Should not throw
       await clearPlayerState();


### PR DESCRIPTION
Closes #14.

## The bug is worse than filed

Filed as "`queueSource` isn't persisted, so listening events lose their context after a reload." True, and ADR-0005 needs it. But the same missing-persistence cause has a second effect that a user would actually report:

**Playback silently stops after 50 tracks.**

`setLazyQueue` keeps the full ID list in `lazyQueueIds` and materialises only the first `WINDOW_SIZE = 50` tracks into `queue`. `savePlayerState` never wrote `lazyQueueIds`, and `hydrate()` never restored it — so after a reload it was back to its `null` default, `refillFromReservoir` returned at its first guard, and the queue never grew again. Play the library, reload, keep listening: playback just ends mid-library, with no error and nothing in the UI to explain it.

Two more consequences of the same omission:

- `toggleShuffle`'s lazy branch requires **both** `lazyQueueIds` and `queueSource?.type === 'library'`. With both gone it fell through to the standard branch and permuted only the 50 loaded tracks — silently bypassing the server-side weighted shuffle preset.
- `QueueView` and `TrackListBrowser` both switch on `lazyQueueIds`, so the UI stopped showing the true queue length.

## What changed

Persists `queueSource`, `lazyQueueIds` and `lazyQueueIndex`, and restores all three in `hydrate()`.

The restore is guarded. An absent list, an empty list, or an index at/past the end falls back to non-lazy mode rather than turning lazy mode on with a reservoir that can only ever produce empty refill batches — that would be the same silent stall from the other direction.

### The reservoir gets its own row

This is the part worth reviewing. The reservoir is the one persisted field that is both **large** (~26k UUIDs, ~1 MB for a full library) and **rarely changing** (only `setLazyQueue`, `toggleShuffle`, and refills). Meanwhile `setCurrentTime` persists on every tick, throttled to 500ms.

Keeping them in one record would have rewritten that megabyte **twice a second for the entire duration of playback**, to save a value that hadn't changed. Measured: `structuredClone` of 26,462 ids costs 0.9ms, so main-thread cost is negligible — but ~2 MB/s of sustained flash writes is not, particularly on iOS.

So it lives at `<profileId>::reservoir` and is written only when the array reference actually differs. `playerState` is keyed on `id` alone, so this needs **no Dexie version bump**. `loadPlayerState` stitches the two rows back together, so nothing upstream can tell the difference except by counting writes.

All three fields are optional, so records written before this load as `undefined` and take the non-lazy path — which is exactly today's behaviour.

`PersistedQueueSource` aliases the player's own `QueueSource` through a type-only import rather than restating it structurally, so the two cannot drift. `playerStore.types` has no runtime imports, so `db/` gains no runtime dependency on `player/`.

## A trap removed from the test helpers

`testHelpers.ts` exported a `setupStandardMocks()` that was **never called**. But vitest hoists `vi.mock` to module top-level *even from inside a function body* — so merely importing `createMockTrack` from that module registered mocks for `../persistence`, `../audio/engineInstance` and `../../stores/connectivityStore`, and those hoisted mocks **won over the importing file's own**.

Existing tests got away with it only because their mocks happened to be equivalent. Any test needing a *controllable* persistence mock silently got the inert one instead and failed for reasons unrelated to what it was testing — which is exactly what happened while writing this PR, and took a while to find because vitest swallows the underlying TDZ error and falls back to the real module.

The dead function is removed and the reason is documented in the file, so it doesn't get reintroduced.

## Tests

21 new across two files, plus updates to `playerPersistence.test.ts` for the intentional behaviour change (clear now removes both rows; load merges the reservoir in).

The headline regression test drives the actual reported scenario: persist a 200-ID lazy queue with a 50-track window, hydrate, play past the window boundary, assert the queue grows. Against the old code it fails with `expected 50 to be greater than 50`.

```
Test Files  56 passed (56)
     Tests  844 passed (844)
```

Typecheck output is byte-identical to `main` (9 pre-existing errors in untouched test files). Lint: 0 errors. Web build succeeds.

## Verification

Frontend is deployed to the NAS. Worth checking in the browser: play the library, reload, and confirm playback continues past the 50th track and the queue count still shows the full library.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_014P9p2fvFnyiywBxGkv4gfW