### PR TITLE
fix(prefetch): never evict a track an audio element is still reading

### DIFF
--- a/packages/frontend/src/services/__tests__/prefetchEviction.test.ts
+++ b/packages/frontend/src/services/__tests__/prefetchEviction.test.ts
@@ -1,0 +1,164 @@
+/**
+ * Regression tests for the prefetch cache evicting the track that is playing.
+ *
+ * This was the actual cause of `PIPELINE_ERROR_READ: FFmpegDemuxer: data source error`
+ * (issue #13), after two earlier fixes aimed at bandwidth that turned out to be measuring
+ * the wrong thing — server logs showed 40.5 MB served in 5.1s, ~7.9 MB/s, so bandwidth was
+ * never the constraint.
+ *
+ * The chain:
+ *   1. `WebAudioEngine.resolveTrackUrl` resolves a track through `getUrl()`, so a
+ *      prefetched track plays from `entry.blobUrl`.
+ *   2. `reconcile()` evicts every cache entry not in `getUpcomingTrackIds()`.
+ *   3. `getUpcomingTrackIds` counts from step 1 — the current track is never in it.
+ *   4. `evict()` calls `URL.revokeObjectURL()` on the URL being played.
+ *
+ * Why it looked intermittent: revoking a blob URL does not abort a read already in
+ * flight, it only breaks later fetches. A short track that buffered before the advance
+ * plays through; a large one dies part-way when the element next reaches for data. That
+ * is why every occurrence followed a track change and why file size predicted it.
+ */
+import { describe, it, expect, beforeEach, vi } from 'vitest';
+
+const { playerState, connectivityState } = vi.hoisted(() => ({
+  playerState: {
+    currentTrack: null as { id: string } | null,
+    getUpcomingTrackIds: (_n: number) => [] as string[],
+  },
+  connectivityState: { offlineModeActive: false },
+}));
+
+vi.mock('../../player/playerStore', () => ({
+  usePlayerStore: Object.assign(
+    (sel: (s: typeof playerState) => unknown) => sel(playerState),
+    { getState: () => playerState, subscribe: () => () => {} }
+  ),
+}));
+
+vi.mock('../../stores/connectivityStore', () => ({
+  useConnectivityStore: Object.assign(
+    (sel: (s: typeof connectivityState) => unknown) => sel(connectivityState),
+    { getState: () => connectivityState }
+  ),
+}));
+
+vi.mock('../offlineService', () => ({ isTrackOffline: () => Promise.resolve(false) }));
+vi.mock('../../api/base', () => ({ getApiUrl: (p: string) => `http://test${p}` }));
+vi.mock('../../utils/platform', () => ({ isNativeApp: () => false }));
+
+import { prefetchService } from '../prefetchService';
+
+const revoked: string[] = [];
+globalThis.URL.createObjectURL = vi.fn((_b: Blob) => `blob:mock/${Math.random()}`) as never;
+globalThis.URL.revokeObjectURL = vi.fn((u: string) => {
+  revoked.push(u);
+}) as never;
+
+type Svc = {
+  cache: Map<string, { trackId: string; status: string; blobUrl?: string }>;
+  reconcile(): void;
+  currentTrackId: string | null;
+  previousTrackId: string | null;
+  downloadQueue: string[];
+};
+const svc = prefetchService as unknown as Svc;
+
+/** Put a ready, blob-backed entry in the cache, as a completed prefetch would. */
+function seedCached(trackId: string): string {
+  const blobUrl = `blob:mock/${trackId}`;
+  svc.cache.set(trackId, { trackId, status: 'ready', blobUrl });
+  return blobUrl;
+}
+
+beforeEach(() => {
+  revoked.length = 0;
+  svc.cache.clear();
+  svc.downloadQueue = [];
+  svc.currentTrackId = null;
+  svc.previousTrackId = null;
+  playerState.currentTrack = null;
+  playerState.getUpcomingTrackIds = () => [];
+  connectivityState.offlineModeActive = false;
+});
+
+describe('the playing track is never evicted', () => {
+  it('does not revoke the blob URL the engine is reading from', () => {
+    // The exact situation: the queue advanced onto a track that had been prefetched, so
+    // it is now current and therefore no longer "upcoming".
+    const playingUrl = seedCached('now-playing');
+    playerState.currentTrack = { id: 'now-playing' };
+    playerState.getUpcomingTrackIds = () => ['next-1', 'next-2'];
+
+    svc.reconcile();
+
+    expect(revoked).not.toContain(playingUrl);
+    expect(svc.cache.has('now-playing')).toBe(true);
+  });
+
+  it('still evicts tracks that are genuinely neither playing nor upcoming', () => {
+    const staleUrl = seedCached('long-gone');
+    seedCached('now-playing');
+    playerState.currentTrack = { id: 'now-playing' };
+    playerState.getUpcomingTrackIds = () => ['next-1'];
+
+    svc.reconcile();
+
+    expect(revoked).toContain(staleUrl);
+    expect(svc.cache.has('long-gone')).toBe(false);
+  });
+
+  it('keeps the outgoing track alive across a crossfade', () => {
+    // Both elements read at once during a crossfade. The instant the queue advances the
+    // outgoing track is neither current nor upcoming — evicting it revokes a source
+    // still being faded out, which surfaced as "Crossfade failed, rolling back".
+    const outgoingUrl = seedCached('outgoing');
+    playerState.currentTrack = { id: 'outgoing' };
+    playerState.getUpcomingTrackIds = () => ['incoming'];
+    svc.reconcile();
+
+    seedCached('incoming');
+    playerState.currentTrack = { id: 'incoming' };
+    playerState.getUpcomingTrackIds = () => ['after-that'];
+    svc.reconcile();
+
+    expect(revoked).not.toContain(outgoingUrl);
+  });
+
+  it('releases the outgoing track once it is two advances behind', () => {
+    // Retention is bounded — one extra entry, not an unbounded leak.
+    const firstUrl = seedCached('first');
+    playerState.currentTrack = { id: 'first' };
+    playerState.getUpcomingTrackIds = () => ['second'];
+    svc.reconcile();
+
+    playerState.currentTrack = { id: 'second' };
+    playerState.getUpcomingTrackIds = () => ['third'];
+    svc.reconcile();
+
+    playerState.currentTrack = { id: 'third' };
+    playerState.getUpcomingTrackIds = () => ['fourth'];
+    svc.reconcile();
+
+    expect(revoked).toContain(firstUrl);
+    expect(svc.cache.has('first')).toBe(false);
+  });
+
+  it('does not retain anything when nothing is playing', () => {
+    const staleUrl = seedCached('stale');
+    playerState.currentTrack = null;
+    playerState.getUpcomingTrackIds = () => [];
+
+    svc.reconcile();
+
+    expect(revoked).toContain(staleUrl);
+  });
+
+  it('leaves the cache alone in offline mode', () => {
+    const url = seedCached('offline-track');
+    connectivityState.offlineModeActive = true;
+
+    svc.reconcile();
+
+    expect(revoked).not.toContain(url);
+  });
+});

