### PR TITLE
fix(player): make the logical queue real, so going offline stops destroying it

### DIFF
--- a/docs/decisions/ADR-0003-server-owns-the-playback-queue.md
+++ b/docs/decisions/ADR-0003-server-owns-the-playback-queue.md
@@ -1,10 +1,23 @@
 # ADR-0003: The Server Owns the Playback Queue
 
-Status: proposed
+Status: accepted
 
 Date: 2026-07-26
 
 Extends [ADR-0001](ADR-0001-native-apple-clients-supersede-capacitor.md).
+
+Implementation:
+- Decision points 1, 3, 5 and 6 were revised before acceptance, after investigating the client, and
+  points 8 and 9 are new. The original point 5 asserted that the logical/playable queue split already
+  existed and would be "preserved, not replaced"; it does not exist, and building it is now the first
+  phase of work. The original point 3 named the `pendingActions` outbox as an append log, which is the
+  wrong shape for state. Point 1 gained `position_seconds` and `reservoir_hash`, and lost `device_id`.
+- Both follow-ups from the original draft are resolved at acceptance — see **Resolved** under
+  Consequences. `PlaybackSession` is keyed by **profile alone**.
+- Execution order, each phase its own branch: (1) the logical/playable split, client-only, no server
+  involved; (2) `PlaybackSession`, migration and endpoints; (3) client sync behind a flag. Phase 1 is
+  deliberately separate — it fixes existing data loss, and without it phase 3 would upload an
+  offline-filtered queue and overwrite the logical one on every other device.
 
 ## Context
 
@@ -26,31 +39,78 @@ Three consequences follow:
    permanent and invisible.
 
 The obvious objection to a server-owned queue is that it breaks offline playback. It does not, but
-only if the design is explicit about it — which is the substance of this ADR. The necessary pieces
-already exist and are proven:
+only if the design is explicit about it — which is the substance of this ADR. Two of the pieces the
+original draft called proven are proven; two are not, and are recorded here so nobody re-derives them.
 
-- **An outbox pattern.** `packages/frontend/src/services/syncService.ts` already queues
-  `scrobble | now_playing | favorite_toggle | listen_event` actions into the `pendingActions` table
-  with retry counts and replays them on reconnect. `listen_event` was added by
-  [ADR-0004](ADR-0004-listening-feedback-is-event-sourced.md) after this was drafted — the mechanism
-  has already been extended once without trouble.
-- **Offline queue filtering.** `packages/frontend/src/player/useAudioEngine.ts` already rebuilds the
-  queue down to downloaded tracks when connectivity drops and restores the full queue on reconnect.
-- **A regression guard.** `packages/web/e2e/offline-invariant.spec.ts` already asserts this
-  behaviour.
-- **Connectivity state.** `packages/frontend/src/stores/connectivityStore.ts` (320 lines) already
-  models `browserOnline` / `reachabilityState` / `forcedOffline` with consecutive-failure debouncing.
+**What is proven:**
+
+- **An outbox exists and has been extended once.** `packages/frontend/src/services/syncService.ts`
+  queues `scrobble | now_playing | favorite_toggle | listen_event` actions into the `pendingActions`
+  table and replays them on reconnect. `listen_event` was added by
+  [ADR-0004](ADR-0004-listening-feedback-is-event-sourced.md) after this was drafted.
+- **Connectivity state.** `packages/frontend/src/stores/connectivityStore.ts` (320 lines) models
+  `browserOnline` / `reachabilityState` / `forcedOffline` with consecutive-failure debouncing, and
+  derives a single `offlineModeActive` flag that every consumer reads.
+
+**Four premises in the original draft were wrong:**
+
+1. **The logical/playable queue split does not exist.** The draft said `useAudioEngine.ts` "already
+   rebuilds the queue down to downloaded tracks when connectivity drops and restores the full queue
+   on reconnect," and that this ADR would preserve that behaviour. What the code actually does is
+   destructive: the rebuild effect calls `setQueue(filteredTracks, …)`
+   (`packages/frontend/src/player/useAudioEngine.ts:545`), which replaces the queue outright, and
+   `setQueue` also nulls `lazyQueueIds` / `lazyQueueIndex` (`queueStore.ts:517-518`). The pre-filter
+   queue survives only in `preOfflineQueueRef` (`useAudioEngine.ts:119`) — an in-memory React ref.
+
+   Two failures follow, both present today:
+
+   - **A reload while offline loses the logical queue permanently.** The ref is gone and the
+     persisted copy is the filtered one, so there is nothing left to restore from.
+   - **A reconnect restores a non-lazy queue.** The reservoir was nulled going in and the ref holds
+     only materialised tracks, so a library queue silently stops at the end of the ~50-track window —
+     the same failure PR #20 fixed for reloads, still live for the offline round trip.
+
+   So the split must be **built**, not preserved. That is decision point 5 and the first phase of
+   work, and it is the single most valuable part of this ADR independent of any server.
+
+2. **The cited regression guard guards something else.** `packages/web/e2e/offline-invariant.spec.ts`
+   asserts that the Downloads view agrees with IndexedDB; it never builds a queue and never varies
+   connectivity. The actual coverage is two unit tests at
+   `packages/frontend/src/player/__tests__/playerStore.test.ts:273-292` and the PR #20 reservoir suite
+   in `queuePersistence.test.ts`. The e2e claim should not be used when judging how much risk this
+   change carries.
+
+3. **The outbox is an event log, not a state channel.** It is proven for events and unsuited to
+   state as built: no dedupe, no backoff, an action dropped after four attempts
+   (`syncService.ts:111-119`), global millisecond-resolution `createdAt` ordering across all profiles
+   and action types (`:75`), and `executeAction` ignoring `action.profileId` entirely (`:173-201`) —
+   the profile comes from the `X-Profile-ID` interceptor at request time (`api/base.ts:167-172`), so
+   an action queued under one profile replays against whichever profile is selected when the drain
+   runs. [ADR-0006](ADR-0006-offline-ranking-is-precomputed-server-side.md) reached the same
+   conclusion from the other direction and recorded it as a resolved follow-up: "`syncService` was the
+   wrong vehicle; it is an outbound `pendingActions` replay queue with no inbound path."
+
+4. **Device identity is greenfield, not merely unsettled.** The draft's follow-up treated
+   `Profile.device_id` as a starting point. It is a nullable column with **zero readers** anywhere in
+   `backend/app/` (`db/models/profiles.py:33`), the IndexedDB `deviceProfile.deviceId` is written as
+   the empty string (`services/profileSelection.ts:56`), and no endpoint reads any device header. So
+   keying by device is not "use the field that exists" — it is inventing the concept.
 
 ## Decision
 
 The server becomes the source of truth for the durable queue; every client holds an **authoritative
 local replica** and never blocks playback on the network.
 
-1. **A `PlaybackSession` model server-side**, keyed by profile and device: `track_ids[]`, `cursor`,
-   `shuffle_order[]`, `shuffle_index`, `repeat`, `consume`, `queue_source`, `reservoir_ids[]`,
-   `reservoir_cursor`, `version`, `updated_at`.
+1. **A `PlaybackSession` model server-side, keyed by profile alone**: `track_ids[]`, `cursor`,
+   `shuffle_order[]`, `shuffle_index`, `shuffle`, `repeat`, `consume`, `queue_source`,
+   `reservoir_ids[]`, `reservoir_cursor`, `reservoir_hash`, `position_seconds`, `version`,
+   `updated_at`.
 
-   The last three fields were added after this ADR was drafted and are not optional detail. Both
+   **There is no `device_id`.** One live queue per profile, so handoff needs no explicit transfer
+   action and the device identity that does not exist stays uninvented — see Context point 4 and the
+   alternative below.
+
+   Three fields were added after the ADR was drafted and are not optional detail. The first two
    concerns were found missing from client persistence in PR #20, each causing a distinct silent
    failure:
 
@@ -61,42 +121,77 @@ local replica** and never blocks playback on the network.
      list with only a ~50-track window materialised. Without them the queue silently truncates to
      that window and **playback simply ends after the 50th track**, with no error and nothing in the
      UI to explain it.
+   - **`position_seconds`** — without it a handoff resumes at the top of the track rather than where
+     the listener left off, which is most of what handoff is for. The client already persists this
+     (`PersistedPlayerState.currentTime`); the original field list simply omitted it.
 
-   A server-owned queue that omitted these would reproduce that bug on every client, including the
-   Swift one, and it would be materially harder to diagnose there than it was on the web.
+   A server-owned queue that omitted the first two would reproduce that bug on every client,
+   including the Swift one, and it would be materially harder to diagnose there than it was on the web.
 
 2. **Local-first mutation.** Every queue mutation applies to the local replica immediately and
    synchronously. Playback, reordering, and skipping never wait on a request. This is
    non-negotiable — a queue that stutters on a slow network is worse than no sync at all.
 
