### PR TITLE
feat(radio): POST /api/v1/queue/suggestions — ADR-0005 part 5

### DIFF
--- a/backend/app/api/routes/queue.py
+++ b/backend/app/api/routes/queue.py
@@ -1,0 +1,129 @@
+"""Queue suggestion endpoints (ADR-0005).
+
+Radio: tracks the listener is likely to enjoy, slipped into a queue they are already
+playing. It reuses the ambient ranking engine under the `RADIO` weight profile rather
+than being a second recommender — see `services/ranking_profiles.py`.
+
+Unlike the ambient routes this is **profile-aware**. Ambient ranks purely on musical
+compatibility with the current track and needs no notion of who is listening; radio
+weighs taste and past skips, which are per-profile by definition. `ambient` is
+allowlisted as profile-less in `scripts/lint_profile_contracts.py`; this module
+deliberately does not inherit that exemption.
+"""
+
+from uuid import UUID
+
+from fastapi import APIRouter
+from pydantic import BaseModel, Field
+from sqlalchemy import select
+from sqlalchemy.orm import selectinload
+
+from app.api.deps import DbSession, RequiredProfile
+from app.api.exceptions import TrackNotFoundError, ValidationError
+from app.api.schemas.tracks import TrackResponse
+from app.db.models import Track
+from app.services.ambient import get_candidates
+from app.services.ranking_profiles import get_profile
+
+router = APIRouter(prefix="/queue", tags=["queue"])
+
+
+# ============================================================================
+# Request / Response schemas
+# ============================================================================
+
+
+class SuggestionsRequest(BaseModel):
+    """What to suggest from, and what to avoid repeating."""
+
+    # UUID rather than str: the ambient routes take strings and call bare `UUID(...)`,
+    # so a malformed id raises ValueError and surfaces as a 500 instead of a 422.
+    current_track_id: UUID
+    recent_track_ids: list[UUID] = Field(default_factory=list)
+    recent_artist_names: list[str] = Field(default_factory=list)
+    profile: str = Field(default="radio", description="Ranking profile: 'radio' or 'ambient'")
+    limit: int = Field(default=5, ge=1, le=20)
+
+
+class Suggestion(BaseModel):
+    """One suggested track and how well it scored."""
+
+    track: TrackResponse
+    score: float
+
+
+class SuggestionsResponse(BaseModel):
+    """Ranked suggestions for insertion into the playing queue."""
+
+    suggestions: list[Suggestion]
+    # Size of the retrieved candidate pool before ranking, and whether it was too small
+    # to rank meaningfully — the client can use this to stay quiet rather than insert
+    # something arbitrary.
+    pool_size: int
+    pool_collapsed: bool
+
+
+# ============================================================================
+# Endpoints
+# ============================================================================
+
+
+@router.post("/suggestions", response_model=SuggestionsResponse)
+async def suggestions(
+    request: SuggestionsRequest,
+    db: DbSession,
+    profile: RequiredProfile,
+) -> SuggestionsResponse:
+    """Rank tracks to insert into the queue, weighted by this profile's taste."""
+    try:
+        ranking_profile = get_profile(request.profile)
+    except ValueError as exc:
+        raise ValidationError(str(exc)) from exc
+
+    candidates, pool_size, pool_collapsed = await get_candidates(
+        db,
+        current_track_id=request.current_track_id,
+        recent_track_ids=request.recent_track_ids,
+        recent_artist_names=request.recent_artist_names,
+        limit=request.limit,
+        profile=ranking_profile,
+        profile_id=profile.id,
+    )
+
+    if not candidates:
+        # An unanalyzed or unknown seed collapses the pool rather than erroring, which is
+        # ambient's existing contract; preserve it so the client can just not insert.
+        return SuggestionsResponse(suggestions=[], pool_size=pool_size, pool_collapsed=pool_collapsed)
+
+    # The ranker works in descriptors, so fetch the tracks themselves for the handful
+    # that survived — the client inserts tracks, not descriptors. `analyses` is eagerly
+    # loaded because `Track.analysis_version` returns 0 when it is not.
+    ordered_ids = [c.descriptor.track_id for c in candidates]
+    tracks = (
+        (
+            await db.execute(
+                select(Track)
+                .options(selectinload(Track.analyses))
+                .where(Track.id.in_(ordered_ids))
+            )
+        )
+        .scalars()
+        .all()
+    )
+    by_id = {t.id: t for t in tracks}
+
+    if not by_id:
+        raise TrackNotFoundError("Suggested tracks could not be loaded")
+
+    return SuggestionsResponse(
+        suggestions=[
+            Suggestion(
+                track=TrackResponse.model_validate(by_id[c.descriptor.track_id]),
+                score=round(c.compatibility_score, 4),
+            )
+            for c in candidates
+            if c.descriptor.track_id in by_id
+        ],
+        pool_size=pool_size,
+        pool_collapsed=pool_collapsed,
+    )

