### PR TITLE
fix(api): a missing API route is a 404, not a 200 saying "Not found"

### DIFF
--- a/backend/app/main.py
+++ b/backend/app/main.py
@@ -27,7 +27,7 @@ from slowapi.errors import RateLimitExceeded
 from sqlalchemy.exc import SQLAlchemyError
 from starlette.types import ASGIApp, Message, Receive, Scope, Send
 
-from app.api.exceptions import FamiliarError
+from app.api.exceptions import FamiliarError, NotFoundError
 from app.api.ratelimit import limiter
 from app.api.routes import (
     admin_artists,
@@ -505,6 +505,34 @@ app.include_router(pending_review.router, prefix="/api/v1", responses=DEFAULT_ER
 # Serve frontend static files in production
 # The static folder is created during Docker build
 STATIC_DIR = Path(__file__).parent.parent / "static"
+
+# Prefixes the single-page app must never swallow. A miss inside these belongs to the API, and the
+# answer to it is a 404 rather than an HTML document.
+NON_SPA_PREFIXES = ("api/", "docs", "redoc", "openapi.json", "health")
+
+
+async def spa_fallback(full_path: str) -> FileResponse:
+    """Serve index.html for SPA routing (catches all non-API routes).
+
+    **Raises rather than returns** for an unmatched API path. Returning `{"detail": "Not found"}`
+    made FastAPI serialise it as a normal response body with **HTTP 200**, so every mistyped,
+    renamed or unaddressable `/api/` route answered success-shaped. A generated client
+    ([ADR-0007](../../docs/decisions/ADR-0007-clients-are-generated-from-openapi.md)) then failed
+    while *decoding* a 200 instead of handling a typed 404, and route drift stayed invisible.
+
+    Found while building the Apple client's artist pages: the detail endpoints are path-keyed, and
+    the 79 artists whose names contain a slash produced exactly this — HTTP 200, undecodable body.
+
+    Defined at module scope, and registered below only when `static/` exists, so it is importable by
+    a test. As a closure inside that `if` it was unreachable from the suite, which is why a bug this
+    visible in production survived: tests run without a static directory, where FastAPI's own 404
+    applies and the handler never runs at all.
+    """
+    if full_path.startswith(NON_SPA_PREFIXES):
+        raise NotFoundError("Not found")
+    return FileResponse(STATIC_DIR / "index.html")
+
+
 if STATIC_DIR.exists():
     # Serve static assets
     app.mount("/assets", StaticFiles(directory=STATIC_DIR / "assets"), name="assets")
@@ -534,13 +562,7 @@ if STATIC_DIR.exists():
         return FileResponse(STATIC_DIR / "index.html")
 
     # SPA fallback - serve index.html for all non-API routes
-    @app.get("/{full_path:path}", response_model=None)
-    async def spa_fallback(full_path: str) -> FileResponse | dict[str, Any]:
-        """Serve index.html for SPA routing (catches all non-API routes)."""
-        # Don't catch API or docs routes
-        if full_path.startswith(("api/", "docs", "redoc", "openapi.json", "health")):
-            return {"detail": "Not found"}
-        return FileResponse(STATIC_DIR / "index.html")
+    app.get("/{full_path:path}", response_model=None)(spa_fallback)
 else:
     # Development mode - just show API info
     @app.get("/")

--- a/backend/tests/test_contract_error_shapes.py
+++ b/backend/tests/test_contract_error_shapes.py
@@ -94,3 +94,52 @@ def test_chat_invalid_profile_header_error_shape(client: TestClient) -> None:
     )
     assert_error_shape(response, status_code=400)
     assert response.json()["message"] == "Invalid profile ID format"
+
+
+# The SPA fallback only exists in production, where `backend/static/` is created during the Docker
+# build. The suite runs without it, so the route below is never registered and FastAPI's own 404
+# answers instead — which is exactly why the defect these two guard survived unseen.
+#
+# They call the handler directly for that reason. Going through `client` would assert the behaviour
+# of a route that is not mounted, and pass whatever the handler did.
+
+
+async def test_spa_fallback_raises_for_unmatched_api_paths() -> None:
+    """An unmatched `/api/` path must 404, not 200.
+
+    It used to `return {"detail": "Not found"}`, which FastAPI serialises as an ordinary body with
+    **HTTP 200**. Every mistyped or renamed API route therefore answered success-shaped, and a
+    generated client (ADR-0007) failed while decoding a 200 rather than handling a typed 404.
+
+    Found through the Apple client's artist pages: `/library/artists/{artist_name}` is path-keyed,
+    and the 79 artists whose names contain a slash produced precisely this.
+    """
+    import pytest
+
+    from app.api.exceptions import NotFoundError
+    from app.main import spa_fallback
+
+    for path in (
+        "api/v1/nope",
+        "api/v1/library/artists/Kruder/Dorfmeister",
+        "docs/nope",
+        "openapi.json/nope",
+        "health/nope",
+    ):
+        with pytest.raises(NotFoundError) as caught:
+            await spa_fallback(path)
+        assert caught.value.status_code == 404
+
+
+async def test_spa_fallback_still_serves_the_app_for_client_routes() -> None:
+    """Everything that is not the API is still the single-page app.
+
+    The counterpart to the test above: raising for too much would turn every client-side route into
+    a 404 and take the web app down.
+    """
+    from fastapi.responses import FileResponse
+
+    from app.main import spa_fallback
+
+    for path in ("", "library", "playlists/abc", "settings/audio"):
+        assert isinstance(await spa_fallback(path), FileResponse)


### PR DESCRIPTION
## The bug

`spa_fallback` catches every unmatched path so the single-page app can do client-side routing. For paths under `api/`, `docs`, `redoc`, `openapi.json` or `health` it did this:

```python
return {"detail": "Not found"}
```

Returning a dict makes FastAPI serialise it as an ordinary response body with **HTTP 200**. Every mistyped, renamed or unaddressable API route has therefore been answering success-shaped, with a body that is neither the resource nor the Familiar error envelope.

Against the live server:

```
GET /api/v1/library/artists/Kruder/Dorfmeister
→ HTTP 200
→ {"detail":"Not found"}
```

## Why it matters more now

Generated clients are the point (ADR-0007). A Swift client gets a 200 it cannot decode instead of the typed 404 the schema promises, so the failure arrives as a decoding error carrying no route information — and genuine route drift stays invisible.

Found while building the Apple client's artist pages: `/library/artists/{artist_name}` is path-keyed, and **79 artists have a slash in the name** (`Kruder/Dorfmeister`, `M/A/R/R/S`, `TR/ST`). Every one produced exactly this.

## The fix

Raise `NotFoundError`, which the existing `FamiliarError` handler already renders as a 404 in the standard envelope. Non-API paths still serve `index.html` — raising for too much would take the web app down, so there is a test for that direction too.

## Why no test caught it

The handler was a closure inside `if STATIC_DIR.exists():`, and the suite runs **without** a static directory — the route is never mounted, FastAPI's own 404 answers instead, and the handler never runs.

So it moves to module scope and is registered below only when `static/` exists. The two new tests call it directly for that reason: going through `client` would assert the behaviour of a route that is not mounted, and pass whatever the handler did.

## Verification

1,326 tests pass. Four failures, all pre-existing and confirmed against a stashed tree:

- three chat contract tests that cannot provoke "no API key" while a live key is configured locally
- `test_models_in_sync_with_migrations`, which fails identically on `main` (a `spotify_imports.imported_at` nullability drift)

`ruff` and `mypy` clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_014P9p2fvFnyiywBxGkv4gfW