-3. **Mutations append to an outbox.** Reuse the `pendingActions` mechanism in
-   `packages/frontend/src/services/syncService.ts` rather than inventing a second sync path. On
-   reconnect the outbox replays and the server increments `version`. That mechanism has since been
-   extended once already, gaining `listen_event` under
-   [ADR-0004](ADR-0004-listening-feedback-is-event-sourced.md), so reusing it is proven rather than
-   assumed.
+3. **Mutations coalesce into a single outbox row per profile, replaced rather than appended.** Reuse
+   `pendingActions` as the *transport* — inventing a second sync path is still the wrong move — but
+   not its append semantics. A queue is state, not an event: appending a snapshot per mutation would
+   replay hundreds of stale queues on reconnect, all but the last one pointless, and the four-attempt
+   drop (`syncService.ts:111-119`) would strand the server mid-history, contradicting point 6's
+   promise that nothing is destroyed. One row per profile, always current, is both cheaper and
+   correct under last-writer-wins.
+
+   Three defects in the outbox must be fixed for this to be safe, and all three are latent bugs
+   today rather than new requirements: `executeAction` must honour the captured `action.profileId`
+   instead of letting the interceptor choose (Context point 3); the drain needs an in-flight guard,
+   because the `window 'online'` handler and `components/PWA/OfflineIndicator.tsx` can currently run
+   it concurrently; and the drain must also fire on `connectivityStore`'s probe-driven
+   `forcedOffline → reachable` recovery, which emits no browser `online` event.
 
 4. **The reservoir syncs separately from the queue, and not on every mutation.** For this library
    `reservoir_ids` is 26,462 UUIDs — roughly 1 MB. Shipping that with each cursor advance would be
    absurd, and it is a different problem from syncing a 50-track queue, which the original draft did
    not distinguish.
 
-   The reservoir changes only on `setLazyQueue`, `toggleShuffle` and a refill, so it is sent when it
-   changes and referenced by hash otherwise. The same reasoning already applies client-side: PR #20
-   stores it in its own IndexedDB row precisely so a 500ms `setCurrentTime` throttle does not rewrite
-   a megabyte twice a second.
+   The reservoir changes only on `setLazyQueue`, `toggleShuffle` and a refill, so it is **sent when it
+   changes and referenced by `reservoir_hash` otherwise**: a write may omit `reservoir_ids`, meaning
+   "unchanged, and it hashes to this"; a hash the server does not hold is rejected so the client
+   resends in full. The same reasoning already applies client-side: PR #20 stores it in its own
+   IndexedDB row precisely so a 500 ms `setCurrentTime` throttle does not rewrite a megabyte twice a
+   second, and skips the write by reference equality when the array has not been replaced.
 
-5. **The server queue is the *logical* queue; clients derive a *playable* queue.** When offline, a
-   client filters the logical queue to locally-available tracks for playback, and restores the full
-   logical queue on reconnect. This is exactly what `useAudioEngine.ts` does today; the behaviour is
-   preserved, not replaced.
+5. **The server queue is the *logical* queue; clients derive a *playable* queue — and this must be
+   built.** When offline, a client filters the logical queue to locally-available tracks for playback
+   and restores the full logical queue on reconnect. Today the filter is destructive and the logical
+   queue survives only in memory (Context point 1), so the first phase of work makes the logical queue
+   real persisted state: the pre-filter track IDs and the reservoir both survive a reload while
+   offline, and the reconnect path restores a lazy queue rather than a truncated one.
 
-6. **Conflict rule: later `updated_at` wins, and nothing is destroyed.** If two devices diverged
-   while offline, the later one becomes current and the loser's queue is retained as a restorable
-   entry. A user must never lose a queue they built to a silent merge.
+   Only the logical queue is ever synced. Uploading a filtered queue would overwrite every other
+   device's copy with whatever this device happened to have downloaded — the worst failure this ADR
+   could introduce, and the reason phase 1 comes first.
+
+6. **Conflict rule: later `updated_at` wins, and the loser is archived rather than dropped.** If two
+   devices diverged while offline, the later one becomes current and the loser is written to an
+   archive table as a restorable entry. A user must never lose a queue they built to a silent merge.
+   Because `updated_at` uses ORM-level `onupdate=func.now()`, the conflict path must go through ORM
+   updates and never a bulk `update()` statement, which would not bump it.
 
 7. **Land it behind a flag, in the web app, before Swift depends on it.** The native client consumes
-   this only once it is proven against the existing test suite.
+   this only once it is proven against the existing test suite. The flag is per-device
+   (`localStorage`) so rollout can be staged, paired with a server-side setting so an unflagged server
+   rejects writes rather than silently accepting them.
+
+8. **`queue_source` uses the client's queue-source vocabulary, stored whole.** `QueueSourceType`
+   (`player/playerStore.types.ts:1`) is `library | album | playlist | artist | ephemeral | other`.
+   The server's `PlayContext` (`routes/tracks/playback.py:51-53`) adds `radio` and `ambient`, which
+   are listening *contexts*, not queue *sources* — the sets differ deliberately and must not be
+   conflated. The whole object is stored as JSONB rather than decomposed into columns, because
+   `toggleShuffle` (`queueStore.ts:897`) replays `filters` verbatim against `tracksApi.getIds`.
+
+9. **`history` stays device-local and is not synced.** It is not persisted even locally today
+   (`queueStore.ts:124` is absent from the persist getter at `:1081-1092`), it is capped at 50 entries,
+   and "previous track" is a per-device navigation affordance rather than shared queue state. Syncing
+   it would mean deciding whose history wins on handoff, for no benefit.
 
 ## Alternatives Considered
 
@@ -110,25 +205,65 @@ local replica** and never blocks playback on the network.
   a case that resolves fine with a timestamp.
 - **Sync only the *current track*, not the queue.** Rejected. It solves the handoff case but not the
   duplicated-logic case, which is the larger long-term cost.
+- **Key `PlaybackSession` by profile *and* device.** Rejected, and this is the closest alternative to
+  the original draft. It is the more flexible model — each device keeps its own queue and handoff
+  becomes an explicit "transfer to here" action — but it requires inventing a device identity the
+  codebase does not have (Context point 4) and plumbing a new header through every client, and
+  [ADR-0006](ADR-0006-offline-ranking-is-precomputed-server-side.md) rejected exactly that for exactly
+  that reason. Profile keying also makes handoff the default rather than a feature someone has to
+  find. The cost is real and accepted: two devices playing simultaneously under one profile contend
+  over the cursor, and last-writer-wins means the one that stops later overwrites the other's
+  position. That is a single-listener application behaving as a single listener.
+- **Append one outbox row per mutation, and let the server collapse them by `version`.** Rejected.
+  Literal to the original point 3, but it makes reconnect O(mutations) instead of O(1), and the
+  existing four-attempt drop can discard a row from the middle of the history — leaving the server on
+  a state no device ever held. Coalescing makes the drop harmless because the surviving row is always
+  the current one.
+- **Drive sync from the existing `persistCombinedState()` funnel.** Rejected, despite being the
+  obvious seam — it is the single choke point 23 of the store's mutation sites already flow through
+  (`exitLazyMode` at `queueStore.ts:735` is the one that forgets to, which phase 1 fixes). But it also
+  fires on every `setCurrentTime` tick, throttled only to 500 ms, so hanging sync off it would mean a
+  request twice a second for the whole of playback. Structural changes and position changes need
+  different cadences, so they get separate triggers.
 
 ## Consequences
 
-- **Positive:** Cross-device handoff becomes possible for the first time.
+- **Positive:** Cross-device handoff becomes possible for the first time, and with profile keying it
+  needs no user action — the other device is simply already there.
 - **Positive:** The Swift client and any future Windows client carry queue *rendering*, not queue
   *logic*. This is the single largest reduction in per-platform work available.
 - **Positive:** Queue state becomes inspectable and repairable server-side, rather than trapped in
   per-device IndexedDB.
+- **Positive, and not in the original draft:** phase 1 fixes two live data-loss bugs on its own,
+  before any server work — a reload while offline no longer discards the logical queue, and a
+  reconnect no longer truncates a library queue at the materialised window. That value lands whether
+  or not the sync ever ships.
+- **Positive:** Three latent outbox bugs get fixed as a precondition (decision point 3), one of which
+  — `executeAction` ignoring the captured profile — currently misroutes offline favourite toggles
+  after a profile switch.
 - **Tradeoff:** This touches the most heavily tested code in the repository —
   `packages/frontend/src/player/__tests__/queueStore.test.ts` (672 lines) and `playerStore.test.ts`
-  (1,059 lines). Those tests are the safety net and must keep passing unchanged where behaviour is
-  unchanged.
+  (1,059 lines), plus `queuePersistence.test.ts` (278) and `persistence.test.ts` (177). Those tests
+  are the safety net and must keep passing unchanged where behaviour is unchanged.
 - **Tradeoff:** A new class of bug — replica divergence — becomes possible. The conflict rule must be
   tested explicitly, not assumed.
