### PR TITLE
feat(radio): fall back to the precomputed manifest when offline

### DIFF
--- a/docs/decisions/ADR-0006-offline-ranking-is-precomputed-server-side.md
+++ b/docs/decisions/ADR-0006-offline-ranking-is-precomputed-server-side.md
@@ -6,6 +6,22 @@ Date: 2026-07-26
 
 Extends [ADR-0005](ADR-0005-one-ranking-engine-serves-ambient-and-radio.md).
 
+Implementation:
+- Backend and client landed together: `services/offline_manifest.py`, `POST /queue/offline-manifest`,
+  `services/offlineManifestService.ts` and the `offlineManifests` Dexie table, with ambient consuming
+  the manifest via `AmbientCoordinator.lookupOfflineCandidates`.
+- **The `radio` variant was generated but consumed by nothing** until offline radio landed on branch
+  `feat/offline-radio`. `radioController` returned early whenever `offlineModeActive` was set, so
+  radio simply went quiet in airplane mode while the server was already computing and shipping the
+  ranking it needed. It now looks the seed up in that variant. No new ADR: this implements decision
+  points 2 and 5 rather than deciding anything.
+- That matters more than it first appears, because ambient — the manifest's only other consumer — is
+  **iOS-only** (`ambientSynthBridge`: "Web never registers"). Until this, the whole ADR had no effect
+  in the web app at all.
+- The offline path filters neighbours against `connectivityStore.offlineTrackIds` rather than
+  trusting the manifest, since the manifest goes stale when a download is removed. That is the same
+  failure class as the `db.cachedTracks` follow-up below — metadata present, audio absent.
+
 ## Context
 
 [ADR-0005](ADR-0005-one-ranking-engine-serves-ambient-and-radio.md) puts candidate ranking on the

--- a/packages/frontend/src/player/__tests__/radioController.test.ts
+++ b/packages/frontend/src/player/__tests__/radioController.test.ts
@@ -12,12 +12,27 @@
  */
 import { describe, it, expect, beforeEach, vi } from 'vitest';
 
-const { mockGetSuggestions, connectivityState } = vi.hoisted(() => ({
-  mockGetSuggestions: vi.fn(),
-  connectivityState: { offlineModeActive: false, offlineTrackIds: new Set<string>() },
-}));
+const { mockGetSuggestions, mockGetOfflineNeighbours, mockResolveTrackIds, connectivityState } =
+  vi.hoisted(() => ({
+    mockGetSuggestions: vi.fn(),
+    mockGetOfflineNeighbours: vi.fn(),
+    mockResolveTrackIds: vi.fn(),
+    connectivityState: { offlineModeActive: false, offlineTrackIds: new Set<string>() },
+  }));
 
 vi.mock('../../api/queue', () => ({ queueApi: { getSuggestions: mockGetSuggestions } }));
