### PR TITLE
fix(player): stop hydration overriding a track the listener just started

### DIFF
--- a/packages/frontend/src/player/__tests__/queuePersistence.test.ts
+++ b/packages/frontend/src/player/__tests__/queuePersistence.test.ts
@@ -27,15 +27,12 @@ import { createMockTrack, mockConnectivityState } from './testHelpers';
 // mockLoadPlayerState` does) hits the temporal dead zone. Vitest swallows that and falls
 // back to the real module, so the mocks appear to do nothing and every test fails for a
 // reason unrelated to what it is testing.
-const { mockLoadPlayerState, mockSave } = vi.hoisted(() => ({
+const { mockLoadPlayerState, mockSave, mockFetchTracksBatched } = vi.hoisted(() => ({
   mockLoadPlayerState: vi.fn(() => Promise.resolve(null as unknown)),
   mockSave: vi.fn(),
-}));
-
-vi.mock('../persistence', () => ({
-  debouncedSavePlayerState: mockSave,
-  loadPlayerState: mockLoadPlayerState,
-  fetchTracksBatched: (ids: string[]) =>
+  // A vi.fn, not an inline arrow, so a test can hold the promise open and interleave a
+  // listener action with hydration — which is the whole point of the race below.
+  mockFetchTracksBatched: vi.fn((ids: string[]) =>
     Promise.resolve(ids.map((id) => ({
       id,
       title: `Track ${id}`,
@@ -43,7 +40,14 @@ vi.mock('../persistence', () => ({
       album: 'Test Album',
       duration_seconds: 180,
       file_path: `/music/${id}.mp3`,
-    }))),
+    })))
+  ),
+}));
+
+vi.mock('../persistence', () => ({
+  debouncedSavePlayerState: mockSave,
+  loadPlayerState: mockLoadPlayerState,
+  fetchTracksBatched: mockFetchTracksBatched,
   migrateOldPlayerState: vi.fn(() => Promise.resolve()),
 }));
 
@@ -132,6 +136,9 @@ function resetStores() {
 beforeEach(() => {
   resetStores();
   mockSave.mockClear();
+  // Cleared, or `untilFetching()` resolves from a previous test's call and the interleaved
+  // action lands before hydration has even reached the phase under test.
+  mockFetchTracksBatched.mockClear();
   mockGetBatch.mockReset();
   mockGetBatch.mockImplementation((batchIds: string[]) =>
     Promise.resolve(batchIds.map((id) => createMockTrack(id)))
@@ -219,6 +226,93 @@ describe('hydrating', () => {
     expect(mockGetIds).toHaveBeenCalled();
     // The library filters have to survive too, or the reshuffle spans the wrong set.
     expect(mockGetIds.mock.calls[0][0]).toMatchObject({ genre: 'jazz' });
+  });
+});
+
+/**
+ * The reload race.
+ *
+ * `hydrate()` refetches the whole queue, which takes seconds on a large one. Starting a
+ * track before that finished used to get overridden: hydration completed and resumed the
+ * pre-reload track, several seconds in. The existing `currentTrack?.id !== existingTrackId`
+ * check could not catch it — it exists to skip a redundant write, and a listener-chosen
+ * track differs from the persisted one by definition, so it let exactly the wrong case
+ * through.
+ */
+describe('a listener acting mid-hydration', () => {
+  /**
+   * Hold the queue fetch open so an action can be interleaved, as it is in reality.
+   *
+   * The promise is built up front rather than inside the mock implementation: the executor
+   * only runs when the mock is called, so capturing `resolve` from in there leaves it
+   * unset at the moment the test wants to release it.
+   */
+  function deferFetch() {
+    let release: (tracks: unknown[]) => void = () => {};
+    const pending = new Promise((resolve) => { release = resolve as (t: unknown[]) => void; });
+    mockFetchTracksBatched.mockImplementationOnce(() => pending as Promise<never[]>);
+    return () => release(ids(50).map((id) => createMockTrack(id)));
+  }
+
+  /** Resolves once hydration has reached the queue fetch, i.e. past the current-track phase. */
+  const untilFetching = () =>
+    vi.waitFor(() => expect(mockFetchTracksBatched).toHaveBeenCalled());
+
+  it('does not override the track they started', async () => {
+    mockLoadPlayerState.mockResolvedValue(persistedLazyQueue(200, 50));
+    const finishFetch = deferFetch();
+
+    const hydrating = useQueueStore.getState().hydrate();
+    await untilFetching();
+    // They pick something while the queue is still loading.
+    usePlaybackStore.setState({ currentTrack: createMockTrack('their-choice'), isPlaying: true });
+    finishFetch();
+    await hydrating;
+
+    expect(usePlaybackStore.getState().currentTrack?.id).toBe('their-choice');
+  });
+
+  it('leaves their queue alone too, not just the track', async () => {
+    // Their choice usually arrives via setQueue, so restoring the persisted queue would
+    // strand them: their track playing against somebody else's queue.
+    mockLoadPlayerState.mockResolvedValue(persistedLazyQueue(200, 50));
+    const finishFetch = deferFetch();
+
+    const hydrating = useQueueStore.getState().hydrate();
+    await untilFetching();
+    useQueueStore.setState({
+      queue: [{ track: createMockTrack('their-choice'), queueId: 'q0' }],
+      queueIndex: 0,
+    });
+    usePlaybackStore.setState({ currentTrack: createMockTrack('their-choice') });
+    finishFetch();
+    await hydrating;
+
+    expect(useQueueStore.getState().queue.map((i) => i.track.id)).toEqual(['their-choice']);
+  });
+
+  it('still hydrates normally when they do not act', async () => {
+    // The guard must not break the ordinary reload, which is the common case.
+    mockLoadPlayerState.mockResolvedValue(persistedLazyQueue(200, 50));
+
+    await useQueueStore.getState().hydrate();
+
+    expect(useQueueStore.getState().queue).toHaveLength(50);
+    expect(usePlaybackStore.getState().currentTrack?.id).toBe('t0');
+  });
+
+  it('clears the hydrating flag even when it abandons', async () => {
+    // Left set, the queue view would show a loading state forever.
+    mockLoadPlayerState.mockResolvedValue(persistedLazyQueue(200, 50));
+    const finishFetch = deferFetch();
+
+    const hydrating = useQueueStore.getState().hydrate();
+    await untilFetching();
+    usePlaybackStore.setState({ currentTrack: createMockTrack('their-choice') });
+    finishFetch();
+    await hydrating;
+
+    expect(useQueueStore.getState().isQueueHydrating).toBe(false);
   });
 });
 

--- a/packages/frontend/src/player/queueStore.ts
+++ b/packages/frontend/src/player/queueStore.ts
@@ -1029,6 +1029,27 @@ export const useQueueStore = create<QueueState & QueueActions>((set, get) => ({
       const clampedShuffleOrder = (persisted.shuffleOrder || []).filter(i => i < queue.length);
 
       const existingTrackId = usePlaybackStore.getState().currentTrack?.id;
+
+      // Hydration is asynchronous — refetching a large queue takes seconds. If the
+      // listener started something in the meantime, their choice wins: applying the
+      // persisted queue now would stop the track they just picked and resume the one from
+      // before the reload, several seconds in. Phase 1b already set `currentTrack` from
+      // the persisted id, so anything else playing means they acted.
+      //
+      // The `currentTrack?.id !== existingTrackId` check below cannot cover this — it was
+      // written to skip a redundant write, and a listener-chosen track differs from the
+      // persisted one by definition, so it lets exactly the wrong case through.
+      const listenerTookOver =
+        existingTrackId != null && existingTrackId !== persisted.currentTrackId;
+      if (listenerTookOver) {
+        log.info('Hydration abandoned — listener started playing before it finished', {
+          playing: existingTrackId,
+          persisted: persisted.currentTrackId,
+        });
+        set({ isQueueHydrating: false });
+        return;
+      }
+
       set({
         queue,
         queueIndex: clampedQueueIndex,


### PR DESCRIPTION
Reload the app, start a song, and a few seconds later it stops and resumes whatever was playing before the reload — several seconds in.

`hydrate()` refetches the whole queue, which takes seconds on a large one. Its final phase then applied the persisted queue and `currentTrack` unconditionally.

The existing guard could not prevent it:

```js
if (currentTrack?.id !== existingTrackId) {
  usePlaybackStore.setState({ currentTrack });   // ← stomps their choice
}
```

That check exists to skip a *redundant* write. A listener-chosen track differs from the persisted one by definition, so it let exactly the wrong case through while filtering the harmless one.

### Fix

Hydration abandons its final phase when the track playing is not the one it put there itself in phase 1b. It gives up the **queue** as well as the track — their choice usually arrives via `setQueue`, so restoring the persisted queue would leave their track playing against somebody else's queue.

### Testing

Four tests. Two hold the queue fetch open to interleave a listener action the way it actually happens, and **both were confirmed to fail without the guard**. The other two cover the ordinary reload still hydrating normally, and the hydrating flag being cleared on the abandon path — left set, the queue view spins forever.

Getting the race right took two attempts worth noting for anyone extending these: the deferred promise has to be built up front (its executor doesn't run until the mock is called), and `mockFetchTracksBatched` has to be cleared per test or the wait resolves from a previous test's call and the action lands before the phase under test.

Found while dogfooding the server-owned queue (#36); predates that work and is independent of it.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_014P9p2fvFnyiywBxGkv4gfW