-- **Follow-up:** Decide whether `queueStore.ts` becomes a thin replica adapter or is substantially
-  rewritten. Prefer adapter: its shuffle-order and consume semantics are correct and well covered.
-- **Follow-up:** Define device identity. `Profile.device_id` exists as a legacy field and
-  `deviceProfile` exists in IndexedDB; neither is currently authoritative. This is now a shared
-  problem: [ADR-0006](ADR-0006-offline-ranking-is-precomputed-server-side.md) hit the same wall and
-  routed around it by having the client supply its own state rather than the server tracking it per
-  device. If this ADR keys `PlaybackSession` by device, it must solve what ADR-0006 avoided — and
-  that decision should be made deliberately, not inherited.
+- **Tradeoff:** One session per profile means simultaneous playback on two devices contends over the
+  cursor. Accepted deliberately; see the device-keying alternative.
+- **Tradeoff:** `queueId` values come from an in-memory counter (`queueStore.ts:23`), so queue item
+  identity is positional rather than stable across devices or reloads. Last-writer-wins does not need
+  stable identity, but any future per-item merge would.
+- **Resolved:** ~~Decide whether `queueStore.ts` becomes a thin replica adapter or is substantially
+  rewritten~~ — **adapter.** Its shuffle-order and consume semantics are correct and well covered, and
+  the persist getter at `queueStore.ts:1081-1092` already exposes almost exactly the `PlaybackSession`
+  field set. Phase 1 adds two fields to it rather than restructuring the store.
+- **Resolved:** ~~Define device identity~~ — **not needed.** `PlaybackSession` is keyed by profile, so
+  this ADR does not have to solve what
+  [ADR-0006](ADR-0006-offline-ranking-is-precomputed-server-side.md) avoided. `Profile.device_id`
+  stays vestigial; if a later ADR needs device identity, it starts from nothing, and that should be
+  stated plainly rather than discovered.
+- **Follow-up:** The archive from decision point 6 needs a retention policy. Bounded per profile is
+  enough to start; unbounded growth of superseded queues is not urgent at personal-library scale but
+  should not be ignored forever.
+- **Follow-up:** `position_seconds` syncs on a coarse cadence, so a handoff can resume a few seconds
+  behind where the other device actually was. Decide empirically whether that is worth tightening
+  once it is possible to feel it.

--- a/packages/frontend/src/db/index.ts
+++ b/packages/frontend/src/db/index.ts
@@ -192,6 +192,15 @@ export interface PersistedPlayerState {
   lazyQueueIds?: string[] | null;
   lazyQueueIndex?: number;
 
+  // The logical queue behind an offline-filtered one (ADR-0003 point 5). `queueTrackIds`
+  // above holds what is *playable*; while offline that is only the downloaded subset, so
+  // without these a reload discarded the rest of the queue permanently — the pre-filter
+  // list existed solely in a React ref. Like the reservoir, the ID list lives in its own
+  // row and only the cursor is stored here. Optional, so older records load as `undefined`
+  // and simply mean "not filtered" — no Dexie version bump needed.
+  logicalTrackIds?: string[] | null;
+  logicalIndex?: number;
+
   updatedAt: Date;
 }
 

--- a/packages/frontend/src/hooks/__tests__/useAudioEngine.integration.test.tsx
+++ b/packages/frontend/src/hooks/__tests__/useAudioEngine.integration.test.tsx
@@ -172,10 +172,12 @@ vi.mock('../../player/audioSettingsStore', () => ({
   }),
 }));
 
+const mockFetchTracksBatched = vi.hoisted(() => vi.fn(async (_ids: string[]) => [] as unknown[]));
+
 vi.mock('../../player/persistence', () => ({
   debouncedSavePlayerState: vi.fn(),
   loadPlayerState: vi.fn(async () => null),
-  fetchTracksBatched: vi.fn(async () => []),
+  fetchTracksBatched: mockFetchTracksBatched,
   migrateOldPlayerState: vi.fn(async () => {}),
 }));
 
@@ -227,7 +229,11 @@ describe('useAudioEngine + playerStore integration parity', () => {
       isLoadingAudio: false,
       isHydrated: true,
       isQueueHydrating: false,
+      logicalTrackIds: null,
+      logicalIndex: -1,
     });
+    mockFetchTracksBatched.mockReset();
+    mockFetchTracksBatched.mockImplementation(async (ids: string[]) => ids.map((id) => makeTrack(id)));
   });
 
   it('auto-advances exactly one track on ended event', async () => {
@@ -522,7 +528,11 @@ describe('continuous play reliability', () => {
       isLoadingAudio: false,
       isHydrated: true,
       isQueueHydrating: false,
+      logicalTrackIds: null,
+      logicalIndex: -1,
     });
+    mockFetchTracksBatched.mockReset();
+    mockFetchTracksBatched.mockImplementation(async (ids: string[]) => ids.map((id) => makeTrack(id)));
   });
 
   it('calls engine.load and engine.play for the next track after ended', async () => {
@@ -632,5 +642,130 @@ describe('continuous play reliability', () => {
       mockEngine.__emit({ type: 'canplay' });
     });
     expect(mockEngine.play).not.toHaveBeenCalled();
+  });
+
+  /**
+   * The offline queue round trip (ADR-0003 point 5).
+   *
+   * The narrowing effect used to keep the pre-filter queue in a React ref, so the logical
+   * queue existed nowhere durable. These tests drive the real effect rather than the store
+   * helpers, because the ref was the bug — the store was never the problem.
+   */
+  describe('offline queue narrowing and restore', () => {
+    /**
+     * Flip connectivity and let the hook observe it.
+     *
+     * The connectivity mock is a plain function over a mutable object, not a real store, so
+     * writing to it notifies nobody — the change is only picked up on the next render.
+     * `rerender` supplies that render, standing in for the subscription the real store has.
+     */
+    async function setConnectivity(
+      rerender: () => void,
+      next: { offlineModeActive: boolean; offlineTrackIds?: Set<string> },
+    ) {
+      mockConnectivityStore.setState(next);
+      await act(async () => {
+        rerender();
+      });
+    }
+
+    /** A three-track lazy library queue with only 'a' downloaded. */
+    function seedPartlyDownloadedQueue() {
+      const tracks = ['a', 'b', 'c'].map((id) => makeTrack(id));
+      usePlayerStore.setState({
+        queue: tracks.map((track, i) => ({ track, queueId: `q${i}` })),
+        queueIndex: 0,
+        currentTrack: tracks[0],
+        queueSource: { type: 'library' },
+        lazyQueueIds: ['a', 'b', 'c', 'd', 'e'],
+        lazyQueueIndex: 3,
+      });
+      return tracks;
+    }
+
+    it('records the logical queue and keeps the reservoir when narrowing', async () => {
+      seedPartlyDownloadedQueue();
+      const { rerender } = renderHook(() => useAudioEngine());
+      await act(async () => {});
+
+      await setConnectivity(rerender, {
+        offlineModeActive: true,
+        offlineTrackIds: new Set(['a']),
+      });
+
+      const s = usePlayerStore.getState();
+      expect(s.queue.map((i) => i.track.id)).toEqual(['a']);
+      // Durable, not a ref — this is what a reload used to destroy.
+      expect(s.logicalTrackIds).toEqual(['a', 'b', 'c']);
+      // And the queue is still lazy, so reconnecting does not strand it at the window.
+      expect(s.lazyQueueIds).toEqual(['a', 'b', 'c', 'd', 'e']);
+      expect(s.lazyQueueIndex).toBe(3);
+    });
+
+    it('widens back to the logical queue when connectivity returns', async () => {
+      seedPartlyDownloadedQueue();
+      const { rerender } = renderHook(() => useAudioEngine());
+      await act(async () => {});
+
+      await setConnectivity(rerender, {
+        offlineModeActive: true,
+        offlineTrackIds: new Set(['a']),
+      });
+      expect(usePlayerStore.getState().queue).toHaveLength(1);
+
+      await setConnectivity(rerender, { offlineModeActive: false });
+
+      const s = usePlayerStore.getState();
+      expect(s.queue.map((i) => i.track.id)).toEqual(['a', 'b', 'c']);
+      expect(s.logicalTrackIds).toBeNull();
+      // Same session, so the in-memory cache served it — no refetch needed.
+      expect(mockFetchTracksBatched).not.toHaveBeenCalled();
+    });
+
+    it('refetches the logical queue when the cache is empty, as after a reload', async () => {
+      // The headline fix: previously the pre-filter queue lived only in a ref, so a reload
+      // while offline lost it and reconnecting left the queue permanently narrowed.
+      const tracks = ['a', 'b', 'c'].map((id) => makeTrack(id));
+      usePlayerStore.setState({
+        queue: [{ track: tracks[0], queueId: 'q0' }],
+        queueIndex: 0,
+        currentTrack: tracks[0],
+        queueSource: { type: 'library' },
+        // As hydrate() would restore it: narrowed queue, logical queue intact, no cache.
+        logicalTrackIds: ['a', 'b', 'c'],
+        logicalIndex: 0,
+      });
+      mockConnectivityStore.setState({
+        offlineModeActive: true,
+        offlineTrackIds: new Set(['a']),
+      });
+
+      const { rerender } = renderHook(() => useAudioEngine());
+      await act(async () => {});
+
+      await setConnectivity(rerender, { offlineModeActive: false });
+      await act(async () => {});
+
+      expect(mockFetchTracksBatched).toHaveBeenCalledWith(['a', 'b', 'c']);
+      const s = usePlayerStore.getState();
+      expect(s.queue.map((i) => i.track.id)).toEqual(['a', 'b', 'c']);
+      expect(s.logicalTrackIds).toBeNull();
+    });
+
+    it('does not narrow when every queued track is downloaded', async () => {
+      seedPartlyDownloadedQueue();
+      const { rerender } = renderHook(() => useAudioEngine());
+      await act(async () => {});
+
+      await setConnectivity(rerender, {
+        offlineModeActive: true,
+        offlineTrackIds: new Set(['a', 'b', 'c']),
+      });
+
+      const s = usePlayerStore.getState();
+      expect(s.queue).toHaveLength(3);
+      // No narrowing happened, so there is no logical queue to restore later.
+      expect(s.logicalTrackIds).toBeNull();
+    });
   });
 });