--- a/backend/app/main.py
+++ b/backend/app/main.py
@@ -53,6 +53,7 @@ from app.api.routes import (
     playlists,
     profiles,
     proposed_changes,
+    queue,
     s3_backup,
     smart_playlists,
     spotify_import,
@@ -483,6 +484,7 @@ app.include_router(download.router, prefix="/api/v1")
 app.include_router(updates.router, prefix="/api/v1")
 app.include_router(spotify_import.router, prefix="/api/v1")
 app.include_router(ambient.router, prefix="/api/v1")
+app.include_router(queue.router, prefix="/api/v1")
 app.include_router(external_albums.router, prefix="/api/v1")
 app.include_router(new_releases.router, prefix="/api/v1")
 app.include_router(admin_artists.router, prefix="/api/v1")

--- a/backend/app/services/ambient.py
+++ b/backend/app/services/ambient.py
@@ -6,15 +6,24 @@ No session persistence; all state lives on the client.
 """
 
 from dataclasses import dataclass
+from datetime import timedelta
 from typing import Any
 from uuid import UUID
 
 from sqlalchemy import and_, func, select, text
 from sqlalchemy.ext.asyncio import AsyncSession
 
-from app.db.models import Track, TrackAnalysis
+from app.db.models import (
+    PlayEvent,
+    ProfileFavorite,
+    ProfilePlayHistory,
+    Track,
+    TrackAnalysis,
+)
 from app.logging_config import get_logger
 from app.services.ranking_profiles import AMBIENT, RankingProfile
+from app.services.taste_weighting import SHUFFLE_PRESETS, compute_track_weight
+from app.utils.time import utcnow
 
 logger = get_logger(__name__)
 
@@ -449,6 +458,131 @@ async def pick_surprise_seed(
     return _row_to_descriptor(best[0], best[1])
 
 
+# How far back skips and rejections count against a track. Recent dislikes matter and
+# old ones fade — taste changes, and a track skipped repeatedly last year should not be
+# exiled forever. Also bounds the aggregate as `play_events` grows.
+NEGATIVE_SIGNAL_WINDOW_DAYS = 90
+
+# Which shuffle preset supplies radio's taste signal: favour well-played tracks that have
+# not been heard lately. That "I'd forgotten about this" quality is what makes an
+# insertion land; `comfort_zone` would mostly re-surface what already plays often.
+RADIO_TASTE_PRESET = "rediscover"
+
+
+async def _fetch_taste_scores(
+    db: AsyncSession,
+    profile_id: UUID,
+    track_ids: list[UUID],
+) -> dict[UUID, float]:
+    """Taste weight per candidate, normalised to [0, 1].
+
+    Reuses `compute_track_weight` rather than reimplementing play-count/recency/favourite
+    weighting (ADR-0005 point 3). The join shape mirrors `routes/tracks/listing.py`: the
+    `profile_id` predicate lives **inside** the ON clause, because in a WHERE the outer
+    join degrades to an inner join and every unplayed or unfavourited track disappears.
+
+    Normalisation matters. `compute_track_weight` returns an unbounded multiplier while
+    `score_candidate` clamps `taste_score` to [0, 1] — passing it raw would saturate at
+    1.0 for essentially every track and reorder nothing. Dividing by the candidate set's
+    max preserves the ratios between candidates; min-max scaling was rejected because it
+    manufactures a full 0–1 spread even when every candidate is near-identical, turning
+    noise into ranking signal.
+    """
+    if not track_ids:
+        return {}
+
+    preset = SHUFFLE_PRESETS[RADIO_TASTE_PRESET]
+
+    rows = (
+        await db.execute(
+            select(
+                Track.id,
+                Track.created_at,
+                ProfilePlayHistory.play_count,
+                ProfilePlayHistory.last_played_at,
+                ProfileFavorite.favorited_at,
+            )
+            .outerjoin(
+                ProfilePlayHistory,
+                (ProfilePlayHistory.track_id == Track.id)
+                & (ProfilePlayHistory.profile_id == profile_id),
+            )
+            .outerjoin(
+                ProfileFavorite,
+                (ProfileFavorite.track_id == Track.id)
+                & (ProfileFavorite.profile_id == profile_id),
+            )
+            .where(Track.id.in_(track_ids))
+        )
+    ).all()
+
+    if not rows:
+        return {}
+
+    now = utcnow()  # one clock for the whole batch, as listing.py does
+    max_pc = max((r.play_count or 0) for r in rows) or 1
+
+    raw = {
+        r.id: compute_track_weight(
+            play_count=r.play_count,
+            last_played_at=r.last_played_at,
+            created_at=r.created_at,
+            is_favorited=r.favorited_at is not None,
+            preset=preset,
+            now=now,
+            max_play_count=max_pc,
+        )
+        for r in rows
+    }
+
+    max_w = max(raw.values())
+    if max_w <= 0:
+        return {}
+    return {tid: w / max_w for tid, w in raw.items()}
+
+
+async def _fetch_negative_signal(
+    db: AsyncSession,
+    profile_id: UUID,
+    track_ids: list[UUID],
+) -> dict[UUID, tuple[int, int]]:
+    """(skip_count, reject_count) per candidate, from ADR-0004 `PlayEvent`.
+
+    Counts only `'skipped'` and `'rejected'`. **`'errored'` must never appear here** — it
+    means playback failed, not that the listener disliked the track, and treating a
+    stream failure as a taste signal would let a bad network night quietly poison the
+    recommender. The FILTER clauses exclude it by construction; a test asserts it.
+
+    Served by `ix_play_events_profile_track`, added for exactly this query.
+    """
+    if not track_ids:
+        return {}
+
+    cutoff = utcnow() - timedelta(days=NEGATIVE_SIGNAL_WINDOW_DAYS)
+
+    rows = (
+        await db.execute(
+            select(
+                PlayEvent.track_id,
+                func.count().filter(PlayEvent.outcome == "skipped").label("skips"),
+                func.count().filter(PlayEvent.outcome == "rejected").label("rejects"),
+            )
+            .where(
+                PlayEvent.profile_id == profile_id,
+                PlayEvent.track_id.in_(track_ids),
+                PlayEvent.started_at >= cutoff,
+                # Belt and braces with the FILTER clauses above: excluding 'errored' and
+                # 'completed' here as well means the property holds even if someone later
+                # edits the aggregate, and it scans far fewer rows.
+                PlayEvent.outcome.in_(("skipped", "rejected")),
+            )
+            .group_by(PlayEvent.track_id)
+        )
+    ).all()
+
+    return {r.track_id: (r.skips or 0, r.rejects or 0) for r in rows}
+
+
 async def get_candidates(
     db: AsyncSession,
     current_track_id: UUID,
@@ -457,13 +591,25 @@ async def get_candidates(
     recent_track_ids: list[UUID] | None = None,
     recent_artist_names: list[str] | None = None,
     limit: int = 10,
+    profile: RankingProfile | None = None,
+    profile_id: UUID | None = None,
 ) -> tuple[list[AmbientCandidate], int, bool]:
     """Fetch and rank candidates for ambient continuation.
 
     Two-phase: SQL fetches top-150 by embedding distance, Python scores & sorts.
 
+    ``profile`` selects the weighting (ADR-0005), defaulting to ``AMBIENT``.
+    ``profile_id`` is whose listening history to weigh. The taste and negative terms are
+    per-candidate, so they can only be fetched once the candidate set is known — hence
+    they happen here, between the two phases, rather than at the call site.
+
+    Both extra queries are skipped entirely unless ``profile_id`` is given **and** the
+    ranking profile actually uses those terms, so ambient callers run exactly the SQL
+    they ran before.
+
     Returns: (candidates, pool_size, pool_collapsed)
     """
+    profile = profile or AMBIENT
     recent_ids = set(recent_track_ids or [])
     recent_ids.add(current_track_id)
 
@@ -474,6 +620,10 @@ async def get_candidates(
 
     # Build SQL query — top 150 by embedding similarity
     base_conditions = [
+        # Excludes MISSING tracks — files no longer on disk, which 404 on stream.
+        # This was absent, so ambient could and did surface unplayable tracks; putting
+        # one into a queue is exactly the failure `active_filter` exists to prevent.
+        Track.active_filter(),
         Track.id.notin_(recent_ids),
         Track.duration_seconds >= 45,
         TrackAnalysis.energy.isnot(None),
@@ -521,6 +671,17 @@ async def get_candidates(
     pool_size = len(rows)
     pool_collapsed = pool_size < 5
 
+    # Per-candidate taste and listening history. Only fetched when a profile is supplied
+    # and the ranking profile actually weighs them — ambient runs neither query.
+    taste_scores: dict[UUID, float] = {}
+    negative: dict[UUID, tuple[int, int]] = {}
+    if profile_id is not None and rows:
+        candidate_ids = [row[0].id for row in rows]
+        if profile.taste_weight:
+            taste_scores = await _fetch_taste_scores(db, profile_id, candidate_ids)
+        if profile.max_negative_penalty:
+            negative = await _fetch_negative_signal(db, profile_id, candidate_ids)
+
     # Python-side scoring
     scored: list[AmbientCandidate] = []
     for row in rows:
@@ -528,6 +689,7 @@ async def get_candidates(
         descriptor = _row_to_descriptor(track, analysis)
         emb_sim_float = float(emb_sim) if emb_sim is not None else None
 
+        skips, rejects = negative.get(track.id, (0, 0))
         key_compat = key_compatibility(current.key, descriptor.key)
         total_score = score_candidate(
             current,
@@ -535,6 +697,10 @@ async def get_candidates(
             intensity=intensity,
             embedding_similarity=emb_sim_float,
             recent_artist_names=recent_artist_names,
+            profile=profile,
+            taste_score=taste_scores.get(track.id),
+            skip_count=skips,
+            reject_count=rejects,
         )
 
         start_pct, end_pct = suggest_snippet_window(

--- a/backend/tests/test_contract_auth_matrix.py
+++ b/backend/tests/test_contract_auth_matrix.py
@@ -24,6 +24,9 @@ REQUIRED_PROFILE_ENDPOINTS = [
     ("POST", f"/api/v1/tracks/{ZERO_UUID}/played"),
     ("POST", f"/api/v1/tracks/{ZERO_UUID}/skipped"),
     ("POST", f"/api/v1/tracks/{ZERO_UUID}/rejected"),
+    # Radio suggestions weigh this profile's taste and skip history, so unlike the
+    # ambient routes they cannot run profile-less (ADR-0005).
+    ("POST", "/api/v1/queue/suggestions"),
 ]
 
 

--- a/backend/tests/test_queue_suggestions.py
+++ b/backend/tests/test_queue_suggestions.py
@@ -1,0 +1,286 @@
+"""Tests for the radio suggestion path (ADR-0005 part 5).
+
+These exercise the two data sources the pure scorer cannot fetch for itself — taste from
+`ProfilePlayHistory`/`ProfileFavorite`, and negative signal from `PlayEvent` — plus the
+endpoint that wires them together.
+
+The single most important assertion here is that an `errored` PlayEvent never demotes a
+track. `errored` means playback *failed*, not that the listener disliked it. Treating a
+bad network night as a taste signal would let the recommender quietly learn to avoid
+whatever happened to be playing when the connection dropped — a failure that would be
+invisible for months and unattributable when finally noticed.
+"""
+
+from datetime import timedelta
+from uuid import uuid4
+
+import pytest
+
+from app.services.ambient import (
+    NEGATIVE_SIGNAL_WINDOW_DAYS,
+    _fetch_negative_signal,
+    _fetch_taste_scores,
+    get_candidates,
+)
+from app.services.ranking_profiles import AMBIENT, RADIO
+from app.utils.time import utcnow
+from tests.factories import (
+    insert_test_analysis,
+    insert_test_play_event,
+    insert_test_profile,
+    insert_test_track,
+)
+
+pytestmark = pytest.mark.asyncio
+
+
+async def _track_with_analysis(db, **kw):
+    features = kw.pop("features", None) or {}
+    track = await insert_test_track(db, **kw)
+    await insert_test_analysis(
+        db,
+        track.id,
+        {"energy": 0.5, "brightness": 0.5, "valence": 0.5, "key": "C", "bpm": 120.0, **features},
+    )
+    return track
+
+
+# ---------------------------------------------------------------------------
+# Negative signal
+# ---------------------------------------------------------------------------
+
+
+class TestNegativeSignal:
+    async def test_errored_events_are_not_a_taste_signal(self, async_db):
+        """The one that would silently poison the recommender."""
+        profile = await insert_test_profile(async_db)
+        track = await _track_with_analysis(async_db, title="Unlucky")
+        for _ in range(5):
+            await insert_test_play_event(
+                async_db, profile.id, track.id, outcome="errored"
+            )
+
+        counts = await _fetch_negative_signal(async_db, profile.id, [track.id])
+
+        assert counts.get(track.id, (0, 0)) == (0, 0), (
+            "a track that failed to stream five times must not be demoted for it"
+        )
+
+    async def test_completed_events_are_not_negative(self, async_db):
+        profile = await insert_test_profile(async_db)
+        track = await _track_with_analysis(async_db)
+        await insert_test_play_event(async_db, profile.id, track.id, outcome="completed")
+
+        assert await _fetch_negative_signal(async_db, profile.id, [track.id]) == {}
+
+    async def test_counts_skips_and_rejections_separately(self, async_db):
+        profile = await insert_test_profile(async_db)
+        track = await _track_with_analysis(async_db)
+        for _ in range(3):
+            await insert_test_play_event(async_db, profile.id, track.id, outcome="skipped")
+        await insert_test_play_event(async_db, profile.id, track.id, outcome="rejected")
+
+        assert (await _fetch_negative_signal(async_db, profile.id, [track.id]))[track.id] == (3, 1)
+
+    async def test_events_older_than_the_window_are_ignored(self, async_db):
+        """Taste changes; a track skipped repeatedly last year is not exiled forever."""
+        profile = await insert_test_profile(async_db)
+        track = await _track_with_analysis(async_db)
+        await insert_test_play_event(
+            async_db, profile.id, track.id, outcome="skipped",
+            started_at=utcnow() - timedelta(days=NEGATIVE_SIGNAL_WINDOW_DAYS + 5),
+        )
+
+        assert await _fetch_negative_signal(async_db, profile.id, [track.id]) == {}
+
+    async def test_events_inside_the_window_count(self, async_db):
+        profile = await insert_test_profile(async_db)
+        track = await _track_with_analysis(async_db)
+        await insert_test_play_event(
+            async_db, profile.id, track.id, outcome="skipped",
+            started_at=utcnow() - timedelta(days=NEGATIVE_SIGNAL_WINDOW_DAYS - 5),
+        )
+
+        assert (await _fetch_negative_signal(async_db, profile.id, [track.id]))[track.id] == (1, 0)
+
+    async def test_another_profile_s_dislikes_do_not_leak(self, async_db):
+        mine = await insert_test_profile(async_db, name="Mine")
+        theirs = await insert_test_profile(async_db, name="Theirs")
+        track = await _track_with_analysis(async_db)
+        for _ in range(4):
+            await insert_test_play_event(async_db, theirs.id, track.id, outcome="rejected")
+
+        assert await _fetch_negative_signal(async_db, mine.id, [track.id]) == {}
+
+
+# ---------------------------------------------------------------------------
+# Taste
+# ---------------------------------------------------------------------------
+
+
+class TestTasteScores:
+    async def test_normalised_into_range(self, async_db):
+        profile = await insert_test_profile(async_db)
+        tracks = [await _track_with_analysis(async_db, title=f"T{i}") for i in range(4)]
+
+        scores = await _fetch_taste_scores(async_db, profile.id, [t.id for t in tracks])
+
+        assert scores, "expected a score per candidate"
+        assert all(0.0 <= v <= 1.0 for v in scores.values()), scores
+        assert max(scores.values()) == pytest.approx(1.0), "top candidate anchors the scale"
+
+    async def test_a_favourite_outranks_an_otherwise_identical_track(self, async_db):
+        from app.db.models import ProfileFavorite
+
+        profile = await insert_test_profile(async_db)
+        plain = await _track_with_analysis(async_db, title="Plain")
+        loved = await _track_with_analysis(async_db, title="Loved")
+        async_db.add(ProfileFavorite(profile_id=profile.id, track_id=loved.id))
+        await async_db.flush()
+
+        scores = await _fetch_taste_scores(async_db, profile.id, [plain.id, loved.id])
+
+        # `rediscover` has favorites_boost 1.0, so a favourite alone need not win — but it
+        # must never score lower than an identical non-favourite.
+        assert scores[loved.id] >= scores[plain.id]
+
+    async def test_empty_candidate_set_is_not_a_query(self, async_db):
+        profile = await insert_test_profile(async_db)
+        assert await _fetch_taste_scores(async_db, profile.id, []) == {}
+
+
+# ---------------------------------------------------------------------------
+# Retrieval
+# ---------------------------------------------------------------------------
+
+
+class TestRetrieval:
+    async def test_missing_tracks_are_never_suggested(self, async_db):
+        """A file that is gone from disk 404s on stream; suggesting it is the bug
+        `Track.active_filter()` exists to prevent."""
+        from app.db.models.base import TrackStatus
+
+        profile = await insert_test_profile(async_db)
+        seed = await _track_with_analysis(async_db, title="Seed")
+        gone = await _track_with_analysis(async_db, title="Gone")
+        gone.status = TrackStatus.MISSING
+        await async_db.flush()
+
+        candidates, _, _ = await get_candidates(
+            async_db, current_track_id=seed.id, profile=RADIO, profile_id=profile.id, limit=20
+        )
+
+        assert gone.id not in {c.descriptor.track_id for c in candidates}
+
+    async def test_the_seed_and_recent_tracks_are_excluded(self, async_db):
+        profile = await insert_test_profile(async_db)
+        seed = await _track_with_analysis(async_db, title="Seed")
+        recent = await _track_with_analysis(async_db, title="Recent")
+        other = await _track_with_analysis(async_db, title="Other")
+
+        candidates, _, _ = await get_candidates(
+            async_db, current_track_id=seed.id, recent_track_ids=[recent.id],
+            profile=RADIO, profile_id=profile.id, limit=20,
+        )
+        ids = {c.descriptor.track_id for c in candidates}
+
+        assert seed.id not in ids
+        assert recent.id not in ids
+        assert other.id in ids
+
+    async def test_an_unknown_seed_collapses_rather_than_raising(self, async_db):
+        profile = await insert_test_profile(async_db)
+        candidates, pool_size, collapsed = await get_candidates(
+            async_db, current_track_id=uuid4(), profile=RADIO, profile_id=profile.id
+        )
+        assert candidates == [] and pool_size == 0 and collapsed is True
+
+    async def test_ambient_runs_without_a_profile_id(self, async_db):
+        """Ambient passes neither argument and must be unaffected."""
+        seed = await _track_with_analysis(async_db, title="Seed")
+        await _track_with_analysis(async_db, title="Other")
+
+        candidates, _, _ = await get_candidates(async_db, current_track_id=seed.id)
+
+        assert candidates, "ambient retrieval still returns candidates"
+
+    async def test_rejected_track_ranks_below_an_equivalent_clean_one(self, async_db):
+        profile = await insert_test_profile(async_db)
+        seed = await _track_with_analysis(async_db, title="Seed")
+        clean = await _track_with_analysis(async_db, title="Clean", artist="A")
+        disliked = await _track_with_analysis(async_db, title="Disliked", artist="A")
+        for _ in range(3):
+            await insert_test_play_event(async_db, profile.id, disliked.id, outcome="rejected")
+
+        candidates, _, _ = await get_candidates(
+            async_db, current_track_id=seed.id, profile=RADIO, profile_id=profile.id, limit=20
+        )
+        scores = {c.descriptor.track_id: c.compatibility_score for c in candidates}
+
+        assert scores[disliked.id] < scores[clean.id]
+
+    async def test_ambient_ignores_the_same_history(self, async_db):
+        """Both terms are zero-weighted under AMBIENT, so history must not move it."""
+        profile = await insert_test_profile(async_db)
+        seed = await _track_with_analysis(async_db, title="Seed")
+        clean = await _track_with_analysis(async_db, title="Clean", artist="A")
+        disliked = await _track_with_analysis(async_db, title="Disliked", artist="A")
+        for _ in range(5):
+            await insert_test_play_event(async_db, profile.id, disliked.id, outcome="rejected")
+
+        candidates, _, _ = await get_candidates(
+            async_db, current_track_id=seed.id, profile=AMBIENT, profile_id=profile.id, limit=20
+        )
+        scores = {c.descriptor.track_id: c.compatibility_score for c in candidates}
+
+        assert scores[disliked.id] == pytest.approx(scores[clean.id])
+
+
+# ---------------------------------------------------------------------------
+# Endpoint
+# ---------------------------------------------------------------------------
+
+
+class TestEndpoint:
+    async def test_requires_a_profile(self, client):
+        r = client.post("/api/v1/queue/suggestions", json={"current_track_id": str(uuid4())})
+        assert r.status_code == 401
+
+    async def test_unknown_profile_name_is_a_validation_error_not_a_500(
+        self, client, test_profile
+    ):
+        """`get_profile` raises ValueError; unmapped that would be a 500."""
+        from tests.conftest import make_profile_headers
+
+        r = client.post(
+            "/api/v1/queue/suggestions",
+            json={"current_track_id": str(uuid4()), "profile": "jazz-o-matic"},
+            headers=make_profile_headers(test_profile),
+        )
+        # `ValidationError` from app.api.exceptions maps to 400, not 422 — 422 is
+        # FastAPI's own body-validation status.
+        assert r.status_code == 400, r.text
+        assert "jazz-o-matic" in r.text
+
+    async def test_malformed_uuid_is_422_not_500(self, client, test_profile):
+        from tests.conftest import make_profile_headers
+
+        r = client.post(
+            "/api/v1/queue/suggestions",
+            json={"current_track_id": "not-a-uuid"},
+            headers=make_profile_headers(test_profile),
+        )
+        assert r.status_code == 422, r.text
+
+    async def test_unknown_seed_returns_an_empty_collapsed_pool(self, client, test_profile):
+        from tests.conftest import make_profile_headers
+
+        r = client.post(
+            "/api/v1/queue/suggestions",
+            json={"current_track_id": str(uuid4())},
+            headers=make_profile_headers(test_profile),
+        )
+        assert r.status_code == 200, r.text
+        body = r.json()
+        assert body["suggestions"] == []
+        assert body["pool_collapsed"] is True


### PR DESCRIPTION
ADR-0005 decision point 5. This is the half that makes radio real.

`score_candidate` has accepted `taste_score`, `skip_count` and `reject_count` since #23, but nothing was passing them — the only production caller passed none, so both terms were dead code and `RADIO` was unreachable.

## Extends `get_candidates` rather than forking it

Taste and negative data are **per-candidate**, so they can only be fetched once the candidate set exists. That forces the fetch to sit between the SQL and Python phases, i.e. inside the function. A sibling retrieval function would have duplicated the HNSW query, the filter presets and the descriptor building — which is the outcome ADR-0005 exists to prevent.

Two optional parameters (`profile`, `profile_id`), and both extra queries are skipped unless a `profile_id` is given **and** the profile actually weighs those terms. Ambient runs exactly the SQL it ran before. A test asserts ambient is unmoved by history that visibly reorders radio.

## Taste

Reuses `compute_track_weight` with the **`rediscover`** preset — favour well-played tracks not heard lately. That "I'd forgotten about this" quality is what makes an insertion land; `comfort_zone` would mostly re-surface what already plays often.

The join mirrors `listing.py` with the `profile_id` predicate **inside the ON clause**. In a WHERE the outer join degrades to an inner join and every unplayed track silently disappears from the candidate set.

**Normalised by dividing by the candidate set's max.** `compute_track_weight` returns an unbounded multiplier while `score_candidate` clamps to [0, 1] — raw values would saturate at 1.0 for essentially every track and reorder nothing. Min-max scaling was rejected: it manufactures a full 0–1 spread even when every candidate is near-identical, turning noise into ranking signal.

## Negative signal

Counts only `'skipped'` and `'rejected'`, in **both** the WHERE and the FILTER clauses.

`'errored'` means playback *failed*, not that the listener disliked the track. Treating a bad network night as taste would let the recommender quietly learn to avoid whatever happened to be playing when the connection dropped — invisible for months, and unattributable when finally noticed. Given how much of this session was spent on stream read failures, that is not hypothetical. It gets the first test in the file.

90-day window, so old dislikes fade and the aggregate stays bounded as `play_events` grows. Served by `ix_play_events_profile_track`, added for exactly this.

## Also: a retrieval bug fix

`Track.active_filter()` was **absent** from the shared retrieval conditions, so ambient could and did surface `MISSING` tracks — files gone from disk, which 404 on stream. Suggesting one into a queue is precisely the failure that filter exists to prevent.

A deliberate behaviour change to a shipped feature, flagged rather than slipped in. The 45 characterisation tests cover *scoring*, not retrieval, so they neither catch nor block it — and all still pass.

## Contract compliance

- Takes `RequiredProfile`, and is deliberately **not** added to `lint_profile_contracts`' allowlist — ADR-0005 point 5 names that exemption as one this module must not inherit.
- Request ids are `UUID`, not `str`. The ambient routes take strings and call bare `UUID(...)`, so a malformed id is a 500; here it is a 422.
- **No `lint_openapi` allowlist entries were needed.** 256 operations validated, still 50 allowlisted — unchanged.
- Added to `REQUIRED_PROFILE_ENDPOINTS` in the auth-matrix contract test.

## Tests

19 new. Full backend suite 1,169 pass. The 2 failures are pre-existing test-isolation issues in `test_background_fault_injection.py` — verified identical on a stashed clean tree, which actually has one *more* failure. ruff and mypy clean.

## What's still inert

The negative term will do little at first: `play_events` only started accumulating with ADR-0004, and rejections need part 7 (accept/reject affordances in the queue) before they exist at all. Expected, and why ADR-0004 was sequenced first.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_014P9p2fvFnyiywBxGkv4gfW