### PR TITLE
feat(radio): client controller and queue affordances — ADR-0005 parts 6-8

### DIFF
--- a/packages/frontend/src/api/index.ts
+++ b/packages/frontend/src/api/index.ts
@@ -1,5 +1,6 @@
 export { default as api, getApiUrl, getApiOrigin, encodePathSegment } from './base';
 export * from './tracks';
+export * from './queue';
 export * from './library';
 export * from './playlists';
 export * from './integrations';

--- a/packages/frontend/src/api/queue.ts
+++ b/packages/frontend/src/api/queue.ts
@@ -1,0 +1,32 @@
+/**
+ * Queue suggestion API client (ADR-0005).
+ */
+
+import api from './base';
+import type { Track } from '../types';
+
+export interface QueueSuggestionsRequest {
+  current_track_id: string;
+  recent_track_ids?: string[];
+  recent_artist_names?: string[];
+  profile?: 'radio' | 'ambient';
+  limit?: number;
+}
+
+export interface QueueSuggestion {
+  track: Track;
+  score: number;
+}
+
+export interface QueueSuggestionsResponse {
+  suggestions: QueueSuggestion[];
+  pool_size: number;
+  pool_collapsed: boolean;
+}
+
+export const queueApi = {
+  getSuggestions: async (request: QueueSuggestionsRequest): Promise<QueueSuggestionsResponse> => {
+    const { data } = await api.post('/queue/suggestions', request);
+    return data;
+  },
+};

--- a/packages/frontend/src/components/Queue/QueueView.tsx
+++ b/packages/frontend/src/components/Queue/QueueView.tsx
@@ -1,8 +1,9 @@
 import { useState, useCallback, useRef, useEffect } from 'react';
 import { useVirtualizer } from '@tanstack/react-virtual';
-import { ListMusic, ListX, GripVertical, X, Shuffle, Trash2, Music, Plus } from 'lucide-react';
+import { ListMusic, ListX, GripVertical, X, Shuffle, Trash2, Music, Plus, Check, ThumbsDown, Sparkles } from 'lucide-react';
 import { useShallow } from 'zustand/react/shallow';
 import { usePlayerStore } from '../../stores/playerStore';
+import { deliverListenEvent } from '../../services/syncService';
 import { PlayIndicator } from '../common/PlayIndicator';
 import { useThemeStore } from '../../stores/themeStore';
 import { useSelectionStore } from '../../stores/selectionStore';
@@ -34,6 +35,7 @@ export function QueueView({ onTrackDropped }: QueueViewProps = {}) {
   );
   const clearQueue = usePlayerStore((s) => s.clearQueue);
   const removeFromQueue = usePlayerStore((s) => s.removeFromQueue);
+  const acceptSuggestion = usePlayerStore((s) => s.acceptSuggestion);
   const exitLazyMode = usePlayerStore((s) => s.exitLazyMode);
   const addToQueue = usePlayerStore((s) => s.addToQueue);
   const toggleConsume = usePlayerStore((s) => s.toggleConsume);
@@ -198,6 +200,23 @@ export function QueueView({ onTrackDropped }: QueueViewProps = {}) {
   }, [jumpToQueueIndex]);
 
   // Handle removing a track from queue
