### PR TITLE
fix(api): make the whole generated surface describable

### DIFF
--- a/backend/app/api/routes/queue.py
+++ b/backend/app/api/routes/queue.py
@@ -303,7 +303,9 @@ def _apply(
     row.shuffle = body.shuffle
     row.repeat = body.repeat
     row.consume = body.consume
-    row.queue_source = body.queue_source.model_dump(exclude_none=True) if body.queue_source else None
+    row.queue_source = (
+        body.queue_source.model_dump(exclude_none=True) if body.queue_source else None
+    )
     row.reservoir_ids, row.reservoir_hash = reservoir
     row.reservoir_cursor = body.reservoir_cursor
     row.position_seconds = body.position_seconds
@@ -327,9 +329,7 @@ def _copy_payload(src: PlaybackSessionPayload, dst: PlaybackSessionPayload) -> N
 
 def _archive(db: DbSession, session: PlaybackSession) -> None:
     """Retain a superseded queue. ADR-0003 point 6: the loser is never destroyed."""
-    row = PlaybackSessionArchive(
-        profile_id=session.profile_id, superseded_at=session.updated_at
-    )
+    row = PlaybackSessionArchive(profile_id=session.profile_id, superseded_at=session.updated_at)
     _copy_payload(session, row)
     db.add(row)
 
@@ -360,9 +360,7 @@ async def _trim_archive(db: DbSession, profile_id: UUID) -> None:
         .all()
     )
     if stale:
-        await db.execute(
-            delete(PlaybackSessionArchive).where(PlaybackSessionArchive.id.in_(stale))
-        )
+        await db.execute(delete(PlaybackSessionArchive).where(PlaybackSessionArchive.id.in_(stale)))
 
 
 def _to_response(session: PlaybackSession, *, superseded: bool = False) -> PlaybackSessionResponse:
@@ -374,7 +372,9 @@ def _to_response(session: PlaybackSession, *, superseded: bool = False) -> Playb
         shuffle=session.shuffle,
         repeat=session.repeat,  # type: ignore[arg-type]
         consume=session.consume,
-        queue_source=QueueSource.model_validate(session.queue_source) if session.queue_source else None,
+        queue_source=QueueSource.model_validate(session.queue_source)
+        if session.queue_source
+        else None,
         reservoir_ids=[UUID(i) for i in session.reservoir_ids] if session.reservoir_ids else None,
         reservoir_cursor=session.reservoir_cursor,
         reservoir_hash=session.reservoir_hash,
@@ -400,9 +400,7 @@ def _require_queue_sync_enabled() -> None:
 
 async def _load_session(db: DbSession, profile_id: UUID) -> PlaybackSession | None:
     return (
-        await db.execute(
-            select(PlaybackSession).where(PlaybackSession.profile_id == profile_id)
-        )
+        await db.execute(select(PlaybackSession).where(PlaybackSession.profile_id == profile_id))
     ).scalar_one_or_none()
 
 
@@ -411,7 +409,15 @@ async def _load_session(db: DbSession, profile_id: UUID) -> PlaybackSession | No
 # ============================================================================
 
 
