### PR TITLE
chore(ci): stop CI starving the music server, and stop reporting false failures

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -45,6 +45,10 @@ jobs:
 
   macos-compose-integration:
     name: macOS Compose Integration
+    # Pull requests only, for the same NAS-contention reason as docker-build. Its
+    # keychain failure is environmental and it is already advisory, so running it on
+    # every merge adds a red check that means nothing.
+    if: github.event_name != 'push'
     runs-on: [self-hosted, macOS]
     timeout-minutes: 15
     # Advisory: the self-hosted macOS runner runs as a launchd service with
@@ -146,7 +150,10 @@ jobs:
         uses: astral-sh/setup-uv@v4
         with:
           version: "latest"
-          enable-cache: true
+          # Every job here runs on a self-hosted runner, whose uv cache already persists
+          # on local disk between runs — the hosted cache adds nothing and its post-job
+          # prune has been failing (exit 2), marking jobs red while all tests passed.
+          enable-cache: false
 
       - name: Set up Python
         run: uv python install 3.12
@@ -170,7 +177,10 @@ jobs:
         uses: astral-sh/setup-uv@v4
         with:
           version: "latest"
-          enable-cache: true
+          # Every job here runs on a self-hosted runner, whose uv cache already persists
+          # on local disk between runs — the hosted cache adds nothing and its post-job
+          # prune has been failing (exit 2), marking jobs red while all tests passed.
+          enable-cache: false
 
       - name: Set up Python
         run: uv python install 3.12
@@ -233,7 +243,10 @@ jobs:
         uses: astral-sh/setup-uv@v4
         with:
           version: "latest"
-          enable-cache: true
+          # Every job here runs on a self-hosted runner, whose uv cache already persists
+          # on local disk between runs — the hosted cache adds nothing and its post-job
+          # prune has been failing (exit 2), marking jobs red while all tests passed.
+          enable-cache: false
 
       - name: Set up Python
         run: uv python install 3.12
@@ -315,7 +328,10 @@ jobs:
         uses: astral-sh/setup-uv@v4
         with:
           version: "latest"
-          enable-cache: true
+          # Every job here runs on a self-hosted runner, whose uv cache already persists
+          # on local disk between runs — the hosted cache adds nothing and its post-job
+          # prune has been failing (exit 2), marking jobs red while all tests passed.
+          enable-cache: false
 
       - name: Set up Python
         run: uv python install 3.12
@@ -396,7 +412,10 @@ jobs:
         uses: astral-sh/setup-uv@v4
         with:
           version: "latest"
-          enable-cache: true
+          # Every job here runs on a self-hosted runner, whose uv cache already persists
+          # on local disk between runs — the hosted cache adds nothing and its post-job
+          # prune has been failing (exit 2), marking jobs red while all tests passed.
+          enable-cache: false
 
       - name: Set up Python
         run: uv python install 3.12
@@ -581,6 +600,11 @@ jobs:
 
   docker-build:
     name: Docker Build
+    # Pull requests only. The self-hosted runner is the same machine that serves the
+    # music library, and a Docker build saturates its disks — during one, serving a 20MB
+    # track went from ~1.5s to ~40s and playback stalled outright. On a merge this would
+    # re-validate content the PR run already built, so the cost buys nothing.
+    if: github.event_name != 'push'
     runs-on: [self-hosted, Linux]
     timeout-minutes: 60
     # Advisory only: the self-hosted NAS runner's upstream connection is
@@ -631,6 +655,9 @@ jobs:
 
   e2e-test:
     name: E2E Tests (Playwright)
+    # Pull requests only — see docker-build. It also depends on docker-build, which does
+    # not run on push, so leaving it enabled would leave it permanently skipped anyway.
+    if: github.event_name != 'push'
     runs-on: [self-hosted, Linux]
     needs: [docker-build]
     # Advisory only: this job only runs when docker-build succeeds, and
@@ -672,7 +699,10 @@ jobs:
         uses: astral-sh/setup-uv@v4
         with:
           version: "latest"
-          enable-cache: true
+          # Every job here runs on a self-hosted runner, whose uv cache already persists
+          # on local disk between runs — the hosted cache adds nothing and its post-job
+          # prune has been failing (exit 2), marking jobs red while all tests passed.
+          enable-cache: false
 
       - name: Set up Python
         run: uv python install 3.12


### PR DESCRIPTION
Three fixes. None affect correctness — but a red check nobody trusts is the same as no check, and today CI was producing exactly that.

## 1. The `uv` cache has been reddening every E2E run

Every job runs on a **self-hosted** runner whose `uv` cache already persists on local disk between runs, so `enable-cache: true` uploads to GitHub's cache service for no benefit. Its post-job prune step exits 2 and marks the job red.

Every E2E run today: **26 tests passed, 0 failed, job red.** I investigated that four separate times before recognising it, and each time the answer was "tests passed, ignore the job". That is a check actively costing more than it provides.

`enable-cache: false` on all six `setup-uv` uses.

## 2. Docker Build, E2E and macOS Compose Integration now run on PRs only

**The self-hosted runner is the machine that serves the music library.** A Docker build saturates the same disks playback reads from. Measured during one today:

- serving a ~20 MB track went from ~1.5 s to **~40 s**
- the offline download queue aborted repeatedly on its activity timeout
- the player hung with `Loading timeout - clearing stuck loading state`

That was reported as a bug and investigated as one before I checked the host and found `buildkitd` at 13% with 36 GB of block reads — six CI runs queued by three merges.

On a merge these jobs re-validate content the PR run already covered. **All three were already `continue-on-error: true`**, so this removes no gate whatsoever. Every fast, blocking job — lint, all backend tests, frontend tests, migration lint, iOS — still runs on push to `main`.

| | on PR | on push to main |
|---|---|---|
| lint / unit / migration / iOS (10 jobs) | ✅ | ✅ |
| Docker Build, E2E, macOS Compose Integration | ✅ | skipped |

## 3. Documented the macOS keychain failure where it will be read

The runner is a launchd service with no interactive session, so its login keychain stays locked and Docker's `osxkeychain` helper fails. **Unlocking it interactively does not help** — that's a different session, which I suggested and was wrong about.

The fix is on the runner host: remove `"credsStore": "osxkeychain"` from that user's `~/.docker/config.json`. Not a repo change, so it's recorded rather than fixed here.

## Not addressed

The runner sharing hardware with the media server is the underlying problem; gating jobs only reduces how often it bites. Moving the runner off the NAS is the real fix and a bigger decision than a CI tweak.

## Verification

Workflow YAML parses; the resulting matrix is 10 always-run jobs and 3 PR-only. `e2e-test` `needs: [docker-build]` and both are PR-only, so no job can end up permanently blocked. No other workflow targets the NAS — `release.yml` is tag-triggered, `pages.yml` is path-filtered, `fly-deploy-demo.yml` is disabled, and all three use `ubuntu-latest`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_014P9p2fvFnyiywBxGkv4gfW