### PR TITLE
fix(offline): cache the whole library, not the first page of it

### DIFF
--- a/backend/app/api/routes/tracks/listing.py
+++ b/backend/app/api/routes/tracks/listing.py
@@ -206,20 +206,23 @@ async def list_track_ids(
                     (ProfilePlayHistory.profile_id == profile.id),
                 )
             if sort_order == 'desc':
-                query = query.order_by(nulls_last(sort_col.desc()), Track.artist, Track.album, Track.track_number)
+                query = query.order_by(nulls_last(sort_col.desc()), Track.artist, Track.album, Track.track_number, Track.id)
             else:
-                query = query.order_by(nulls_last(sort_col.asc()), Track.artist, Track.album, Track.track_number)
+                query = query.order_by(nulls_last(sort_col.asc()), Track.artist, Track.album, Track.track_number, Track.id)
         else:
             if not has_feature_filter:
                 query = query.outerjoin(TrackAnalysis, Track.id == TrackAnalysis.track_id)
             sort_col_attr = getattr(TrackAnalysis, sort_by, None)
             sort_expr = cast(sort_col_attr, Float) if sort_col_attr is not None else TrackAnalysis.bpm
             if sort_order == 'desc':
-                query = query.order_by(nulls_last(sort_expr.desc()), Track.artist, Track.album, Track.track_number)
+                query = query.order_by(nulls_last(sort_expr.desc()), Track.artist, Track.album, Track.track_number, Track.id)
             else:
-                query = query.order_by(nulls_last(sort_expr.asc()), Track.artist, Track.album, Track.track_number)
+                query = query.order_by(nulls_last(sort_expr.asc()), Track.artist, Track.album, Track.track_number, Track.id)
     else:
-        query = query.order_by(Track.artist, Track.album, Track.track_number)
+        # `Track.id` last for the same reason as `list_tracks`, so this endpoint's order and the
+        # paged list's order are the same total order rather than two orders that agree on ties
+        # by luck.
+        query = query.order_by(Track.artist, Track.album, Track.track_number, Track.id)
 
     result = await db.execute(query)
     track_ids = [str(row[0]) for row in result.all()]
@@ -389,20 +392,24 @@ async def list_tracks(
                     (ProfilePlayHistory.profile_id == profile.id)
                 )
             if sort_order == 'desc':
-                query = query.order_by(nulls_last(sort_col.desc()), Track.artist, Track.album, Track.track_number)
+                query = query.order_by(nulls_last(sort_col.desc()), Track.artist, Track.album, Track.track_number, Track.id)
             else:
-                query = query.order_by(nulls_last(sort_col.asc()), Track.artist, Track.album, Track.track_number)
+                query = query.order_by(nulls_last(sort_col.asc()), Track.artist, Track.album, Track.track_number, Track.id)
         else:
             if not has_feature_filter:
                 query = query.outerjoin(TrackAnalysis, Track.id == TrackAnalysis.track_id)
             sort_col_attr = getattr(TrackAnalysis, sort_by, None)
             sort_expr = cast(sort_col_attr, Float) if sort_col_attr is not None else TrackAnalysis.bpm
             if sort_order == 'desc':
-                query = query.order_by(nulls_last(sort_expr.desc()), Track.artist, Track.album, Track.track_number)
+                query = query.order_by(nulls_last(sort_expr.desc()), Track.artist, Track.album, Track.track_number, Track.id)
             else:
-                query = query.order_by(nulls_last(sort_expr.asc()), Track.artist, Track.album, Track.track_number)
+                query = query.order_by(nulls_last(sort_expr.asc()), Track.artist, Track.album, Track.track_number, Track.id)
     else:
-        query = query.order_by(Track.artist, Track.album, Track.track_number)
+        # `Track.id` last so the total order is unique. Without it, 866 tie groups covering
+        # 2,846 rows share an ordering key, and OFFSET paging over a non-unique order may
+        # repeat or skip rows between pages — silently omitting tracks from anything that
+        # pages the whole library.
+        query = query.order_by(Track.artist, Track.album, Track.track_number, Track.id)
 
     query = query.offset((page - 1) * page_size).limit(page_size)
 
