### PR TITLE
fix(offline): debounce manifest refresh so a download job doesn't rebuild per track

### DIFF
--- a/packages/frontend/src/services/__tests__/offlineManifestService.test.ts
+++ b/packages/frontend/src/services/__tests__/offlineManifestService.test.ts
@@ -14,7 +14,7 @@
  * than throws. Offline ambient getting worse is acceptable; offline ambient crashing is
  * not, and it would happen exactly when the listener has no way to recover.
  */
-import { describe, it, expect, beforeEach, vi } from 'vitest';
+import { describe, it, expect, beforeEach, afterEach, vi } from 'vitest';
 
 const { mockGetManifest, mockGetOfflineTrackIds, mockGetProfileId, store } = vi.hoisted(() => ({
   mockGetManifest: vi.fn(),
@@ -44,7 +44,9 @@ vi.mock('../../api/queue', () => ({ queueApi: { getOfflineManifest: mockGetManif
 
 import {
   MIN_POOL_SIZE,
+  REFRESH_DEBOUNCE_MS,
   getOfflineNeighbours,
+  initOfflineManifestSync,
   pickOfflineSeed,
   refreshManifest,
 } from '../offlineManifestService';
@@ -191,5 +193,48 @@ describe('refresh', () => {
 
     await expect(refreshManifest()).resolves.toBeUndefined();
     expect(store.has(PROFILE)).toBe(true);
+  });
+});
+
+
+describe('refresh is debounced', () => {
+  // Found in use: `offline-tracks-updated` fires once per completed download, so a
+  // 1,573-track job triggered a rebuild per track. Measured 17 rebuilds in 15 minutes,
+  // 21s of server time, and the cost per rebuild grows with the set.
+  beforeEach(() => {
+    vi.useFakeTimers();
+    mockGetOfflineTrackIds.mockResolvedValue(Array.from({ length: 12 }, (_, i) => `t${i}`));
+    mockGetManifest.mockResolvedValue({ variants: [], track_count: 12 });
+  });
+
+  afterEach(() => vi.useRealTimers());
+
+  it('collapses a burst of downloads into one rebuild', async () => {
+    const stop = initOfflineManifestSync();
+    await vi.advanceTimersByTimeAsync(0);
+    mockGetManifest.mockClear(); // ignore the eager refresh at startup
+
+    for (let i = 0; i < 50; i++) {
+      window.dispatchEvent(new CustomEvent('offline-tracks-updated'));
+      await vi.advanceTimersByTimeAsync(200); // downloads land faster than the window
+    }
+    expect(mockGetManifest).not.toHaveBeenCalled();
+
+    await vi.advanceTimersByTimeAsync(REFRESH_DEBOUNCE_MS + 100);
+    expect(mockGetManifest).toHaveBeenCalledTimes(1);
+
+    stop();
+  });
+
+  it('cancels a pending rebuild on teardown', async () => {
+    const stop = initOfflineManifestSync();
+    await vi.advanceTimersByTimeAsync(0);
+    mockGetManifest.mockClear();
+
+    window.dispatchEvent(new CustomEvent('offline-tracks-updated'));
+    stop();
+    await vi.advanceTimersByTimeAsync(REFRESH_DEBOUNCE_MS + 100);
+
+    expect(mockGetManifest).not.toHaveBeenCalled();
   });
 });

--- a/packages/frontend/src/services/offlineManifestService.ts
+++ b/packages/frontend/src/services/offlineManifestService.ts
@@ -21,6 +21,19 @@ const log = createLogger('OfflineManifest');
 /** Below this the pool is too small to rank meaningfully — matches offlineScoring's old floor. */
 export const MIN_POOL_SIZE = 8;
 
+/**
+ * How long the offline set must stop changing before the manifest is rebuilt.
+ *
+ * `offline-tracks-updated` fires once per completed download, so a bulk job of 1,573
+ * tracks would otherwise trigger 1,573 rebuilds. Measured on the NAS before this was
+ * added: 17 rebuilds in 15 minutes, 21 seconds of server time, and the cost per rebuild
+ * grows as the set grows.
+ *
+ * A manifest is only useful once the device is offline, so rebuilding mid-download buys
+ * nothing — waiting for the job to settle is both cheaper and more accurate.
+ */
+export const REFRESH_DEBOUNCE_MS = 30_000;
+
 export async function loadManifest(): Promise<OfflineManifest | null> {
   const profileId = await getSelectedProfileId();
   if (!profileId) return null;
@@ -143,11 +156,23 @@ export async function pickOfflineSeed(
 export function initOfflineManifestSync(): () => void {
   if (typeof window === 'undefined') return () => {};
 
+  let timer: ReturnType<typeof setTimeout> | null = null;
+
+  // Trailing debounce: a download job produces a burst of these, and only the final
+  // state is worth ranking.
   const handler = () => {
-    void refreshManifest();
+    if (timer) clearTimeout(timer);
+    timer = setTimeout(() => {
+      timer = null;
+      void refreshManifest();
+    }, REFRESH_DEBOUNCE_MS);
   };
+
   window.addEventListener('offline-tracks-updated', handler);
   void refreshManifest();
 
-  return () => window.removeEventListener('offline-tracks-updated', handler);
+  return () => {
+    if (timer) clearTimeout(timer);
+    window.removeEventListener('offline-tracks-updated', handler);
+  };
 }


### PR DESCRIPTION
Found by watching the NAS during real use, not by a test.

## The bug

`offline-tracks-updated` fires **once per completed download**, and `initOfflineManifestSync` called `refreshManifest()` on every one.

Measured during a live 1,573-track download job:

```
17 manifest rebuilds in 15 minutes
21 seconds of server time
```

On course for ~1,500 rebuilds — and the cost per rebuild *grows* with the offline set, so it gets worse as the job progresses.

## The fix

Trailing 30-second debounce. A manifest is only useful once the device is offline, so rebuilding mid-job buys nothing: every intermediate manifest describes a set that's about to change. Waiting for the download to settle is both cheaper and more accurate.

Teardown cancels a pending rebuild rather than letting it fire after unmount.

## Tests

A 50-event burst collapses to one rebuild. **Verified against the undebounced handler** to confirm they fail without the fix — both new tests do.

```
Test Files  59 passed (59)
     Tests  885 passed (885)
```

Types identical to `main`, lint 0 errors, build succeeds.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_014P9p2fvFnyiywBxGkv4gfW