+vi.mock('../../services/offlineManifestService', () => ({
+  getOfflineNeighbours: mockGetOfflineNeighbours,
+}));
+vi.mock('../../services/playlistCache', () => ({
+  resolveTrackIds: mockResolveTrackIds,
+  // The real converter is trivial and its field mapping is what we want to exercise.
+  cachedTrackToTrack: (c: { id: string; title: string }) => ({
+    id: c.id, title: c.title, artist: null, album: null, album_artist: null,
+    album_type: 'album', track_number: null, disc_number: null, year: null,
+    genre: null, duration_seconds: null, format: null, file_path: '', analysis_version: 0,
+  }),
+}));
 vi.mock('../../stores/connectivityStore', () => ({
   useConnectivityStore: Object.assign(
     (sel: (s: typeof connectivityState) => unknown) => sel(connectivityState),
@@ -49,7 +64,14 @@ function seedQueue(ids: string[], index = 0) {
 beforeEach(() => {
   mockGetSuggestions.mockReset();
   mockGetSuggestions.mockResolvedValue({ suggestions: [suggestion('s1')], pool_size: 50, pool_collapsed: false });
+  mockGetOfflineNeighbours.mockReset();
+  mockGetOfflineNeighbours.mockResolvedValue([]);
+  mockResolveTrackIds.mockReset();
+  mockResolveTrackIds.mockImplementation((ids: string[]) =>
+    Promise.resolve(ids.map((id) => ({ id, title: `Track ${id}` })))
+  );
   connectivityState.offlineModeActive = false;
+  connectivityState.offlineTrackIds = new Set<string>();
   radioController.stop();
   useRadioStore.setState({ enabled: true });
   seedQueue(['a', 'b', 'c', 'd', 'e', 'f']);
@@ -72,11 +94,22 @@ describe('staying quiet', () => {
     expect(usePlayerStore.getState().queue.length).toBe(before);
   });
 
-  it('does not insert while offline', async () => {
-    // A suggestion that cannot stream is worse than no suggestion.
+  it('never asks the server while offline', async () => {
     connectivityState.offlineModeActive = true;
     await radioController.suggest();
     expect(mockGetSuggestions).not.toHaveBeenCalled();
+  });
+
+  it('does not insert while offline when the manifest knows nothing', async () => {
+    // No manifest yet, or a seed downloaded since the last refresh. A suggestion that
+    // cannot stream is worse than no suggestion.
+    connectivityState.offlineModeActive = true;
+    mockGetOfflineNeighbours.mockResolvedValue([]);
+    const before = usePlayerStore.getState().queue.length;
+
+    await radioController.suggest();
+
+    expect(usePlayerStore.getState().queue.length).toBe(before);
   });
 
   it('does not insert without a current track', async () => {
@@ -249,5 +282,102 @@ describe('accepting and rejecting', () => {
     usePlayerStore.getState().removeFromQueue(item.queueId);
 
     expect(usePlayerStore.getState().queue.find((i) => i.track.id === 's1')).toBeUndefined();
+  });
+});
+
+/**
+ * Offline radio (ADR-0006).
+ *
+ * The server generates a `radio` variant of the offline manifest and, until this, nothing
+ * consumed it — radio simply went quiet in airplane mode. The ranking is still entirely
+ * server-side: these assert that the client does lookup and ordering, never scoring, and
+ * that it refuses to suggest a track whose audio is not actually on the device.
+ */
+describe('offline', () => {
+  beforeEach(() => {
+    connectivityState.offlineModeActive = true;
+    connectivityState.offlineTrackIds = new Set(['n1', 'n2', 'n3']);
+  });
+
+  it('suggests from the manifest instead of going quiet', async () => {
+    mockGetOfflineNeighbours.mockResolvedValue([{ trackId: 'n1', score: 0.88 }]);
+
+    await radioController.suggest();
+
+    expect(usePlayerStore.getState().queue.some((i) => i.track.id === 'n1')).toBe(true);
+    expect(mockGetSuggestions).not.toHaveBeenCalled();
+  });
+
+  it('asks for the radio variant, not ambient', async () => {
+    // Weight profile is what makes a suggestion radio-shaped rather than ambient-shaped.
+    mockGetOfflineNeighbours.mockResolvedValue([{ trackId: 'n1', score: 0.8 }]);
+
+    await radioController.suggest();
+
+    expect(mockGetOfflineNeighbours).toHaveBeenCalledWith(
+      'a',
+      expect.objectContaining({ profile: 'radio', filterPreset: 'all' })
+    );
+  });
+
+  it('preserves the manifest order rather than re-ranking', async () => {
+    // There is no scorer on this client, so "best" can only mean "first as sent".
+    mockGetOfflineNeighbours.mockResolvedValue([
+      { trackId: 'n2', score: 0.4 },
+      { trackId: 'n1', score: 0.9 },
+    ]);
+
+    await radioController.suggest();
+
+    expect(usePlayerStore.getState().queue.some((i) => i.track.id === 'n2')).toBe(true);
+    expect(usePlayerStore.getState().queue.some((i) => i.track.id === 'n1')).toBe(false);
+  });
+
+  it('refuses a neighbour whose audio is not downloaded', async () => {
+    // The manifest goes stale when a track is removed. Suggesting metadata-only tracks is
+    // the exact bug ADR-0006 flagged in offlineScoring (cachedTracks vs offlineTracks),
+    // and addToQueue would silently drop it anyway.
+    connectivityState.offlineTrackIds = new Set(['n2']);
+    mockGetOfflineNeighbours.mockResolvedValue([
+      { trackId: 'n1', score: 0.9 },
+      { trackId: 'n2', score: 0.5 },
+    ]);
+
+    await radioController.suggest();
+
+    const queue = usePlayerStore.getState().queue;
+    expect(queue.some((i) => i.track.id === 'n1')).toBe(false);
+    expect(queue.some((i) => i.track.id === 'n2')).toBe(true);
+  });
+
+  it('stays quiet when nothing in the manifest is downloaded', async () => {
+    connectivityState.offlineTrackIds = new Set<string>();
+    mockGetOfflineNeighbours.mockResolvedValue([{ trackId: 'n1', score: 0.9 }]);
+    const before = usePlayerStore.getState().queue.length;
+
+    await radioController.suggest();
+
+    expect(usePlayerStore.getState().queue.length).toBe(before);
+    // Nothing playable, so no point resolving metadata for it.
+    expect(mockResolveTrackIds).not.toHaveBeenCalled();
+  });
+
+  it('marks an offline suggestion the same as an online one', async () => {
+    mockGetOfflineNeighbours.mockResolvedValue([{ trackId: 'n1', score: 0.88 }]);
+
+    await radioController.suggest();
+
+    const item = usePlayerStore.getState().queue.find((i) => i.track.id === 'n1');
+    expect(item?.suggested).toBe(true);
+  });
+
+  it('passes recent tracks so the manifest lookup can skip them', async () => {
+    seedQueue(['a', 'b', 'c'], 2);
+    mockGetOfflineNeighbours.mockResolvedValue([{ trackId: 'n1', score: 0.9 }]);
+
+    await radioController.suggest();
+
+    const opts = mockGetOfflineNeighbours.mock.calls[0][1];
+    expect(opts.recentTrackIds).toEqual(expect.arrayContaining(['a', 'b', 'c']));
   });
 });

--- a/packages/frontend/src/player/radio/radioController.ts
+++ b/packages/frontend/src/player/radio/radioController.ts
@@ -3,9 +3,15 @@
  * (ADR-0005 decision points 6 and 8).
  *
  * Follows the shape of `player/ambient/AmbientCoordinator`: subscribe to queue position,
- * ask the server to rank candidates, insert ahead of the play head. The ranking itself is
- * entirely server-side — the same engine ambient uses, under the `RADIO` weight profile —
- * so this file holds cadence and insertion policy only, no scoring.
+ * rank candidates, insert ahead of the play head. The ranking itself is entirely
+ * server-side — the same engine ambient uses, under the `RADIO` weight profile — so this
+ * file holds cadence and insertion policy only, no scoring.
+ *
+ * That holds offline too. Rather than going quiet, the offline path looks the ranking up
+ * in the precomputed manifest (ADR-0006), which the server built from the downloaded set
+ * using the identical scorer. So an offline suggestion is the same suggestion the online
+ * path would make over that set, not a degraded approximation — and there is still no
+ * scoring code on any client.
  *
  * Cadence is every `INSERT_EVERY_N_TRACKS` (ADR decision point 8). Inserting on queue
  * exhaustion was rejected: a library queue is a lazy reservoir over the whole collection
@@ -15,9 +21,18 @@ import { usePlayerStore } from '../playerStore';
 import { useConnectivityStore } from '../../stores/connectivityStore';
 import { queueApi } from '../../api/queue';
 import { useRadioStore } from '../../stores/radioStore';
+import { getOfflineNeighbours } from '../../services/offlineManifestService';
+import { cachedTrackToTrack, resolveTrackIds } from '../../services/playlistCache';
+import type { Track } from '../../types';
 import { createLogger } from '../../utils/logger';
 
 const log = createLogger('Radio');
+
+/** A track worth inserting, and how well it scored. Same shape online and offline. */
+interface Candidate {
+  track: Track;
+  score: number;
+}
 
 /** Insert a suggestion every N track changes. Revisit once ADR-0004 data exists. */
 export const INSERT_EVERY_N_TRACKS = 4;
@@ -81,35 +96,25 @@ class RadioController {
     const current = state.currentTrack;
     if (!current) return;
 
-    // Nothing to fetch with, and inserting a track that cannot stream is worse than
-    // inserting nothing.
-    if (useConnectivityStore.getState().offlineModeActive) return;
-
     this.inFlight = true;
     try {
       const recent = state.queue
         .slice(Math.max(0, state.queueIndex - RECENT_WINDOW), state.queueIndex + 1)
         .map((item) => item.track);
+      const recentTrackIds = Array.from(new Set(recent.map((t) => t.id)));
 
-      const response = await queueApi.getSuggestions({
-        current_track_id: current.id,
-        recent_track_ids: Array.from(new Set(recent.map((t) => t.id))),
-        recent_artist_names: Array.from(
-          new Set(recent.map((t) => t.artist).filter((a): a is string => !!a))
-        ),
-        profile: 'radio',
-        limit: 5,
-      });
+      const candidates = useConnectivityStore.getState().offlineModeActive
+        ? await this.offlineCandidates(current.id, recentTrackIds)
+        : await this.onlineCandidates(current.id, recent, recentTrackIds);
 
-      if (response.pool_collapsed || response.suggestions.length === 0) {
-        // Too few candidates to rank meaningfully. Stay quiet rather than insert
-        // something arbitrary, and try again after the next N tracks.
-        log.debug('No usable suggestion (pool_size %d)', response.pool_size);
+      if (candidates.length === 0) {
+        // Too few candidates to rank meaningfully, or nothing downloaded to draw from.
+        // Stay quiet rather than insert something arbitrary; retry after the next N.
         this.tracksSinceInsert = 0;
         return;
       }
 
-      const pick = response.suggestions.find(
+      const pick = candidates.find(
         (s) => !this.inserted.has(s.track.id) && !this.isQueuedNearby(s.track.id)
       );
       if (!pick) {
@@ -142,6 +147,78 @@ class RadioController {
     } finally {
       this.inFlight = false;
     }
+  }
+
+  /** Rank against the whole library, server-side. */
+  private async onlineCandidates(
+    currentTrackId: string,
+    recent: Track[],
+    recentTrackIds: string[],
+  ): Promise<Candidate[]> {
+    const response = await queueApi.getSuggestions({
+      current_track_id: currentTrackId,
+      recent_track_ids: recentTrackIds,
+      recent_artist_names: Array.from(
+        new Set(recent.map((t) => t.artist).filter((a): a is string => !!a))
+      ),
+      profile: 'radio',
+      limit: 5,
+    });
+
+    if (response.pool_collapsed) {
+      log.debug('No usable suggestion (pool_size %d)', response.pool_size);
+      return [];
+    }
+    return response.suggestions.map((s) => ({ track: s.track, score: s.score }));
+  }
+
+  /**
+   * Look the ranking up in the precomputed manifest (ADR-0006).
+   *
+   * No scoring happens here and none ever should — the server ranked the downloaded set
+   * against itself using the same `score_candidate()` the online path uses, so an offline
+   * suggestion is the same suggestion, not an approximation of one. This resolves ids to
+   * tracks and preserves the server's order.
+   *
+   * The `radio` variant has been generated since ADR-0006 landed and, until now, was
+   * consumed by nothing.
+   */
+  private async offlineCandidates(
+    currentTrackId: string,
+    recentTrackIds: string[],
+  ): Promise<Candidate[]> {
+    const neighbours = await getOfflineNeighbours(currentTrackId, {
+      profile: 'radio',
+      // Radio has no preset control; the server emits its variant under 'all'.
+      filterPreset: 'all',
+      recentTrackIds,
+      limit: 5,
+    });
+    if (neighbours.length === 0) {
+      // Either no manifest yet, or it does not know this seed — a track downloaded since
+      // the last refresh is not usable as a seed until then (ADR-0006 accepts this).
+      log.debug('No offline neighbours for %s', currentTrackId);
+      return [];
+    }
+
+    // Filter against what is *actually downloaded* right now, not merely what the manifest
+    // was built from. The manifest goes stale when a track is removed, and suggesting a
+    // track whose audio is absent is the failure mode ADR-0006 flagged in `offlineScoring`
+    // (it read `cachedTracks` — metadata — rather than `offlineTracks`). `addToQueue`
+    // enforces the same invariant and would silently drop the insert, leaving this
+    // controller's `inserted` bookkeeping out of step with the queue.
+    const downloaded = useConnectivityStore.getState().offlineTrackIds;
+    const playable = neighbours.filter((n) => downloaded.has(n.trackId));
+    if (playable.length === 0) return [];
+
+    const scoreById = new Map(playable.map((n) => [n.trackId, n.score]));
+    const cached = await resolveTrackIds(playable.map((n) => n.trackId));
+
+    // resolveTrackIds preserves the requested order, which is the server's ranking.
+    return cached.map((track) => ({
+      track: cachedTrackToTrack(track),
+      score: scoreById.get(track.id) ?? 0,
+    }));
   }
 
   /** Already sitting in the upcoming queue — suggesting it again would be noise. */

--- a/packages/frontend/src/services/playlistCache.ts
+++ b/packages/frontend/src/services/playlistCache.ts
@@ -12,6 +12,7 @@ import {
   type CachedTrack,
 } from '../db';
 import type { PlaylistDetail, SmartPlaylist } from '../api';
+import type { Track } from '../types';
 import { createLogger } from '../utils/logger';
 
 const log = createLogger('PlaylistCache');
@@ -387,6 +388,35 @@ export async function getFavoritesCacheInfo(): Promise<{
  * Resolve track IDs to cached track metadata.
  * Returns tracks in the same order as the input IDs.
  */
+/**
+ * Widen a cached track into the `Track` the player works in.
+ *
+ * Cached metadata is deliberately narrower than `Track` — it carries no `file_path`,
+ * `format` or analysis. Those come back as empty/zero rather than being faked: offline
+ * playback resolves audio through `offlineService` by id, and nothing offline reads
+ * analysis features.
+ *
+ * `useFavorites` does this same mapping inline; it can move onto this when next touched.
+ */
+export function cachedTrackToTrack(cached: CachedTrack): Track {
+  return {
+    id: cached.id,
+    file_path: '',
+    title: cached.title || null,
+    artist: cached.artist || null,
+    album: cached.album || null,
+    album_artist: cached.albumArtist ?? null,
+    album_type: 'album',
+    track_number: cached.trackNumber ?? null,
+    disc_number: cached.discNumber ?? null,
+    year: cached.year ?? null,
+    genre: cached.genre ?? null,
+    duration_seconds: cached.durationSeconds ?? null,
+    format: null,
+    analysis_version: 0,
+  };
+}
+
 export async function resolveTrackIds(
   trackIds: string[]
 ): Promise<CachedTrack[]> {


### PR DESCRIPTION
The server has been generating a `radio` variant of the offline manifest since ADR-0006 landed, and **nothing consumed it**. `radioController` returned early whenever `offlineModeActive` was set, so radio simply went quiet in airplane mode while the ranking it needed was already computed, shipped, and sitting in IndexedDB.

That gap matters more than it looks: ambient is the manifest's only other consumer and is **iOS-only** (`ambientSynthBridge`: "Web never registers"), so until now ADR-0006 had no effect in the web app at all.

### What changed

The offline path looks the current track up in the manifest and inserts the best neighbour not heard recently. **No scoring moves to the client** — the server ranked the downloaded set against itself with the same `score_candidate()` the online path uses, so an offline suggestion is the same suggestion, not a degraded approximation. Resolving ids to tracks and preserving the server's order is the whole of the client-side algorithm.

`suggest()` splits into `onlineCandidates` / `offlineCandidates` over a shared `Candidate` shape, so cadence, dedup, shuffle-aware placement and the `suggested` marker are identical on both paths.

### The part worth reviewing

Neighbours are filtered against `connectivityStore.offlineTrackIds` rather than trusting the manifest, which goes stale when a download is removed. Suggesting a track whose audio is absent is the failure ADR-0006 flagged in `offlineScoring` — it read `cachedTracks` (metadata) rather than `offlineTracks` — and `addToQueue` enforces the same invariant, so an unfiltered suggestion would be silently dropped and leave this controller's `inserted` bookkeeping out of step with the queue.

### Testing

8 new tests. The existing `does not insert while offline` was renamed and split — **it would otherwise have kept passing for the wrong reason**, since with no manifest mocked the new path also yields nothing. The downloaded-filter and weight-profile assertions were each checked against a deliberately reverted fix.

Also adds `cachedTrackToTrack` next to `resolveTrackIds`; `useFavorites` does the same mapping inline and can move onto it when next touched.

**No ADR needed** — this implements ADR-0006 decision points 2 and 5 rather than deciding anything. ADR-0006 gains an `Implementation:` block recording that its radio variant finally has a consumer.

Independent of the ADR-0003 stack (#33–#36) and can merge in any order.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_014P9p2fvFnyiywBxGkv4gfW