--- a/packages/frontend/src/player/__tests__/persistence.test.ts
+++ b/packages/frontend/src/player/__tests__/persistence.test.ts
@@ -1,16 +1,17 @@
 /**
  * Tests for the persistence layer's storage shape.
  *
- * The lazy reservoir is the one persisted field that is both large and rarely changing:
- * ~26k UUIDs (~1 MB) for a full library, changed only by `setLazyQueue`, `toggleShuffle`
- * and refills. But `setCurrentTime` persists on every tick, throttled to 500ms, so a
- * reservoir kept in the main record would be rewritten twice a second for the whole of
- * playback — ~2 MB/s of flash writes to save a value that did not change.
+ * Two persisted fields are both large and rarely changing. The lazy reservoir is ~26k UUIDs
+ * (~1 MB) for a full library, changed only by `setLazyQueue`, `toggleShuffle` and refills.
+ * The logical queue (ADR-0003) is the pre-filter track list, changed only when connectivity
+ * flips. But `setCurrentTime` persists on every tick, throttled to 500ms, so either one kept
+ * in the main record would be rewritten twice a second for the whole of playback — ~2 MB/s
+ * of flash writes to save a value that did not change.
  *
- * It therefore lives in its own row, written only when it actually differs. These tests
+ * Each therefore lives in its own row, written only when it actually differs. These tests
  * pin that down, because it is invisible from the store's point of view: `loadPlayerState`
- * stitches the two rows back together, so nothing upstream can tell the difference except
- * by counting writes.
+ * stitches the rows back together, so nothing upstream can tell the difference except by
+ * counting writes.
  */
 import { describe, it, expect, beforeEach, vi } from 'vitest';
 
@@ -43,6 +44,7 @@ vi.mock('../../api', () => ({ tracksApi: { getBatch: vi.fn() } }));
 import { savePlayerState, loadPlayerState, clearPlayerState } from '../persistence';
 
 const RESERVOIR_KEY = 'profile-1::reservoir';
+const LOGICAL_KEY = 'profile-1::logical';
 
 const baseState = {
   volume: 1,
@@ -123,6 +125,71 @@ describe('reservoir storage', () => {
   });
 });
 
