### PR TITLE
docs(adr): record ADR-0009 phases 1–3, and what the device tests settled

### DIFF
--- a/docs/decisions/ADR-0001-native-apple-clients-supersede-capacitor.md
+++ b/docs/decisions/ADR-0001-native-apple-clients-supersede-capacitor.md
@@ -85,6 +85,14 @@ Implementation:
   only translates, and the risk sits in whatever *else* shared that layer's file. Auditing by asking
   "what does this file do besides marshalling" would have caught this before a listener did.
 
+- **The load-bearing claim is now demonstrated, 2026-07-30.** This decision rejects renovating the
+  PWA because it "cannot deliver background downloads on iOS" — the strongest of the three reported
+  symptoms, and the argument the whole programme leans on hardest. It was still an argument until
+  [ADR-0009](ADR-0009-offline-downloads-are-background-transfers.md) phase 2 was tested on a
+  physical iPhone: transfers continued while the app was suspended, survived `SIGKILL`, and the
+  system relaunched the app to deliver them. Evidence and method are recorded under that ADR's
+  phase 2 rather than duplicated here.
+
 - **Grandfathered past the freeze:** PR #3 (`refactor(carplay): in-place template updates instead of
   setRootTemplate spam`) was merged on 2026-07-26, after acceptance. It is a refactor, not a bug fix,
   so it does not satisfy the rule above; it was opened in May, well before this ADR, and landed by

--- a/docs/decisions/ADR-0009-offline-downloads-are-background-transfers.md
+++ b/docs/decisions/ADR-0009-offline-downloads-are-background-transfers.md
@@ -65,6 +65,32 @@ Implementation:
   broken wiring. `print` does not reach the unified log there either. The macOS app is the cheap way
   to separate "my code is wrong" from "this environment cannot do it"; the phone is the only way to
   prove the rest.
+- Phase 3 — play from disk, on `familiar-apple` branch `feat/adr-0009-play-from-disk`.
+  `PlaybackSource` prefers the downloaded file and falls back to the stream, resolved **per load**
+  rather than when the queue is built: a library queue is 26,396 entries, and an entry resolved at
+  queue time is stale the moment its download finishes. `load(url:)` gained the `file://` routing
+  the auto-advance path already had. 12 tests, 195 total.
+
+  Point 5 says "play time asks the store first", and *play time* turned out to be three places, not
+  one. Beyond the obvious load, the engine hands over to its **pending next** track by itself when
+  the current one ends without going back through the load path — so a track resolved only at load
+  time streams on auto-advance, the one moment nobody is watching. And the lock screen's **previous**
+  button never returns through `previous()`; the engine loads `pendingPreviousUrl` directly. A
+  resolver placed only at the load call would have been correct on the surface a listener is
+  watching and wrong on both of the ones they are not.
+
+  **The failure that made this need a device.** `AVAudioFile` refused every download with
+  `avfaudio error 2003334207`. Both load paths turned a URL string into a path with
+  `replacingOccurrences(of: "file://", with: "")`, which strips the scheme and leaves the
+  percent-encoding — and point 2 put downloads under `Application Support`, so the path opened
+  contained a literal `Application%20Support`. The lesson is in the *reporting*: a nonexistent
+  directory surfaced as a **decode** error, which reads as a corrupt download and sends you to
+  inspect the file rather than the path. The bug predated this phase and was invisible to the suite,
+  because nothing in `swift test` opens a real file under a real container path.
+
+  Verified by playing a downloaded track whose stream URL pointed at a closed port, so a successful
+  load could only have come from disk — no need to take the device offline, and no way for a cached
+  response to muddy the result.
 
 ## Context
 

--- a/docs/decisions/ADR-0009-offline-downloads-are-background-transfers.md
+++ b/docs/decisions/ADR-0009-offline-downloads-are-background-transfers.md
@@ -16,6 +16,55 @@ Implementation:
   Phase 1 is deliberately first and deliberately alone: it is the whole data model, it is pure
   logic, and `swift test` can see it — the later phases are where the app target and its
   untestable seams start.