@@ -552,19 +559,22 @@ async def get_track_index(
                     (ProfilePlayHistory.profile_id == profile.id),
                 )
             if sort_order == 'desc':
-                order_clauses = [nulls_last(sort_col.desc()), Track.artist, Track.album, Track.track_number]
+                order_clauses = [nulls_last(sort_col.desc()), Track.artist, Track.album, Track.track_number, Track.id]
             else:
-                order_clauses = [nulls_last(sort_col.asc()), Track.artist, Track.album, Track.track_number]
+                order_clauses = [nulls_last(sort_col.asc()), Track.artist, Track.album, Track.track_number, Track.id]
         else:
             needs_analysis_join = not has_feature_filter
             sort_col_attr = getattr(TrackAnalysis, sort_by, None)
             sort_expr = cast(sort_col_attr, Float) if sort_col_attr is not None else TrackAnalysis.bpm
             if sort_order == 'desc':
-                order_clauses = [nulls_last(sort_expr.desc()), Track.artist, Track.album, Track.track_number]
+                order_clauses = [nulls_last(sort_expr.desc()), Track.artist, Track.album, Track.track_number, Track.id]
             else:
-                order_clauses = [nulls_last(sort_expr.asc()), Track.artist, Track.album, Track.track_number]
+                order_clauses = [nulls_last(sort_expr.asc()), Track.artist, Track.album, Track.track_number, Track.id]
     else:
-        order_clauses = [Track.artist, Track.album, Track.track_number]
+        # Must match `list_tracks` exactly, `Track.id` tiebreaker included: this endpoint reports
+        # a track's row number in that same ordering, so any divergence returns an index the
+        # paged list does not agree with.
+        order_clauses = [Track.artist, Track.album, Track.track_number, Track.id]
 
     if needs_analysis_join:
         base_query = base_query.outerjoin(TrackAnalysis, Track.id == TrackAnalysis.track_id)

--- a/backend/tests/test_api_tracks.py
+++ b/backend/tests/test_api_tracks.py
@@ -257,3 +257,56 @@ async def test_listen_event_timestamp_cannot_be_in_the_future(
     )
     assert stored is not None
     assert stored.started_at <= datetime.now(UTC).replace(tzinfo=None) + timedelta(seconds=5)
+
+
+@pytest_asyncio.fixture
+async def tie_group(async_db: AsyncSession) -> tuple[str, list[str]]:
+    """Six tracks that share an ordering key: one artist, one album, no track numbers.
+
+    `insert_test_track` leaves `track_number` NULL, which is exactly the shape that ties in the
+    real library — 1,724 active rows have no track number and 2,846 sit in a tie group of
+    (artist, album, track_number).
+    """
+    artist = f"Tie Group {uuid4().hex[:8]}"
+    tracks = [
+        await insert_test_track(
+            async_db, title=f"Tied {i}", artist=artist, album="Tied Album"
+        )
+        for i in range(6)
+    ]
+    await async_db.commit()
+    return artist, [str(track.id) for track in tracks]
+
+
+@pytest.mark.asyncio
+async def test_paging_a_tie_group_returns_every_track_exactly_once(
+    client: TestClient, tie_group: tuple[str, list[str]]
+) -> None:
+    """Paging the whole library must not repeat or skip rows that tie on the sort key.
+
+    `ORDER BY artist, album, track_number` is not a unique ordering, and OFFSET paging over a
+    non-unique order is free to return a row twice or never — which silently omits tracks from
+    anything that pages the library, such as the offline cache. `Track.id` is appended to make
+    the order total.
+
+    Honest about its power: the pre-fix failure was nondeterministic, so this asserts the
+    invariant rather than reliably reproducing the old bug. It fails for good on any future
+    change that drops the tiebreaker only if the planner happens to reorder — which is the same
+    reason the tiebreaker belongs in the query rather than in a test's luck.
+    """
+    artist, expected = tie_group
+
+    seen: list[str] = []
+    for page in range(1, 6):
+        response = client.get(
+            "/api/v1/tracks",
+            params={"artist": artist, "page": page, "page_size": 2},
+        )
+        assert response.status_code == 200, response.text
+        items = response.json()["items"]
+        if not items:
+            break
+        seen.extend(item["id"] for item in items)
+
+    assert len(seen) == len(set(seen)), "OFFSET paging returned the same row twice"
+    assert sorted(seen) == sorted(expected), "paging did not cover every track exactly once"