-@router.get("/session", response_model=PlaybackSessionResponse, operation_id="getPlaybackSession")
+@router.get(
+    "/session",
+    response_model=PlaybackSessionResponse,
+    # 503 is control flow too: these four are gated behind `queue_sync_enabled`, so "the server
+    # does not do this" is an ordinary answer a client must expect on its very first call, not a
+    # server fault. Undeclared, a generated client has no case to branch on and reports an
+    # unexpected response for the flag simply being off.
+    responses=error_responses(503),
+)
 async def get_playback_session(
     db: DbSession,
     profile: RequiredProfile,
@@ -432,12 +438,11 @@ async def get_playback_session(
 @router.put(
     "/session",
     response_model=PlaybackSessionResponse,
-    operation_id="putPlaybackSession",
     # 409 is control flow here, not an error condition: it means the client named a reservoir
     # hash the server does not hold and must resend `reservoir_ids` in full. A client that cannot
     # discover that from the schema will treat it as a generic failure and stop syncing
     # (ADR-0003 point 4).
-    responses=error_responses(409),
+    responses=error_responses(409, 503),
 )
 async def put_playback_session(
     body: PlaybackSessionWrite,
@@ -498,7 +503,7 @@ async def put_playback_session(
 @router.get(
     "/session/archive",
     response_model=ArchivedSessionsResponse,
-    operation_id="listArchivedPlaybackSessions",
+    responses=error_responses(503),
 )
 async def list_archived_sessions(
     db: DbSession,
@@ -526,7 +531,9 @@ async def list_archived_sessions(
                 id=row.id,
                 track_ids=[UUID(i) for i in row.track_ids],
                 cursor=row.cursor,
-                queue_source=QueueSource.model_validate(row.queue_source) if row.queue_source else None,
+                queue_source=QueueSource.model_validate(row.queue_source)
+                if row.queue_source
+                else None,
                 position_seconds=row.position_seconds,
                 superseded_at=row.superseded_at,
                 archived_at=row.archived_at,
@@ -539,7 +546,7 @@ async def list_archived_sessions(
 @router.post(
     "/session/archive/{archive_id}/restore",
     response_model=PlaybackSessionResponse,
-    operation_id="restoreArchivedPlaybackSession",
+    responses=error_responses(404, 503),
 )
 async def restore_archived_session(
     archive_id: UUID,
@@ -575,9 +582,7 @@ async def restore_archived_session(
     session.updated_at = utcnow()
 
     # The restored queue is live now, so it is no longer an archive entry.
-    await db.execute(
-        delete(PlaybackSessionArchive).where(PlaybackSessionArchive.id == archive_id)
-    )
+    await db.execute(delete(PlaybackSessionArchive).where(PlaybackSessionArchive.id == archive_id))
     await _trim_archive(db, profile.id)
     await db.commit()
     await db.refresh(session)
@@ -609,7 +614,9 @@ async def suggestions(
     if not candidates:
         # An unanalyzed or unknown seed collapses the pool rather than erroring, which is
         # ambient's existing contract; preserve it so the client can just not insert.
-        return SuggestionsResponse(suggestions=[], pool_size=pool_size, pool_collapsed=pool_collapsed)
+        return SuggestionsResponse(
+            suggestions=[], pool_size=pool_size, pool_collapsed=pool_collapsed
+        )
 
     # The ranker works in descriptors, so fetch the tracks themselves for the handful
     # that survived — the client inserts tracks, not descriptors. `analyses` is eagerly
@@ -618,9 +625,7 @@ async def suggestions(
     tracks = (
         (
             await db.execute(
-                select(Track)
-                .options(selectinload(Track.analyses))
-                .where(Track.id.in_(ordered_ids))
+                select(Track).options(selectinload(Track.analyses)).where(Track.id.in_(ordered_ids))
             )
         )
         .scalars()

--- a/backend/openapi.json
+++ b/backend/openapi.json
@@ -26706,7 +26706,7 @@
     "/api/v1/queue/session": {
       "get": {
         "description": "Return this profile's durable queue.\n\nAn empty session rather than a 404 when there is none: \"no queue yet\" is the ordinary\nstarting state, not an error, and a client adopting it should not have to special-case\na status code.",
-        "operationId": "getPlaybackSession",
+        "operationId": "queue_get_playback_session",
         "responses": {
           "200": {
             "content": {
@@ -26767,6 +26767,16 @@
               }
             },
             "description": "Internal Server Error"
+          },
+          "503": {
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/ErrorEnvelope"
+                }
+              }
+            },
+            "description": "Service Unavailable"
           }
         },
         "security": [
@@ -26781,7 +26791,7 @@
       },
       "put": {
         "description": "Upsert this profile's durable queue.\n\nOrdinary case: the client's `version` matches what is stored, so this is the next step\nin one device's own history and simply overwrites.\n\nConflict case: the client wrote from a stale version, meaning two devices diverged \u2014\ntypically because one was offline. The later `updated_at` wins and the loser is\narchived, never dropped (ADR-0003 point 6). A losing write still gets the winning\nsession back, so the client adopts rather than retries.",
-        "operationId": "putPlaybackSession",
+        "operationId": "queue_put_playback_session",
         "requestBody": {
           "content": {
             "application/json": {
@@ -26862,6 +26872,16 @@
               }
             },
             "description": "Internal Server Error"
+          },
+          "503": {
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/ErrorEnvelope"
+                }
+              }
+            },
+            "description": "Service Unavailable"
           }
         },
         "security": [
@@ -26878,7 +26898,7 @@
     "/api/v1/queue/session/archive": {
       "get": {
         "description": "List queues that lost a conflict and can still be restored.",
-        "operationId": "listArchivedPlaybackSessions",
+        "operationId": "queue_list_archived_sessions",
         "responses": {
           "200": {
             "content": {
@@ -26939,6 +26959,16 @@
               }
             },
             "description": "Internal Server Error"
+          },
+          "503": {
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/ErrorEnvelope"
+                }
+              }
+            },
+            "description": "Service Unavailable"
           }
         },
         "security": [
@@ -26955,7 +26985,7 @@
     "/api/v1/queue/session/archive/{archive_id}/restore": {
       "post": {
         "description": "Make an archived queue current again.\n\nSymmetrical with the conflict rule: whatever is live now is archived in its place, so\nrestoring cannot itself destroy a queue.",
-        "operationId": "restoreArchivedPlaybackSession",
+        "operationId": "queue_restore_archived_session",
         "parameters": [
           {
             "in": "path",
@@ -27028,6 +27058,16 @@
               }
             },
             "description": "Internal Server Error"
+          },
+          "503": {
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/ErrorEnvelope"
+                }
+              }
+            },
+            "description": "Service Unavailable"
           }
         },
         "security": [

--- a/backend/openapi.json
+++ b/backend/openapi.json
@@ -8033,12 +8033,6 @@
             "type": "string"
           },
           "value": {
-            "anyOf": [
-              {},
-              {
-                "type": "null"
-              }
-            ],
             "description": "Value to compare against",
             "title": "Value"
           }

--- a/backend/scripts/dump_openapi.py
+++ b/backend/scripts/dump_openapi.py
@@ -75,6 +75,16 @@ def _normalise_nullable(node: Any, required: list[str] | None = None, key: str |
                 node = {**rest, **other}
                 if required is not None and key is not None and key in required:
                     required.remove(key)
+            elif not other:
+                # `anyOf: [{}, null]` — a deliberately free-form value, which Pydantic emits for
+                # `Any | None`. The empty member means "any JSON", so the union collapses to it.
+                # Without this the property is dropped like any other unhandled null member, and
+                # "deliberately loose" quietly becomes "absent": `RuleSchema.value` vanished, so a
+                # generated client could describe a smart-playlist rule's field and operator but
+                # not what to compare against.
+                node = rest
+                if required is not None and key is not None and key in required:
+                    required.remove(key)
 
     properties = node.get("properties")
     if isinstance(properties, dict):


### PR DESCRIPTION
Two schema defects found by widening the generated Swift client from one tag to eight. Both are invisible from the web client, which reads the schema through nothing at all, and both would have shipped into the first native screen.

## Free-form fields were being dropped

`_normalise_nullable` in `dump_openapi.py` rewrites Pydantic's `anyOf: [X, {"type": "null"}]` into `type: [X, "null"]`, because swift-openapi-generator silently discards a property whose `anyOf` contains a bare null — that is how 35% of the favourites schema went missing while still compiling.

It handled a typed member and a `$ref` member. It did not handle `anyOf: [{}, {"type": "null"}]`, which is what a deliberately-polymorphic field looks like — `RuleSchema.value`, whose whole point is that a smart-playlist rule value can be a string, a number or a list. That fell through and the property vanished, so a generated client could read every part of a rule except the value it tests.

Now collapses to a free-form schema: `{}` already permits null, so the nullability is not lost, only the shape that confused the generator.

## The queue session endpoints were undescribable

Two problems, both mine, from ADR-0003 phase 2.

The four session endpoints carried explicit `operation_id`s set before `custom_generate_unique_id` existed. Everything else derives its name from `{tag}_{function}`, so these generated as bare `getPlaybackSession()` among `queueSuggestions()` and `tracksListTracks()` — reading like a mistake and hiding which tag they belong to. Dropping the overrides puts all 261 operationIds under one rule. It changes the generated method names, which is exactly why it should happen now, while the only caller is a test.

Those same four are gated behind `queue_sync_enabled` and answer **503** when it is off — declared nowhere. That is control flow, not a fault: "this server does not sync queues" is an ordinary answer to a client's first call. Undeclared, the generated client has no case to branch on; the widened-surface test could not compile a `.serviceUnavailable` branch at all, which is how this surfaced. Same reasoning as the 409 already declared on the PUT. Also declares the 404 that restore returns for an unknown archive id.

## Verification

- `lint_openapi.py` green: 261 operations, 8 tags, zero unlisted violations
- `test_playback_session.py` + the four contract suites: 74 passed
- Against the real NAS via the generated Swift client: 108 operations across 8 tags, 20,335 lines, **no schema warnings**, and every in-tag operation present — checked by name against the schema rather than assumed, since a compiling client has hidden a silent drop here before

Three chat/LLM tests fail locally and did so before this branch: they assert "no API key → 503" and my gitignored `data/settings.json` has a real key. CI has no such file.

Pairs with seethroughlab/familiar-apple#3, which consumes the schema this produces — land this one first.