--- a/packages/frontend/src/services/prefetchService.ts
+++ b/packages/frontend/src/services/prefetchService.ts
@@ -59,6 +59,10 @@ class PrefetchService {
   private unsubscribe: (() => void) | null = null;
   private downloadQueue: string[] = [];
   private isDownloading = false;
+  // Which tracks an audio element may still be reading from. Neither is "upcoming", and
+  // both must survive eviction — see `reconcile`.
+  private currentTrackId: string | null = null;
+  private previousTrackId: string | null = null;
 
   /**
    * Start the prefetch service — subscribes to playerStore changes.
@@ -121,9 +125,38 @@ class PrefetchService {
 
     const upcomingIds = usePlayerStore.getState().getUpcomingTrackIds(PREFETCH_COUNT);
 
-    // Evict entries not in the upcoming list
+    // A track an audio element may still be reading from must never be evicted.
+    //
+    // `getUpcomingTrackIds` counts from step 1, so the current track is by definition
+    // never "upcoming". The engine resolves its source through `getUrl()`
+    // (`WebAudioEngine.resolveTrackUrl`), so evicting the current track revokes the very
+    // blob URL the element is reading from, and that surfaces as
+    // `PIPELINE_ERROR_READ: FFmpegDemuxer: data source error` (issue #13).
+    //
+    // The delay is what made this hard to see. `URL.revokeObjectURL` does not abort a
+    // read already in flight; it only breaks *subsequent* fetches. A short track that
+    // buffered fully before the advance plays through fine, while a large one dies
+    // part-way when the element next reaches for data — so it looked intermittent and
+    // size-dependent, and it always followed a track change.
+    //
+    // The previous track is retained too: during a crossfade both elements read at once,
+    // and the instant the queue advances the outgoing track is neither current nor
+    // upcoming. Evicting it revokes a source still fading out — the "Crossfade failed,
+    // rolling back" case. Tracking advances *before* the retention set is built, so on
+    // the reconcile following a change `previousTrackId` is the track just stepped off.
+    const currentTrackId = usePlayerStore.getState().currentTrack?.id ?? null;
+    if (currentTrackId !== this.currentTrackId) {
+      this.previousTrackId = this.currentTrackId;
+      this.currentTrackId = currentTrackId;
+    }
+
+    const retained = new Set(upcomingIds);
+    if (this.currentTrackId) retained.add(this.currentTrackId);
+    if (this.previousTrackId) retained.add(this.previousTrackId);
+
+    // Evict entries that are neither being read nor coming up
     for (const [trackId, entry] of this.cache) {
-      if (!upcomingIds.includes(trackId)) {
+      if (!retained.has(trackId)) {
         this.evict(trackId, entry);
       }
     }
@@ -325,6 +358,10 @@ class PrefetchService {
     }
     this.cache.clear();
     this.downloadQueue = [];
+    // Nothing is playing once everything is evicted; stale retention would otherwise
+    // keep the next session's first reconcile from clearing a dead entry.
+    this.currentTrackId = null;
+    this.previousTrackId = null;
   }
 }
 


### PR DESCRIPTION
The actual cause of `PIPELINE_ERROR_READ` (#13).

## My earlier diagnosis was wrong

#21 and #22 both aimed at bandwidth, on a measurement I got wrong: I derived ~850 KB/s from **client log timestamps** spanning queueing and the IndexedDB write, not the transfer.

Server-side durations say otherwise:

```
40.5 MB served in 5,129 ms  →  ~7.9 MB/s
```

A track needs 40 KB/s — half a percent of that. **Bandwidth was never the constraint.**

## The real chain

1. `WebAudioEngine.resolveTrackUrl:607` resolves through `prefetchService.getUrl()`, so a prefetched track plays from `entry.blobUrl`.
2. `reconcile()` evicts every cache entry not in `getUpcomingTrackIds()`.
3. `getUpcomingTrackIds` is `for (let step = 1; ...)` — **the current track is never in that set**.
4. `evict()` calls `URL.revokeObjectURL()` on the URL being played.

Advancing onto a prefetched track revokes the element's own source.

## Why it hid for so long

`URL.revokeObjectURL` does **not** abort a read already in flight — it only breaks *subsequent* fetches. So:

- a short track that buffered fully before the advance plays through fine
- a large one dies part-way, when the element next reaches for data

That is exactly the observed pattern: intermittent, size-dependent, always just after a track change, and **invisible in server logs** — the request had succeeded minutes earlier, with a clean `206`. Every server-side investigation came back healthy because the server *was* healthy.

## Fix

Retain the current track, plus the previous one for one reconcile.

The previous-track retention is not belt-and-braces: during a crossfade both elements read at once, and the instant the queue advances the outgoing track is neither current nor upcoming. Evicting it revokes a source still fading out — that is the "Crossfade failed, rolling back" case, same root cause.

Retention is bounded at two entries. A test asserts a track is released once it is two advances behind, so this is not a leak.

## Verification

Reverted the retention in place and re-ran: the "playing track" and "crossfade" tests **both fail without it** and pass with it. Tests that would pass either way aren't worth much here, so that check mattered.

```
Test Files  59 passed (59)
     Tests  869 passed (869)
```

Typecheck identical to `main` (9 pre-existing). Lint 0 errors. Web build succeeds.

## Follow-up worth having

The throttles from #21 and #22 were justified by a number that turned out to be wrong. They aren't incorrect code, but they now solve a non-problem — and the prefetch one holds each connection roughly 4× longer than necessary. Worth reverting or reconsidering once this is confirmed in use; deliberately not folded into this PR, so the fix can be judged on its own.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_014P9p2fvFnyiywBxGkv4gfW