### PR TITLE
fix(prefetch): stop the prefetcher starving the track that's playing

### DIFF
--- a/packages/frontend/src/services/__tests__/prefetchThrottle.test.ts
+++ b/packages/frontend/src/services/__tests__/prefetchThrottle.test.ts
@@ -1,0 +1,207 @@
+/**
+ * Tests for prefetch reading against playback.
+ *
+ * The prefetcher pulled whole tracks with `response.arrayBuffer()` — an unbounded
+ * transfer with no chunk loop, so the throttle added for the offline download queue could
+ * not apply to it even in principle. It is how the component that exists to make playback
+ * smooth became the thing breaking it: measured, 10-24 MB prefetches saturating a
+ * ~850 KB/s link while the playing track needed 40 KB/s, producing PIPELINE_ERROR_READ
+ * and tracks that ended about a second after starting (issue #13).
+ *
+ * The riskiest part of the fix is not the throttling — it is that reassembling chunks
+ * must reproduce the bytes exactly. Corrupt audio would be the quietest possible failure,
+ * so that is tested first and with real data rather than a length check.
+ */
+import { describe, it, expect, beforeEach, afterEach, vi } from 'vitest';
+
+import { usePlaybackStore } from '../../player/playbackStore';
+import { prefetchService } from '../prefetchService';
+import { THROTTLE_BURST_MS, THROTTLE_IDLE_MS } from '../playbackGate';
+
+const setPlaying = (isPlaying: boolean) => usePlaybackStore.setState({ isPlaying });
+
+/**
+ * Minimal stand-in for the parts of `Response` that `readThrottled` touches.
+ *
+ * `tickMs` advances the mocked clock on each read. Without it a fake-timer test reads
+ * every chunk at a frozen `Date.now()`, the throttle's burst window never lapses, and the
+ * whole transfer completes without pacing — the test would pass against a broken throttle.
+ */
+function fakeResponse(
+  chunks: Uint8Array[],
+  opts: { withBody?: boolean; tickMs?: number } = {}
+) {
+  const withBody = opts.withBody !== false;
+  const tickMs = opts.tickMs ?? 0;
+  let i = 0;
+  const cancel = vi.fn(() => Promise.resolve());
+
+  return {
+    cancel,
+    response: {
+      arrayBuffer: () => {
+        const total = chunks.reduce((n, c) => n + c.length, 0);
+        const out = new Uint8Array(total);
+        let off = 0;
+        for (const c of chunks) {
+          out.set(c, off);
+          off += c.length;
+        }
+        return Promise.resolve(out.buffer);
+      },
+      body: withBody
+        ? {
+            getReader: () => ({
+              read: () => {
+                if (tickMs) vi.setSystemTime(Date.now() + tickMs);
+                return Promise.resolve(
+                  i < chunks.length
+                    ? { done: false, value: chunks[i++] }
+                    : { done: true, value: undefined }
+                );
+              },
+              cancel,
+            }),
+          }
+        : null,
+    } as unknown as Response,
+  };
+}
+
+// `readThrottled` is private; the reassembly and abort behaviour it owns is exactly what
+// carries risk, so it is exercised directly rather than through the store subscriptions.
+const readThrottled = (response: Response, signal: AbortSignal): Promise<ArrayBuffer> =>
+  (prefetchService as unknown as {
+    readThrottled(r: Response, s: AbortSignal): Promise<ArrayBuffer>;
+  }).readThrottled(response, signal);
+
+beforeEach(() => {
+  setPlaying(false);
+});
+
+afterEach(() => {
+  vi.useRealTimers();
+});
+
+describe('reassembly', () => {
+  it('reproduces the bytes exactly across chunk boundaries', async () => {
+    // Deterministic, non-uniform, and larger than one chunk — a length-only check would
+    // pass on data that was silently reordered or overlapped.
+    const source = new Uint8Array(4096);
+    for (let i = 0; i < source.length; i++) source[i] = (i * 31 + 7) % 256;
+
+    const chunks: Uint8Array[] = [];
+    for (let off = 0; off < source.length; off += 300) {
+      chunks.push(source.slice(off, Math.min(off + 300, source.length)));
+    }
+    expect(chunks.length).toBeGreaterThan(10);
+
+    const { response } = fakeResponse(chunks);
+    const out = new Uint8Array(await readThrottled(response, new AbortController().signal));
+
+    expect(out.length).toBe(source.length);
+    expect(Array.from(out)).toEqual(Array.from(source));
+  });
+
+  it('handles a single chunk', async () => {
+    const source = new Uint8Array([1, 2, 3, 4, 5]);
+    const { response } = fakeResponse([source]);
+
+    const out = new Uint8Array(await readThrottled(response, new AbortController().signal));
+    expect(Array.from(out)).toEqual([1, 2, 3, 4, 5]);
+  });
+
+  it('handles an empty body', async () => {
+    const { response } = fakeResponse([]);
+    const out = await readThrottled(response, new AbortController().signal);
+    expect(out.byteLength).toBe(0);
+  });
+
+  it('falls back to arrayBuffer when the body is not a stream', async () => {
+    const { response } = fakeResponse([new Uint8Array([9, 8, 7])], { withBody: false });
+
+    const out = new Uint8Array(await readThrottled(response, new AbortController().signal));
+    expect(Array.from(out)).toEqual([9, 8, 7]);
+  });
+});
+
+describe('pacing', () => {
+  it('runs at full speed when nothing is playing', async () => {
+    setPlaying(false);
+    const chunks = Array.from({ length: 40 }, () => new Uint8Array(64));
+    const { response } = fakeResponse(chunks);
+
+    // No fake timers: if this paced, the test would take 40 x 600ms and time out.
+    const out = await readThrottled(response, new AbortController().signal);
+    expect(out.byteLength).toBe(40 * 64);
+  });
+
+  it('paces while audio is playing', async () => {
+    vi.useFakeTimers();
+    setPlaying(true);
+    // Each read consumes half a burst window, so the throttle must sleep every 2 chunks.
+    const chunks = Array.from({ length: 20 }, () => new Uint8Array(64));
+    const { response } = fakeResponse(chunks, { tickMs: THROTTLE_BURST_MS / 2 });
+
+    let done = false;
+    readThrottled(response, new AbortController().signal).then(() => {
+      done = true;
+    });
+
+    // Far more than enough wall-clock for an unthrottled read of 20 tiny chunks.
+    await vi.advanceTimersByTimeAsync(THROTTLE_IDLE_MS - 50);
+    expect(done).toBe(false);
+
+    await vi.advanceTimersByTimeAsync(THROTTLE_IDLE_MS * 20);
+    expect(done).toBe(true);
+  });
+
+  it('stops pacing when playback stops mid-transfer', async () => {
+    vi.useFakeTimers();
+    setPlaying(true);
+    const chunks = Array.from({ length: 20 }, () => new Uint8Array(64));
+    const { response } = fakeResponse(chunks, { tickMs: THROTTLE_BURST_MS / 2 });
+
+    let done = false;
+    readThrottled(response, new AbortController().signal).then(() => {
+      done = true;
+    });
+
+    await vi.advanceTimersByTimeAsync(THROTTLE_IDLE_MS + 50);
+    expect(done).toBe(false);
+
+    setPlaying(false); // user hits pause — the rest should finish at full speed
+    await vi.advanceTimersByTimeAsync(THROTTLE_IDLE_MS + 50);
+    expect(done).toBe(true);
+  });
+});
+
+describe('eviction', () => {
+  it('aborts promptly and cancels the reader rather than finishing a discarded download', async () => {
+    setPlaying(false);
+    const chunks = Array.from({ length: 50 }, () => new Uint8Array(64));
+    const { response, cancel } = fakeResponse(chunks);
+
+    const controller = new AbortController();
+    controller.abort();
+
+    await expect(readThrottled(response, controller.signal)).rejects.toMatchObject({
+      name: 'AbortError',
+    });
+    // Releasing the connection is the point — an evicted prefetch must stop consuming
+    // bandwidth immediately, not run to completion for a result nobody will read.
+    expect(cancel).toHaveBeenCalled();
+  });
+
+  it('surfaces as AbortError so the existing handler treats it as expected, not a failure', async () => {
+    setPlaying(false);
+    const { response } = fakeResponse([new Uint8Array(8)]);
+    const controller = new AbortController();
+    controller.abort();
+
+    const err = await readThrottled(response, controller.signal).catch((e) => e);
+    // prefetchService's catch checks `(e as Error).name === 'AbortError'` and returns
+    // silently; anything else gets logged as a prefetch failure.
+    expect((err as Error).name).toBe('AbortError');
+  });
+});

