### PR TITLE
ci: remove the iOS job that never ran a test

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -475,28 +475,6 @@ jobs:
             grep 'rerun' results-integration.xml || true
           fi
 
-  ios-native-tests:
-    name: iOS Native AppTests
-    runs-on: [self-hosted, macOS]
-    steps:
-      - uses: actions/checkout@v4
-      - name: Run iOS unit tests
-        working-directory: packages/ios/native
-        run: |
-          xcodebuild test \
-            -scheme App \
-            -destination 'platform=iOS Simulator,name=iPhone 16,OS=latest' \
-            -resultBundlePath TestResults \
-            CODE_SIGNING_ALLOWED=NO \
-            | xcpretty || true
-      - name: Upload test results
-        if: always()
-        uses: actions/upload-artifact@v4
-        with:
-          name: ios-test-results
-          path: packages/ios/native/TestResults
-          retention-days: 7
-
   frontend-lint:
     name: Frontend Lint
     runs-on: self-hosted


### PR DESCRIPTION
`iOS Native AppTests` has been reporting green without executing a single test.

Two independent reasons it could never have worked, neither visible:

1. **It fails before reaching a test.** `xcodebuild: error: Could not resolve package dependencies: .../packages/ios/node_modules/@capacitor/preferences doesn't exist` — no step runs `pnpm install`.
2. **Its destination matches no simulator.** `name=iPhone 16`; the runner has iPhone 16 Pro, Pro Max and 16e.

`| xcpretty || true` hid both. A pipe returns the *last* command's status, and `|| true` discards even that.

## Why delete rather than repair

The engine and all four XCTest suites now live in `familiar-apple`, where CI runs them for real (`seethroughlab/familiar-apple#2`). `packages/ios` is frozen bug-fix-only by ADR-0001 point 6 and retired at native parity, so repairing a slow job to test a frozen codebase would duplicate coverage that now works elsewhere.

**No coverage is lost, because there was none.**

Worth knowing: two of those four suites were also failing on their merits — `testBrightFixtureDominatesTreble` asserts a 4 kHz fixture dominates treble, while the processor slices bands by bin fraction and puts treble at 11 kHz and up. They are skipped in `familiar-apple` with that diagnosis rather than silently green.

## Checked

The other `|| true` uses in this workflow are grep counts, container cleanup and `df -h` — none masks a test result. YAML validates, 12 jobs remain, no dangling `needs`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_014P9p2fvFnyiywBxGkv4gfW