+  /** Keep a suggestion: drop the marker so it stops offering accept/reject. */
+  const handleAcceptSuggestion = useCallback((queueId: string, e: React.MouseEvent) => {
+    e.stopPropagation();
+    acceptSuggestion(queueId);
+  }, [acceptSuggestion]);
+
+  /**
+   * Reject a suggestion: remove it and report it, so the negative term in the ranker
+   * has something to learn from. Rejection is weighted more heavily than a skip because
+   * it is a stated judgement rather than an ambiguous one.
+   */
+  const handleRejectSuggestion = useCallback((queueId: string, trackId: string, e: React.MouseEvent) => {
+    e.stopPropagation();
+    void deliverListenEvent(trackId, 'rejected', { context: 'radio' });
+    removeFromQueue(queueId);
+  }, [removeFromQueue]);
+
   const handleRemoveTrack = useCallback((queueId: string, e: React.MouseEvent) => {
     e.stopPropagation();
     removeFromQueue(queueId);
@@ -236,6 +255,7 @@ export function QueueView({ onTrackDropped }: QueueViewProps = {}) {
         .map((queueIdx) => ({
           track: queue[queueIdx]?.track,
           queueId: queue[queueIdx]?.queueId,
+          suggested: queue[queueIdx]?.suggested,
           isCurrent: queueIdx === queueIndex,
           actualQueueIndex: queueIdx,
         }))
@@ -243,6 +263,7 @@ export function QueueView({ onTrackDropped }: QueueViewProps = {}) {
     : queue.map((item, index) => ({
         track: item.track,
         queueId: item.queueId,
+        suggested: item.suggested,
         isCurrent: index === queueIndex,
         actualQueueIndex: index,
       }));
@@ -364,7 +385,7 @@ export function QueueView({ onTrackDropped }: QueueViewProps = {}) {
             {virtualizer.getVirtualItems().map((virtualRow) => {
               const displayIndex = virtualRow.index;
               const item = displayTracks[displayIndex];
-              const { track, queueId, isCurrent, actualQueueIndex } = item;
+              const { track, queueId, suggested, isCurrent, actualQueueIndex } = item;
               const isDragged = draggedIndex === displayIndex;
               const isReorderTarget = dropTargetIndex === displayIndex && draggedIndex !== null;
               const isExtDropTarget = externalDropTargetIndex === displayIndex;
@@ -426,7 +447,15 @@ export function QueueView({ onTrackDropped }: QueueViewProps = {}) {
 
                   {/* Track info */}
                   <div className="flex-1 min-w-0">
-                    <div className={`font-medium truncate ${isCurrent ? 'text-green-500' : ''}`}>
+                    <div className={`font-medium truncate flex items-center gap-1.5 ${isCurrent ? 'text-green-500' : ''}`}>
+                      {/* A suggestion the listener cannot identify as one cannot be
+                          evaluated by them or learned from (ADR-0005 point 7). */}
+                      {suggested && (
+                        <Sparkles
+                          className="w-3.5 h-3.5 flex-shrink-0 text-amber-400"
+                          aria-label="Suggested for you"
+                        />
+                      )}
                       {track.title || 'Unknown Title'}
                     </div>
                     <div className="text-sm text-zinc-500 truncate">
@@ -441,6 +470,29 @@ export function QueueView({ onTrackDropped }: QueueViewProps = {}) {
                   <div className="text-sm text-zinc-500 flex-shrink-0">
                     {formatDuration(track.duration_seconds)}
                   </div>
+
+                  {/* Suggestion affordances — accept keeps it and drops the marker,
+                      reject removes it and reports a PlayEvent so the ranker learns
+                      (ADR-0004). Only a suggestion the listener can identify as one can
+                      be judged by them. */}
+                  {suggested && (
+                    <>
+                      <button
+                        onClick={(e) => handleAcceptSuggestion(queueId, e)}
+                        className="p-1.5 rounded-lg hover:bg-zinc-700/50"
+                        title="Keep this suggestion"
+                      >
+                        <Check className="w-4 h-4 text-zinc-400 hover:text-green-400" />
+                      </button>
+                      <button
+                        onClick={(e) => handleRejectSuggestion(queueId, track.id, e)}
+                        className="p-1.5 rounded-lg hover:bg-zinc-700/50"
+                        title="Not for me — remove and learn from it"
+                      >
+                        <ThumbsDown className="w-4 h-4 text-zinc-400 hover:text-red-400" />
+                      </button>
+                    </>
+                  )}
 
                   {/* Remove button */}
                   <button

--- a/packages/frontend/src/components/Settings/RadioSettings.tsx
+++ b/packages/frontend/src/components/Settings/RadioSettings.tsx
@@ -1,0 +1,47 @@
+import { Sparkles } from 'lucide-react';
+import { useRadioStore } from '../../stores/radioStore';
+import { INSERT_EVERY_N_TRACKS } from '../../player/radio/radioController';
+
+/**
+ * Opt-in for radio suggestions (ADR-0005).
+ *
+ * Off by default: this inserts tracks the listener did not choose into a queue they are
+ * already enjoying, so turning it on should be their decision.
+ */
+export function RadioSettings() {
+  const enabled = useRadioStore((s) => s.enabled);
+  const setEnabled = useRadioStore((s) => s.setEnabled);
+
+  return (
+    <div className="bg-zinc-800/50 dark:bg-zinc-800/50 light:bg-zinc-100 rounded-lg p-4">
+      <div className="flex items-center justify-between">
+        <div className="flex items-center gap-3">
+          <Sparkles className="w-5 h-5 text-amber-400" />
+          <div>
+            <h4 className="text-sm font-medium text-white dark:text-white light:text-zinc-900">Radio Suggestions</h4>
+            <p className="text-xs text-zinc-400 dark:text-zinc-400 light:text-zinc-600">
+              Slip in a track you might like every {INSERT_EVERY_N_TRACKS} songs, matched on
+              sound and your listening history
+            </p>
+          </div>
+        </div>
+        <label className="relative inline-flex items-center cursor-pointer">
+          <input
+            type="checkbox"
+            checked={enabled}
+            onChange={(e) => setEnabled(e.target.checked)}
+            className="sr-only peer"
+          />
+          <div className="w-11 h-6 bg-zinc-600 peer-focus:outline-none peer-focus:ring-2 peer-focus:ring-amber-500 rounded-full peer peer-checked:after:translate-x-full peer-checked:after:border-white after:content-[''] after:absolute after:top-[2px] after:left-[2px] after:bg-white after:rounded-full after:h-5 after:w-5 after:transition-all peer-checked:bg-amber-500"></div>
+        </label>
+      </div>
+
+      {enabled && (
+        <p className="mt-3 text-xs text-zinc-500 dark:text-zinc-500 light:text-zinc-600">
+          Suggestions are marked with <Sparkles className="w-3 h-3 inline text-amber-400" /> in the
+          queue. Rejecting one teaches it what not to pick again.
+        </p>
+      )}
+    </div>
+  );
+}

--- a/packages/frontend/src/components/Settings/index.tsx
+++ b/packages/frontend/src/components/Settings/index.tsx
@@ -16,6 +16,7 @@ import { ApiKeyStatus } from './ApiKeyStatus';
 import { CommunityCache } from './CommunityCache';
 import { ServerSettings } from './ServerSettings';
 import { ShuffleWeightSettings } from './ShuffleWeightSettings';
+import { RadioSettings } from './RadioSettings';
 import { isNativeApp } from '../../utils/platform';
 import { areAudioEffectsAvailable } from '../../player/audio/engineInstance';
 
@@ -100,6 +101,7 @@ export function SettingsPanel() {
           <div className="space-y-4">
             <PlaybackSettings />
             <ShuffleWeightSettings />
+            <RadioSettings />
             {areAudioEffectsAvailable() && <AudioEffectsSettings />}
           </div>
         </section>

--- a/packages/frontend/src/player/__tests__/radioController.test.ts
+++ b/packages/frontend/src/player/__tests__/radioController.test.ts
@@ -1,0 +1,202 @@
+/**
+ * Tests for the radio controller (ADR-0005 parts 6-8).
+ *
+ * The controller holds cadence and insertion policy only — ranking is entirely
+ * server-side, under the `RADIO` weight profile. So these cover *when* and *where* a
+ * suggestion lands, and the cases where it should stay quiet.
+ *
+ * Staying quiet matters more than it sounds. This feature inserts tracks the listener did
+ * not choose, into a queue they are already enjoying. Inserting something arbitrary
+ * because the candidate pool was too small, or stacking duplicates, is worse than
+ * inserting nothing at all.
+ */
+import { describe, it, expect, beforeEach, vi } from 'vitest';
+
+const { mockGetSuggestions, connectivityState } = vi.hoisted(() => ({
+  mockGetSuggestions: vi.fn(),
+  connectivityState: { offlineModeActive: false, offlineTrackIds: new Set<string>() },
+}));
+
+vi.mock('../../api/queue', () => ({ queueApi: { getSuggestions: mockGetSuggestions } }));
+vi.mock('../../stores/connectivityStore', () => ({
+  useConnectivityStore: Object.assign(
+    (sel: (s: typeof connectivityState) => unknown) => sel(connectivityState),
+    { getState: () => connectivityState }
+  ),
+}));
+
+import { radioController, INSERT_EVERY_N_TRACKS } from '../radio/radioController';
+import { usePlayerStore } from '../playerStore';
+import { useRadioStore } from '../../stores/radioStore';
+import type { Track } from '../../types';
+
+const track = (id: string, title = `Track ${id}`): Track => ({
+  id, title, artist: 'A', album: 'Al', album_artist: null, album_type: 'album' as const,
+  track_number: 1, disc_number: 1, year: 2024, genre: null, duration_seconds: 200,
+  format: 'mp3', file_path: `/m/${id}.mp3`, analysis_version: 1,
+});
+
+const suggestion = (id: string, score = 0.9) => ({ track: track(id), score });
+
+function seedQueue(ids: string[], index = 0) {
+  usePlayerStore.setState({
+    queue: ids.map((id, i) => ({ track: track(id), queueId: `q${i}` })),
+    queueIndex: index,
+    currentTrack: track(ids[index]),
+  });
+}
+
+beforeEach(() => {
+  mockGetSuggestions.mockReset();
+  mockGetSuggestions.mockResolvedValue({ suggestions: [suggestion('s1')], pool_size: 50, pool_collapsed: false });
+  connectivityState.offlineModeActive = false;
+  radioController.stop();
+  useRadioStore.setState({ enabled: true });
+  seedQueue(['a', 'b', 'c', 'd', 'e', 'f']);
+});
+
+describe('staying quiet', () => {
+  it('does nothing while disabled', async () => {
+    useRadioStore.setState({ enabled: false });
+    await radioController.suggest();
+    expect(mockGetSuggestions).not.toHaveBeenCalled();
+  });
+
+  it('does not insert when the candidate pool collapsed', async () => {
+    // Too few candidates to rank meaningfully — inserting anyway would be arbitrary.
+    mockGetSuggestions.mockResolvedValue({ suggestions: [], pool_size: 2, pool_collapsed: true });
+    const before = usePlayerStore.getState().queue.length;
+
+    await radioController.suggest();
+
+    expect(usePlayerStore.getState().queue.length).toBe(before);
+  });
+
+  it('does not insert while offline', async () => {
+    // A suggestion that cannot stream is worse than no suggestion.
+    connectivityState.offlineModeActive = true;
+    await radioController.suggest();
+    expect(mockGetSuggestions).not.toHaveBeenCalled();
+  });
+
+  it('does not insert without a current track', async () => {
+    usePlayerStore.setState({ currentTrack: null });
+    await radioController.suggest();
+    expect(mockGetSuggestions).not.toHaveBeenCalled();
+  });
+
+  it('swallows a failed request rather than surfacing it', async () => {
+    // The listener did not ask for this; a visible error would be noise.
+    mockGetSuggestions.mockRejectedValue(new Error('boom'));
+    await expect(radioController.suggest()).resolves.toBeUndefined();
+  });
+
+  it('does not re-suggest a track it already inserted', async () => {
+    await radioController.suggest();
+    const afterFirst = usePlayerStore.getState().queue.length;
+
+    mockGetSuggestions.mockResolvedValue({
+      suggestions: [suggestion('s1')], pool_size: 50, pool_collapsed: false,
+    });
+    await radioController.suggest();
+
+    expect(usePlayerStore.getState().queue.length).toBe(afterFirst);
+  });
+
+  it('skips a candidate already sitting in the upcoming queue', async () => {
+    mockGetSuggestions.mockResolvedValue({
+      suggestions: [suggestion('c'), suggestion('fresh')], pool_size: 50, pool_collapsed: false,
+    });
+
+    await radioController.suggest();
+
+    const titles = usePlayerStore.getState().queue.map((i) => i.track.id);
+    expect(titles.filter((t) => t === 'c')).toHaveLength(1); // not duplicated
+    expect(titles).toContain('fresh');
+  });
+});
+
+describe('insertion', () => {
+  it('marks the inserted track as a suggestion', async () => {
+    await radioController.suggest();
+
+    const inserted = usePlayerStore.getState().queue.find((i) => i.track.id === 's1');
+    expect(inserted?.suggested).toBe(true);
+  });
+
+  it('does not displace the listener’s very next track', async () => {
+    // Landing at queueIndex+1 would read as the app overriding their choice.
+    seedQueue(['a', 'b', 'c', 'd'], 1);
+
+    await radioController.suggest();
+
+    const q = usePlayerStore.getState().queue.map((i) => i.track.id);
+    expect(q[2]).toBe('c');   // their next track, untouched
+    expect(q[3]).toBe('s1');  // suggestion lands after it
+  });
+
+  it('sends recent tracks and artists so the server can avoid repeats', async () => {
+    seedQueue(['a', 'b', 'c'], 2);
+
+    await radioController.suggest();
+
+    const body = mockGetSuggestions.mock.calls[0][0];
+    expect(body.current_track_id).toBe('c');
+    expect(body.recent_track_ids).toEqual(expect.arrayContaining(['a', 'b', 'c']));
+    expect(body.profile).toBe('radio');
+  });
+
+  it('clamps the insert position to the end of a short queue', async () => {
+    seedQueue(['a'], 0);
+    await radioController.suggest();
+    expect(usePlayerStore.getState().queue.map((i) => i.track.id)).toEqual(['a', 's1']);
+  });
+});
+
+describe('cadence', () => {
+  it('waits N track changes before suggesting', async () => {
+    radioController.start();
+    seedQueue(['a', 'b', 'c', 'd', 'e', 'f'], 0);
+
+    for (let i = 1; i < INSERT_EVERY_N_TRACKS; i++) {
+      usePlayerStore.setState({ currentTrack: track(String(i)) });
+    }
+    await vi.waitFor(() => expect(mockGetSuggestions).not.toHaveBeenCalled());
+
+    usePlayerStore.setState({ currentTrack: track('final') });
+    await vi.waitFor(() => expect(mockGetSuggestions).toHaveBeenCalled());
+
+    radioController.stop();
+  });
+});
+
+describe('accepting and rejecting', () => {
+  it('accepting clears the marker so the affordances go away', async () => {
+    await radioController.suggest();
+    const item = usePlayerStore.getState().queue.find((i) => i.track.id === 's1')!;
+
+    usePlayerStore.getState().acceptSuggestion(item.queueId);
+
+    const after = usePlayerStore.getState().queue.find((i) => i.track.id === 's1');
+    expect(after?.suggested).toBe(false);
+    expect(after).toBeDefined(); // kept, not removed
+  });
+
+  it('accepting a non-suggestion is a no-op', () => {
+    seedQueue(['a', 'b']);
+    const before = usePlayerStore.getState().queue;
+
+    usePlayerStore.getState().acceptSuggestion('q0');
+
+    expect(usePlayerStore.getState().queue).toEqual(before);
+  });
+
+  it('rejecting removes it from the queue', async () => {
+    await radioController.suggest();
+    const item = usePlayerStore.getState().queue.find((i) => i.track.id === 's1')!;
+
+    usePlayerStore.getState().removeFromQueue(item.queueId);
+
+    expect(usePlayerStore.getState().queue.find((i) => i.track.id === 's1')).toBeUndefined();
+  });
+});

--- a/packages/frontend/src/player/queueStore.ts
+++ b/packages/frontend/src/player/queueStore.ts
@@ -131,8 +131,9 @@ export interface QueueState {
 }
 
 export interface QueueActions {
-  addToQueue: (track: Track, insertIndex?: number, shuffleInsertPosition?: number) => void;
+  addToQueue: (track: Track, insertIndex?: number, shuffleInsertPosition?: number, options?: { suggested?: boolean }) => void;
   removeFromQueue: (queueId: string) => void;
+  acceptSuggestion: (queueId: string) => void;
   clearQueue: () => void;
   playTrack: (track: Track, options?: { reason?: AdvanceReason }) => void;
   playNext: (options?: { reason?: AdvanceReason }) => void | Promise<void>;
@@ -163,7 +164,7 @@ export const useQueueStore = create<QueueState & QueueActions>((set, get) => ({
   queueSource: null,
   isQueueHydrating: false,
 
-  addToQueue: (track, insertIndex, shuffleInsertPosition) => {
+  addToQueue: (track, insertIndex, shuffleInsertPosition, options) => {
     const connectivity = useConnectivityStore.getState();
     if (connectivity.offlineModeActive && !connectivity.offlineTrackIds.has(track.id)) {
       log.warn('addToQueue blocked by offline invariant', { trackId: track.id });
@@ -175,7 +176,7 @@ export const useQueueStore = create<QueueState & QueueActions>((set, get) => ({
 
     const insertAt = insertIndex ?? queue.length;
     const newQueue = [...queue];
-    newQueue.splice(insertAt, 0, { track, queueId: generateQueueId() });
+    newQueue.splice(insertAt, 0, { track, queueId: generateQueueId(), suggested: options?.suggested });
 
     const newQueueIndex = insertAt <= queueIndex ? queueIndex + 1 : queueIndex;
 
@@ -193,6 +194,22 @@ export const useQueueStore = create<QueueState & QueueActions>((set, get) => ({
       queue: newQueue,
       queueIndex: newQueueIndex,
       shuffleOrder: newShuffleOrder,
+    });
+    persistCombinedState();
+  },
+
+  /**
+   * Keep a suggested track: clear the marker so the queue stops offering accept/reject.
+   * Acceptance is implicit in playing it, so nothing is reported here — a PlayEvent is
+   * already written when it plays (ADR-0004).
+   */
+  acceptSuggestion: (queueId) => {
+    const { queue } = get();
+    if (!queue.some((item) => item.queueId === queueId && item.suggested)) return;
+    set({
+      queue: queue.map((item) =>
+        item.queueId === queueId ? { ...item, suggested: false } : item
+      ),
     });
     persistCombinedState();
   },

--- a/packages/frontend/src/player/radio/radioController.ts
+++ b/packages/frontend/src/player/radio/radioController.ts
@@ -1,0 +1,145 @@
+/**
+ * Radio controller — inserts tracks the listener is likely to enjoy into a playing queue
+ * (ADR-0005 decision points 6 and 8).
+ *
+ * Follows the shape of `player/ambient/AmbientCoordinator`: subscribe to queue position,
+ * ask the server to rank candidates, insert ahead of the play head. The ranking itself is
+ * entirely server-side — the same engine ambient uses, under the `RADIO` weight profile —
+ * so this file holds cadence and insertion policy only, no scoring.
+ *
+ * Cadence is every `INSERT_EVERY_N_TRACKS` (ADR decision point 8). Inserting on queue
+ * exhaustion was rejected: a library queue is a lazy reservoir over the whole collection
+ * and would effectively never empty, so the trigger would never fire.
+ */
+import { usePlayerStore } from '../playerStore';
+import { useConnectivityStore } from '../../stores/connectivityStore';
+import { queueApi } from '../../api/queue';
+import { useRadioStore } from '../../stores/radioStore';
+import { createLogger } from '../../utils/logger';
+
+const log = createLogger('Radio');
+
+/** Insert a suggestion every N track changes. Revisit once ADR-0004 data exists. */
+export const INSERT_EVERY_N_TRACKS = 4;
+
+/** How many recent tracks/artists to send so the server avoids repeating them. */
+const RECENT_WINDOW = 10;
+
+/**
+ * How far ahead to insert. 1 = immediately next.
+ *
+ * 2 leaves the listener's own next choice intact — a suggestion that displaces the very
+ * next track reads as the app overriding them, which is the opposite of the intent.
+ */
+const INSERT_OFFSET = 2;
+
+class RadioController {
+  private unsubscribe: (() => void) | null = null;
+  private tracksSinceInsert = 0;
+  private inFlight = false;
+  /** Suggestions already inserted, so a re-suggest doesn't stack duplicates. */
+  private inserted = new Set<string>();
+
+  start(): void {
+    if (this.unsubscribe) return;
+    log.info('Radio controller started');
+
+    let prevTrackId = usePlayerStore.getState().currentTrack?.id ?? null;
+
+    this.unsubscribe = usePlayerStore.subscribe(() => {
+      const trackId = usePlayerStore.getState().currentTrack?.id ?? null;
+      if (trackId === prevTrackId) return;
+      prevTrackId = trackId;
+      if (!trackId) return;
+
+      this.tracksSinceInsert += 1;
+      if (this.tracksSinceInsert >= INSERT_EVERY_N_TRACKS) {
+        void this.suggest();
+      }
+    });
+  }
+
+  stop(): void {
+    this.unsubscribe?.();
+    this.unsubscribe = null;
+    this.tracksSinceInsert = 0;
+    this.inFlight = false;
+    this.inserted.clear();
+    log.info('Radio controller stopped');
+  }
+
+  /** Reads the persisted opt-in. Radio is off until the listener turns it on. */
+  isEnabled(): boolean {
+    return useRadioStore.getState().enabled;
+  }
+
+  /** Ask for a suggestion and insert it. Safe to call directly (e.g. a "suggest now" action). */
+  async suggest(): Promise<void> {
+    if (!this.isEnabled() || this.inFlight) return;
+
+    const state = usePlayerStore.getState();
+    const current = state.currentTrack;
+    if (!current) return;
+
+    // Nothing to fetch with, and inserting a track that cannot stream is worse than
+    // inserting nothing.
+    if (useConnectivityStore.getState().offlineModeActive) return;
+
+    this.inFlight = true;
+    try {
+      const recent = state.queue
+        .slice(Math.max(0, state.queueIndex - RECENT_WINDOW), state.queueIndex + 1)
+        .map((item) => item.track);
+
+      const response = await queueApi.getSuggestions({
+        current_track_id: current.id,
+        recent_track_ids: Array.from(new Set(recent.map((t) => t.id))),
+        recent_artist_names: Array.from(
+          new Set(recent.map((t) => t.artist).filter((a): a is string => !!a))
+        ),
+        profile: 'radio',
+        limit: 5,
+      });
+
+      if (response.pool_collapsed || response.suggestions.length === 0) {
+        // Too few candidates to rank meaningfully. Stay quiet rather than insert
+        // something arbitrary, and try again after the next N tracks.
+        log.debug('No usable suggestion (pool_size %d)', response.pool_size);
+        this.tracksSinceInsert = 0;
+        return;
+      }
+
+      const pick = response.suggestions.find(
+        (s) => !this.inserted.has(s.track.id) && !this.isQueuedNearby(s.track.id)
+      );
+      if (!pick) {
+        this.tracksSinceInsert = 0;
+        return;
+      }
+
+      // Re-read: the queue may have moved while the request was in flight.
+      const fresh = usePlayerStore.getState();
+      const insertAt = Math.min(fresh.queueIndex + INSERT_OFFSET, fresh.queue.length);
+      fresh.addToQueue(pick.track, insertAt, undefined, { suggested: true });
+
+      this.inserted.add(pick.track.id);
+      this.tracksSinceInsert = 0;
+      log.info('Inserted suggestion "%s" at %d (score %s)', pick.track.title, insertAt, pick.score);
+    } catch (error) {
+      // A failed suggestion is not worth surfacing — the listener did not ask for one,
+      // and playback is unaffected. Retry naturally after the next N tracks.
+      log.warn('Suggestion request failed:', error);
+      this.tracksSinceInsert = 0;
+    } finally {
+      this.inFlight = false;
+    }
+  }
+
+  /** Already sitting in the upcoming queue — suggesting it again would be noise. */
+  private isQueuedNearby(trackId: string): boolean {
+    const { queue, queueIndex } = usePlayerStore.getState();
+    return queue.slice(queueIndex, queueIndex + 20).some((item) => item.track.id === trackId);
+  }
+}
+
+export const radioController = new RadioController();

--- a/packages/frontend/src/player/useAudioEngine.ts
+++ b/packages/frontend/src/player/useAudioEngine.ts
@@ -13,6 +13,7 @@ import { log } from './audio/platform';
 import { useConnectivityStore } from '../stores/connectivityStore';
 import { useOutputStore } from '../stores/outputStore';
 import { prefetchService } from '../services/prefetchService';
+import { radioController } from './radio/radioController';
 import {
   getCrossfadeTrigger,
   getEffectiveCrossfadeDuration,
@@ -257,6 +258,14 @@ export function useAudioEngine() {
     if (!isInitialized) return;
     prefetchService.start();
     return () => prefetchService.stop();
+  }, [isInitialized]);
+
+  // Radio suggestions share the engine's lifecycle. Started but disabled by default —
+  // nothing is inserted until the listener turns it on (ADR-0005).
+  useEffect(() => {
+    if (!isInitialized) return;
+    radioController.start();
+    return () => radioController.stop();
   }, [isInitialized]);
 
   // --------------------------------------------------------------------------

--- a/packages/frontend/src/stores/radioStore.ts
+++ b/packages/frontend/src/stores/radioStore.ts
@@ -1,0 +1,24 @@
+/**
+ * Radio suggestions toggle (ADR-0005).
+ *
+ * Persisted and off by default. Radio inserts tracks the listener did not choose into a
+ * queue they are already enjoying, so it is opt-in — defaulting it on would be the app
+ * making that decision for them.
+ */
+import { create } from 'zustand';
+import { persist } from 'zustand/middleware';
+
+interface RadioState {
+  enabled: boolean;
+  setEnabled: (enabled: boolean) => void;
+}
+
+export const useRadioStore = create<RadioState>()(
+  persist(
+    (set) => ({
+      enabled: false,
+      setEnabled: (enabled) => set({ enabled }),
+    }),
+    { name: 'familiar-radio' }
+  )
+);

--- a/packages/frontend/src/types/index.ts
+++ b/packages/frontend/src/types/index.ts
@@ -71,5 +71,12 @@ export interface LibraryStats {
 export interface QueueItem {
   track: Track;
   queueId: string;
+  /**
+   * Set when the radio controller inserted this track rather than the listener
+   * choosing it (ADR-0005). The queue shows it differently and offers accept/reject —
+   * a suggestion the listener cannot identify as one cannot be judged by them or
+   * learned from.
+   */
+  suggested?: boolean;
 }
 


### PR DESCRIPTION
Completes ADR-0005. #24 gave the server a ranked list; this is what asks for one and puts it in front of the listener.

## Part 6 — the controller

`player/radio/radioController.ts` mirrors `AmbientCoordinator`'s shape: subscribe to track changes, ask the server, insert ahead of the play head. It holds **cadence and insertion policy only** — all ranking stays server-side under the `RADIO` profile, so no scoring logic is duplicated on the client.

**Insertion lands at `queueIndex + 2`, not +1.** Displacing the listener's very next track reads as the app overriding their choice, which is the opposite of what this feature is for.

## Part 8 — cadence

Every 4 track changes, per the ADR. Queue exhaustion was rejected because a library queue is a lazy reservoir over the whole collection and would effectively never empty, so the trigger would never fire.

## Part 7 — the affordances

Inserted tracks carry `suggested` and render with a ✨ marker plus accept and reject:

- **Accept** clears the marker and keeps the track. Nothing is reported — playing it already writes a `PlayEvent`.
- **Reject** removes it and writes a `rejected` `PlayEvent`, which is what feeds the negative term added in #23.

Worth being explicit: **parts 4 and 7 only work together.** Without the reject affordance the negative term has no rejections to learn from, so it would have stayed permanently inert.

## Most of this is about staying quiet

The controller declines to insert when the candidate pool collapsed, when offline, when the track is already queued nearby, or when it has already suggested that track — and it swallows request failures rather than surfacing them, since the listener never asked for a suggestion in the first place.

That's deliberate. This feature puts tracks someone didn't choose into a queue they're already enjoying. Inserting something arbitrary because the pool was too small, or stacking duplicates, is worse than inserting nothing — so the tests weight those paths more heavily than the happy one.

## Off by default

Behind a persisted opt-in (`radioStore`) with a settings panel in Playback. Radio should be the listener's decision — and a controller nobody can switch on isn't a feature, which is why the toggle is in this PR rather than deferred.

## Tests

15 new, mostly on the decline-to-insert paths.

```
Test Files  58 passed (58)
     Tests  865 passed (865)
```

Typecheck identical to `main` (9 pre-existing). Lint 0 errors. Web build succeeds.

## Not verified in use

The cadence, the insert offset, and `RADIO`'s weights are all first guesses. They can't be judged until it's actually used — and the negative term stays inert until rejections accumulate. Worth turning on for a few sessions before tuning anything.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_014P9p2fvFnyiywBxGkv4gfW