### PR TITLE
feat(ranking): ADR-0005 parts 1/3/4 — AMBIENT/RADIO profiles, taste and negative terms

### DIFF
--- a/backend/app/api/routes/tracks/listing.py
+++ b/backend/app/api/routes/tracks/listing.py
@@ -2,7 +2,6 @@
 
 import math
 import random
-from dataclasses import dataclass
 from typing import Any
 from uuid import UUID
 
@@ -14,6 +13,11 @@ from sqlalchemy.orm import selectinload
 from app.api.deps import CurrentProfile, DbSession
 from app.api.exceptions import TrackNotFoundError, ValidationError
 from app.db.models import ProfileFavorite, ProfilePlayHistory, Track, TrackAnalysis, TrackStatus
+from app.services.taste_weighting import (
+    SHUFFLE_PRESETS,
+    apply_artist_variety,
+    compute_track_weight,
+)
 from app.utils.time import utcnow
 
 from . import (
@@ -37,139 +41,6 @@ class TrackIndexResponse(BaseModel):
 
 
 # --- Weighted shuffle presets ---
-
-VALID_SHUFFLE_PRESETS = {"rediscover", "fresh_finds", "comfort_zone", "deep_dive"}
-
-
-@dataclass
-class ShufflePresetWeights:
-    """Weight configuration for a shuffle preset."""
-    play_count_dir: float  # +1 = favor high play count, -1 = favor low
-    recency_dir: float     # +1 = favor recent, -1 = favor old
-    newness_dir: float     # +1 = favor recently added, -1 = favor old additions
-    favorites_boost: float # multiplier for favorited tracks (1.0 = no boost)
-    variety_strength: float  # 0-1 for artist spacing post-process
-
-
-SHUFFLE_PRESETS: dict[str, ShufflePresetWeights] = {
-    "rediscover": ShufflePresetWeights(
-        play_count_dir=1.0, recency_dir=-1.0, newness_dir=0.0,
-        favorites_boost=1.0, variety_strength=0.5,
-    ),
-    "fresh_finds": ShufflePresetWeights(
-        play_count_dir=-1.0, recency_dir=0.0, newness_dir=1.0,
-        favorites_boost=1.0, variety_strength=0.7,
-    ),
-    "comfort_zone": ShufflePresetWeights(
-        play_count_dir=1.0, recency_dir=0.5, newness_dir=0.0,
-        favorites_boost=3.0, variety_strength=0.2,
-    ),
-    "deep_dive": ShufflePresetWeights(
-        play_count_dir=-1.0, recency_dir=-1.0, newness_dir=0.0,
-        favorites_boost=1.0, variety_strength=0.8,
-    ),
-}
-
-
-def _compute_track_weight(
-    play_count: int | None,
-    last_played_at: Any,
-    created_at: Any,
-    is_favorited: bool,
-    preset: ShufflePresetWeights,
-    now: Any,
-    max_play_count: int,
-) -> float:
-    """Compute weight for a single track based on preset parameters."""
-    weight = 1.0
-
-    pc = play_count or 0
-    # Play count influence
-    if preset.play_count_dir != 0 and max_play_count > 0:
-        normalized = pc / max_play_count  # 0..1
-        if preset.play_count_dir > 0:
-            # Favor high play count
-            weight *= 1.0 + abs(preset.play_count_dir) * normalized * 3.0
-        else:
-            # Favor low play count (unplayed gets max boost)
-            weight *= 1.0 + abs(preset.play_count_dir) * (1.0 - normalized) * 3.0
-
-    # Recency influence (last_played_at)
-    if preset.recency_dir != 0 and last_played_at is not None:
-        days_ago = max((now - last_played_at).total_seconds() / 86400, 0.1)
-        if preset.recency_dir < 0:
-            # Favor tracks NOT played recently
-            recency_score = min(days_ago / 180.0, 1.0)  # Cap at 6 months
-            weight *= 1.0 + abs(preset.recency_dir) * recency_score * 3.0
-        else:
-            # Favor recently played
-            recency_score = max(1.0 - days_ago / 30.0, 0.0)  # Recent = within 30 days
-            weight *= 1.0 + preset.recency_dir * recency_score * 3.0
-    elif preset.recency_dir < 0 and last_played_at is None:
-        # Never played = maximally "not recent"
-        weight *= 1.0 + abs(preset.recency_dir) * 3.0
-
-    # Library newness (created_at)
-    if preset.newness_dir != 0 and created_at is not None:
-        days_in_lib = max((now - created_at).total_seconds() / 86400, 0.1)
-        if preset.newness_dir > 0:
-            newness_score = max(1.0 - days_in_lib / 90.0, 0.0)  # "New" = within 90 days
-            weight *= 1.0 + preset.newness_dir * newness_score * 3.0
-        else:
-            oldness_score = min(days_in_lib / 365.0, 1.0)
-            weight *= 1.0 + abs(preset.newness_dir) * oldness_score * 3.0
-
-    # Favorites boost
-    if is_favorited and preset.favorites_boost > 1.0:
-        weight *= preset.favorites_boost
-
-    return max(weight, 0.01)  # Floor to avoid zero weights
-
-
-def _apply_artist_variety(track_ids_with_artists: list[tuple[str, str | None]], strength: float) -> list[str]:
-    """Post-process track IDs to space out same-artist tracks.
-
-    Uses a greedy algorithm: scan forward and swap tracks to avoid
-    back-to-back same-artist sequences. Strength controls how aggressively
-    we enforce spacing (0 = no change, 1 = maximum spacing).
-    """
-    if strength <= 0 or len(track_ids_with_artists) <= 2:
-        return [tid for tid, _ in track_ids_with_artists]
-
-    result = list(track_ids_with_artists)
-    min_gap = max(1, int(strength * 5))  # At strength=1, require 5 tracks between same artist
-
-    for i in range(1, len(result)):
-        current_artist = result[i][1]
-        if not current_artist:
-            continue
-
-        # Check if any of the previous min_gap tracks share the artist
-        conflict = False
-        for j in range(max(0, i - min_gap), i):
-            if result[j][1] == current_artist:
-                conflict = True
-                break
-
-        if conflict:
-            # Try to find a non-conflicting track to swap with
-            best_swap = None
-            for k in range(i + 1, min(i + 20, len(result))):  # Look ahead up to 20 tracks
-                swap_artist = result[k][1]
-                swap_ok = True
-                for j in range(max(0, i - min_gap), i):
-                    if result[j][1] == swap_artist:
-                        swap_ok = False
-                        break
-                if swap_ok:
-                    best_swap = k
-                    break
-
-            if best_swap is not None:
-                result[i], result[best_swap] = result[best_swap], result[i]
-
-    return [tid for tid, _ in result]
-
 
 @router.get("/ids", response_model=TrackIdsResponse)
 async def list_track_ids(
@@ -294,7 +165,7 @@ async def list_track_ids(
         # Compute weights and apply Efraimidis-Spirakis weighted sampling
         weighted_items: list[tuple[float, str, str | None]] = []
         for row in rows:
-            w = _compute_track_weight(
+            w = compute_track_weight(
                 play_count=row.play_count,
                 last_played_at=row.last_played_at,
                 created_at=row.created_at,
@@ -314,7 +185,7 @@ async def list_track_ids(
 
         # Apply artist variety post-processing
         ids_with_artists = [(tid, artist) for _, tid, artist in weighted_items]
-        track_ids = _apply_artist_variety(ids_with_artists, preset.variety_strength)
+        track_ids = apply_artist_variety(ids_with_artists, preset.variety_strength)
 
         if start_with and start_with in track_ids:
             track_ids.remove(start_with)

--- a/backend/app/services/ambient.py
+++ b/backend/app/services/ambient.py
@@ -14,6 +14,7 @@ from sqlalchemy.ext.asyncio import AsyncSession
 
 from app.db.models import Track, TrackAnalysis
 from app.logging_config import get_logger
+from app.services.ranking_profiles import AMBIENT, RankingProfile
 
 logger = get_logger(__name__)
 
@@ -182,11 +183,24 @@ def score_candidate(
     intensity: str = "balanced",
     embedding_similarity: float | None = None,
     recent_artist_names: list[str] | None = None,
+    profile: RankingProfile | None = None,
+    taste_score: float | None = None,
+    skip_count: int = 0,
+    reject_count: int = 0,
 ) -> float:
     """Score a candidate track against the current track.
 
     Returns a score in [0, 1] range (higher = better fit).
+
+    ``profile`` selects the weighting (ADR-0005); it defaults to ``AMBIENT``, which
+    reproduces this function's original hard-coded behaviour exactly. ``taste_score``,
+    ``skip_count`` and ``reject_count`` are inert under ``AMBIENT`` — their profile
+    weights are zero — so ambient callers are unaffected by their presence.
+
+    Stays pure: taste and listening history arrive as numbers rather than being queried
+    here, so this remains directly testable and usable from either retrieval path.
     """
+    profile = profile or AMBIENT
     # Key compatibility
     key_score = key_compatibility(current.key, candidate.key)
 
@@ -217,24 +231,8 @@ def score_candidate(
     )
     dr_score = 1.0 - min(dr_diff / 20.0, 1.0)
 
-    # Base weights
-    weights = {
-        "key": 0.30,
-        "energy": 0.20,
-        "embedding": 0.15,
-        "vocal": 0.10,
-        "brightness": 0.10,
-        "valence": 0.10,
-        "dr": 0.05,
-    }
-
-    # Intensity modifiers
-    if intensity == "quiet":
-        weights["energy"] = 0.30
-        weights["key"] = 0.20
-    elif intensity == "immersive":
-        weights["embedding"] = 0.25
-        weights["key"] = 0.20
+    # Base weights, with this intensity's overrides applied (see ranking_profiles).
+    weights = profile.weights_for(intensity)
 
     total = (
         weights["key"] * key_score
@@ -246,24 +244,40 @@ def score_candidate(
         + weights["dr"] * dr_score
     )
 
+    # Taste: play count, recency, favourites — reuses the weighting already tuned for
+    # this library (`taste_weighting`). Zero-weighted under AMBIENT.
+    if profile.taste_weight and taste_score is not None:
+        total += profile.taste_weight * max(0.0, min(1.0, taste_score))
+
     # BPM penalty
     cur_bpm = _safe_float(current.bpm)
     cand_bpm = _safe_float(candidate.bpm)
-    if cur_bpm > 0 and cand_bpm > 0 and abs(cur_bpm - cand_bpm) > 40:
-        total -= 0.15
+    if cur_bpm > 0 and cand_bpm > 0 and abs(cur_bpm - cand_bpm) > profile.bpm_threshold:
+        total -= profile.bpm_penalty
 
     # Quiet intensity bonus for low-energy tracks
-    if intensity == "quiet" and _safe_float(candidate.energy) < 0.35:
-        total += 0.10
+    if (
+        profile.quiet_energy_bonus
+        and intensity == "quiet"
+        and _safe_float(candidate.energy) < profile.quiet_energy_threshold
+    ):
+        total += profile.quiet_energy_bonus
 
     # Dark filter bonus for minor keys
-    if candidate.modal_character and "minor" in (candidate.modal_character or "").lower():
-        total += 0.02  # Small bonus, mainly used by dark filter
+    if profile.minor_key_bonus and candidate.modal_character and "minor" in (candidate.modal_character or "").lower():
+        total += profile.minor_key_bonus  # Small bonus, mainly used by dark filter
 
     # Artist cooldown
     if recent_artist_names and candidate.artist:
         if candidate.artist.lower() in [a.lower() for a in recent_artist_names]:
-            total -= 0.25
+            total -= profile.artist_cooldown_penalty
+
+    # Negative signal from ADR-0004 PlayEvent. Capped so a track the listener happened to
+    # skip a few times is demoted rather than permanently exiled — skips are ambiguous,
+    # and an uncapped penalty would make the catalogue shrink over time.
+    if profile.max_negative_penalty:
+        penalty = profile.skip_penalty * skip_count + profile.reject_penalty * reject_count
+        total -= min(penalty, profile.max_negative_penalty)
 
     return max(0.0, min(1.0, total))
 

--- a/backend/app/services/ranking_profiles.py
+++ b/backend/app/services/ranking_profiles.py
@@ -1,0 +1,160 @@
+"""Named weight profiles for the shared ranking engine (ADR-0005).
+
+`ambient.py` was already a working "what should play next" engine — HNSW candidate
+retrieval plus a tuned scorer with a Camelot-style harmonic compatibility table. What made
+it *ambient* rather than general was only its weighting and its preference for
+instrumental content. Radio is that same engine with different numbers, so the weights
+live here rather than being duplicated into a second recommender that would drift.
+
+``AMBIENT`` reproduces the previous hard-coded behaviour **exactly**, including the
+intensity overrides and every adjustment. That is a hard requirement, not an aspiration —
+ambient mode is shipped, and `tests/test_ambient_scoring.py` characterised it before this
+split landed so any drift fails a test.
+
+``RADIO`` weights are a starting guess, as ADR-0005 says they must be: they cannot be
+tuned until ADR-0004 listening events accumulate.
+"""
+
+from dataclasses import dataclass, field
+
+# Weight keys used by `score_candidate`. Kept explicit so a typo in a profile is a
+# KeyError at import rather than a silently-ignored term.
+WEIGHT_KEYS = ("key", "energy", "embedding", "vocal", "brightness", "valence", "dr")
+
+
+@dataclass(frozen=True)
+class RankingProfile:
+    """How one mode weighs a candidate transition.
+
+    ``weights`` must cover exactly ``WEIGHT_KEYS`` and is expected to sum to 1.0 so the
+    weighted terms stay in [0, 1] before adjustments.
+    """
+
+    name: str
+    # Must cover exactly WEIGHT_KEYS. These plus `taste_weight` are a convex combination
+    # summing to 1.0 — taste takes a share rather than being added on top of a full 1.0,
+    # where it could only push an already-saturating score into the clamp and would
+    # barely reorder anything.
+    weights: dict[str, float]
+
+    # Partial weight overrides applied on top of `weights`, keyed by listening intensity.
+    intensity_overrides: dict[str, dict[str, float]] = field(default_factory=dict)
+
+    # --- adjustments applied after the weighted sum ---
+    bpm_penalty: float = 0.0
+    bpm_threshold: float = 40.0
+    quiet_energy_bonus: float = 0.0
+    quiet_energy_threshold: float = 0.35
+    minor_key_bonus: float = 0.0
+    artist_cooldown_penalty: float = 0.0
+
+    # --- ADR-0005 additions, inert for AMBIENT ---
+    # How much a track's taste weight (play count / recency / favourites, via
+    # `taste_weighting`) contributes. Normalised to [0, 1] by the caller.
+    taste_weight: float = 0.0
+    # Demotion per skip and per explicit rejection, from ADR-0004 `PlayEvent`. Rejection
+    # is weighted more heavily: skipping is ambiguous (wrong moment, heard it recently),
+    # rejecting is a stated judgement.
+    skip_penalty: float = 0.0
+    reject_penalty: float = 0.0
+    max_negative_penalty: float = 0.0
+
+    def weights_for(self, intensity: str) -> dict[str, float]:
+        """Base weights with this intensity's overrides applied."""
+        merged = dict(self.weights)
+        merged.update(self.intensity_overrides.get(intensity, {}))
+        return merged
+
+
+AMBIENT = RankingProfile(
+    name="ambient",
+    # Key first: ambient transitions are judged mostly on harmonic compatibility.
+    weights={
+        "key": 0.30,
+        "energy": 0.20,
+        "embedding": 0.15,
+        "vocal": 0.10,
+        "brightness": 0.10,
+        "valence": 0.10,
+        "dr": 0.05,
+    },
+    intensity_overrides={
+        "quiet": {"energy": 0.30, "key": 0.20},
+        "immersive": {"embedding": 0.25, "key": 0.20},
+    },
+    bpm_penalty=0.15,
+    quiet_energy_bonus=0.10,
+    minor_key_bonus=0.02,
+    artist_cooldown_penalty=0.25,
+)
+
+
+RADIO = RankingProfile(
+    name="radio",
+    # Embedding first: radio is "more of this", which is a similarity question before it
+    # is a mixing question. `vocal` drops to zero — the term exists to keep ambient
+    # instrumental, and penalising vocals in radio would exclude most of a music library.
+    # Its 0.10 plus most of key's 0.30 go to embedding and taste.
+    weights={
+        "key": 0.10,
+        "energy": 0.15,
+        "embedding": 0.35,
+        "vocal": 0.0,
+        "brightness": 0.05,
+        "valence": 0.10,
+        "dr": 0.05,
+        # Not in WEIGHT_KEYS: taste is scored separately, see `taste_weight`.
+    },
+    # Intensity is an ambient concept (the user picks it there). Radio has no equivalent
+    # control, so no overrides — `weights_for` returns the base weights for any value.
+    bpm_penalty=0.10,
+    artist_cooldown_penalty=0.25,
+    taste_weight=0.20,
+    skip_penalty=0.08,
+    reject_penalty=0.25,
+    max_negative_penalty=0.40,
+)
+
+
+PROFILES: dict[str, RankingProfile] = {
+    AMBIENT.name: AMBIENT,
+    RADIO.name: RADIO,
+}
+
+
+def get_profile(name: str | None) -> RankingProfile:
+    """Look up a profile by name, defaulting to AMBIENT.
+
+    Defaults rather than raising so existing ambient callers that pass nothing keep
+    working unchanged.
+    """
+    if not name:
+        return AMBIENT
+    try:
+        return PROFILES[name]
+    except KeyError:
+        raise ValueError(
+            f"Unknown ranking profile {name!r}. Known: {sorted(PROFILES)}"
+        ) from None
+
+
+def _validate() -> None:
+    """Fail at import if a profile is malformed, rather than scoring silently wrong."""
+    for profile in PROFILES.values():
+        missing = set(WEIGHT_KEYS) - set(profile.weights)
+        if missing:
+            raise ValueError(f"{profile.name}: missing weights {sorted(missing)}")
+        total = sum(profile.weights[k] for k in WEIGHT_KEYS) + profile.taste_weight
+        if abs(total - 1.0) > 1e-9:
+            raise ValueError(
+                f"{profile.name}: feature weights + taste_weight must sum to 1.0, got {total}"
+            )
+        for intensity, overrides in profile.intensity_overrides.items():
+            unknown = set(overrides) - set(WEIGHT_KEYS)
+            if unknown:
+                raise ValueError(
+                    f"{profile.name}/{intensity}: unknown weight keys {sorted(unknown)}"
+                )
+
+
+_validate()

--- a/backend/app/services/taste_weighting.py
+++ b/backend/app/services/taste_weighting.py
@@ -1,0 +1,145 @@
+"""Taste weighting shared by weighted shuffle and the radio ranking engine.
+
+Extracted verbatim from ``app/api/routes/tracks/listing.py`` so a service can use it
+without importing from a route module, which would invert the dependency (ADR-0005
+decision point 3). The logic is unchanged; only its location moved.
+
+Note that ``compute_track_weight`` returns an **unbounded multiplier**, not a 0-1 score.
+It starts at 1.0 and each of three axes multiplies by up to 4x, plus a favourites boost
+of up to 3x. Anything combining it with a normalised score must scale it first.
+"""
+
+from dataclasses import dataclass
+from typing import Any
+
+VALID_SHUFFLE_PRESETS = {"rediscover", "fresh_finds", "comfort_zone", "deep_dive"}
+
+
+@dataclass
+class ShufflePresetWeights:
+    """Weight configuration for a shuffle preset."""
+    play_count_dir: float  # +1 = favor high play count, -1 = favor low
+    recency_dir: float     # +1 = favor recent, -1 = favor old
+    newness_dir: float     # +1 = favor recently added, -1 = favor old additions
+    favorites_boost: float # multiplier for favorited tracks (1.0 = no boost)
+    variety_strength: float  # 0-1 for artist spacing post-process
+
+
+SHUFFLE_PRESETS: dict[str, ShufflePresetWeights] = {
+    "rediscover": ShufflePresetWeights(
+        play_count_dir=1.0, recency_dir=-1.0, newness_dir=0.0,
+        favorites_boost=1.0, variety_strength=0.5,
+    ),
+    "fresh_finds": ShufflePresetWeights(
+        play_count_dir=-1.0, recency_dir=0.0, newness_dir=1.0,
+        favorites_boost=1.0, variety_strength=0.7,
+    ),
+    "comfort_zone": ShufflePresetWeights(
+        play_count_dir=1.0, recency_dir=0.5, newness_dir=0.0,
+        favorites_boost=3.0, variety_strength=0.2,
+    ),
+    "deep_dive": ShufflePresetWeights(
+        play_count_dir=-1.0, recency_dir=-1.0, newness_dir=0.0,
+        favorites_boost=1.0, variety_strength=0.8,
+    ),
+}
+
+
+def compute_track_weight(
+    play_count: int | None,
+    last_played_at: Any,
+    created_at: Any,
+    is_favorited: bool,
+    preset: ShufflePresetWeights,
+    now: Any,
+    max_play_count: int,
+) -> float:
+    """Compute weight for a single track based on preset parameters."""
+    weight = 1.0
+
+    pc = play_count or 0
+    # Play count influence
+    if preset.play_count_dir != 0 and max_play_count > 0:
+        normalized = pc / max_play_count  # 0..1
+        if preset.play_count_dir > 0:
+            # Favor high play count
+            weight *= 1.0 + abs(preset.play_count_dir) * normalized * 3.0
+        else:
+            # Favor low play count (unplayed gets max boost)
+            weight *= 1.0 + abs(preset.play_count_dir) * (1.0 - normalized) * 3.0
+
+    # Recency influence (last_played_at)
+    if preset.recency_dir != 0 and last_played_at is not None:
+        days_ago = max((now - last_played_at).total_seconds() / 86400, 0.1)
+        if preset.recency_dir < 0:
+            # Favor tracks NOT played recently
+            recency_score = min(days_ago / 180.0, 1.0)  # Cap at 6 months
+            weight *= 1.0 + abs(preset.recency_dir) * recency_score * 3.0
+        else:
+            # Favor recently played
+            recency_score = max(1.0 - days_ago / 30.0, 0.0)  # Recent = within 30 days
+            weight *= 1.0 + preset.recency_dir * recency_score * 3.0
+    elif preset.recency_dir < 0 and last_played_at is None:
+        # Never played = maximally "not recent"
+        weight *= 1.0 + abs(preset.recency_dir) * 3.0
+
+    # Library newness (created_at)
+    if preset.newness_dir != 0 and created_at is not None:
+        days_in_lib = max((now - created_at).total_seconds() / 86400, 0.1)
+        if preset.newness_dir > 0:
+            newness_score = max(1.0 - days_in_lib / 90.0, 0.0)  # "New" = within 90 days
+            weight *= 1.0 + preset.newness_dir * newness_score * 3.0
+        else:
+            oldness_score = min(days_in_lib / 365.0, 1.0)
+            weight *= 1.0 + abs(preset.newness_dir) * oldness_score * 3.0
+
+    # Favorites boost
+    if is_favorited and preset.favorites_boost > 1.0:
+        weight *= preset.favorites_boost
+
+    return max(weight, 0.01)  # Floor to avoid zero weights
+
+
+def apply_artist_variety(track_ids_with_artists: list[tuple[str, str | None]], strength: float) -> list[str]:
+    """Post-process track IDs to space out same-artist tracks.
+
+    Uses a greedy algorithm: scan forward and swap tracks to avoid
+    back-to-back same-artist sequences. Strength controls how aggressively
+    we enforce spacing (0 = no change, 1 = maximum spacing).
+    """
+    if strength <= 0 or len(track_ids_with_artists) <= 2:
+        return [tid for tid, _ in track_ids_with_artists]
+
+    result = list(track_ids_with_artists)
+    min_gap = max(1, int(strength * 5))  # At strength=1, require 5 tracks between same artist
+
+    for i in range(1, len(result)):
+        current_artist = result[i][1]
+        if not current_artist:
+            continue
+
+        # Check if any of the previous min_gap tracks share the artist
+        conflict = False
+        for j in range(max(0, i - min_gap), i):
+            if result[j][1] == current_artist:
+                conflict = True
+                break
+
+        if conflict:
+            # Try to find a non-conflicting track to swap with
+            best_swap = None
+            for k in range(i + 1, min(i + 20, len(result))):  # Look ahead up to 20 tracks
+                swap_artist = result[k][1]
+                swap_ok = True
+                for j in range(max(0, i - min_gap), i):
+                    if result[j][1] == swap_artist:
+                        swap_ok = False
+                        break
+                if swap_ok:
+                    best_swap = k
+                    break
+
+            if best_swap is not None:
+                result[i], result[best_swap] = result[best_swap], result[i]
+
+    return [tid for tid, _ in result]

--- a/backend/tests/test_ambient_scoring.py
+++ b/backend/tests/test_ambient_scoring.py
@@ -1,0 +1,290 @@
+"""Characterisation tests for the ambient ranking engine.
+
+These lock in what `app.services.ambient` does **today**, before ADR-0005 splits its
+weights into named AMBIENT/RADIO profiles. Ambient mode is a shipped feature and had no
+test coverage at all, so without this the refactor would have nothing to be checked
+against.
+
+They are deliberately written against observed behaviour rather than intended behaviour.
+Where something looks questionable — `_safe_float` treating a missing feature as 0.0
+(maximally distant) instead of neutral, `key_compatibility` scoring an unknown key higher
+than an unrelated one — that is recorded as-is and marked. Changing any of it is a
+separate decision, not a side effect of a refactor.
+
+Every number here was read from the implementation, not assumed.
+"""
+
+from uuid import uuid4
+
+import pytest
+
+from app.services.ambient import (
+    AmbientDescriptor,
+    _safe_float,
+    key_compatibility,
+    parse_key,
+    score_candidate,
+    suggest_snippet_window,
+)
+
+
+def make_descriptor(**overrides) -> AmbientDescriptor:
+    """A descriptor with every feature at a neutral mid-point unless overridden."""
+    base = {
+        "track_id": uuid4(),
+        "title": "Test Track",
+        "artist": "Test Artist",
+        "album": "Test Album",
+        "duration_seconds": 200.0,
+        "key": "C",
+        "bpm": 120.0,
+        "energy": 0.5,
+        "brightness": 0.5,
+        "valence": 0.5,
+        "instrumentalness": 0.5,
+        "speechiness": 0.5,
+        "dynamic_range_db": 10.0,
+        "energy_shape": None,
+        "section_count": None,
+        "modal_character": None,
+        "acousticness": 0.5,
+    }
+    base.update(overrides)
+    return AmbientDescriptor(**base)
+
+
+class TestParseKey:
+    @pytest.mark.parametrize(
+        "text,expected",
+        [
+            ("C", (0, "major")),
+            ("C major", (0, "major")),
+            ("C maj", (0, "major")),
+            ("Am", (9, "minor")),
+            ("A minor", (9, "minor")),
+            ("A min", (9, "minor")),
+            ("C#", (1, "major")),
+            ("Db", (1, "major")),  # enharmonic spellings share a pitch class
+            ("Eb", (3, "major")),
+            ("Bb", (10, "major")),
+        ],
+    )
+    def test_parses_known_spellings(self, text, expected):
+        assert parse_key(text) == expected
+
+    def test_is_case_insensitive_via_fallback_scan(self):
+        assert parse_key("am") == (9, "minor")
+        assert parse_key("C MAJOR") == (0, "major")
+
+    def test_strips_surrounding_whitespace(self):
+        assert parse_key("  Am  ") == (9, "minor")
+
+    @pytest.mark.parametrize("text", [None, "", "   ", "H", "not-a-key", "Am7"])
+    def test_unparseable_returns_none(self, text):
+        assert parse_key(text) is None
+
+
+class TestKeyCompatibility:
+    def test_same_key(self):
+        assert key_compatibility("Am", "Am") == 1.0
+        assert key_compatibility("C", "C") == 1.0
+
+    def test_relative_major_minor(self):
+        # Am -> C and C -> Am, in both directions
+        assert key_compatibility("Am", "C") == 0.9
+        assert key_compatibility("C", "Am") == 0.9
+
+    def test_perfect_fifth_same_mode(self):
+        assert key_compatibility("C", "G") == 0.8   # +7
+        assert key_compatibility("C", "F") == 0.8   # +5
+        assert key_compatibility("Am", "Em") == 0.8
+
+    def test_parallel_major_minor(self):
+        assert key_compatibility("C", "Cm") == 0.7
+
+    def test_two_steps_on_the_circle_same_mode(self):
+        assert key_compatibility("C", "D") == 0.5   # +2
+        assert key_compatibility("C", "Bb") == 0.5  # +10
+
+    def test_unrelated(self):
+        assert key_compatibility("C", "F#") == 0.2
+
+    def test_unknown_key_is_neutral_not_penalised(self):
+        # NOTE: an unknown key (0.5) scores HIGHER than a known-unrelated one (0.2).
+        # Locked as observed; whether that is desirable is a separate question.
+        assert key_compatibility(None, "C") == 0.5
+        assert key_compatibility("C", None) == 0.5
+        assert key_compatibility("garbage", "C") == 0.5
+        assert key_compatibility("C", "F#") == 0.2
+
+    def test_enharmonic_spellings_are_equivalent(self):
+        assert key_compatibility("C#", "Db") == 1.0
+
+
+class TestSafeFloat:
+    def test_missing_reads_as_zero_not_neutral(self):
+        # This is the consequential one: a NULL feature is treated as maximally
+        # distant (0.0), not as "no information". Locked as-is.
+        assert _safe_float(None) == 0.0
+        assert _safe_float("nonsense") == 0.0
+        assert _safe_float(None, default=0.5) == 0.5
+
+    def test_passes_through_numbers(self):
+        assert _safe_float(0.25) == 0.25
+        assert _safe_float(3) == 3.0
+        assert _safe_float("0.75") == 0.75
+
+
+class TestScoreCandidateWeights:
+    """The weighted sum, before any bonus or penalty applies."""
+
+    def test_identical_track_scores_near_maximum(self):
+        d = make_descriptor(key="C", energy=0.5, brightness=0.5, valence=0.5,
+                            instrumentalness=1.0, speechiness=0.0, dynamic_range_db=10.0)
+        score = score_candidate(d, d, embedding_similarity=1.0)
+        assert score == pytest.approx(1.0, abs=1e-9)
+
+    def test_balanced_weights_sum_to_one(self):
+        # key .30 + energy .20 + embedding .15 + vocal .10
+        # + brightness .10 + valence .10 + dr .05
+        current = make_descriptor()
+        candidate = make_descriptor(instrumentalness=1.0, speechiness=0.0)
+        score = score_candidate(current, candidate, intensity="balanced",
+                                embedding_similarity=1.0)
+        assert score == pytest.approx(1.0, abs=1e-9)
+
+    def test_quiet_shifts_weight_from_key_to_energy(self):
+        # quiet: energy .30, key .20 — a candidate strong on energy but weak on key
+        # scores higher under 'quiet' than under 'balanced'.
+        current = make_descriptor(key="C", energy=0.5)
+        candidate = make_descriptor(key="F#", energy=0.5,
+                                    instrumentalness=1.0, speechiness=0.0)
+        balanced = score_candidate(current, candidate, intensity="balanced",
+                                   embedding_similarity=1.0)
+        quiet = score_candidate(current, candidate, intensity="quiet",
+                                embedding_similarity=1.0)
+        assert quiet > balanced
+
+    def test_immersive_shifts_weight_from_key_to_embedding(self):
+        current = make_descriptor(key="C")
+        candidate = make_descriptor(key="F#", instrumentalness=1.0, speechiness=0.0)
+        balanced = score_candidate(current, candidate, intensity="balanced",
+                                   embedding_similarity=1.0)
+        immersive = score_candidate(current, candidate, intensity="immersive",
+                                    embedding_similarity=1.0)
+        assert immersive > balanced
+
+    def test_absent_embedding_similarity_defaults_to_half(self):
+        current = make_descriptor()
+        candidate = make_descriptor(instrumentalness=1.0, speechiness=0.0)
+        explicit = score_candidate(current, candidate, embedding_similarity=0.5)
+        implicit = score_candidate(current, candidate, embedding_similarity=None)
+        assert explicit == pytest.approx(implicit)
+
+    def test_vocal_term_penalises_singing(self):
+        # vocal_score = instrumentalness * 0.7 + (1 - speechiness) * 0.3, weight 0.10.
+        # This is the ambient-specific bias ADR-0005's RADIO profile removes.
+        current = make_descriptor()
+        instrumental = make_descriptor(instrumentalness=1.0, speechiness=0.0)
+        vocal = make_descriptor(instrumentalness=0.0, speechiness=0.0)
+        assert score_candidate(current, instrumental, embedding_similarity=1.0) > \
+               score_candidate(current, vocal, embedding_similarity=1.0)
+
+    def test_dynamic_range_difference_saturates_at_20db(self):
+        current = make_descriptor(dynamic_range_db=10.0)
+        at_20 = make_descriptor(dynamic_range_db=30.0, instrumentalness=1.0, speechiness=0.0)
+        beyond = make_descriptor(dynamic_range_db=60.0, instrumentalness=1.0, speechiness=0.0)
+        assert score_candidate(current, at_20, embedding_similarity=1.0) == \
+               pytest.approx(score_candidate(current, beyond, embedding_similarity=1.0))
+
+
+class TestScoreCandidateAdjustments:
+    """Each bonus and penalty, isolated."""
+
+    def test_bpm_penalty_beyond_40(self):
+        current = make_descriptor(bpm=120.0)
+        close = make_descriptor(bpm=155.0, instrumentalness=1.0, speechiness=0.0)   # 35 apart
+        far = make_descriptor(bpm=165.0, instrumentalness=1.0, speechiness=0.0)     # 45 apart
+        assert score_candidate(current, close, embedding_similarity=1.0) - \
+               score_candidate(current, far, embedding_similarity=1.0) == pytest.approx(0.15)
+
+    def test_bpm_penalty_needs_both_tempos_known(self):
+        current = make_descriptor(bpm=None)
+        far = make_descriptor(bpm=200.0, instrumentalness=1.0, speechiness=0.0)
+        known = make_descriptor(bpm=120.0, instrumentalness=1.0, speechiness=0.0)
+        assert score_candidate(current, far, embedding_similarity=1.0) == \
+               pytest.approx(score_candidate(current, known, embedding_similarity=1.0))
+
+    def test_quiet_energy_bonus_below_035(self):
+        # Needs headroom below the 1.0 clamp for the +0.10 to be observable, hence the
+        # deliberately imperfect embedding similarity.
+        current = make_descriptor(energy=0.3)
+        low = make_descriptor(energy=0.3, instrumentalness=1.0, speechiness=0.0)
+        high = make_descriptor(energy=0.4, instrumentalness=1.0, speechiness=0.0)
+
+        # Below 0.35 gets the bonus under 'quiet'...
+        assert score_candidate(current, low, intensity="quiet", embedding_similarity=0.3) > \
+               score_candidate(current, low, intensity="balanced", embedding_similarity=0.3)
+
+        # ...and a candidate at or above 0.35 does not.
+        quiet_high = score_candidate(current, high, intensity="quiet", embedding_similarity=0.3)
+        balanced_high = score_candidate(current, high, intensity="balanced", embedding_similarity=0.3)
+        assert quiet_high - balanced_high < 0.10
+
+    def test_minor_key_bonus(self):
+        # +0.02, but an identical track already clamps at 1.0, so give it headroom.
+        current = make_descriptor(energy=0.9)
+        minor = make_descriptor(energy=0.5, modal_character="natural minor",
+                                instrumentalness=1.0, speechiness=0.0)
+        major = make_descriptor(energy=0.5, modal_character="major",
+                                instrumentalness=1.0, speechiness=0.0)
+        assert score_candidate(current, minor, embedding_similarity=0.5) - \
+               score_candidate(current, major, embedding_similarity=0.5) == pytest.approx(0.02)
+
+    def test_artist_cooldown(self):
+        current = make_descriptor(energy=0.9)
+        candidate = make_descriptor(energy=0.5, artist="Recently Played",
+                                    instrumentalness=1.0, speechiness=0.0)
+        without = score_candidate(current, candidate, embedding_similarity=0.5)
+        with_cooldown = score_candidate(current, candidate, embedding_similarity=0.5,
+                                        recent_artist_names=["Recently Played"])
+        assert without - with_cooldown == pytest.approx(0.25)
+
+    def test_artist_cooldown_is_case_insensitive(self):
+        current = make_descriptor(energy=0.9)
+        candidate = make_descriptor(energy=0.5, artist="Boards of Canada",
+                                    instrumentalness=1.0, speechiness=0.0)
+        assert score_candidate(current, candidate, embedding_similarity=0.5,
+                               recent_artist_names=["BOARDS OF CANADA"]) == \
+               pytest.approx(score_candidate(current, candidate, embedding_similarity=0.5,
+                                             recent_artist_names=["Boards of Canada"]))
+
+    def test_score_is_clamped_to_unit_range(self):
+        current = make_descriptor(bpm=120.0)
+        # Stack every penalty: unrelated key, opposite energy, huge BPM gap, cooldown.
+        worst = make_descriptor(key="F#", energy=1.0, brightness=1.0, valence=1.0,
+                                bpm=300.0, instrumentalness=0.0, speechiness=1.0,
+                                dynamic_range_db=100.0, artist="Same")
+        current = make_descriptor(key="C", energy=0.0, brightness=0.0, valence=0.0,
+                                  bpm=120.0, dynamic_range_db=0.0, artist="Same")
+        score = score_candidate(current, worst, embedding_similarity=0.0,
+                                recent_artist_names=["Same"])
+        assert 0.0 <= score <= 1.0
+        assert score == 0.0
+
+
+class TestSuggestSnippetWindow:
+    def test_short_tracks_use_full_bounds(self):
+        assert suggest_snippet_window(20.0) == (0.1, 0.9)
+        assert suggest_snippet_window(None) == (0.1, 0.9)
+
+    def test_energy_shape_shifts_the_window(self):
+        building = suggest_snippet_window(300.0, "building")
+        declining = suggest_snippet_window(300.0, "declining")
+        assert building[0] > declining[0]
+
+    def test_window_is_ordered_and_within_bounds(self):
+        for duration in (60.0, 200.0, 600.0):
+            for shape in (None, "building", "declining", "peak_middle"):
+                start, end = suggest_snippet_window(duration, shape)
+                assert 0.0 <= start < end <= 1.0

--- a/backend/tests/test_ranking_profiles.py
+++ b/backend/tests/test_ranking_profiles.py
@@ -1,0 +1,218 @@
+"""Tests for the named ranking profiles (ADR-0005).
+
+`tests/test_ambient_scoring.py` is the regression lock for `AMBIENT` — it characterised
+the engine before the weights were extracted, so any drift in ambient behaviour fails
+there. This file covers what the split *adds*: that `RADIO` differs in the ways the ADR
+says it should, and that the taste and negative terms are genuinely inert under `AMBIENT`
+rather than merely small.
+
+`RADIO`'s specific weights are a starting guess and will change once ADR-0004 events
+accumulate, so these assert relationships and invariants rather than exact scores. A test
+that pinned `RADIO` to a number would have to be rewritten by the first tuning pass and
+would be protecting nothing.
+"""
+
+from uuid import uuid4
+
+import pytest
+
+from app.services.ambient import AmbientDescriptor, score_candidate
+from app.services.ranking_profiles import (
+    AMBIENT,
+    PROFILES,
+    RADIO,
+    WEIGHT_KEYS,
+    get_profile,
+)
+
+
+def make_descriptor(**overrides) -> AmbientDescriptor:
+    base = {
+        "track_id": uuid4(),
+        "title": "Test Track",
+        "artist": "Test Artist",
+        "album": "Test Album",
+        "duration_seconds": 200.0,
+        "key": "C",
+        "bpm": 120.0,
+        "energy": 0.5,
+        "brightness": 0.5,
+        "valence": 0.5,
+        "instrumentalness": 0.5,
+        "speechiness": 0.5,
+        "dynamic_range_db": 10.0,
+        "energy_shape": None,
+        "section_count": 5,
+        "modal_character": None,
+        "acousticness": 0.5,
+    }
+    base.update(overrides)
+    return AmbientDescriptor(**base)
+
+
+class TestProfileIntegrity:
+    @pytest.mark.parametrize("profile", list(PROFILES.values()), ids=lambda p: p.name)
+    def test_covers_every_weight_key(self, profile):
+        assert set(profile.weights) >= set(WEIGHT_KEYS)
+
+    @pytest.mark.parametrize("profile", list(PROFILES.values()), ids=lambda p: p.name)
+    def test_feature_weights_and_taste_sum_to_one(self, profile):
+        """Taste is part of the convex combination, not a bonus on top of a full 1.0.
+
+        Added on top it could only push an already-saturating score into the clamp, so it
+        would barely reorder anything. Taking a share means it genuinely competes with
+        similarity and harmonic fit. AMBIENT is 1.0 + 0.0; RADIO is 0.80 + 0.20.
+        """
+        total = sum(profile.weights[k] for k in WEIGHT_KEYS) + profile.taste_weight
+        assert total == pytest.approx(1.0)
+
+    @pytest.mark.parametrize("profile", list(PROFILES.values()), ids=lambda p: p.name)
+    def test_intensity_overrides_preserve_the_sum(self, profile):
+        for intensity in profile.intensity_overrides:
+            merged = profile.weights_for(intensity)
+            total = sum(merged[k] for k in WEIGHT_KEYS) + profile.taste_weight
+            assert total == pytest.approx(1.0), intensity
+
+    def test_unknown_profile_is_rejected_loudly(self):
+        with pytest.raises(ValueError, match="Unknown ranking profile"):
+            get_profile("jazz-o-matic")
+
+    def test_missing_name_defaults_to_ambient(self):
+        """Existing ambient callers pass nothing and must keep working."""
+        assert get_profile(None) is AMBIENT
+        assert get_profile("") is AMBIENT
+
+
+class TestRadioDiffersAsTheADRSays:
+    def test_radio_does_not_penalise_vocals(self):
+        """The vocal term exists to keep ambient instrumental.
+
+        Applying it to radio would demote most of a music library.
+        """
+        assert AMBIENT.weights["vocal"] > 0
+        assert RADIO.weights["vocal"] == 0.0
+
+    def test_a_vocal_track_is_not_disadvantaged_under_radio(self):
+        current = make_descriptor()
+        instrumental = make_descriptor(instrumentalness=1.0, speechiness=0.0)
+        vocal = make_descriptor(instrumentalness=0.0, speechiness=0.6)
+
+        radio_gap = (
+            score_candidate(current, instrumental, profile=RADIO)
+            - score_candidate(current, vocal, profile=RADIO)
+        )
+        ambient_gap = (
+            score_candidate(current, instrumental, profile=AMBIENT)
+            - score_candidate(current, vocal, profile=AMBIENT)
+        )
+
+        assert radio_gap == pytest.approx(0.0)
+        assert ambient_gap > 0.0
+
+    def test_radio_leans_on_similarity_more_than_ambient(self):
+        assert RADIO.weights["embedding"] > AMBIENT.weights["embedding"]
+
+    def test_ambient_leans_on_harmonic_key_more_than_radio(self):
+        assert AMBIENT.weights["key"] > RADIO.weights["key"]
+
+    def test_only_radio_weighs_taste(self):
+        assert AMBIENT.taste_weight == 0.0
+        assert RADIO.taste_weight > 0.0
+
+    def test_radio_has_no_intensity_overrides(self):
+        """Intensity is an ambient control with no radio equivalent."""
+        assert RADIO.intensity_overrides == {}
+        for intensity in ("quiet", "immersive", "balanced", "anything"):
+            assert RADIO.weights_for(intensity) == RADIO.weights
+
+
+class TestTasteTerm:
+    def test_raises_the_score_under_radio(self):
+        current, cand = make_descriptor(), make_descriptor()
+        low = score_candidate(current, cand, profile=RADIO, taste_score=0.0)
+        high = score_candidate(current, cand, profile=RADIO, taste_score=1.0)
+        assert high > low
+
+    def test_is_bounded_by_its_weight(self):
+        current, cand = make_descriptor(), make_descriptor()
+        base = score_candidate(current, cand, profile=RADIO, taste_score=0.0)
+        best = score_candidate(current, cand, profile=RADIO, taste_score=1.0)
+        assert best - base == pytest.approx(RADIO.taste_weight, abs=1e-9)
+
+    def test_out_of_range_taste_is_clamped_not_trusted(self):
+        current, cand = make_descriptor(), make_descriptor()
+        sane = score_candidate(current, cand, profile=RADIO, taste_score=1.0)
+        absurd = score_candidate(current, cand, profile=RADIO, taste_score=99.0)
+        assert absurd == pytest.approx(sane)
+
+    def test_is_inert_under_ambient(self):
+        current, cand = make_descriptor(), make_descriptor()
+        assert score_candidate(current, cand, profile=AMBIENT, taste_score=1.0) == (
+            score_candidate(current, cand, profile=AMBIENT, taste_score=0.0)
+        )
+
+
+class TestNegativeTerm:
+    def test_skips_demote(self):
+        current, cand = make_descriptor(), make_descriptor()
+        clean = score_candidate(current, cand, profile=RADIO)
+        skipped = score_candidate(current, cand, profile=RADIO, skip_count=2)
+        assert skipped < clean
+
+    def test_rejection_counts_for_more_than_a_skip(self):
+        """Skipping is ambiguous — wrong moment, heard it recently. Rejecting is a
+        stated judgement, so it should weigh more."""
+        current, cand = make_descriptor(), make_descriptor()
+        one_skip = score_candidate(current, cand, profile=RADIO, skip_count=1)
+        one_reject = score_candidate(current, cand, profile=RADIO, reject_count=1)
+        assert one_reject < one_skip
+
+    def test_penalty_is_capped(self):
+        """An uncapped penalty would permanently exile anything skipped often, and the
+        candidate pool would shrink over time."""
+        current, cand = make_descriptor(), make_descriptor()
+        base = score_candidate(current, cand, profile=RADIO)
+        hammered = score_candidate(current, cand, profile=RADIO, skip_count=500, reject_count=500)
+        assert base - hammered <= RADIO.max_negative_penalty + 1e-9
+
+    def test_is_inert_under_ambient(self):
+        current, cand = make_descriptor(), make_descriptor()
+        assert score_candidate(current, cand, profile=AMBIENT, skip_count=9, reject_count=9) == (
+            score_candidate(current, cand, profile=AMBIENT)
+        )
+
+
+class TestScoresStayInRange:
+    @pytest.mark.parametrize("profile", list(PROFILES.values()), ids=lambda p: p.name)
+    def test_every_extreme_stays_within_zero_and_one(self, profile):
+        current = make_descriptor(key="C", bpm=60.0, energy=0.0, brightness=0.0,
+                                  valence=0.0, dynamic_range_db=0.0)
+        candidate = make_descriptor(key="F#", bpm=200.0, energy=1.0, brightness=1.0,
+                                    valence=1.0, dynamic_range_db=30.0,
+                                    artist="Test Artist", modal_character="minor")
+
+        for taste in (0.0, 1.0):
+            for skips, rejects in ((0, 0), (50, 50)):
+                score = score_candidate(
+                    current, candidate,
+                    intensity="quiet",
+                    embedding_similarity=1.0,
+                    recent_artist_names=["Test Artist"],
+                    profile=profile,
+                    taste_score=taste,
+                    skip_count=skips,
+                    reject_count=rejects,
+                )
+                assert 0.0 <= score <= 1.0
+
+
+class TestDefaultProfileIsAmbient:
+    def test_omitting_the_profile_scores_as_ambient(self):
+        """Every existing ambient call site omits it."""
+        current = make_descriptor(key="C", energy=0.4)
+        cand = make_descriptor(key="G", energy=0.6, modal_character="minor")
+
+        for intensity in ("quiet", "balanced", "immersive"):
+            assert score_candidate(current, cand, intensity=intensity) == (
+                score_candidate(current, cand, intensity=intensity, profile=AMBIENT)
+            )

--- a/docs/decisions/ADR-0005-one-ranking-engine-serves-ambient-and-radio.md
+++ b/docs/decisions/ADR-0005-one-ranking-engine-serves-ambient-and-radio.md
@@ -1,6 +1,6 @@
 # ADR-0005: One Ranking Engine Serves Both Ambient and Radio
 
-Status: proposed
+Status: accepted
 
 Date: 2026-07-26
 
@@ -84,6 +84,13 @@ Generalise the existing engine into named weight profiles rather than building a
    feeding [ADR-0004](ADR-0004-listening-feedback-is-event-sourced.md). A suggestion the listener
    cannot identify as a suggestion cannot be evaluated by them or learned from.
 
+8. **Insertion fires every N tracks, N = 4, not user-configurable initially.** Resolved at
+   acceptance; it had been left open and decision point 6 cannot be built without it. Inserting only
+   on queue exhaustion was rejected because the queue does not empty in normal use — a library queue
+   is a lazy reservoir over the whole collection (`queueStore.setLazyQueue`), so the trigger would
+   effectively never fire. A setting was rejected for now on the grounds that a preference nobody
+   finds does not help; N is a constant to be revisited once ADR-0004 data shows whether 4 is right.
+
 ## Alternatives Considered
 
 - **Build a separate recommender service.** Rejected. It would duplicate a tuned scorer, a harmonic
@@ -116,5 +123,5 @@ Generalise the existing engine into named weight profiles rather than building a
 - **Follow-up:** Tune `RADIO` weights against real listening once
   [ADR-0004](ADR-0004-listening-feedback-is-event-sourced.md) data exists. Initial values are a
   starting guess.
-- **Follow-up:** Decide the insertion cadence — every N tracks, or on queue exhaustion — and whether
-  it is user-configurable.
+- **Follow-up:** Revisit `N = 4` and whether the cadence should become user-configurable, once
+  ADR-0004 data shows how often suggestions are accepted. Decided at acceptance as decision point 8.


### PR DESCRIPTION
Implements ADR-0005 decision points 1, 3 and 4, accepts the ADR, and resolves its one open question.

## What this does

`score_candidate`'s hard-coded weight dict and every post-hoc adjustment move into named `RankingProfile`s in a new `services/ranking_profiles.py`.

**`AMBIENT` reproduces the previous behaviour exactly.** All 45 characterisation tests from `b91a27a` pass untouched — which is precisely why they were written *before* this refactor rather than after. ADR-0005 point 2 makes that a hard requirement, not an aspiration.

**`RADIO`** drops the vocal term to zero (it exists to keep ambient instrumental; applied to radio it would demote most of a music library), leans on embedding similarity over harmonic key, and gives taste a 0.20 share.

## A test caught a real design error

My first `RADIO` had feature weights summing to 0.80 with taste as a 0.20 bonus *on top* of a full 1.0. That is subtly broken: added on top, taste could only push an already-saturating score into the clamp, so it would barely reorder anything.

Taste has to take a **share** of the convex combination to genuinely compete with similarity and harmonic fit. Feature weights + `taste_weight` now sum to 1.0, asserted in tests and enforced at import — `ranking_profiles.py` refuses to load a malformed profile rather than scoring silently wrong.

## Negative term

Demotes on ADR-0004 `PlayEvent`s, with rejection weighted more heavily than a skip: skipping is ambiguous (wrong moment, heard it recently), rejecting is a stated judgement. Capped, because an uncapped penalty would permanently exile anything skipped a few times and shrink the candidate pool over time.

## Design notes

`score_candidate` **stays pure** — taste and history arrive as numbers rather than being queried inside it, so it remains directly testable and usable from either retrieval path. Part 5 (`POST /api/v1/queue/suggestions`) is what supplies them; until it lands both terms are inert and `RADIO` is unreachable, so this merges safely on its own.

Both new terms are genuinely inert under `AMBIENT` (zero weights), which is asserted rather than assumed.

`RADIO`'s weights are a starting guess and cannot be tuned until ADR-0004 events accumulate, so its tests assert **relationships and invariants rather than exact scores**. A test pinning `RADIO` to a number would be rewritten by the first tuning pass and would protect nothing.

## ADR

Flips to `accepted` and gains decision point 8: insertion fires every N=4 tracks, not user-configurable initially. Queue-exhaustion was rejected because a library queue is a lazy reservoir over the whole collection and would effectively never empty.

## Tests

70 passing across `test_ambient_scoring.py` (45, untouched) and `test_ranking_profiles.py` (25, new). Full backend suite 1,147 pass; ruff and mypy clean. The 3 failures on my machine are pre-existing "LLM not configured" contract tests that fail locally because an Anthropic key is set.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_014P9p2fvFnyiywBxGkv4gfW