+describe('logical queue storage', () => {
+  it('writes the logical queue to its own row, keeping the bulk out of the main record', async () => {
+    const ids = ['a', 'b', 'c'];
+    await savePlayerState({ ...baseState, logicalTrackIds: ids, logicalIndex: 1 });
+
+    const rows = putFor(LOGICAL_KEY);
+    expect(rows).toHaveLength(1);
+    expect(rows[0].logicalTrackIds).toEqual(ids);
+
+    const main = putFor('profile-1')[0];
+    expect(main.logicalTrackIds).toBeUndefined();
+    // The cursor is small and tracks the queue, so it stays with the main record.
+    expect(main.logicalIndex).toBe(1);
+  });
+
+  it('does not rewrite an unchanged logical queue', async () => {
+    const ids = ['a', 'b', 'c'];
+    await savePlayerState({ ...baseState, logicalTrackIds: ids, logicalIndex: 1 });
+    mockPut.mockClear();
+
+    // What playback does twice a second while offline: same logical queue, later position.
+    for (let t = 1; t <= 5; t++) {
+      await savePlayerState({ ...baseState, currentTime: t, logicalTrackIds: ids, logicalIndex: 1 });
+    }
+
+    expect(putFor('profile-1')).toHaveLength(5);
+    expect(putFor(LOGICAL_KEY)).toHaveLength(0);
+  });
+
+  it('deletes the row once the queue is no longer filtered', async () => {
+    await savePlayerState({ ...baseState, logicalTrackIds: ['a'], logicalIndex: 0 });
+    mockDelete.mockClear();
+
+    await savePlayerState({ ...baseState, logicalTrackIds: null, logicalIndex: -1 });
+
+    expect(mockDelete).toHaveBeenCalledWith(LOGICAL_KEY);
+  });
+
+  it('tracks the two side rows independently', async () => {
+    const reservoir = ['r1', 'r2'];
+    const logical = ['l1', 'l2'];
+    await savePlayerState({
+      ...baseState,
+      lazyQueueIds: reservoir,
+      lazyQueueIndex: 2,
+      logicalTrackIds: logical,
+      logicalIndex: 0,
+    });
+    mockPut.mockClear();
+
+    // Only the logical queue changes. The reservoir must not be rewritten with it —
+    // a shared dirty flag would rewrite ~1 MB every time connectivity flapped.
+    await savePlayerState({
+      ...baseState,
+      lazyQueueIds: reservoir,
+      lazyQueueIndex: 2,
+      logicalTrackIds: ['l1', 'l2', 'l3'],
+      logicalIndex: 0,
+    });
+
+    expect(putFor(RESERVOIR_KEY)).toHaveLength(0);
+    expect(putFor(LOGICAL_KEY)).toHaveLength(1);
+  });
+});
+
 describe('loading stitches the rows back together', () => {
   it('returns the reservoir alongside the main record', async () => {
     mockGet.mockImplementation((key: string) =>
@@ -157,9 +224,9 @@ describe('loading stitches the rows back together', () => {
 });
 
 describe('clearing', () => {
-  it('removes both rows, so the reservoir cannot outlive its state', async () => {
+  it('removes every row, so a side list cannot outlive its state', async () => {
     await clearPlayerState();
-    expect(mockBulkDelete).toHaveBeenCalledWith(['profile-1', RESERVOIR_KEY]);
+    expect(mockBulkDelete).toHaveBeenCalledWith(['profile-1', RESERVOIR_KEY, LOGICAL_KEY]);
   });
 
   it('lets a later save rewrite the reservoir it had already written', async () => {

--- a/packages/frontend/src/player/__tests__/queuePersistence.test.ts
+++ b/packages/frontend/src/player/__tests__/queuePersistence.test.ts
@@ -124,6 +124,8 @@ function resetStores() {
     lazyQueueIndex: -1,
     queueSource: null,
     isQueueHydrating: false,
+    logicalTrackIds: null,
+    logicalIndex: -1,
   });
   mockConnectivityState.offlineModeActive = false;
   mockConnectivityState.offlineTrackIds = new Set<string>();
@@ -169,6 +171,20 @@ describe('saving', () => {
 
     const saved = mockSave.mock.calls.at(-1)![0];
     expect(saved.lazyQueueIndex).toBeGreaterThan(50);
+  });
+
+  it('writes when exitLazyMode ends lazy mode', async () => {
+    await useQueueStore.getState().setLazyQueue(ids(200), { type: 'library' });
+    mockSave.mockClear();
+
+    useQueueStore.getState().exitLazyMode();
+
+    // exitLazyMode clears persisted fields but used not to save, so the reservoir stayed
+    // in IndexedDB and the next reload put the queue straight back into lazy mode.
+    expect(mockSave).toHaveBeenCalled();
+    const saved = mockSave.mock.calls.at(-1)![0];
+    expect(saved.lazyQueueIds).toBeNull();
+    expect(saved.queueSource).toBeNull();
   });
 });
 
@@ -219,6 +235,133 @@ describe('hydrating', () => {
     expect(mockGetIds).toHaveBeenCalled();
     // The library filters have to survive too, or the reshuffle spans the wrong set.
     expect(mockGetIds.mock.calls[0][0]).toMatchObject({ genre: 'jazz' });
+  });
+});
+
+/**
+ * The offline round trip (ADR-0003 point 5).
+ *
+ * Narrowing the queue to downloaded tracks used to go through a plain `setQueue`, which
+ * replaces the queue *and* nulls the reservoir, with the pre-filter queue kept only in a
+ * React ref inside `useAudioEngine`. Two things broke, and neither surfaced as an error:
+ * a reload while offline lost the full queue for good, and reconnecting produced a
+ * non-lazy queue that stopped dead at the end of the materialised window.
+ */
+describe('the offline round trip', () => {
+  /** Narrow to `keep`, the way the offline rebuild effect does. */
+  function narrowTo(keep: string[]) {
+    const s = useQueueStore.getState();
+    const all = s.queue.map((item) => item.track);
+    s.setLogicalQueue(all.map((t) => t.id), s.queueIndex);
+    s.setQueue(
+      all.filter((t) => keep.includes(t.id)),
+      0,
+      s.queueSource ?? undefined,
+      { preservePlaybackState: true, preserveReservoir: true },
+    );
+  }
+
+  it('keeps the reservoir when the queue is narrowed for offline playback', async () => {
+    mockLoadPlayerState.mockResolvedValue(persistedLazyQueue(200, 50));
+    await useQueueStore.getState().hydrate();
+
+    narrowTo(['t0', 't1', 't2']);
+
+    const s = useQueueStore.getState();
+    expect(s.queue).toHaveLength(3);
+    // The reservoir is what makes the queue lazy; losing it here is what stranded
+    // playback at the window after reconnecting.
+    expect(s.lazyQueueIds).toHaveLength(200);
+    expect(s.lazyQueueIndex).toBe(50);
+  });
+
+  it('still ends lazy mode for a genuine queue replacement', async () => {
+    mockLoadPlayerState.mockResolvedValue(persistedLazyQueue(200, 50));
+    await useQueueStore.getState().hydrate();
+
+    // No preserveReservoir: this is a real replacement, e.g. playing an album.
+    useQueueStore.getState().setQueue([createMockTrack('album-1')], 0, { type: 'album', id: 'a1' });
+
+    expect(useQueueStore.getState().lazyQueueIds).toBeNull();
+  });
+
+  it('records the logical queue so reconnecting can widen back out', async () => {
+    mockLoadPlayerState.mockResolvedValue(persistedLazyQueue(200, 50));
+    await useQueueStore.getState().hydrate();
+
+    narrowTo(['t0', 't1']);
+
+    expect(useQueueStore.getState().logicalTrackIds).toHaveLength(50);
+    expect(useQueueStore.getState().logicalIndex).toBe(0);
+  });
+
+  it('persists the logical queue, so a reload while offline does not lose it', async () => {
+    mockLoadPlayerState.mockResolvedValue(persistedLazyQueue(200, 50));
+    await useQueueStore.getState().hydrate();
+    mockSave.mockClear();
+
+    narrowTo(['t0', 't1']);
+
+    // The whole point: it reaches the persistence layer rather than living in a ref.
+    const written = mockSave.mock.calls.at(-1)?.[0];
+    expect(written.logicalTrackIds).toHaveLength(50);
+  });
+
+  it('restores the logical queue on hydrate, so a reload while offline can still recover', async () => {
+    const persisted = persistedLazyQueue(200, 50);
+    // As written while offline: only two tracks playable, the other 48 still logical.
+    const record = {
+      ...persisted,
+      queueTrackIds: ['t0', 't1'],
+      logicalTrackIds: ids(50),
+      logicalIndex: 0,
+    };
+    mockLoadPlayerState.mockResolvedValue(record);
+
+    await useQueueStore.getState().hydrate();
+
+    const s = useQueueStore.getState();
+    expect(s.queue).toHaveLength(2);
+    expect(s.logicalTrackIds).toHaveLength(50);
+  });
+
+  it('keeps playing past the window after an offline round trip', async () => {
+    // The user-visible bug: go offline, come back, and playback ends at track ~50.
+    mockLoadPlayerState.mockResolvedValue(persistedLazyQueue(200, 50));
+    await useQueueStore.getState().hydrate();
+
+    narrowTo(['t0', 't1', 't2']);
+
+    // Reconnect: widen back to the logical queue, as the restore path does.
+    const logical = useQueueStore.getState().logicalTrackIds!;
+    useQueueStore.getState().setQueue(
+      logical.map((id) => createMockTrack(id)),
+      0,
+      { type: 'library', filters: { genre: 'jazz' } },
+      { preservePlaybackState: true, preserveReservoir: true },
+    );
+    useQueueStore.getState().setLogicalQueue(null, -1);
+
+    useQueueStore.setState({ queueIndex: 45 });
+    await useQueueStore.getState().playNext();
+
+    await vi.waitFor(() => {
+      expect(useQueueStore.getState().queue.length).toBeGreaterThan(50);
+    });
+  });
+
+  it('clears the logical queue once the full queue is back', async () => {
+    mockLoadPlayerState.mockResolvedValue(persistedLazyQueue(200, 50));
+    await useQueueStore.getState().hydrate();
+    narrowTo(['t0']);
+    mockSave.mockClear();
+
+    useQueueStore.getState().setLogicalQueue(null, -1);
+
+    expect(useQueueStore.getState().logicalTrackIds).toBeNull();
+    expect(useQueueStore.getState().logicalIndex).toBe(-1);
+    // Cleared in storage too, or the next reload thinks it is still filtered.
+    expect(mockSave.mock.calls.at(-1)?.[0].logicalTrackIds).toBeNull();
   });
 });
 

--- a/packages/frontend/src/player/persistence.ts
+++ b/packages/frontend/src/player/persistence.ts
@@ -31,21 +31,25 @@ export interface PersistablePlayerState {
   queueSource?: PersistedQueueSource | null;
   lazyQueueIds?: string[] | null;
   lazyQueueIndex?: number;
+  logicalTrackIds?: string[] | null;
+  logicalIndex?: number;
 }
 
 /**
- * Key for a profile's lazy reservoir, stored as its own row in the same table.
+ * Keys for the two large ID lists that hang off a profile's player state, each stored as
+ * its own row in the same table.
  *
- * The reservoir is the one field here that is both large and rarely changing. For a full
- * library it is ~26k UUIDs (~1 MB), but it only changes on `setLazyQueue`, `toggleShuffle`
- * and a refill. Meanwhile `setCurrentTime` persists on every tick, throttled to 500ms —
- * so keeping the reservoir in the main record would rewrite that megabyte twice a second
- * for the whole of playback. The clone cost is negligible (~0.9ms measured), but the
- * sustained ~2 MB/s of flash writes is not, particularly on iOS.
+ * Both are large and rarely changing. The reservoir for a full library is ~26k UUIDs
+ * (~1 MB) and only changes on `setLazyQueue`, `toggleShuffle` and a refill; the logical
+ * queue changes only when connectivity flips. Meanwhile `setCurrentTime` persists on every
+ * tick, throttled to 500ms — so keeping either in the main record would rewrite that bulk
+ * twice a second for the whole of playback. The clone cost is negligible (~0.9ms measured),
+ * but the sustained ~2 MB/s of flash writes is not, particularly on iOS.
  *
- * `playerState` is keyed on `id` alone, so a second row costs no schema change.
+ * `playerState` is keyed on `id` alone, so extra rows cost no schema change.
  */
 const reservoirKey = (profileId: string) => `${profileId}::reservoir`;
+const logicalQueueKey = (profileId: string) => `${profileId}::logical`;
 
 interface ReservoirRecord {
   id: string;
@@ -54,34 +58,72 @@ interface ReservoirRecord {
   updatedAt: Date;
 }
 
-// Last reservoir written, per profile, so unchanged ones can be skipped. Compared by
-// reference: the store replaces the array wholesale whenever it changes.
-const lastWrittenReservoir = new Map<string, string[] | null>();
+interface LogicalQueueRecord {
+  id: string;
+  logicalTrackIds: string[] | null;
+  logicalIndex: number;
+  updatedAt: Date;
+}
 
-async function saveReservoir(
-  profileId: string,
+// Last list written per row key, so unchanged ones can be skipped. Compared by reference:
+// the store replaces these arrays wholesale whenever they change.
+const lastWrittenSideList = new Map<string, string[] | null>();
+
+/**
+ * Write one of the side rows, skipping the write when the list has not been replaced.
+ *
+ * `buildRow` keeps each row's field names as they are on disk rather than normalising them,
+ * so records written before this helper existed still load.
+ */
+async function saveSideList(
+  key: string,
   ids: string[] | null,
-  index: number
+  buildRow: (ids: string[]) => Record<string, unknown>
 ): Promise<void> {
-  if (lastWrittenReservoir.get(profileId) === ids) return;
-  lastWrittenReservoir.set(profileId, ids);
+  if (lastWrittenSideList.get(key) === ids) return;
+  lastWrittenSideList.set(key, ids);
 
-  const key = reservoirKey(profileId);
   if (!ids || ids.length === 0) {
     await db.playerState.delete(key);
     return;
   }
   await db.playerState.put({
     id: key,
-    lazyQueueIds: ids,
-    lazyQueueIndex: index,
+    ...buildRow(ids),
     updatedAt: new Date(),
   } as unknown as PersistedPlayerState);
+}
+
+async function saveReservoir(
+  profileId: string,
+  ids: string[] | null,
+  index: number
+): Promise<void> {
+  await saveSideList(reservoirKey(profileId), ids, (list) => ({
+    lazyQueueIds: list,
+    lazyQueueIndex: index,
+  }));
+}
+
+async function saveLogicalQueue(
+  profileId: string,
+  ids: string[] | null,
+  index: number
+): Promise<void> {
+  await saveSideList(logicalQueueKey(profileId), ids, (list) => ({
+    logicalTrackIds: list,
+    logicalIndex: index,
+  }));
 }
 
 async function loadReservoir(profileId: string): Promise<ReservoirRecord | null> {
   const row = await db.playerState.get(reservoirKey(profileId));
   return (row as unknown as ReservoirRecord) ?? null;
+}
+
+async function loadLogicalQueue(profileId: string): Promise<LogicalQueueRecord | null> {
+  const row = await db.playerState.get(logicalQueueKey(profileId));
+  return (row as unknown as LogicalQueueRecord) ?? null;
 }
 
 /**
@@ -110,14 +152,16 @@ export async function savePlayerState(state: PersistablePlayerState): Promise<vo
       shuffleIndex: state.shuffleIndex,
       currentTime: state.currentTime,
       queueSource: state.queueSource ?? null,
-      // The reservoir itself lives in its own row; the cursor into it is small and
-      // changes with the queue, so it stays here.
+      // The reservoir and logical-queue lists live in their own rows; the cursors into
+      // them are small and change with the queue, so they stay here.
       lazyQueueIndex: state.lazyQueueIndex ?? -1,
+      logicalIndex: state.logicalIndex ?? -1,
       updatedAt: new Date(),
     };
 
     await db.playerState.put(persistedState);
     await saveReservoir(profileId, state.lazyQueueIds ?? null, state.lazyQueueIndex ?? -1);
+    await saveLogicalQueue(profileId, state.logicalTrackIds ?? null, state.logicalIndex ?? -1);
   } catch (error) {
     log.warn('Failed to save player state:', error);
   }
@@ -126,8 +170,16 @@ export async function savePlayerState(state: PersistablePlayerState): Promise<vo
 async function readPlayerState(profileId: string): Promise<PersistedPlayerState | null> {
   const state = await db.playerState.get(profileId);
   if (!state) return null;
-  const reservoir = await loadReservoir(profileId);
-  return { ...state, lazyQueueIds: reservoir?.lazyQueueIds ?? null };
+  // In parallel: this is on the hydration path, and first paint waits on it.
+  const [reservoir, logical] = await Promise.all([
+    loadReservoir(profileId),
+    loadLogicalQueue(profileId),
+  ]);
+  return {
+    ...state,
+    lazyQueueIds: reservoir?.lazyQueueIds ?? null,
+    logicalTrackIds: logical?.logicalTrackIds ?? null,
+  };
 }
 
 /**
@@ -227,9 +279,12 @@ export async function clearPlayerState(): Promise<void> {
   }
 
   try {
-    // Both rows, or the reservoir outlives the state that referenced it.
-    await db.playerState.bulkDelete([profileId, reservoirKey(profileId)]);
-    lastWrittenReservoir.delete(profileId);
+    // Every row, or a side list outlives the state that referenced it.
+    const reservoir = reservoirKey(profileId);
+    const logical = logicalQueueKey(profileId);
+    await db.playerState.bulkDelete([profileId, reservoir, logical]);
+    lastWrittenSideList.delete(reservoir);
+    lastWrittenSideList.delete(logical);
   } catch (error) {
     log.warn('Failed to clear player state:', error);
   }

--- a/packages/frontend/src/player/persistenceAdapter.ts
+++ b/packages/frontend/src/player/persistenceAdapter.ts
@@ -10,6 +10,8 @@ interface PersistableQueueState {
   queueSource: import('../db').PersistedQueueSource | null;
   lazyQueueIds: string[] | null;
   lazyQueueIndex: number;
+  logicalTrackIds: string[] | null;
+  logicalIndex: number;
 }
 
 let getQueueState: (() => PersistableQueueState) | null = null;
@@ -22,6 +24,8 @@ const EMPTY_QUEUE_STATE: PersistableQueueState = {
   queueSource: null,
   lazyQueueIds: null,
   lazyQueueIndex: -1,
+  logicalTrackIds: null,
+  logicalIndex: -1,
 };
 
 export function _setQueueStateGetter(fn: typeof getQueueState) {
@@ -46,6 +50,8 @@ export function persistCombinedState() {
     queueSource: queue.queueSource,
     lazyQueueIds: queue.lazyQueueIds,
     lazyQueueIndex: queue.lazyQueueIndex,
+    logicalTrackIds: queue.logicalTrackIds,
+    logicalIndex: queue.logicalIndex,
   });
 }
 

--- a/packages/frontend/src/player/queueStore.ts
+++ b/packages/frontend/src/player/queueStore.ts
@@ -67,6 +67,25 @@ function restoreReservoir(
   return { lazyQueueIds: ids, lazyQueueIndex: index };
 }
 
+/**
+ * Validate a persisted logical queue before trusting it.
+ *
+ * An out-of-range cursor is recoverable here in a way the reservoir's is not: the index only
+ * decides where playback resumes within the restored queue, so it is clamped rather than
+ * causing the whole logical queue to be discarded. Losing the list would mean losing the
+ * full queue on reconnect, which is the failure this field exists to prevent.
+ */
+function restoreLogicalQueue(
+  ids: string[] | null | undefined,
+  index: number | undefined
+): { logicalTrackIds: string[] | null; logicalIndex: number } {
+  if (!ids || ids.length === 0) return { logicalTrackIds: null, logicalIndex: -1 };
+  const resolved = typeof index === 'number' && index >= 0
+    ? Math.min(index, ids.length - 1)
+    : -1;
+  return { logicalTrackIds: ids, logicalIndex: resolved };
+}
+
 const refillFromReservoir = async () => {
   if (isRefilling) return;
 
@@ -128,6 +147,22 @@ export interface QueueState {
   lazyQueueIndex: number;
   queueSource: QueueSource | null;
   isQueueHydrating: boolean;
+
+  /**
+   * The *logical* queue, when `queue` is currently a filtered view of it (ADR-0003 point 5).
+   *
+   * `null` means `queue` **is** the logical queue — the normal case. It becomes non-null only
+   * while offline, when the queue has been narrowed to downloaded tracks, and holds the track
+   * IDs from before that filtering.
+   *
+   * This used to be a React ref in `useAudioEngine`, which meant a reload while offline lost
+   * the full queue for good: the ref was gone and the only persisted copy was the filtered
+   * one. Keeping it in the store puts it through the normal persistence path, so the logical
+   * queue survives a reload and can still be restored on reconnect.
+   */
+  logicalTrackIds: string[] | null;
+  /** Cursor into `logicalTrackIds`; -1 when there is no logical queue or no current track. */
+  logicalIndex: number;
 }
 
 export interface QueueActions {
@@ -138,8 +173,9 @@ export interface QueueActions {
   playTrack: (track: Track, options?: { reason?: AdvanceReason }) => void;
   playNext: (options?: { reason?: AdvanceReason }) => void | Promise<void>;
   playPrevious: (options?: { reason?: AdvanceReason }) => void;
-  setQueue: (tracks: Track[], startIndex?: number, source?: QueueSource, options?: { preservePlaybackState?: boolean; reason?: AdvanceReason }) => void;
-  setQueueByTrackId: (tracks: Track[], trackId: string, source?: QueueSource, options?: { reason?: AdvanceReason }) => void;
+  setQueue: (tracks: Track[], startIndex?: number, source?: QueueSource, options?: { preservePlaybackState?: boolean; reason?: AdvanceReason; preserveReservoir?: boolean }) => void;
+  setLogicalQueue: (trackIds: string[] | null, index: number) => void;
+  setQueueByTrackId: (tracks: Track[], trackId: string, source?: QueueSource, options?: { reason?: AdvanceReason; preserveReservoir?: boolean }) => void;
   reorderQueue: (fromIndex: number, toIndex: number) => void;
   reorderShuffleOrder: (fromIndex: number, toIndex: number) => void;
   jumpToQueueIndex: (index: number, options?: { reason?: AdvanceReason }) => void;
@@ -163,6 +199,8 @@ export const useQueueStore = create<QueueState & QueueActions>((set, get) => ({
   lazyQueueIndex: -1,
   queueSource: null,
   isQueueHydrating: false,
+  logicalTrackIds: null,
+  logicalIndex: -1,
 
   addToQueue: (track, insertIndex, shuffleInsertPosition, options) => {
     const connectivity = useConnectivityStore.getState();
@@ -466,7 +504,7 @@ export const useQueueStore = create<QueueState & QueueActions>((set, get) => ({
     }
   },
 
-  setQueue: (tracks, startIndex = 0, source?: QueueSource, options?: { preservePlaybackState?: boolean; reason?: AdvanceReason }) => {
+  setQueue: (tracks, startIndex = 0, source?: QueueSource, options?: { preservePlaybackState?: boolean; reason?: AdvanceReason; preserveReservoir?: boolean }) => {
     // Callers are queue rebuilds, hydration and profile switches — not listener actions.
     const reason = normalizeAdvanceReason(options?.reason ?? 'system');
     const requestedTrackId = tracks[startIndex]?.id;
@@ -509,13 +547,20 @@ export const useQueueStore = create<QueueState & QueueActions>((set, get) => ({
       shuffleIndex = 0;
     }
 
+    // Replacing the queue normally ends lazy mode — the new tracks are the whole queue.
+    // The offline filter and its restore are the exceptions: they are re-materialising a
+    // view of a queue that is still lazy underneath, so dropping the reservoir there would
+    // silently truncate playback at the end of the ~50-track window (ADR-0003 point 5).
+    const reservoirFields = options?.preserveReservoir
+      ? {}
+      : { lazyQueueIds: null, lazyQueueIndex: -1 };
+
     set({
       queue: queueItems,
       queueIndex: finalStartIndex,
       shuffleOrder,
       shuffleIndex,
-      lazyQueueIds: null,
-      lazyQueueIndex: -1,
+      ...reservoirFields,
       queueSource: source || null,
     });
     usePlaybackStore.setState({
@@ -528,8 +573,9 @@ export const useQueueStore = create<QueueState & QueueActions>((set, get) => ({
     persistCombinedState();
   },
 
-  setQueueByTrackId: (tracks, trackId, source?: QueueSource, options?: { reason?: AdvanceReason }) => {
+  setQueueByTrackId: (tracks, trackId, source?: QueueSource, options?: { reason?: AdvanceReason; preserveReservoir?: boolean }) => {
     const reason = normalizeAdvanceReason(options?.reason ?? 'system');
+    const preserveReservoir = options?.preserveReservoir;
     const offlineModeActive = useConnectivityStore.getState().offlineModeActive;
     const queueTracks = enforceOfflineQueueInvariant(tracks);
     const resolvedIndex = queueTracks.findIndex((track) => track.id === trackId);
@@ -552,10 +598,10 @@ export const useQueueStore = create<QueueState & QueueActions>((set, get) => ({
         });
         return;
       }
-      get().setQueue(queueTracks, 0, source, { reason });
+      get().setQueue(queueTracks, 0, source, { reason, preserveReservoir });
       return;
     }
-    get().setQueue(queueTracks, resolvedIndex, source, { reason });
+    get().setQueue(queueTracks, resolvedIndex, source, { reason, preserveReservoir });
   },
 
   reorderQueue: (fromIndex: number, toIndex: number) => {
@@ -732,8 +778,26 @@ export const useQueueStore = create<QueueState & QueueActions>((set, get) => ({
     }
   },
 
+  /**
+   * Record (or clear) the logical queue behind an offline-filtered one.
+   *
+   * Called by the offline rebuild in `useAudioEngine` with the pre-filter IDs, and again
+   * with `null` once the full queue has been restored on reconnect.
+   */
+  setLogicalQueue: (trackIds, index) => {
+    const normalized = trackIds && trackIds.length > 0 ? trackIds : null;
+    set({
+      logicalTrackIds: normalized,
+      logicalIndex: normalized ? index : -1,
+    });
+    persistCombinedState();
+  },
+
   exitLazyMode: () => {
+    // Persist: this clears fields that are part of the persisted record, so without a write
+    // the reservoir stayed in IndexedDB and a reload put the queue back into lazy mode.
     set({ lazyQueueIds: null, lazyQueueIndex: -1, queueSource: null });
+    persistCombinedState();
   },
 
   getNextTrack: () => {
@@ -990,10 +1054,14 @@ export const useQueueStore = create<QueueState & QueueActions>((set, get) => ({
       // Without the reservoir, `refillFromReservoir` bails at its first guard and the
       // queue never grows past the materialised window — playback just stops at track
       // ~50 with no error. Both were dropped on every reload.
+      // The logical queue is restored too, so a session that was offline-filtered when the
+      // app closed can still be widened back to the full queue on reconnect. Before this,
+      // that list lived only in a React ref and a reload discarded it for good.
       set({
         isQueueHydrating: persisted.queueTrackIds.length > 0,
         queueSource: persisted.queueSource ?? null,
         ...restoreReservoir(persisted.lazyQueueIds, persisted.lazyQueueIndex),
+        ...restoreLogicalQueue(persisted.logicalTrackIds, persisted.logicalIndex),
       });
 
       if (persisted.queueTrackIds.length === 0) return;
@@ -1058,6 +1126,8 @@ export const useQueueStore = create<QueueState & QueueActions>((set, get) => ({
       lazyQueueIndex: -1,
       queueSource: null,
       isQueueHydrating: false,
+      logicalTrackIds: null,
+      logicalIndex: -1,
     });
     usePlaybackStore.setState({
       currentTrack: null,
@@ -1088,5 +1158,7 @@ _setQueueStateGetter(() => {
     queueSource: s.queueSource,
     lazyQueueIds: s.lazyQueueIds,
     lazyQueueIndex: s.lazyQueueIndex,
+    logicalTrackIds: s.logicalTrackIds,
+    logicalIndex: s.logicalIndex,
   };
 });

--- a/packages/frontend/src/player/useAudioEngine.ts
+++ b/packages/frontend/src/player/useAudioEngine.ts
@@ -14,6 +14,7 @@ import { useConnectivityStore } from '../stores/connectivityStore';
 import { useOutputStore } from '../stores/outputStore';
 import { prefetchService } from '../services/prefetchService';
 import { radioController } from './radio/radioController';
+import { fetchTracksBatched } from './persistence';
 import {
   getCrossfadeTrigger,
   getEffectiveCrossfadeDuration,
@@ -94,6 +95,9 @@ export function useAudioEngine() {
   const { crossfadeDuration, crossfadeEnabled, normalizationEnabled, normalizationMode, normalizationTargetLufs, normalizationPreamp, normalizationPreventClipping } = useAudioSettingsStore();
   const offlineModeActive = useConnectivityStore((s) => s.offlineModeActive);
   const offlineTrackIds = useConnectivityStore((s) => s.offlineTrackIds);
+  // Subscribed so the restore effect re-runs when hydration populates the logical queue
+  // from IndexedDB, which happens after the effect's first pass.
+  const logicalTrackIds = usePlayerStore((s) => s.logicalTrackIds);
   const noteStreamLoadFailure = useConnectivityStore((s) => s.noteStreamLoadFailure);
   const noteStreamLoadSuccess = useConnectivityStore((s) => s.noteStreamLoadSuccess);
   const incrementConnectivityCounter = useConnectivityStore((s) => s.incrementCounter);
@@ -115,8 +119,11 @@ export function useAudioEngine() {
   // Queue transition flag — scoped to hook lifecycle (not module-level)
   const queueTransitionRef = useRef(false);
 
-  // Pre-offline queue snapshot — restored when connectivity recovers
-  const preOfflineQueueRef = useRef<{ tracks: Track[]; index: number; source: import('./playerStore.types').QueueSource | null } | null>(null);
+  // In-memory copy of the logical queue's tracks, so the ordinary restore — connectivity
+  // flapped within one session — needs no network. `queueStore.logicalTrackIds` is the
+  // durable record; this is only a cache. After a reload it is empty and the tracks are
+  // refetched from the persisted IDs, which is the case the old ref-only snapshot lost.
+  const logicalTracksCacheRef = useRef<Track[] | null>(null);
 
   // Album gain cache — scoped to hook lifecycle
   const albumGainCacheRef = useRef(new Map<string, { avgLufs: number; albumPeak: number | null }>());
@@ -315,7 +322,10 @@ export function useAudioEngine() {
             setCrossfadeState('idle');
             const prevTrack = state.history[state.history.length - 1];
             if (prevTrack) {
-              state.setQueueByTrackId(state.queue.map(q => q.track), prevTrack.id, state.queueSource ?? undefined, { reason: 'error' });
+              // preserveReservoir: this rebuilds the queue from itself only to move the
+              // cursor back, so it is not a queue replacement — dropping the reservoir
+              // here would leave a lazy queue stranded at the materialised window.
+              state.setQueueByTrackId(state.queue.map(q => q.track), prevTrack.id, state.queueSource ?? undefined, { reason: 'error', preserveReservoir: true });
             }
             setIsLoadingAudio(false);
             break;
@@ -503,55 +513,90 @@ export function useAudioEngine() {
     toggleFavorite,
   ]);
 
+  // Keep the playable queue in step with what is actually reachable: narrow it to
+  // downloaded tracks while offline, widen it back to the logical queue on reconnect
+  // (ADR-0003 point 5). `logicalTrackIds` is durable state rather than a ref, so the
+  // widening still works after a reload that happened while offline.
   useEffect(() => {
-    const state = usePlayerStore.getState();
+    let cancelled = false;
 
-    if (!offlineModeActive) {
-      // Restore pre-offline queue when connectivity recovers
-      const saved = preOfflineQueueRef.current;
-      if (saved && saved.tracks.length > 0) {
+    /** Widen back out to `logical`, whose tracks may need refetching after a reload. */
+    const widenTo = (logical: string[]) => {
+      const restore = (tracks: Track[]) => {
+        if (cancelled || tracks.length === 0) return;
+        const state = usePlayerStore.getState();
         const currentId = state.currentTrack?.id;
         const restoredIndex = currentId
-          ? saved.tracks.findIndex((t) => t.id === currentId)
-          : saved.index;
-        state.setQueue(saved.tracks, Math.max(0, restoredIndex), saved.source ?? undefined, { preservePlaybackState: true });
-        preOfflineQueueRef.current = null;
-      }
-      return;
-    }
-
-    if (state.queue.length === 0) return;
-
-    const allTracks = state.queue.map((item) => item.track);
-    const filteredTracks = allTracks.filter((track) => offlineTrackIds.has(track.id));
-    if (filteredTracks.length === allTracks.length) return;
-
-    // Save the full queue before filtering so we can restore on recovery
-    if (!preOfflineQueueRef.current) {
-      preOfflineQueueRef.current = {
-        tracks: allTracks,
-        index: state.queueIndex,
-        source: state.queueSource,
+          ? tracks.findIndex((track) => track.id === currentId)
+          : state.logicalIndex;
+        // preserveReservoir: a lazy queue is still lazy underneath the filter, and
+        // dropping the reservoir here would strand playback at the end of the
+        // materialised window.
+        state.setQueue(tracks, Math.max(0, restoredIndex), state.queueSource ?? undefined, {
+          preservePlaybackState: true,
+          preserveReservoir: true,
+        });
+        state.setLogicalQueue(null, -1);
+        logicalTracksCacheRef.current = null;
       };
+
+      const cached = logicalTracksCacheRef.current;
+      const cacheHit =
+        cached !== null &&
+        cached.length === logical.length &&
+        cached.every((track, i) => track.id === logical[i]);
+
+      if (cacheHit) {
+        restore(cached);
+      } else {
+        fetchTracksBatched(logical)
+          .then(restore)
+          .catch((error) => log.warn('Failed to restore logical queue:', error));
+      }
+    };
+
+    /** Narrow the queue down to `filteredTracks`, recording what it was first. */
+    const narrowTo = (allTracks: Track[], filteredTracks: Track[]) => {
+      const state = usePlayerStore.getState();
+
+      // Record the logical queue before narrowing, so reconnect has something to widen
+      // back to. Only on the first narrowing — a second pass would capture the already
+      // filtered queue and make the restore a no-op.
+      if (!state.logicalTrackIds) {
+        logicalTracksCacheRef.current = allTracks;
+        state.setLogicalQueue(allTracks.map((track) => track.id), state.queueIndex);
+      }
+
+      incrementConnectivityCounter('offline_queue_rebuild_count');
+      const currentId = state.currentTrack?.id;
+      const newIndex = currentId
+        ? filteredTracks.findIndex((track) => track.id === currentId)
+        : -1;
+
+      // preserveReservoir for the same reason as the widening path above.
+      state.setQueue(filteredTracks, Math.max(0, newIndex), state.queueSource ?? undefined, {
+        preservePlaybackState: true,
+        preserveReservoir: true,
+      });
+      if (filteredTracks.length === 0) {
+        setIsPlaying(false);
+        setIsLoadingAudio(false);
+      }
+    };
+
+    const state = usePlayerStore.getState();
+    if (!offlineModeActive) {
+      if (logicalTrackIds && logicalTrackIds.length > 0) widenTo(logicalTrackIds);
+    } else if (state.queue.length > 0) {
+      const allTracks = state.queue.map((item) => item.track);
+      const filteredTracks = allTracks.filter((track) => offlineTrackIds.has(track.id));
+      if (filteredTracks.length !== allTracks.length) narrowTo(allTracks, filteredTracks);
     }
 
-    incrementConnectivityCounter('offline_queue_rebuild_count');
-    const currentId = state.currentTrack?.id;
-    const newIndex = currentId
-      ? filteredTracks.findIndex((track) => track.id === currentId)
-      : -1;
-
-    if (newIndex >= 0) {
-      state.setQueue(filteredTracks, newIndex, state.queueSource ?? undefined, { preservePlaybackState: true });
-      return;
-    }
-
-    state.setQueue(filteredTracks, 0, state.queueSource ?? undefined, { preservePlaybackState: true });
-    if (filteredTracks.length === 0) {
-      setIsPlaying(false);
-      setIsLoadingAudio(false);
-    }
-  }, [offlineModeActive, offlineTrackIds, incrementConnectivityCounter, setIsLoadingAudio, setIsPlaying]);
+    return () => {
+      cancelled = true;
+    };
+  }, [offlineModeActive, offlineTrackIds, logicalTrackIds, incrementConnectivityCounter, setIsLoadingAudio, setIsPlaying]);
 
   // --------------------------------------------------------------------------
   // Effect: Update Media Session when track changes

--- a/packages/frontend/src/services/__tests__/playerPersistence.test.ts
+++ b/packages/frontend/src/services/__tests__/playerPersistence.test.ts
@@ -200,10 +200,12 @@ describe('playerPersistence', () => {
 
       const result = await loadPlayerState();
 
-      // `lazyQueueIds` is stitched in from the reservoir row, which is absent here.
-      expect(result).toEqual({ ...persisted, lazyQueueIds: null });
+      // `lazyQueueIds` and `logicalTrackIds` are stitched in from their own rows, both
+      // absent here.
+      expect(result).toEqual({ ...persisted, lazyQueueIds: null, logicalTrackIds: null });
       expect(mockPlayerState.get).toHaveBeenCalledWith('profile-123');
       expect(mockPlayerState.get).toHaveBeenCalledWith('profile-123::reservoir');
+      expect(mockPlayerState.get).toHaveBeenCalledWith('profile-123::logical');
     });
 
     it('should return null when no saved state', async () => {
@@ -255,9 +257,10 @@ describe('playerPersistence', () => {
 
       const result = await loadPlayerStateForProfile('other-profile');
 
-      expect(result).toEqual({ ...persisted, lazyQueueIds: null });
+      expect(result).toEqual({ ...persisted, lazyQueueIds: null, logicalTrackIds: null });
       expect(mockPlayerState.get).toHaveBeenCalledWith('other-profile');
       expect(mockPlayerState.get).toHaveBeenCalledWith('other-profile::reservoir');
+      expect(mockPlayerState.get).toHaveBeenCalledWith('other-profile::logical');
     });
 
     it('should return null when IndexedDB unavailable', async () => {
@@ -276,13 +279,14 @@ describe('playerPersistence', () => {
   });
 
   describe('clearPlayerState', () => {
-    it('should delete both rows for current profile', async () => {
+    it('should delete every row for current profile', async () => {
       await clearPlayerState();
 
-      // Including the reservoir, or a ~1 MB ID list outlives the state referencing it.
+      // Including both side rows, or a large ID list outlives the state referencing it.
       expect(mockPlayerState.bulkDelete).toHaveBeenCalledWith([
         'profile-123',
         'profile-123::reservoir',
+        'profile-123::logical',
       ]);
     });
 


### PR DESCRIPTION
ADR-0003 phase 1. **Client only — no server involved.** This fixes two existing data-loss bugs and stands on its own regardless of what happens to queue sync.

### The bugs

The queue narrows to downloaded tracks when connectivity drops, and that narrowing was destructive in two ways nobody could see. `setQueue(filteredTracks)` replaced the queue outright *and* nulled the reservoir, while the pre-filter queue lived only in a React ref inside `useAudioEngine`.

- **A reload while offline lost the full queue permanently.** The ref was gone and the only persisted copy was the narrowed one, so reconnecting had nothing to widen back to and the queue stayed narrow for good.
- **Reconnecting produced a non-lazy queue.** The reservoir was nulled on the way in and the ref held only materialised tracks, so a library queue silently stopped at the end of the ~50-track window — the failure PR #20 fixed for reloads, still live for the offline round trip.

### The fix

`logicalTrackIds` / `logicalIndex` on `queueStore`, persisted through the normal path. Like the reservoir, the ID list lives in its own row (`<profile>::logical`) with a reference-equality dirty check, so the 500 ms `setCurrentTime` throttle does not rewrite it twice a second; only the small cursor sits in the main record. `useAudioEngine` keeps an in-memory track cache so the ordinary same-session restore still needs no network, and refetches from the persisted IDs when that cache is empty — the reload case that previously just lost data.

`setQueue` and `setQueueByTrackId` gain `preserveReservoir`, used by the narrowing, the widening, and the crossfade-error rollback. All three rebuild a *view* of a queue that is still lazy underneath rather than replacing it; a genuine replacement still ends lazy mode, which is covered by a test.

Also fixes `exitLazyMode` — the one mutation of persisted fields that never called `persistCombinedState`, so it cleared the reservoir in memory while leaving it in IndexedDB and the next reload put the queue straight back into lazy mode.

### Testing

16 new tests. The reservoir assertion was checked against a deliberately reverted fix to confirm it fails without it. Existing suites pass unchanged except three assertions widened for the third row and the extra stitched field.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_014P9p2fvFnyiywBxGkv4gfW