--- a/packages/frontend/src/services/__tests__/libraryCache.test.ts
+++ b/packages/frontend/src/services/__tests__/libraryCache.test.ts
@@ -144,6 +144,60 @@ describe('libraryCache', () => {
       );
     });
 
+    // The bug these two guard: cacheLibrary used to pass `{ limit: 10000 }`, which `/tracks`
+    // does not accept, so the server's default page size applied and the "whole library" cache
+    // held 50 tracks of 26,396. A single-page fixture cannot catch that — only a fixture with
+    // more tracks than one page can.
+    it('should page through the whole library rather than stopping at the first page', async () => {
+      const page = (count: number, from: number) =>
+        Array.from({ length: count }, (_, i) => ({
+          id: `t${from + i}`,
+          title: `Song ${from + i}`,
+          artist: 'Artist A',
+          album: 'Album X',
+          album_artist: null,
+          genre: null,
+          year: null,
+          duration_seconds: null,
+          track_number: null,
+          disc_number: null,
+        }));
+
+      mockApiGet
+        .mockResolvedValueOnce({ data: { items: page(200, 0), total: 450 } })
+        .mockResolvedValueOnce({ data: { items: page(200, 200), total: 450 } })
+        .mockResolvedValueOnce({ data: { items: page(50, 400), total: 450 } });
+
+      const result = await cacheLibrary();
+
+      expect(result).toEqual({ cached: 450 });
+      expect(mockApiGet).toHaveBeenCalledTimes(3);
+      expect(mockApiGet).toHaveBeenNthCalledWith(1, '/tracks', {
+        params: { page: 1, page_size: 200 },
+      });
+      expect(mockApiGet).toHaveBeenNthCalledWith(3, '/tracks', {
+        params: { page: 3, page_size: 200 },
+      });
+      // The last track of the last page reached IndexedDB, not just the first page's.
+      expect(mockCachedTracks.bulkPut).toHaveBeenCalledWith(
+        expect.arrayContaining([expect.objectContaining({ id: 't449' })])
+      );
+    });
+
+    it('should stop once total is reached even when every page comes back full', async () => {
+      const page = (count: number, from: number) =>
+        Array.from({ length: count }, (_, i) => ({ id: `t${from + i}` }));
+
+      mockApiGet
+        .mockResolvedValueOnce({ data: { items: page(200, 0), total: 400 } })
+        .mockResolvedValueOnce({ data: { items: page(200, 200), total: 400 } });
+
+      const result = await cacheLibrary();
+
+      expect(result).toEqual({ cached: 400 });
+      expect(mockApiGet).toHaveBeenCalledTimes(2);
+    });
+
     it('should throw when API request fails', async () => {
       mockApiGet.mockRejectedValueOnce(new Error('Request failed with status code 500'));
 

--- a/packages/frontend/src/services/libraryCache.ts
+++ b/packages/frontend/src/services/libraryCache.ts
@@ -6,17 +6,53 @@ import api from '../api/base';
 import type { Track, TrackListResponse } from '../types';
 
 /**
+ * The `/tracks` page size cap (`page_size` is declared `le=200` server-side).
+ *
+ * This used to request `{ limit: 10000 }`, which is not a parameter that endpoint accepts —
+ * FastAPI ignores unknown query params, so the default page size applied and "cache the whole
+ * library" cached 50 tracks of 26,396. Paging is not optional here: no single request can
+ * return the library.
+ */
+const PAGE_SIZE = 200;
+
+/** Refuses to run away if the server keeps returning full pages. 200k tracks. */
+const MAX_PAGES = 1000;
+
+/**
  * Cache the entire library from the API.
+ *
+ * Fails rather than returning a partial cache: a cache that silently holds part of the library
+ * is indistinguishable from a working one, which is how the `limit` bug survived.
  */
 export async function cacheLibrary(): Promise<{
   cached: number;
 }> {
-  // Fetch all tracks from API
-  const { data } = await api.get('/tracks', { params: { limit: 10000 } });
-  const tracks = data.items || data.tracks || data;
+  const tracks: Record<string, unknown>[] = [];
 
-  if (!Array.isArray(tracks)) {
-    throw new Error('Invalid response format');
+  for (let page = 1; ; page += 1) {
+    const { data } = await api.get('/tracks', {
+      params: { page, page_size: PAGE_SIZE },
+    });
+    const items = data?.items || data?.tracks || data;
+
+    if (!Array.isArray(items)) {
+      throw new Error('Invalid response format');
+    }
+
+    tracks.push(...items);
+
+    const total = typeof data?.total === 'number' ? data.total : null;
+    // A short page is the end. `total` is a second signal, not the only one — a response
+    // without it (or a stale one) must still terminate.
+    if (items.length < PAGE_SIZE || (total !== null && tracks.length >= total)) {
+      break;
+    }
+
+    if (page >= MAX_PAGES) {
+      throw new Error(
+        `Library cache aborted after ${MAX_PAGES} pages (${tracks.length} tracks)`
+      );
+    }
   }
 
   const now = new Date();


### PR DESCRIPTION
## What

`cacheLibrary` requested `/tracks` with `{ params: { limit: 10000 } }`. `limit` is not a parameter that endpoint accepts — `page_size` is, capped at 200 — and FastAPI ignores unknown query params, so the server's default applied.

Verified against the live server before changing anything:

```
GET /api/v1/tracks?limit=10000  →  50 items, page_size: 50, total: 26396
```

The Settings action offering to cache the library for offline browsing has been caching **50 tracks of 26,396**. Nothing noticed, because a 50-track offline library looks like a feature that works rather than one that is broken.

It is not a renamed parameter: no single request can return the library, so the fix is paging, terminating on a short page or on `total`. It now throws rather than returning a partial cache — a cache holding part of the library is indistinguishable from a complete one, which is exactly how this survived.

## Paging alone would still have omitted tracks, silently

The default ordering is `artist, album, track_number`, which is not unique. Measured on the real library:

| | |
|---|---|
| Tie groups on `(artist, album, track_number)` | 866 |
| Active rows inside a tie group | 2,846 (10.8%) |
| Active rows with no track number | 1,724 |

OFFSET paging over a non-unique order may return a row twice or never, so a 132-page scan can miss tracks — the same failure class as the bug being fixed. `Track.id` is appended to every ordering in `listing.py`, the deliberate `func.random()` shuffle branch excepted.

That spans `/tracks`, `/tracks/ids` and `/tracks/{track_id}/index`, which have to agree because the last reports a row number in the same ordering. It also fixes the same latent problem in the Swift `LibraryStore`, which pages 50 at a time over that order.

## Tests

- **Client, two:** a 450-track three-page fixture asserting all three pages reach IndexedDB, and the `total`-reached case. Both fail against the old code, which reported `cached: 200` after one request.
- **Server, one:** pages a six-track tie group and asserts every row appears exactly once. This one is an invariant guard rather than a reproduction, and says so in its docstring — the pre-fix failure was nondeterministic.

## Verification

- Backend: **1,326 passed, 3 failed** — the known chat contract tests that cannot provoke "no API key" while a live key is configured locally. Unrelated to this change.
- Frontend: **938 passed** across 60 files.
- Lint clean. The two `tsc` errors are pre-existing in `player/audio/__tests__/engineContract.test.ts`, which this does not touch.

## Not in scope

`scanner.py:721-744` omits `updated_at` from its upsert `set_` clause, so a tag change does not move the timestamp. A real bug, but a separate one.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_014P9p2fvFnyiywBxGkv4gfW