--- a/packages/frontend/src/services/prefetchService.ts
+++ b/packages/frontend/src/services/prefetchService.ts
@@ -10,6 +10,7 @@
 import { usePlayerStore } from '../player/playerStore';
 import { useConnectivityStore } from '../stores/connectivityStore';
 import { isTrackOffline } from './offlineService';
+import { DownloadThrottle } from './playbackGate';
 import { getApiUrl } from '../api/base';
 import { isNativeApp } from '../utils/platform';
 import { createLogger } from '../utils/logger';
@@ -184,6 +185,50 @@ class PrefetchService {
   }
 
   /**
+   * Read a response body while leaving bandwidth for the track that is playing.
+   *
+   * `response.arrayBuffer()` pulls the whole file as fast as the link allows, which is
+   * how the prefetcher — the thing that exists to make playback smooth — became the
+   * thing breaking it. Measured: 10-24 MB prefetches saturating a ~850 KB/s link while
+   * the playing track needed 40 KB/s, producing PIPELINE_ERROR_READ and tracks that
+   * ended a second after starting (issue #13).
+   *
+   * Chunked so `DownloadThrottle` can pace it, exactly as the offline download queue
+   * does. Falls back to `arrayBuffer()` if the body isn't a readable stream.
+   */
+  private async readThrottled(response: Response, signal: AbortSignal): Promise<ArrayBuffer> {
+    if (!response.body) return response.arrayBuffer();
+
+    const reader = response.body.getReader();
+    const throttle = new DownloadThrottle();
+    const chunks: Uint8Array[] = [];
+    let total = 0;
+
+    while (true) {
+      const { done, value } = await reader.read();
+      if (done) break;
+      chunks.push(value);
+      total += value.length;
+      // No-op when nothing is playing, so an idle device prefetches at full speed.
+      await throttle.pace(signal);
+      if (signal.aborted) {
+        // Evicted mid-transfer. Release the connection rather than finishing a
+        // download whose result is already going to be discarded.
+        await reader.cancel().catch(() => {});
+        throw new DOMException('Prefetch aborted', 'AbortError');
+      }
+    }
+
+    const out = new Uint8Array(total);
+    let offset = 0;
+    for (const chunk of chunks) {
+      out.set(chunk, offset);
+      offset += chunk.length;
+    }
+    return out.buffer;
+  }
+
+  /**
    * Download a single track to the prefetch cache.
    */
   private async downloadTrack(trackId: string): Promise<void> {
@@ -200,9 +245,10 @@ class PrefetchService {
         throw new Error(`HTTP ${response.status}`);
       }
 
-      const data = await response.arrayBuffer();
+      const data = await this.readThrottled(response, abortController.signal);
 
-      // Check if we were evicted during download
+      // Check if we were evicted during download. A throttled transfer takes longer,
+      // which widens this window rather than narrowing it.
       if (!this.cache.has(trackId) || this.cache.get(trackId) !== entry) return;
 
       if (isNativeApp()) {


### PR DESCRIPTION
Refs #13.

## Third cause of PIPELINE_ERROR_READ — and the one that made tracks end after a second

PR #21 throttled the offline download queue. That fix was correct, but it covered only **one of two** paths that pull whole audio files. `prefetchService.downloadTrack` used `response.arrayBuffer()` — an unbounded full-file transfer with no chunk loop, so `DownloadThrottle` could not apply to it even in principle.

From `frontend_logs`, 14:34–14:37 with music playing:

```
14:34:38  playNext → "Plain Material"
14:34:38  loadTrack → "stall recovery: emitting canplay"
14:34:39  playNext → "Energy Warning"        ← lasted about one second
14:35:44  PIPELINE_ERROR_READ  "kim & jessie"
14:35:46  Prefetched track  19.88 MB         ← in flight during that failure
14:36:57  Prefetched track  23.61 MB
```

Verified these were **not** caused by a backend restart — nearest was over twenty minutes earlier.

`PREFETCH_COUNT = 3`, so while you play track N it pulls N+1, N+2 and N+3. At the measured ~850 KB/s a 23.6 MB prefetch owns the entire link for ~28s while the playing track needs 40 KB/s. The component that exists to make playback smooth was the thing breaking it.

## Fix

Reads are chunked and paced by the same `DownloadThrottle` — no-op when nothing is playing, ~25% of the link when something is.

**The reassembly is the risky part, not the pacing.** Corrupt audio would be the quietest possible failure, so it's tested against a non-uniform 4 KiB source across 14 chunk boundaries byte for byte, rather than by checking a length.

Eviction is preserved and made stricter: an aborted prefetch now cancels the reader and throws `AbortError` immediately rather than running a discarded download to completion. The existing handler already treats `AbortError` as expected.

`PREFETCH_COUNT` stays at 3. With playback protected, prefetching tracks the listener may skip past costs bandwidth but no longer costs correctness; lowering it is a separate judgement call on its own evidence.

## Tests

9 new. One subtlety worth noting for future readers: with fake timers `Date.now()` is frozen, so a naive test reads every chunk at the same instant, the burst window never lapses, and the transfer completes unpaced — passing against a broken throttle. The fake reader therefore advances the mocked clock per read.

```
Test Files  58 passed (58)
     Tests  863 passed (863)
```

Typecheck identical to `main` (9 pre-existing errors in untouched test files). Lint 0 errors. Web build succeeds.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_014P9p2fvFnyiywBxGkv4gfW