### PR TITLE
fix(radio): place suggestions in play order when shuffle is on

### DIFF
--- a/packages/frontend/src/player/__tests__/radioController.test.ts
+++ b/packages/frontend/src/player/__tests__/radioController.test.ts
@@ -25,7 +25,7 @@ vi.mock('../../stores/connectivityStore', () => ({
   ),
 }));
 
-import { radioController, INSERT_EVERY_N_TRACKS } from '../radio/radioController';
+import { radioController, INSERT_EVERY_N_TRACKS, INSERT_OFFSET } from '../radio/radioController';
 import { usePlayerStore } from '../playerStore';
 import { useRadioStore } from '../../stores/radioStore';
 import type { Track } from '../../types';
@@ -150,6 +150,57 @@ describe('insertion', () => {
     seedQueue(['a'], 0);
     await radioController.suggest();
     expect(usePlayerStore.getState().queue.map((i) => i.track.id)).toEqual(['a', 's1']);
+  });
+});
+
+describe('shuffle', () => {
+  // Found in use, not by these tests: with shuffle on, both playback and QueueView follow
+  // shuffleOrder rather than the queue array. addToQueue appends to that order unless
+  // given a position, so the suggestion landed last in play order — at index ~1719 of a
+  // favourites queue. Invisible at the bottom of a virtualised list, and never reached.
+  function seedShuffled(ids: string[], shuffleIndex: number) {
+    seedQueue(ids, 0);
+    usePlayerStore.setState({
+      shuffle: true,
+      shuffleOrder: ids.map((_, i) => i),
+      shuffleIndex,
+      currentTrack: track(ids[shuffleIndex]),
+      queueIndex: shuffleIndex,
+    });
+  }
+
+  it('places the suggestion just ahead in play order, not at the end', async () => {
+    seedShuffled(['a', 'b', 'c', 'd', 'e', 'f'], 1);
+
+    await radioController.suggest();
+
+    const { queue, shuffleOrder } = usePlayerStore.getState();
+    const playOrderIds = shuffleOrder.map((qi) => queue[qi]?.track.id);
+    const position = playOrderIds.indexOf('s1');
+
+    expect(position).toBeGreaterThan(-1);
+    expect(position).toBeLessThan(shuffleOrder.length - 1); // not dumped at the end
+    expect(position).toBe(1 + INSERT_OFFSET);
+  });
+
+  it('does not displace the next track in play order', async () => {
+    seedShuffled(['a', 'b', 'c', 'd', 'e', 'f'], 1);
+    const { queue: before, shuffleOrder: orderBefore } = usePlayerStore.getState();
+    const nextUpId = before[orderBefore[2]].track.id;
+
+    await radioController.suggest();
+
+    const { queue, shuffleOrder } = usePlayerStore.getState();
+    expect(queue[shuffleOrder[2]].track.id).toBe(nextUpId);
+  });
+
+  it('still inserts sensibly with shuffle off', async () => {
+    seedQueue(['a', 'b', 'c', 'd'], 1);
+    usePlayerStore.setState({ shuffle: false, shuffleOrder: [], shuffleIndex: -1 });
+
+    await radioController.suggest();
+
+    expect(usePlayerStore.getState().queue.map((i) => i.track.id)[3]).toBe('s1');
   });
 });
 

--- a/packages/frontend/src/player/radio/radioController.ts
+++ b/packages/frontend/src/player/radio/radioController.ts
@@ -31,7 +31,7 @@ const RECENT_WINDOW = 10;
  * 2 leaves the listener's own next choice intact — a suggestion that displaces the very
  * next track reads as the app overriding them, which is the opposite of the intent.
  */
-const INSERT_OFFSET = 2;
+export const INSERT_OFFSET = 2;
 
 class RadioController {
   private unsubscribe: (() => void) | null = null;
@@ -120,7 +120,16 @@ class RadioController {
       // Re-read: the queue may have moved while the request was in flight.
       const fresh = usePlayerStore.getState();
       const insertAt = Math.min(fresh.queueIndex + INSERT_OFFSET, fresh.queue.length);
-      fresh.addToQueue(pick.track, insertAt, undefined, { suggested: true });
+
+      // Under shuffle, both playback and the queue view follow `shuffleOrder`, not the
+      // queue array. Without an explicit position `addToQueue` appends to the end of that
+      // order, so a suggestion inserted "two ahead" in queue terms lands last in play
+      // order — invisible at the bottom of the list and never actually reached.
+      const shuffleInsertPosition = fresh.shuffle && fresh.shuffleOrder.length > 0
+        ? Math.min(fresh.shuffleIndex + INSERT_OFFSET, fresh.shuffleOrder.length)
+        : undefined;
+
+      fresh.addToQueue(pick.track, insertAt, shuffleInsertPosition, { suggested: true });
 
       this.inserted.add(pick.track.id);
       this.tracksSinceInsert = 0;


### PR DESCRIPTION
Reported as *"I don't see any amber sparkles in the queue."* The suggestion was there — at index ~1719 of a 1,719-track favourites queue.

## The bug

Under shuffle, both playback and `QueueView` follow `shuffleOrder`, not the `queue` array:

```ts
const displayTracks = (shuffle && shuffleOrder.length > 0)
  ? shuffleOrder.map(...)
  : queue.map(...)
```

`addToQueue` appends to that order unless given an explicit position:

```ts
if (shuffleInsertPosition !== undefined) {
  newShuffleOrder.splice(shuffleInsertPosition, 0, insertAt);
} else {
  newShuffleOrder.push(insertAt);   // ← what radioController got
}
```

`radioController` passed `undefined`. So a suggestion inserted two ahead *in queue terms* landed **dead last in play order** — invisible at the bottom of a virtualised list, and never reached.

Client logs confirmed it exactly:

```
Inserted suggestion "How Does It Make You Feel?" at 459 (score 0.8111)
```

with the listener at queue index 457. Correct in queue terms, useless in play terms.

## The fix

Pass `shuffleIndex + INSERT_OFFSET` so the suggestion lands two ahead in the order that actually governs playback — while still not displacing the next track.

## Why the tests missed it

They asserted insertion position **only in queue order**, so they passed while the feature did nothing observable. That's the more useful lesson than the bug itself: the tests described what the code did rather than what the listener would experience.

Three shuffle cases added, and **the fix was reverted in place to confirm they fail without it**. Given the day's history, a test that would have passed either way was worth nothing.

`INSERT_OFFSET` is now exported so the test asserts the real constant rather than a hardcoded `2` that could drift away from it.

## Checks

```
Test Files  58 passed (58)
     Tests  868 passed (868)
```

Types identical to `main` (9 pre-existing). Lint 0 errors. Web build succeeds.

Needs a NAS deploy to be visible, since the frontend is served from there.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_014P9p2fvFnyiywBxGkv4gfW