### PR TITLE
fix(player): set queueSource on the four play paths that omitted it

### DIFF
--- a/packages/frontend/src/components/Chat/ChatPanel.tsx
+++ b/packages/frontend/src/components/Chat/ChatPanel.tsx
@@ -341,7 +341,7 @@ export function ChatPanel({ pendingMessage, onPendingMessageConsumed, onClose }:
           analysis_version: 0,
         }));
         if (tracks.length > 0) {
-          setQueue(tracks, 0);
+          setQueue(tracks, 0, { type: 'ephemeral' });
         }
         break;
       }

--- a/packages/frontend/src/components/Playlists/DownloadsDetail.tsx
+++ b/packages/frontend/src/components/Playlists/DownloadsDetail.tsx
@@ -83,7 +83,9 @@ export function DownloadsDetail({ onBack: onBackProp }: Props) {
       format: null,
       analysis_version: 0,
     }));
-    setQueueByTrackId(queueTracks, clickedTrack.id);
+    // 'other': the union has no member for Downloads. Still better than null — a null
+    // source loses the listening-event context ADR-0005's ranking reads.
+    setQueueByTrackId(queueTracks, clickedTrack.id, { type: 'other' });
   }, [searchedTracks, currentTrack?.id, isPlaying, setIsPlaying, setQueueByTrackId]);
 
   const handleRemoveFromDownloads = async (trackId: string, e: React.MouseEvent) => {

--- a/packages/frontend/src/components/Playlists/FavoritesDetail.tsx
+++ b/packages/frontend/src/components/Playlists/FavoritesDetail.tsx
@@ -117,7 +117,8 @@ export function FavoritesDetail({ onBack: onBackProp }: Props) {
       return;
     }
 
-    setQueueByTrackId(items.map(getTrack), trackForItem.id);
+    // 'other': the union has no member for Favorites. See DownloadsDetail.
+    setQueueByTrackId(items.map(getTrack), trackForItem.id, { type: 'other' });
   }, [filteredFavorites, getTrack, currentTrack?.id, isPlaying, setIsPlaying, setQueueByTrackId]);
 
   const totalDuration = favorites.reduce(

--- a/packages/frontend/src/components/Playlists/PlaylistDetail.tsx
+++ b/packages/frontend/src/components/Playlists/PlaylistDetail.tsx
@@ -200,7 +200,7 @@ export function PlaylistDetail({ playlistId: playlistIdProp, onBack: onBackProp 
       try {
         const response = await tracksApi.list({ artist: item.name, page_size: 50 });
         if (response.items.length > 0) {
-          setQueue(response.items, 0);
+          setQueue(response.items, 0, { type: 'artist', id: item.name });
         }
       } catch (error) {
         log.error('Failed to fetch artist tracks:', error);


### PR DESCRIPTION
Playing from Downloads, Favorites, an artist row, or a chat result left `queueSource` null.

```
DownloadsDetail.tsx:86     setQueueByTrackId(queueTracks, clickedTrack.id)   ← no source
FavoritesDetail.tsx:120    setQueueByTrackId(items.map(getTrack), ...)       ← no source
PlaylistDetail.tsx:203     setQueue(response.items, 0)                       ← no source
ChatPanel.tsx:344          setQueue(tracks, 0)                               ← no source
```

Two consequences, both silent:

- **Listening events lose their context**, which is the signal ADR-0005's ranking reads. A null context isn't a neutral default — it's a discarded dimension.
- **Cross-device handoff has no context to restore**, so the queue arrives on the other device detached from wherever it came from. You don't notice on the origin device, because the UI shows the page you're looking at rather than the queue's own provenance.

### Choices

`PlaylistDetail:203` is the **artist** branch, not a playlist one, so it gets `{type: 'artist', id: item.name}`. `ChatPanel` gets `'ephemeral'`, matching every other chat-generated queue.

Downloads and Favorites get `'other'`: the union has no member for either. Inventing one would mean changing the client type, the server's `QueueSource` literal, and `PlayContext` together — plausibly worth doing for the ranking signal, since "played from Favorites" is a strong positive context, but not inside a bug fix.

### No new test, deliberately

A source-scanning guard would be brittle across multi-line calls and arg counting. The durable fix is making `source` a **required** parameter so the compiler catches it forever — but that touches ~20 call sites and would conflict with the open ADR-0003 stack, so it's better done once #34–#36 merge. Flagging it rather than leaving it implicit.

Found while dogfooding the server-owned queue (#36); predates that work and is independent of it.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_014P9p2fvFnyiywBxGkv4gfW