### PR TITLE
feat(api): let listening events carry when they happened

### DIFF
--- a/backend/app/api/routes/tracks/playback.py
+++ b/backend/app/api/routes/tracks/playback.py
@@ -12,6 +12,7 @@ promises to leave alone.
 """
 
 import logging
+from datetime import datetime
 from typing import Literal
 from uuid import UUID
 
@@ -22,7 +23,7 @@ from sqlalchemy import select
 from app.api.deps import DbSession, RequiredProfile
 from app.api.exceptions import TrackNotFoundError
 from app.db.models import PlayEvent, ProfilePlayHistory, Track
-from app.utils.time import to_rfc3339, utcnow
+from app.utils.time import to_naive_utc, to_rfc3339, utcnow
 
 logger = logging.getLogger(__name__)
 
@@ -64,6 +65,11 @@ class PlayRecordRequest(BaseModel):
     completion_ratio: float | None = None
     context: PlayContext | None = None
     source_track_id: UUID | None = None
+    # When the listening actually happened. Omitted by clients that post immediately; supplied by
+    # clients replaying a queue built while offline, which is exactly when the arrival time is
+    # wrong. ADR-0004 point 7 expects events to survive being offline, and an event that reports
+    # the moment it was finally uploaded misdates the only listening that needed queueing.
+    started_at: datetime | None = None
 
 
 class PlayRecordResponse(BaseModel):
@@ -85,6 +91,11 @@ class ListenEventRequest(BaseModel):
     # The track this one was suggested from, for radio insertions.
     source_track_id: UUID | None = None
     reason: StopReason = "user"
+    # When the listening actually happened. Omitted by clients that post immediately; supplied by
+    # clients replaying a queue built while offline, which is exactly when the arrival time is
+    # wrong. ADR-0004 point 7 expects events to survive being offline, and an event that reports
+    # the moment it was finally uploaded misdates the only listening that needed queueing.
+    started_at: datetime | None = None
 
 
 class ListenEventResponse(BaseModel):
@@ -112,17 +123,29 @@ def _resolve_completion_ratio(
     return max(0.0, min(1.0, played_seconds / track_duration))
 
 
+def _resolve_started_at(supplied: datetime | None) -> datetime:
+    """When the listening happened, trusting the client only as far as is safe.
+
+    Normalised to naive UTC because the column is TIMESTAMP WITHOUT TIME ZONE and a browser or
+    Swift client sends an offset-aware value — comparing the two raises, which is how the queue
+    session endpoints returned 500 on their first real request.
+
+    Clamped to now: a device with a fast clock would otherwise write events into the future, where
+    every "recent listening" window would keep finding them.
+    """
+    now = utcnow()
+    if supplied is None:
+        return now
+    return min(to_naive_utc(supplied) or now, now)
+
+
 def _derive_outcome(reason: StopReason, completion_ratio: float) -> str:
     """Map a stop reason plus completion to a PlayEvent outcome."""
     if reason == "error":
         return OUTCOME_ERRORED
     if reason == "natural":
         return OUTCOME_COMPLETED
-    return (
-        OUTCOME_COMPLETED
-        if completion_ratio >= COMPLETION_RATIO_THRESHOLD
-        else OUTCOME_SKIPPED
-    )
+    return OUTCOME_COMPLETED if completion_ratio >= COMPLETION_RATIO_THRESHOLD else OUTCOME_SKIPPED
 
 
 async def _get_track_or_404(db: DbSession, track_id: UUID) -> Track:
@@ -194,7 +217,9 @@ async def record_play(
             track_id=track_id,
             play_count=1,
             last_played_at=utcnow(),
-            total_play_seconds=request.duration_seconds if request and request.duration_seconds else 0.0,
+            total_play_seconds=request.duration_seconds
+            if request and request.duration_seconds
+            else 0.0,
         )
         db.add(play_history)
 
@@ -206,7 +231,7 @@ async def record_play(
             profile_id=profile.id,
             track_id=track_id,
             source_track_id=request.source_track_id if request else None,
-            started_at=utcnow(),
+            started_at=_resolve_started_at(request.started_at if request else None),
             played_seconds=played_seconds or 0.0,
             track_duration=request.track_duration if request else None,
             completion_ratio=_resolve_completion_ratio(
@@ -254,7 +279,7 @@ async def _record_listen_event(
             profile_id=profile_id,
             track_id=track_id,
             source_track_id=body.source_track_id,
-            started_at=utcnow(),
+            started_at=_resolve_started_at(body.started_at),
             played_seconds=body.played_seconds or 0.0,
             track_duration=body.track_duration,
             completion_ratio=completion_ratio,
@@ -301,9 +326,7 @@ async def record_rejection(
     A deliberate rejection is a stronger signal than a skip and is stored distinctly.
     ProfilePlayHistory is not modified.
     """
