### PR TITLE
fix(downloads): throttle bandwidth while playing, instead of competing for it

### DIFF
--- a/packages/frontend/src/components/StatusMenu.tsx
+++ b/packages/frontend/src/components/StatusMenu.tsx
@@ -115,7 +115,14 @@ function DownloadRow({ job }: { job: DownloadJob }) {
             <div className="h-1 bg-zinc-700 rounded-full overflow-hidden">
               <div className="h-full bg-blue-500 transition-all duration-300" style={{ width: `${progressPercent}%` }} />
             </div>
-            <div className="text-xs text-zinc-500 mt-0.5">{completedCount}/{totalCount} tracks</div>
+            <div className="text-xs text-zinc-500 mt-0.5">
+              {completedCount}/{totalCount} tracks
+              {/* A throttled download is deliberately slow, not stuck. Saying so keeps
+                  it from reading as a hang while music is playing. */}
+              {job.throttled && job.status === 'downloading' && (
+                <span className="text-amber-400/80"> · slowed while playing</span>
+              )}
+            </div>
           </div>
         )}
         {job.status === 'completed' && (

--- a/packages/frontend/src/services/__tests__/playbackGate.test.ts
+++ b/packages/frontend/src/services/__tests__/playbackGate.test.ts
@@ -1,0 +1,152 @@
+/**
+ * Tests for the download/playback bandwidth gate.
+ *
+ * Regression cover for the second cause of issue #13. A bulk offline download saturates
+ * the link — measured on a real failure, one 34.9 MB track took 41s (~850 KB/s, the whole
+ * pipe) — and a track that had started playing 15s earlier died with
+ * `PIPELINE_ERROR_READ: FFmpegDemuxer: data source error`. The download queue had no idea
+ * playback existed.
+ *
+ * The subtle requirement is `RESUME_SETTLE_MS`: `isPlaying` dips briefly during ordinary
+ * transitions, so resuming on the first `false` would restart a large transfer straight
+ * into a track change and starve the next track — reproducing the bug while appearing to
+ * fix it.
+ */
+import { describe, it, expect, beforeEach, afterEach, vi } from 'vitest';
+
+import { usePlaybackStore } from '../../player/playbackStore';
+import {
+  DownloadPausedError,
+  RESUME_SETTLE_MS,
+  isPlaybackActive,
+  waitForPlaybackIdle,
+} from '../playbackGate';
+
+const setPlaying = (isPlaying: boolean) => usePlaybackStore.setState({ isPlaying });
+
+/** Has the promise settled? Lets us assert "still waiting" without hanging the test. */
+function track(p: Promise<void>) {
+  const state = { done: false };
+  p.then(() => {
+    state.done = true;
+  });
+  return state;
+}
+
+beforeEach(() => {
+  vi.useFakeTimers();
+  setPlaying(false);
+});
+
+afterEach(() => {
+  vi.useRealTimers();
+});
+
+describe('isPlaybackActive', () => {
+  it('reflects the playback store', () => {
+    setPlaying(true);
+    expect(isPlaybackActive()).toBe(true);
+    setPlaying(false);
+    expect(isPlaybackActive()).toBe(false);
+  });
+});
+
+describe('waitForPlaybackIdle', () => {
+  it('resolves immediately when nothing is playing', async () => {
+    setPlaying(false);
+    await expect(waitForPlaybackIdle()).resolves.toBeUndefined();
+  });
+
+  it('blocks while audio is playing', async () => {
+    setPlaying(true);
+    const w = track(waitForPlaybackIdle());
+
+    await vi.advanceTimersByTimeAsync(60_000);
+
+    expect(w.done).toBe(false);
+  });
+
+  it('resolves once playback has been stopped for the settle window', async () => {
+    setPlaying(true);
+    const w = track(waitForPlaybackIdle());
+
+    setPlaying(false);
+    await vi.advanceTimersByTimeAsync(RESUME_SETTLE_MS + 50);
+
+    expect(w.done).toBe(true);
+  });
+
+  it('does not resume during a brief gap between tracks', async () => {
+    // The case that would reintroduce the bug: `isPlaying` flickers false on a track
+    // change, a 35 MB transfer restarts, and the next track starves.
+    setPlaying(true);
+    const w = track(waitForPlaybackIdle());
+
+    setPlaying(false);
+    await vi.advanceTimersByTimeAsync(500); // shorter than the settle window
+    setPlaying(true);
+    await vi.advanceTimersByTimeAsync(60_000);
+
+    expect(w.done).toBe(false);
+  });
+
+  it('restarts the settle window each time playback resumes', async () => {
+    setPlaying(true);
+    const w = track(waitForPlaybackIdle());
+
+    for (let i = 0; i < 3; i++) {
+      setPlaying(false);
+      await vi.advanceTimersByTimeAsync(RESUME_SETTLE_MS - 500);
+      setPlaying(true);
+      await vi.advanceTimersByTimeAsync(100);
+    }
+    expect(w.done).toBe(false);
+
+    setPlaying(false);
+    await vi.advanceTimersByTimeAsync(RESUME_SETTLE_MS + 50);
+    expect(w.done).toBe(true);
+  });
+
+  it('resolves when the download is cancelled, so cancellation is not blocked', async () => {
+    setPlaying(true);
+    const controller = new AbortController();
+    const w = track(waitForPlaybackIdle(controller.signal));
+
+    controller.abort();
+    await vi.advanceTimersByTimeAsync(0);
+
+    expect(w.done).toBe(true);
+  });
+
+  it('resolves immediately for an already-aborted signal', async () => {
+    setPlaying(true);
+    const controller = new AbortController();
+    controller.abort();
+
+    await expect(waitForPlaybackIdle(controller.signal)).resolves.toBeUndefined();
+  });
+
+  it('stops listening to the store once resolved', async () => {
+    setPlaying(true);
+    const w = track(waitForPlaybackIdle());
+    setPlaying(false);
+    await vi.advanceTimersByTimeAsync(RESUME_SETTLE_MS + 50);
+    expect(w.done).toBe(true);
+
+    // Further churn must not throw or re-arm anything.
+    setPlaying(true);
+    setPlaying(false);
+    await vi.advanceTimersByTimeAsync(RESUME_SETTLE_MS + 50);
+  });
+});
+
+describe('DownloadPausedError', () => {
+  it('is distinguishable from a real failure', () => {
+    const err = new DownloadPausedError();
+    expect(err).toBeInstanceOf(Error);
+    expect(err).toBeInstanceOf(DownloadPausedError);
+    expect(err.name).toBe('DownloadPausedError');
+    // The queue relies on this to retry rather than mark the track failed.
+    expect(new Error('boom')).not.toBeInstanceOf(DownloadPausedError);
+  });
+});

--- a/packages/frontend/src/services/__tests__/playbackGate.test.ts
+++ b/packages/frontend/src/services/__tests__/playbackGate.test.ts
@@ -1,30 +1,28 @@
 /**
- * Tests for the download/playback bandwidth gate.
+ * Tests for the download/playback bandwidth throttle.
  *
  * Regression cover for the second cause of issue #13. A bulk offline download saturates
  * the link — measured on a real failure, one 34.9 MB track took 41s (~850 KB/s, the whole
  * pipe) — and a track that had started playing 15s earlier died with
- * `PIPELINE_ERROR_READ: FFmpegDemuxer: data source error`. The download queue had no idea
- * playback existed.
+ * `PIPELINE_ERROR_READ: FFmpegDemuxer: data source error`.
  *
- * The subtle requirement is `RESUME_SETTLE_MS`: `isPlaying` dips briefly during ordinary
- * transitions, so resuming on the first `false` would restart a large transfer straight
- * into a track change and starve the next track — reproducing the bug while appearing to
- * fix it.
+ * The throttle deliberately does *not* stop downloads. Measured across 26,446 tracks, a
+ * track needs 33.8 KB/s on average and 102.5 KB/s at p95 — 4% and 12% of that link. The
+ * point is to leave headroom, not to hand playback the whole pipe.
  */
 import { describe, it, expect, beforeEach, afterEach, vi } from 'vitest';
 
 import { usePlaybackStore } from '../../player/playbackStore';
 import {
-  DownloadPausedError,
-  RESUME_SETTLE_MS,
+  DownloadThrottle,
+  THROTTLE_BURST_MS,
+  THROTTLE_IDLE_MS,
   isPlaybackActive,
-  waitForPlaybackIdle,
 } from '../playbackGate';
 
 const setPlaying = (isPlaying: boolean) => usePlaybackStore.setState({ isPlaying });
 
-/** Has the promise settled? Lets us assert "still waiting" without hanging the test. */
+/** Has the promise settled? Lets us assert "still sleeping" without hanging the test. */
 function track(p: Promise<void>) {
   const state = { done: false };
   p.then(() => {
@@ -51,102 +49,131 @@ describe('isPlaybackActive', () => {
   });
 });
 
-describe('waitForPlaybackIdle', () => {
-  it('resolves immediately when nothing is playing', async () => {
-    setPlaying(false);
-    await expect(waitForPlaybackIdle()).resolves.toBeUndefined();
-  });
-
-  it('blocks while audio is playing', async () => {
-    setPlaying(true);
-    const w = track(waitForPlaybackIdle());
-
-    await vi.advanceTimersByTimeAsync(60_000);
-
-    expect(w.done).toBe(false);
-  });
-
-  it('resolves once playback has been stopped for the settle window', async () => {
-    setPlaying(true);
-    const w = track(waitForPlaybackIdle());
-
-    setPlaying(false);
-    await vi.advanceTimersByTimeAsync(RESUME_SETTLE_MS + 50);
-
-    expect(w.done).toBe(true);
-  });
-
-  it('does not resume during a brief gap between tracks', async () => {
-    // The case that would reintroduce the bug: `isPlaying` flickers false on a track
-    // change, a 35 MB transfer restarts, and the next track starves.
-    setPlaying(true);
-    const w = track(waitForPlaybackIdle());
-
-    setPlaying(false);
-    await vi.advanceTimersByTimeAsync(500); // shorter than the settle window
-    setPlaying(true);
-    await vi.advanceTimersByTimeAsync(60_000);
-
-    expect(w.done).toBe(false);
-  });
-
-  it('restarts the settle window each time playback resumes', async () => {
-    setPlaying(true);
-    const w = track(waitForPlaybackIdle());
-
-    for (let i = 0; i < 3; i++) {
-      setPlaying(false);
-      await vi.advanceTimersByTimeAsync(RESUME_SETTLE_MS - 500);
-      setPlaying(true);
-      await vi.advanceTimersByTimeAsync(100);
+describe('DownloadThrottle when nothing is playing', () => {
+  it('never sleeps, so an idle device downloads at full speed', async () => {
+    const t = new DownloadThrottle();
+    for (let i = 0; i < 50; i++) {
+      const w = track(t.pace());
+      await vi.advanceTimersByTimeAsync(0);
+      expect(w.done).toBe(true);
     }
-    expect(w.done).toBe(false);
-
-    setPlaying(false);
-    await vi.advanceTimersByTimeAsync(RESUME_SETTLE_MS + 50);
-    expect(w.done).toBe(true);
-  });
-
-  it('resolves when the download is cancelled, so cancellation is not blocked', async () => {
-    setPlaying(true);
-    const controller = new AbortController();
-    const w = track(waitForPlaybackIdle(controller.signal));
-
-    controller.abort();
-    await vi.advanceTimersByTimeAsync(0);
-
-    expect(w.done).toBe(true);
-  });
-
-  it('resolves immediately for an already-aborted signal', async () => {
-    setPlaying(true);
-    const controller = new AbortController();
-    controller.abort();
-
-    await expect(waitForPlaybackIdle(controller.signal)).resolves.toBeUndefined();
-  });
-
-  it('stops listening to the store once resolved', async () => {
-    setPlaying(true);
-    const w = track(waitForPlaybackIdle());
-    setPlaying(false);
-    await vi.advanceTimersByTimeAsync(RESUME_SETTLE_MS + 50);
-    expect(w.done).toBe(true);
-
-    // Further churn must not throw or re-arm anything.
-    setPlaying(true);
-    setPlaying(false);
-    await vi.advanceTimersByTimeAsync(RESUME_SETTLE_MS + 50);
+    expect(t.throttling).toBe(false);
   });
 });
 
-describe('DownloadPausedError', () => {
-  it('is distinguishable from a real failure', () => {
-    const err = new DownloadPausedError();
-    expect(err).toBeInstanceOf(Error);
-    expect(err).toBeInstanceOf(DownloadPausedError);
-    expect(err.name).toBe('DownloadPausedError');
-    // The queue relies on this to retry rather than mark the track failed.
-    expect(new Error('boom')).not.toBeInstanceOf(DownloadPausedError);
+describe('DownloadThrottle while audio plays', () => {
+  it('lets a burst through before sleeping', async () => {
+    setPlaying(true);
+    const t = new DownloadThrottle();
+
+    // First call opens the burst window; chunks inside it pass straight through.
+    await t.pace();
+    vi.setSystemTime(Date.now() + THROTTLE_BURST_MS - 50);
+    const inBurst = track(t.pace());
+    await vi.advanceTimersByTimeAsync(0);
+
+    expect(inBurst.done).toBe(true);
+  });
+
+  it('sleeps once the burst window is spent', async () => {
+    setPlaying(true);
+    const t = new DownloadThrottle();
+
+    await t.pace();
+    vi.setSystemTime(Date.now() + THROTTLE_BURST_MS + 10);
+    const w = track(t.pace());
+
+    await vi.advanceTimersByTimeAsync(THROTTLE_IDLE_MS - 50);
+    expect(w.done).toBe(false);
+
+    await vi.advanceTimersByTimeAsync(100);
+    expect(w.done).toBe(true);
+  });
+
+  it('reports that it is throttling, for the UI', async () => {
+    setPlaying(true);
+    const t = new DownloadThrottle();
+
+    await t.pace();
+
+    expect(t.throttling).toBe(true);
+  });
+
+  it('does not stop downloads outright', async () => {
+    // The whole point: playback needs ~4-12% of the link, so a throttled download must
+    // keep making progress rather than waiting for silence.
+    setPlaying(true);
+    const t = new DownloadThrottle();
+
+    let chunks = 0;
+    for (let i = 0; i < 12; i++) {
+      const w = track(t.pace());
+      await vi.advanceTimersByTimeAsync(THROTTLE_IDLE_MS + 10);
+      vi.setSystemTime(Date.now() + THROTTLE_BURST_MS + 10);
+      if (w.done) chunks++;
+    }
+
+    expect(chunks).toBe(12);
+  });
+});
+
+describe('DownloadThrottle when playback stops', () => {
+  it('goes back to full speed', async () => {
+    setPlaying(true);
+    const t = new DownloadThrottle();
+    await t.pace();
+    expect(t.throttling).toBe(true);
+
+    setPlaying(false);
+    const w = track(t.pace());
+    await vi.advanceTimersByTimeAsync(0);
+
+    expect(w.done).toBe(true);
+    expect(t.throttling).toBe(false);
+  });
+
+  it('notices playback stopping during a sleep', async () => {
+    setPlaying(true);
+    const t = new DownloadThrottle();
+    await t.pace();
+    vi.setSystemTime(Date.now() + THROTTLE_BURST_MS + 10);
+
+    const w = track(t.pace());
+    setPlaying(false); // stopped mid-sleep
+    await vi.advanceTimersByTimeAsync(THROTTLE_IDLE_MS + 50);
+
+    expect(w.done).toBe(true);
+    expect(t.throttling).toBe(false);
+  });
+
+  it('returns immediately when the download is cancelled mid-sleep', async () => {
+    setPlaying(true);
+    const t = new DownloadThrottle();
+    const controller = new AbortController();
+    await t.pace(controller.signal);
+    vi.setSystemTime(Date.now() + THROTTLE_BURST_MS + 10);
+
+    const w = track(t.pace(controller.signal));
+    controller.abort();
+    await vi.advanceTimersByTimeAsync(THROTTLE_IDLE_MS + 50);
+
+    expect(w.done).toBe(true);
+  });
+});
+
+describe('throttle instances are independent', () => {
+  it('does not share burst state between downloads', async () => {
+    setPlaying(true);
+    const a = new DownloadThrottle();
+    const b = new DownloadThrottle();
+
+    await a.pace();
+    vi.setSystemTime(Date.now() + THROTTLE_BURST_MS + 10);
+
+    // `b` has never paced, so it opens its own burst rather than inheriting a's.
+    const w = track(b.pace());
+    await vi.advanceTimersByTimeAsync(0);
+
+    expect(w.done).toBe(true);
   });
 });

--- a/packages/frontend/src/services/offlineService.ts
+++ b/packages/frontend/src/services/offlineService.ts
@@ -13,7 +13,7 @@ import { computeAlbumHash } from '../utils/albumHash';
 import { trackFetchError } from '../utils/apiErrorTracker';
 import { createLogger } from '../utils/logger';
 import { isNativeApp } from '../utils/platform';
-import { DownloadPausedError, isPlaybackActive } from './playbackGate';
+import { DownloadThrottle } from './playbackGate';
 
 const log = createLogger('Offline');
 
@@ -153,6 +153,8 @@ async function downloadAndStoreAudio(
   partial: PartialDownload | undefined,
   onProgress: DownloadProgressCallback | undefined,
   fs: FilesystemProvider | null,
+  throttle: DownloadThrottle,
+  onThrottleChange?: (throttling: boolean) => void,
 ): Promise<void> {
   const resumeFrom = partial?.bytesDownloaded || 0;
   const existingChunks: Blob[] = partial?.chunks || [];
@@ -257,20 +259,12 @@ async function downloadAndStoreAudio(
         loaded += value.length;
         chunksSinceLastSave++;
 
-        // Give the link back to playback. Checked per chunk rather than only between
-        // tracks because one file can hold the connection for ~40s — long enough to
-        // drain a playing track's buffer and surface as PIPELINE_ERROR_READ (#13).
-        // Cancelling the reader releases the bandwidth now; the bytes already fetched
-        // are saved just below and resumed via the Range request on the next attempt.
-        if (isPlaybackActive()) {
-          if (activityTimer) clearTimeout(activityTimer);
-          if (total > 0) {
-            await savePartialProgress(trackId, loaded, total, chunks);
-          }
-          log.info('Yielding download to playback at', loaded, 'of', total, 'bytes');
-          await reader.cancel().catch(() => {});
-          throw new DownloadPausedError();
-        }
+        // Leave most of the link free while audio is playing. Paced per chunk rather
+        // than only between tracks because one file can hold the connection for ~40s —
+        // far longer than a track's buffer — which is how PIPELINE_ERROR_READ (#13)
+        // happened. No-ops when nothing is playing.
+        await throttle.pace();
+        onThrottleChange?.(throttle.throttling);
 
         onProgress?.({
           loaded,
@@ -290,9 +284,8 @@ async function downloadAndStoreAudio(
       chunks.length = 0; // free constituent chunk Blobs before base64 encoding
     } catch (error) {
       if (activityTimer) clearTimeout(activityTimer);
-      // Save progress before throwing so we can resume later. A pause has already
-      // saved, so don't write the whole chunk list a second time.
-      if (!(error instanceof DownloadPausedError) && chunks.length > existingChunks.length && total > 0) {
+      // Save progress before throwing so we can resume later
+      if (chunks.length > existingChunks.length && total > 0) {
         log.info('Saving partial progress before error:', loaded, 'bytes');
         await savePartialProgress(trackId, loaded, total, chunks);
       }
@@ -380,8 +373,12 @@ async function downloadAndStoreAudio(
  */
 export async function downloadTrackForOffline(
   trackId: string,
-  onProgress?: DownloadProgressCallback
+  onProgress?: DownloadProgressCallback,
+  onThrottleChange?: (throttling: boolean) => void
 ): Promise<void> {
+  // Paces this transfer against playback. Per-download, not shared.
+  const throttle = new DownloadThrottle();
+
   // Check if already downloaded
   const existing = await db.offlineTracks.get(trackId);
   if (existing) {
@@ -399,7 +396,7 @@ export async function downloadTrackForOffline(
     throw new Error('Native filesystem unavailable — cannot download track');
   }
 
-  await downloadAndStoreAudio(trackId, partial, onProgress, fs);
+  await downloadAndStoreAudio(trackId, partial, onProgress, fs, throttle, onThrottleChange);
   // blob is now out of scope — GC-eligible before the steps below
 
   await clearPartialDownload(trackId);

--- a/packages/frontend/src/services/offlineService.ts
+++ b/packages/frontend/src/services/offlineService.ts
@@ -13,6 +13,7 @@ import { computeAlbumHash } from '../utils/albumHash';
 import { trackFetchError } from '../utils/apiErrorTracker';
 import { createLogger } from '../utils/logger';
 import { isNativeApp } from '../utils/platform';
+import { DownloadPausedError, isPlaybackActive } from './playbackGate';
 
 const log = createLogger('Offline');
 
@@ -256,6 +257,21 @@ async function downloadAndStoreAudio(
         loaded += value.length;
         chunksSinceLastSave++;
 
+        // Give the link back to playback. Checked per chunk rather than only between
+        // tracks because one file can hold the connection for ~40s — long enough to
+        // drain a playing track's buffer and surface as PIPELINE_ERROR_READ (#13).
+        // Cancelling the reader releases the bandwidth now; the bytes already fetched
+        // are saved just below and resumed via the Range request on the next attempt.
+        if (isPlaybackActive()) {
+          if (activityTimer) clearTimeout(activityTimer);
+          if (total > 0) {
+            await savePartialProgress(trackId, loaded, total, chunks);
+          }
+          log.info('Yielding download to playback at', loaded, 'of', total, 'bytes');
+          await reader.cancel().catch(() => {});
+          throw new DownloadPausedError();
+        }
+
         onProgress?.({
           loaded,
           total: total || loaded,
@@ -274,8 +290,9 @@ async function downloadAndStoreAudio(
       chunks.length = 0; // free constituent chunk Blobs before base64 encoding
     } catch (error) {
       if (activityTimer) clearTimeout(activityTimer);
-      // Save progress before throwing so we can resume later
-      if (chunks.length > existingChunks.length && total > 0) {
+      // Save progress before throwing so we can resume later. A pause has already
+      // saved, so don't write the whole chunk list a second time.
+      if (!(error instanceof DownloadPausedError) && chunks.length > existingChunks.length && total > 0) {
         log.info('Saving partial progress before error:', loaded, 'bytes');
         await savePartialProgress(trackId, loaded, total, chunks);
       }

--- a/packages/frontend/src/services/playbackGate.ts
+++ b/packages/frontend/src/services/playbackGate.ts
@@ -1,0 +1,90 @@
+/**
+ * Lets background bulk transfers yield to active playback.
+ *
+ * A bulk offline download saturates the link. Measured on a real failure: a single
+ * 34.9 MB track took 41s (~850 KB/s, the whole pipe), and a track that started playing
+ * 15s earlier died with `PIPELINE_ERROR_READ: FFmpegDemuxer: data source error` — the
+ * media element simply had no bandwidth left to read with (issue #13).
+ *
+ * Downloads already run one at a time, so this is not connection-pool contention and
+ * lowering concurrency would not help. The only fix is to stop moving those bytes while
+ * audio needs them.
+ *
+ * Note the check must also apply *inside* a transfer, not just between transfers: one
+ * file occupies the link for the better part of a minute, which is far longer than a
+ * track's buffer.
+ */
+import { usePlaybackStore } from '../player/playbackStore';
+import { createLogger } from '../utils/logger';
+
+const log = createLogger('PlaybackGate');
+
+/**
+ * How long playback must stay stopped before downloads resume.
+ *
+ * `isPlaying` dips briefly during ordinary transitions — track changes, seeks, engine
+ * reloads. Resuming on the first `false` would restart a large transfer into the gap and
+ * starve the very next track, so wait for the stop to look settled.
+ */
+export const RESUME_SETTLE_MS = 3000;
+
+/** Thrown to abandon an in-flight download so playback gets the bandwidth back. */
+export class DownloadPausedError extends Error {
+  constructor(message = 'Download paused: playback is active') {
+    super(message);
+    this.name = 'DownloadPausedError';
+  }
+}
+
+export function isPlaybackActive(): boolean {
+  return usePlaybackStore.getState().isPlaying;
+}
+
+/**
+ * Resolve once playback has been stopped for `RESUME_SETTLE_MS`.
+ *
+ * Returns immediately if nothing is playing. Rejects nothing — if `signal` aborts it
+ * resolves so the caller can observe the abort through its own normal path.
+ */
+export function waitForPlaybackIdle(signal?: AbortSignal): Promise<void> {
+  if (signal?.aborted) return Promise.resolve();
+  if (!isPlaybackActive()) return Promise.resolve();
+
+  log.info('Pausing downloads while playback is active');
+
+  return new Promise<void>((resolve) => {
+    let settleTimer: ReturnType<typeof setTimeout> | null = null;
+
+    const finish = () => {
+      if (settleTimer) clearTimeout(settleTimer);
+      unsubscribe();
+      signal?.removeEventListener('abort', onAbort);
+      resolve();
+    };
+
+    const onAbort = () => finish();
+
+    const evaluate = (playing: boolean) => {
+      if (playing) {
+        // Playback resumed before the settle window elapsed — start it over.
+        if (settleTimer) {
+          clearTimeout(settleTimer);
+          settleTimer = null;
+        }
+        return;
+      }
+      if (settleTimer) return;
+      settleTimer = setTimeout(() => {
+        log.info('Playback idle, resuming downloads');
+        finish();
+      }, RESUME_SETTLE_MS);
+    };
+
+    const unsubscribe = usePlaybackStore.subscribe((state) => evaluate(state.isPlaying));
+
+    signal?.addEventListener('abort', onAbort, { once: true });
+
+    // The store may already be stopped by the time we subscribed.
+    evaluate(isPlaybackActive());
+  });
+}

--- a/packages/frontend/src/services/playbackGate.ts
+++ b/packages/frontend/src/services/playbackGate.ts
@@ -1,90 +1,78 @@
 /**
- * Lets background bulk transfers yield to active playback.
+ * Keeps bulk offline downloads from starving playback.
  *
- * A bulk offline download saturates the link. Measured on a real failure: a single
- * 34.9 MB track took 41s (~850 KB/s, the whole pipe), and a track that started playing
- * 15s earlier died with `PIPELINE_ERROR_READ: FFmpegDemuxer: data source error` — the
- * media element simply had no bandwidth left to read with (issue #13).
+ * A bulk download saturates the link. Measured on a real failure: a single 34.9 MB track
+ * took 41s (~850 KB/s, the whole pipe), and a track that had started playing 15s earlier
+ * died with `PIPELINE_ERROR_READ: FFmpegDemuxer: data source error` — the media element
+ * had no bandwidth left to read with (issue #13).
  *
  * Downloads already run one at a time, so this is not connection-pool contention and
- * lowering concurrency would not help. The only fix is to stop moving those bytes while
- * audio needs them.
+ * lowering concurrency would not help.
  *
- * Note the check must also apply *inside* a transfer, not just between transfers: one
- * file occupies the link for the better part of a minute, which is far longer than a
- * track's buffer.
+ * **Why throttle rather than pause.** Measured across the library (26,446 tracks), a
+ * track needs 33.8 KB/s sustained on average and 102.5 KB/s at p95 — 4% and 12% of that
+ * 850 KB/s link. The failing track itself needed 40 KB/s. Stopping downloads outright
+ * hands playback 100% of the link to do a job that needs a twentieth of it, and a large
+ * offline backlog would then only advance while nobody is listening.
+ *
+ * **Why a duty cycle rather than a KB/s cap.** The link speed is unknown and varies —
+ * Tailscale over WAN, LAN, tethered. A fixed 300 KB/s cap throttles nothing on a 200 KB/s
+ * link. Pacing by time takes a roughly constant *fraction* of whatever is available, with
+ * nothing to measure or configure: at 850 KB/s downloads get ~210 KB/s and leave ~640
+ * free; at 200 KB/s they get ~50 and leave ~150, still above p95.
+ *
+ * Cycles are kept short so the player's buffer rides through each burst.
  */
 import { usePlaybackStore } from '../player/playbackStore';
-import { createLogger } from '../utils/logger';
 
-const log = createLogger('PlaybackGate');
-
-/**
- * How long playback must stay stopped before downloads resume.
- *
- * `isPlaying` dips briefly during ordinary transitions — track changes, seeks, engine
- * reloads. Resuming on the first `false` would restart a large transfer into the gap and
- * starve the very next track, so wait for the stop to look settled.
- */
-export const RESUME_SETTLE_MS = 3000;
-
-/** Thrown to abandon an in-flight download so playback gets the bandwidth back. */
-export class DownloadPausedError extends Error {
-  constructor(message = 'Download paused: playback is active') {
-    super(message);
-    this.name = 'DownloadPausedError';
-  }
-}
+/** Transfer window, then idle window, while audio is playing. ~25% duty cycle. */
+export const THROTTLE_BURST_MS = 200;
+export const THROTTLE_IDLE_MS = 600;
 
 export function isPlaybackActive(): boolean {
   return usePlaybackStore.getState().isPlaying;
 }
 
+const sleep = (ms: number) => new Promise<void>((r) => setTimeout(r, ms));
+
 /**
- * Resolve once playback has been stopped for `RESUME_SETTLE_MS`.
+ * Paces a download loop against playback.
  *
- * Returns immediately if nothing is playing. Rejects nothing — if `signal` aborts it
- * resolves so the caller can observe the abort through its own normal path.
+ * Call once per chunk. Returns immediately when nothing is playing, so an idle device
+ * downloads at full speed. While audio plays it lets `THROTTLE_BURST_MS` of transfer
+ * through, then sleeps `THROTTLE_IDLE_MS`.
+ *
+ * One instance per download; state is per-transfer, not global.
  */
-export function waitForPlaybackIdle(signal?: AbortSignal): Promise<void> {
-  if (signal?.aborted) return Promise.resolve();
-  if (!isPlaybackActive()) return Promise.resolve();
+export class DownloadThrottle {
+  private burstStartedAt = 0;
 
-  log.info('Pausing downloads while playback is active');
+  /** True if the most recent call actually slept — for surfacing "throttled" in the UI. */
+  public throttling = false;
 
-  return new Promise<void>((resolve) => {
-    let settleTimer: ReturnType<typeof setTimeout> | null = null;
+  async pace(signal?: AbortSignal): Promise<void> {
+    if (!isPlaybackActive()) {
+      this.throttling = false;
+      this.burstStartedAt = 0;
+      return;
+    }
 
-    const finish = () => {
-      if (settleTimer) clearTimeout(settleTimer);
-      unsubscribe();
-      signal?.removeEventListener('abort', onAbort);
-      resolve();
-    };
+    this.throttling = true;
+    const now = Date.now();
+    if (this.burstStartedAt === 0) {
+      this.burstStartedAt = now;
+      return;
+    }
+    if (now - this.burstStartedAt < THROTTLE_BURST_MS) return;
 
-    const onAbort = () => finish();
-
-    const evaluate = (playing: boolean) => {
-      if (playing) {
-        // Playback resumed before the settle window elapsed — start it over.
-        if (settleTimer) {
-          clearTimeout(settleTimer);
-          settleTimer = null;
-        }
-        return;
-      }
-      if (settleTimer) return;
-      settleTimer = setTimeout(() => {
-        log.info('Playback idle, resuming downloads');
-        finish();
-      }, RESUME_SETTLE_MS);
-    };
-
-    const unsubscribe = usePlaybackStore.subscribe((state) => evaluate(state.isPlaying));
-
-    signal?.addEventListener('abort', onAbort, { once: true });
-
-    // The store may already be stopped by the time we subscribed.
-    evaluate(isPlaybackActive());
-  });
+    await sleep(THROTTLE_IDLE_MS);
+    // Re-check rather than assume: playback may have stopped during the sleep, in which
+    // case the next burst should run unthrottled.
+    if (signal?.aborted || !isPlaybackActive()) {
+      this.throttling = false;
+      this.burstStartedAt = 0;
+      return;
+    }
+    this.burstStartedAt = Date.now();
+  }
 }

--- a/packages/frontend/src/stores/downloadStore.ts
+++ b/packages/frontend/src/stores/downloadStore.ts
@@ -4,7 +4,6 @@
  */
 import { create } from 'zustand';
 import * as offlineService from '../services/offlineService';
-import { DownloadPausedError, waitForPlaybackIdle } from '../services/playbackGate';
 import { db, type PersistedDownloadJob } from '../db';
 import { showSuccess, showError, showWarning } from './toastStore';
 import { createLogger } from '../utils/logger';
@@ -25,6 +24,9 @@ export interface DownloadJob {
   status: DownloadJobStatus;
   startedAt: Date;
   error?: string;
+  // Deliberately slowed to leave bandwidth for playback (see services/playbackGate).
+  // Surfaced so a throttled download doesn't look like a stalled one.
+  throttled?: boolean;
 }
 
 interface DownloadState {
@@ -347,12 +349,6 @@ async function processNextJob() {
       break;
     }
 
-    // Downloads saturate the link, so hold off entirely while audio is playing —
-    // otherwise a large transfer starves the playing track and it dies with
-    // PIPELINE_ERROR_READ (#13). Resumes once playback has been stopped a few seconds.
-    await waitForPlaybackIdle(abortSignal);
-    if (abortSignal.aborted) break;
-
     const trackId = tracksToDownload[i];
 
     updateJob(nextJob.id, {
@@ -362,10 +358,20 @@ async function processNextJob() {
 
     try {
       log.info('Downloading track', i + 1, 'of', tracksToDownload.length, ':', trackId);
-      await offlineService.downloadTrackForOffline(trackId, (progress) => {
-        // Use throttled update to avoid state update storms
-        throttledProgressUpdate(nextJob.id, progress.percentage);
-      });
+      await offlineService.downloadTrackForOffline(
+        trackId,
+        (progress) => {
+          // Use throttled update to avoid state update storms
+          throttledProgressUpdate(nextJob.id, progress.percentage);
+        },
+        // Surfaced in the UI so a deliberately slowed download doesn't read as a stall.
+        (throttling) => {
+          const job = useDownloadStore.getState().jobs.get(nextJob.id);
+          if (job && job.throttled !== throttling) {
+            updateJob(nextJob.id, { throttled: throttling });
+          }
+        }
+      );
 
       succeeded++;
       log.info('Track completed:', trackId);
@@ -378,13 +384,6 @@ async function processNextJob() {
         });
       }
     } catch (error) {
-      if (error instanceof DownloadPausedError) {
-        // Not a failure: playback claimed the bandwidth mid-transfer. The bytes so far
-        // are saved as a partial, so retry this same track once playback settles.
-        log.info('Download yielded to playback, will resume:', trackId);
-        i--;
-        continue;
-      }
       if (!abortSignal.aborted) {
         log.error(`Failed to download track ${trackId}:`, error);
         failed++;

--- a/packages/frontend/src/stores/downloadStore.ts
+++ b/packages/frontend/src/stores/downloadStore.ts
@@ -4,6 +4,7 @@
  */
 import { create } from 'zustand';
 import * as offlineService from '../services/offlineService';
+import { DownloadPausedError, waitForPlaybackIdle } from '../services/playbackGate';
 import { db, type PersistedDownloadJob } from '../db';
 import { showSuccess, showError, showWarning } from './toastStore';
 import { createLogger } from '../utils/logger';
@@ -346,6 +347,12 @@ async function processNextJob() {
       break;
     }
 
+    // Downloads saturate the link, so hold off entirely while audio is playing —
+    // otherwise a large transfer starves the playing track and it dies with
+    // PIPELINE_ERROR_READ (#13). Resumes once playback has been stopped a few seconds.
+    await waitForPlaybackIdle(abortSignal);
+    if (abortSignal.aborted) break;
+
     const trackId = tracksToDownload[i];
 
     updateJob(nextJob.id, {
@@ -371,6 +378,13 @@ async function processNextJob() {
         });
       }
     } catch (error) {
+      if (error instanceof DownloadPausedError) {
+        // Not a failure: playback claimed the bandwidth mid-transfer. The bytes so far
+        // are saved as a partial, so retry this same track once playback settles.
+        log.info('Download yielded to playback, will resume:', trackId);
+        i--;
+        continue;
+      }
       if (!abortSignal.aborted) {
         log.error(`Failed to download track ${trackId}:`, error);
         failed++;


### PR DESCRIPTION
Refs #13 (reopened).

## The second cause of PIPELINE_ERROR_READ

The `FileResponse` fix in #17 was real — the blocking event-loop I/O and five range-handling defects were genuine and are gone. But `PIPELINE_ERROR_READ` only means *the media element could not read*, and a bulk offline download starves it just as effectively. I closed #13 as though fixing one cause had fixed the symptom.

From `frontend_logs` around a live failure — **265 of 300 entries** in the surrounding 22 minutes were the download queue (174 `Offline`, 91 `Download`) against 19 `AudioEngine`:

```
13:32:51  crossfade Angeles → Space Echo
13:33:06  Download: "track 68 of 1578", content-length 34,948,696
13:33:22  AudioEngine: PIPELINE_ERROR_READ    ← 15s into that download
13:33:48  that one file completes → 34.9 MB in 41s ≈ 850 KB/s
```

Server side was clean throughout: every `/tracks/{id}/stream` returned 200/206, `client_disconnects: 0`, `error_rate: 0.0`, `duration_p95_ms: 67.25`, no sync running. 850 KB/s is the entire link.

Downloads already run **one at a time** (68 → 69 → 70), so this is not connection-pool contention and lowering concurrency would not help — a single transfer consumes everything. Nothing in `downloadStore.ts` or `offlineService.ts` consulted playback state.

## How much bandwidth playback actually needs

This is what decided the design. Measured across all 26,446 tracks:

| | sustained | share of the 850 KB/s link |
|---|---|---|
| average | 33.8 KB/s | **4%** |
| p95 | 102.5 KB/s | **12%** |
| worst | 674.8 KB/s | 79% |

Space Echo itself: 8,822,127 bytes ÷ 215.1s = **40 KB/s**.

So playback needs a twentieth of the pipe. An earlier revision of this PR paused downloads entirely while playing — it worked, but it handed playback 100% of the link to do a 4% job, and meant a 1,578-track backlog would only advance while nobody was listening. Replaced.

## Duty-cycle throttle

200ms of transfer per 600ms idle while audio plays — roughly 25%.

**Why a duty cycle and not a KB/s cap:** link speed is unknown and varies (Tailscale over WAN, LAN, tethered). A fixed 300 KB/s cap throttles nothing on a 200 KB/s link. Pacing by time takes a roughly constant *fraction* of whatever is available, with nothing to measure or configure:

- at 850 KB/s → downloads ~210, playback ~640 free (6× the p95 need)
- at 200 KB/s → downloads ~50, playback ~150 free (still above p95)

Cycles are short enough that the player's buffer rides through each burst.

Applied **inside** the chunk loop, not just between tracks — one file holds the link for ~40s, far longer than a track's buffer, which is how this failure happened in the first place. Throttle state is per-download, not global.

This revision also *removes* code: no aborting mid-file, no save-partial-on-pause, no retry-the-same-track, no settle window. Just a paced sleep.

## UI

`DownloadJob` gains `throttled`, shown in `StatusMenu` as **"· slowed while playing"**, so a deliberately slow download doesn't read as a stalled one.

## Tests

10 in `playbackGate.test.ts`, including that an idle device never sleeps, that a throttled download keeps making progress rather than waiting for silence, that stopping playback mid-sleep restores full speed, and that throttle instances don't share burst state.

```
Test Files  57 passed (57)
     Tests  854 passed (854)
```

Typecheck identical to `main` (9 pre-existing errors in untouched test files). Lint 0 errors. Web build succeeds. Deployed to the NAS.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_014P9p2fvFnyiywBxGkv4gfW