### PR TITLE
docs(adr): correct ADR-0001's "trivial shells" — one held the audio session

### DIFF
--- a/docs/decisions/ADR-0001-native-apple-clients-supersede-capacitor.md
+++ b/docs/decisions/ADR-0001-native-apple-clients-supersede-capacitor.md
@@ -61,6 +61,30 @@ Implementation:
     Casting on the native client is a live question for whenever it enters scope, not a settled
     inclusion.
 
+- **The "trivial shells" were not all trivial — audit, 2026-07-30.** Decision point 3 deletes the
+  Capacitor bridge rather than porting it, and the readiness audit above listed the collateral as
+  "trivial shells in `AppDelegate` (61), `MainSceneDelegate` (40) and `ViewController` (13)". That
+  characterisation cost a real bug: with the phone's ring/silent switch on, the native app played
+  nothing, because `AVAudioSession` was never given a category and its default obeys the switch.
+
+  The configuration had lived in `packages/ios/native/App/AppDelegate.swift:14-19` — `setCategory(.playback)`
+  and `setActive(true)` — one of the two non-boilerplate things in that file. The engine never set it
+  because something else always had, and the something else was on the "trivial" list. Fixed in
+  `familiar-apple` by configuring the session in `NativeAudioEngine` itself, where it belongs.
+
+  **The claim about the bridge proper survives the audit.** `FamiliarAudioPlugin.swift` contains zero
+  references to `AVAudioSession`, `MPNowPlayingInfoCenter` or `MPRemoteCommandCenter` across its 46
+  methods: it really is marshalling, and deleting it really did cost nothing. The error was in the
+  *inventory of what else went with it*, not in the judgement about the bridge.
+
+  The file's other non-boilerplate line, `application.beginReceivingRemoteControlEvents()`, is
+  deliberately **not** carried over: it is the pre-`MPRemoteCommandCenter` API, and the engine
+  registers command-centre targets directly (`NativeAudioEngine.swift:1597`), which supersedes it.
+
+  The general lesson, worth more than the fix: "delete rather than port" is safe for a layer that
+  only translates, and the risk sits in whatever *else* shared that layer's file. Auditing by asking
+  "what does this file do besides marshalling" would have caught this before a listener did.
+
 - **Grandfathered past the freeze:** PR #3 (`refactor(carplay): in-place template updates instead of
   setRootTemplate spam`) was merged on 2026-07-26, after acceptance. It is a refactor, not a bug fix,
   so it does not satisfy the rule above; it was opened in May, well before this ADR, and landed by


### PR DESCRIPTION
Records the result of auditing one of ADR-0001's own claims, after that claim cost a user-visible bug. Docs only — one file, 24 added lines, nothing struck through.

## What happened

With the phone's ring/silent switch on, the native app played nothing. Spotify and Music carry on, so it reads as a bug in ours, and it was: `AVAudioSession` was never given a category, and the default category obeys the switch.

The configuration had lived in the Capacitor app's `packages/ios/native/App/AppDelegate.swift:14-19` — `setCategory(.playback)` and `setActive(true)`. ADR-0001's readiness audit listed that file among the collateral of decision point 3:

> trivial shells in `AppDelegate` (61), `MainSceneDelegate` (40) and `ViewController` (13)

It was not trivial. It was one of the two non-boilerplate things in the file, and the engine never set the category itself because something else always had. Fixed in `familiar-apple` by configuring the session in `NativeAudioEngine`, where it belongs — that's a separate PR on that repo.

## What the audit found, including what survived

**The claim about the bridge proper holds.** `FamiliarAudioPlugin.swift` has zero references to `AVAudioSession`, `MPNowPlayingInfoCenter` or `MPRemoteCommandCenter` across its 46 methods. It really is marshalling; deleting rather than porting it really did cost nothing. The error was in the *inventory of what else went with it*, not in the judgement about the bridge — so decision point 3 stands as written.

**The file's other non-boilerplate line is deliberately not carried over.** `application.beginReceivingRemoteControlEvents()` is the pre-`MPRemoteCommandCenter` API, and the engine registers command-centre targets directly (`NativeAudioEngine.swift:1597`), which supersedes it. Checked rather than assumed, since it sat two lines from the bug.

## Why record it rather than just fix it

The premise generalises further than this one session: **"delete rather than port" is safe for a layer that only translates, and the risk sits in whatever else shared that layer's file.** Auditing by asking "what does this file do *besides* marshalling" would have caught this before a listener did. No test would have — the failure needs a physical switch on a physical phone.

## On the ADR convention

This appends to ADR-0001's `Implementation:` region, which the convention describes as a living record. It does **not** touch `## Decision` — the decision was right, and rule 6 would require a superseding ADR if it weren't.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_014P9p2fvFnyiywBxGkv4gfW