+- Phase 1 — the store and its index, on `familiar-apple` branch `feat/adr-0009-download-store`.
+  `DownloadStore` is an actor over a directory and a `Codable` index: playback asks it for a URL on
+  the main actor while a delegate hands it files from a background queue, and the index must not be
+  interleaved. File names are stored **relative**, never absolute, because iOS moves an app's
+  container between runs — a path recorded today names a directory that will not exist tomorrow.
+  Reconciliation lets the disk win, and the two directions are not equal: an entry with no file
+  makes the app offer a track it cannot play, which is the "metadata present, audio absent" failure
+  ADR-0006 documents in the web client; a file with no entry is merely wasted space. 14 tests.
+
+  Point 3 anticipated coalescing the index write during bulk downloads. There was no bulk writer
+  until phase 2, and a debounce with nothing to debounce is untestable speculation, so it writes per
+  mutation with the reason recorded beside it.
+- Phase 2 — the background session, on `familiar-apple` branch
+  `feat/adr-0009-background-downloads`. `DownloadManager` owns a background `URLSession` and files
+  finished transfers into phase 1's store. Only completed files reach it, per point 1: `URLSession`
+  already owns in-flight state durably, and a second record would disagree after a crash. The
+  finished file is moved **synchronously in the delegate callback**, because the system deletes it
+  the moment that method returns. 179 tests.
+
+  **The claim [ADR-0001](ADR-0001-native-apple-clients-supersede-capacitor.md) rests on is now
+  demonstrated rather than argued** — its rejection of renovating the PWA is that a WebView "cannot
+  deliver background downloads on iOS", and until 2026-07-30 that had only ever been exercised in
+  the foreground. On a physical iPhone: three tracks queued (266/178/106 MB), the app backgrounded
+  after 13 seconds and `SIGKILL`ed 62 seconds later, with a probe writing one heartbeat line per
+  second. The heartbeat matters — this app declares `UIBackgroundModes: audio`, so without it
+  "the download continued after backgrounding" is equally consistent with the app never having
+  stopped running. Its last line landed one second after the app lost the foreground. Then ~170 MB
+  arrived before the kill (transfers continue while **suspended**), ~130 MB more arrived after it
+  with no Familiar process on the device (they survive **termination**), and a new pid appeared
+  unprompted to file all three at full size — the system **relaunches the app to deliver results**,
+  exercising `handleEventsForBackgroundURLSession` → `resumeExistingTasks` → the delegate, a path
+  that exists only after termination.
+
+  **That test found a bug that lives only in the path being proved.** All three were filed with no
+  title and no artist: `taskDescription` carried just the track id, and after a relaunch it is the
+  only thing left, since the in-memory request map belongs to a process that no longer exists. A
+  comment claiming the metadata was "repaired the next time the track is seen in a list" described a
+  repair that did not exist. That defeats **point 3** — an entry needing `/tracks/{id}` to render
+  its own title is not offline-capable — in exactly the case downloads exist for, and no foreground
+  test could have caught it, because in the foreground the map is still populated. The fix carries
+  the metadata as JSON in the same string, preserving point 1's reason for choosing
+  `taskDescription` at all: no side file to fall out of step with session state the app does not
+  own. Three delegate callbacks had been reading that string *as* the track id, so changing its
+  format without routing them through the decoder would have mis-keyed every one.
+
+  The Simulator cost a day first: background transfers do not run there, and the failure reads as
+  broken wiring. `print` does not reach the unified log there either. The macOS app is the cheap way
+  to separate "my code is wrong" from "this environment cannot do it"; the phone is the only way to
+  prove the rest.
 
 ## Context
 


### PR DESCRIPTION
Docs only. ADR-0009's `Implementation:` block still said "Accepted 2026-07-30" plus the phase plan while two phases had shipped — the convention says an accepted ADR is a living record, and ADR-0003 already gets this treatment.

## Phase 1 (#13 on `familiar-apple`)

The actor over a directory and a `Codable` index. Relative file names, because iOS moves an app's container between runs and a path recorded today names a directory that will not exist tomorrow. Reconciliation lets the disk win, asymmetrically: an entry with no file makes the app offer a track it cannot play — the "metadata present, audio absent" failure ADR-0006 documents in the web client — while a file with no entry is merely wasted space.

Also recorded: **point 3's anticipated index-write coalescing was deliberately not built.** There was no bulk writer to debounce until phase 2, and a debounce with nothing to debounce is untestable speculation. Worth stating so nobody reads the gap as an oversight.

## Phase 2 (#16 on `familiar-apple`)

The background session — and the part that deserved more than a commit message.

**ADR-0001's load-bearing claim is now demonstrated rather than argued.** It rejects renovating the PWA because a WebView "cannot deliver background downloads on iOS", which is the strongest of its three reported symptoms. Until yesterday that had only ever been exercised in the foreground, which shows the mechanism works and says nothing about the advantage.

The method is recorded alongside the result, because the method is what makes it evidence rather than an anecdote: **a heartbeat file separates "suspended" from "backgrounded but still running."** That distinction is not pedantry here — this app declares `UIBackgroundModes: audio`, so it is entitled to keep running, and "bytes arrived after I backgrounded it" would be equally consistent with the app never having stopped. The heartbeat's last line landed one second after the app lost the foreground; ~170 MB arrived after that, ~130 MB more after `SIGKILL`, and the system relaunched the app to file all three.

**The bug that test found is recorded too**, because it existed *only* in the path being proved: downloads completing while the app was dead were filed with no title and no artist, defeating point 3 in exactly the case downloads exist for. The generalisable shape is worth an ADR line — state held in a process cannot be assumed present in a callback the system delivers to a *later* process.

## The ADR-0001 bullet

One bullet, pointing at ADR-0009's phase 2 rather than restating the evidence, so the claim and its proof cannot drift apart. It appends to `Implementation:` and does not touch `## Decision` — the decision was right, and rule 6 would require a superseding ADR if it weren't.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_014P9p2fvFnyiywBxGkv4gfW