-    return await _record_listen_event(
-        db, profile.id, track_id, request, outcome=OUTCOME_REJECTED
-    )
+    return await _record_listen_event(db, profile.id, track_id, request, outcome=OUTCOME_REJECTED)
 
 
 @router.get("/stats/plays", response_model=ProfilePlayStatsResponse)

--- a/backend/openapi.json
+++ b/backend/openapi.json
@@ -4941,6 +4941,14 @@
               "null"
             ]
           },
+          "started_at": {
+            "format": "date-time",
+            "title": "Started At",
+            "type": [
+              "string",
+              "null"
+            ]
+          },
           "track_duration": {
             "title": "Track Duration",
             "type": [
@@ -6612,6 +6620,14 @@
           "source_track_id": {
             "format": "uuid",
             "title": "Source Track Id",
+            "type": [
+              "string",
+              "null"
+            ]
+          },
+          "started_at": {
+            "format": "date-time",
+            "title": "Started At",
             "type": [
               "string",
               "null"

--- a/backend/tests/test_api_tracks.py
+++ b/backend/tests/test_api_tracks.py
@@ -4,11 +4,18 @@ Tests for the tracks API endpoints.
 Note: These tests run against the actual database which may have existing data.
 """
 
-from uuid import uuid4
+from datetime import UTC, datetime, timedelta
+from uuid import UUID, uuid4
 
+import pytest
+import pytest_asyncio
 from fastapi.testclient import TestClient
+from sqlalchemy import select
+from sqlalchemy.ext.asyncio import AsyncSession
 
+from app.db.models import PlayEvent
 from tests.conftest import make_profile_headers
+from tests.factories import insert_test_track
 
 
 def test_list_tracks_returns_valid_response(client: TestClient) -> None:
@@ -159,3 +166,94 @@ def test_record_play_and_stats(client: TestClient, test_profile: dict) -> None:
         new_stats = client.get("/api/v1/tracks/stats/plays", headers=headers)
         assert new_stats.status_code == 200
         assert new_stats.json()["total_plays"] == initial_plays + 1
+
+
+@pytest_asyncio.fixture
+async def listen_event_track(async_db: AsyncSession):
+    """A track of our own, so these do not depend on the library having been scanned."""
+    track = await insert_test_track(async_db, title="Timestamped", artist="Test")
+    await async_db.commit()
+    return str(track.id)
+
+
+@pytest.mark.asyncio
+async def test_listen_event_accepts_a_client_timestamp(
+    client: TestClient, test_profile: dict, listen_event_track: str, async_db: AsyncSession
+) -> None:
+    """An event replayed from an offline queue keeps the time it actually happened.
+
+    Without this the server stamps arrival time, so a queue drained hours later would date every
+    event to the moment the network came back — misdating precisely the listening that needed
+    queueing (ADR-0004 point 7).
+    """
+    headers = make_profile_headers(test_profile)
+
+    # Offset-aware, as a Swift or browser client sends it. The column is naive UTC, and comparing
+    # the two raises — the defect that made the queue-session endpoints 500 on first contact.
+    happened = datetime.now(UTC) - timedelta(hours=3)
+    response = client.post(
+        f"/api/v1/tracks/{listen_event_track}/skipped",
+        headers=headers,
+        json={
+            "played_seconds": 12.0,
+            "track_duration": 200.0,
+            "reason": "user",
+            "started_at": happened.isoformat(),
+        },
+    )
+    assert response.status_code == 200, response.text
+    assert response.json()["outcome"] == "skipped"
+
+    # Asserting the *stored* value, not just a 200. Pydantic drops unknown fields silently, so a
+    # server that ignored `started_at` entirely would still answer 200 and this test would pass
+    # while proving nothing.
+    stored = (
+        (
+            await async_db.execute(
+                select(PlayEvent)
+                .where(PlayEvent.track_id == UUID(listen_event_track))
+                .order_by(PlayEvent.started_at.desc())
+            )
+        )
+        .scalars()
+        .first()
+    )
+    assert stored is not None
+    drift = abs((stored.started_at - happened.replace(tzinfo=None)).total_seconds())
+    assert drift < 5, f"stored {stored.started_at}, expected about {happened}"
+
+
+@pytest.mark.asyncio
+async def test_listen_event_timestamp_cannot_be_in_the_future(
+    client: TestClient, test_profile: dict, listen_event_track: str, async_db: AsyncSession
+) -> None:
+    """A device with a fast clock must not write events into the future.
+
+    Anything reading a "recent listening" window would keep finding them, forever.
+    """
+    headers = make_profile_headers(test_profile)
+    response = client.post(
+        f"/api/v1/tracks/{listen_event_track}/skipped",
+        headers=headers,
+        json={
+            "played_seconds": 5.0,
+            "track_duration": 200.0,
+            "reason": "user",
+            "started_at": (datetime.now(UTC) + timedelta(days=2)).isoformat(),
+        },
+    )
+    assert response.status_code == 200, response.text
+
+    stored = (
+        (
+            await async_db.execute(
+                select(PlayEvent)
+                .where(PlayEvent.track_id == UUID(listen_event_track))
+                .order_by(PlayEvent.started_at.desc())
+            )
+        )
+        .scalars()
+        .first()
+    )
+    assert stored is not None
+    assert stored.started_at <= datetime.now(UTC).replace(tzinfo=None) + timedelta(seconds=5)


### PR DESCRIPTION
Groundwork for an offline event queue in the native client, and a defect in its own right.

Both event endpoints stamped `started_at=utcnow()` — the time the request *arrived*. Fine for a client posting immediately; wrong for the exact case ADR-0004 point 7 exists to serve. A queue built while offline and drained when the network returns would date every event to the moment of reconnection, misdating precisely the listening that needed queueing. And offline listening is where skipping is most frequent, so those are the events you least want smeared onto one timestamp.

`started_at` is now optional on both `PlayRecordRequest` and `ListenEventRequest`. Clients that omit it are unaffected.

## Two things the resolver must do

**Normalise to naive UTC.** The column is `TIMESTAMP WITHOUT TIME ZONE` and clients send offset-aware values. Comparing the two raises `TypeError` — which is exactly how the queue-session endpoints returned 500 on their first real request while all 27 tests passed, because the fixtures used naive timestamps.

**Clamp to now.** A device with a fast clock would otherwise write events into the future, where every "recent listening" window keeps finding them, indefinitely.

## The test asserts the stored value, not the status code

Worth calling out: Pydantic drops unknown fields silently, so a server that ignored `started_at` entirely would still answer `200`. A test asserting only the response would have passed while proving nothing.

So it reads the `PlayEvent` back and checks the timestamp. Verified by reverting the handler and watching it fail — it does.

13 tests pass in `test_api_tracks.py`, OpenAPI lint green at 261 operations.

`test_chat_no_api_key_error_shape` fails locally and did before this branch: it asserts "no API key → 503" and my gitignored `data/settings.json` has a real key. CI has no such file.