### PR TITLE
Propose ADR-0013–0016: management surfaces come to the Mac

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -68,6 +68,19 @@ ranking engine, precomputed offline ranking, and OpenAPI-generated clients.
 The ordering principle: **server-side work that every client inherits comes before client work**, and
 anything that accumulates data over time starts as early as possible.
 
+**`ADR-0013`–`ADR-0016` bring management surfaces to the Mac app** (proposed 2026-08-01). `0013`
+supersedes `0002`: macOS becomes a management surface alongside the web app, which keeps everything;
+iOS stays the listening path. Their own order:
+
+| # | ADR | Why here |
+|---|---|---|
+| 1 | `0013` | Framing only, and the one that supersedes. Nothing else is coherent without it. |
+| 2 | `0014` | Widens the generated surface to eleven tags. Cheap, and unblocks pending review, proposed changes and mixtapes. |
+| 3 | `0015`, `0016` | Independent of each other. `0015` exposes five effects the engine already has; `0016` decides embed-vs-native and covers Discover and Music Map. |
+
+Smart playlist CRUD and the album/artist grids need no ADR — ordinary work inside `0013`'s direction,
+and both depend on nothing, so they are the fastest visible wins once `0013` is accepted.
+
 ## Key Directories
 
 ```

--- a/docs/decisions/ADR-0002-web-app-is-the-management-surface.md
+++ b/docs/decisions/ADR-0002-web-app-is-the-management-surface.md
@@ -1,6 +1,6 @@
 # ADR-0002: The Web App Is the Management Surface
 
-Status: accepted
+Status: superseded by [ADR-0013](ADR-0013-the-mac-is-a-management-surface-too.md)
 
 Date: 2026-07-26
 

--- a/docs/decisions/ADR-0013-the-mac-is-a-management-surface-too.md
+++ b/docs/decisions/ADR-0013-the-mac-is-a-management-surface-too.md
@@ -1,0 +1,143 @@
+# ADR-0013: The Mac Is a Management Surface Too
+
+Status: proposed
+
+Date: 2026-08-01
+
+Supersedes [ADR-0002](ADR-0002-web-app-is-the-management-surface.md).
+
+## Context
+
+[ADR-0002](ADR-0002-web-app-is-the-management-surface.md) made the web app the **sole** home for
+administration, and [ADR-0001](ADR-0001-native-apple-clients-supersede-capacitor.md) point 5 put the
+visualizer, ambient mode, the 23 settings panels, import/cleanup/review queues, embedding maps,
+mixtapes and S3 backup out of the native v1 "possibly permanently". ADR-0002 point 4 stated the
+principle plainly: *"feature parity between web and native is explicitly not a goal. Divergence is
+the intended outcome, not drift to be corrected."*
+
+Both were right for what they were deciding. ADR-0002 was written on 2026-07-26, before a native app
+existed, when the risk was a v1 that never shipped because its scope was the whole product. Bounding
+native to the listening path is what let it ship — and it did ship: browse, search, playlists,
+album and artist detail, the player, the full-screen now-playing, the queue, offline downloads,
+favorites and CarPlay all exist and are in daily use.
+
+What changed is not the argument but the vantage point. Using the Mac app daily, the absent
+management surfaces read as gaps rather than as scope, and the reason is specific to *that* platform:
+a Mac is where this library is actually administered. The phone is not, and never was.
+
+**The premise that has weakened is "web *or* native", not "web is good at this".** The web app
+remains an excellent management client; nothing about it has gone wrong. What no longer holds is the
+conclusion that management must therefore live in only one place, on a machine where the native app
+is already open.
+
+Three things investigation established that bear on the decision, and which the earlier ADRs could
+not have known:
+
+1. **The Mac's audio effects already exist.** `NativeAudioEngine` carries `AVAudioUnitEQ`, reverb,
+   delay, compressor and the custom `WaveshaperAudioUnit`, with public `setEQ` (line 1042),
+   `setReverb` (1062), `setDelay` (1090), `setCompressor` (1119) and `setFilter` (1151). They came
+   across intact under ADR-0001 point 2 and have never been called by anything. The cost of exposing
+   them is a settings screen, not a DSP project.
+2. **Music Map is 690 lines of Canvas 2D in one file**
+   (`packages/frontend/src/components/Library/browsers/VibeMap/VibeMap.tsx`), and its data is capped
+   at 200 entities, 500 maximum, in `backend/app/api/routes/library_maps.py` (lines 58 and 73).
+   ADR-0001 point 5's
+   "4,017 lines of three.js" is the **visualizer**, a different feature. The map was grouped with it
+   by association rather than by measurement.
+3. **Much of the API is already generated for these surfaces.** `smart-playlists` is one of
+   ADR-0007's eight tags, so smart playlist CRUD needs no backend or schema work at all; and
+   `/library/map`, `/library/map/3d` and `/library/map/ego` carry the `library` tag, which
+   `backend/scripts/lint_openapi.py` already notes is generated whole "despite mixing ~18 listening
+   operations with ~17 management ones".
+
+**A contradiction this resolves.** ADR-0002 point 5 says new listening-path features go to native
+first once the native app exists. [ADR-0005](ADR-0005-one-ranking-engine-serves-ambient-and-radio.md)
+point 6 designs radio's client half against `packages/frontend/src/player/ambient/AmbientCoordinator.ts`
+— the web player — because it was written when native did not exist. Radio is a listening-path
+feature, so those two now disagree. This ADR does not settle it; it records that the disagreement is
+real so that whoever builds radio decides deliberately rather than by whichever document they read
+first.
+
+## Decision
+
+**macOS becomes a management surface alongside the web app. The web app loses nothing.**
+
+1. **Both clients keep everything.** Nothing is removed from the web app, frozen, or reduced to
+   bug-fix-only as `packages/ios` was. A browser on any machine stays fully capable, which is the
+   property ADR-0002 valued most and which costs nothing to keep.
+
+2. **iOS stays the listening path.** The phone is not a management client. ADR-0001 point 4's v1
+   scope stands for it unchanged, and the mobile web experience remains not a target (ADR-0002
+   point 3, carried forward). Managing this library from a phone means the web app in a mobile
+   browser, and that is still a second-class experience by design.
+
+3. **In scope for the Mac**, each as its own piece of work: smart playlist CRUD, audio effects,
+   pending review, proposed changes, Music Map, mixtapes, and Discover.
+
+4. **Still web-only, and now for stated reasons rather than by inclusion in a list:**
+   - the **visualizer** — 4,017 lines of three.js across 23 files per ADR-0001's audit, with no
+     native analogue and no management purpose;
+   - **ambient/generative mode** — out of v1 per ADR-0001 point 5, and `ambient` is deliberately
+     absent from the generated surface per ADR-0007;
+   - the **23 settings panels** — they configure the *server*, and a server has one configuration
+     whichever client edits it; there is no per-client value in a second editor;
+   - **S3 backup**, **library import** and **Spotify import** — long-running operations tied to
+     server-side filesystem state, where a second client is a second thing to keep correct for no
+     gain.
+
+5. **Full web playback is retained**, unchanged from ADR-0002 point 2. `WebAudioEngine.ts` and the
+   `audioEffects/` chain stay; the web app is a complete player at a computer, not an admin console.
+
+6. **Parity, restated precisely.** Parity between web and **iOS** remains explicitly not a goal —
+   ADR-0002 point 4 holds there in full. Parity between web and **macOS**, on the management
+   surfaces named in point 3, is now the direction. Divergence between the two desktop clients is no
+   longer the intended outcome for those features.
+
+7. **New management features go to whichever client is asked for, and are not required in both.**
+   Point 6 names a target for a specific list, not a standing obligation to build twice. A new
+   management feature is not blocked on having a Mac implementation.
+
+## Alternatives Considered
+
+**Leave ADR-0002 as it is and use the web app for management.** This is the status quo and it works
+— the web app is genuinely good, and this ADR is the more expensive path. Rejected because the friction
+is real and repeated: administering the library means leaving the app that is already open and in
+which the library is already being browsed. Over months that is a large number of small costs, and
+the specific features wanted are ones where the Mac has an advantage the browser cannot match
+(effects belong to the audio engine; a map wants real trackpad gestures).
+
+**Move management to the Mac and remove it from the web app.** Cleaner as a story — one home per
+concern, no duplication, no drift. Rejected on sequencing rather than principle: every removal is a
+capability lost before its replacement is proven, and management from a non-Mac machine disappears
+entirely. If the Mac versions prove better in use, removal can be its own decision later, made
+against evidence.
+
+**Keep the web versions but freeze them, as `packages/ios` was frozen.** Attractive because it caps
+the two-client cost while removing nothing. Rejected because the freeze on `packages/ios` worked as a
+countdown to deletion — it had a stated end. These have none, and a frozen management surface that
+nobody may fix is worse than either keeping it alive or removing it honestly.
+
+**Bring these to iOS as well.** Rejected as a scope trap. The features are wanted because a Mac is
+where administration happens; a review queue on a phone is a screen nobody would open. ADR-0001 point
+4's bar — "fundamental playback and navigation quality, not feature breadth" — is still exactly right
+for the phone.
+
+## Consequences
+
+- **Positive:** The Mac app becomes a complete client for how this library is actually used, rather
+  than a listening front-end onto it.
+- **Positive:** Several of these are far cheaper than ADR-0001 point 5's grouping implied — audio
+  effects are already built and unexposed; smart playlists need no API work; the map is a tenth the
+  size the "4,017 lines of three.js" figure suggested.
+- **Positive:** Zero-install management from any machine is retained, unchanged.
+- **Tradeoff:** Two implementations of each named surface, and they will drift. Accepted knowingly:
+  the alternative is removing a working capability before its replacement has earned it.
+- **Tradeoff:** The Mac app's scope grows well beyond ADR-0001's v1, which was deliberately small so
+  that it shipped. It has shipped; this is what comes after, not a widening of it.
+- **Tradeoff:** ADR-0001 point 5 is now half-right. Its exclusions hold for iOS and for the
+  visualizer, ambient mode, settings and backup; they no longer hold for the Mac on the rest. It is
+  not superseded, because its other six points stand.
+- **Follow-up:** Radio's client half is unowned — ADR-0002 point 5 says native first, ADR-0005 point
+  6 designs for web. Decide it when radio is built, not before.
+- **Follow-up:** If the Mac versions of these surfaces prove better in use, revisit whether the web
+  originals should be removed. That is a decision for evidence, and deliberately not taken here.

--- a/docs/decisions/ADR-0013-the-mac-is-a-management-surface-too.md
+++ b/docs/decisions/ADR-0013-the-mac-is-a-management-surface-too.md
@@ -1,10 +1,17 @@
 # ADR-0013: The Mac Is a Management Surface Too
 
-Status: proposed
+Status: accepted
 
 Date: 2026-08-01
 
 Supersedes [ADR-0002](ADR-0002-web-app-is-the-management-surface.md).
+
+Implementation:
+- Accepted 2026-08-01, alongside [ADR-0015](ADR-0015-audio-effects-are-exposed-not-rebuilt.md), which
+  is the first piece of work to inherit from it. `ADR-0014` and `ADR-0016` remain `proposed` — they
+  are approved separately, when the features they govern are started.
+- The album and artist grids shipped before this was accepted and deliberately did not wait on it:
+  library browse is in ADR-0001 point 4's v1 scope, so it was never a management surface.
 
 ## Context
 

--- a/docs/decisions/ADR-0014-the-generated-surface-widens-to-management.md
+++ b/docs/decisions/ADR-0014-the-generated-surface-widens-to-management.md
@@ -1,0 +1,110 @@
+# ADR-0014: The Generated Surface Widens to Management
+
+Status: proposed
+
+Date: 2026-08-01
+
+Extends [ADR-0007](ADR-0007-clients-are-generated-from-openapi.md).
+Depends on [ADR-0013](ADR-0013-the-mac-is-a-management-surface-too.md).
+
+## Context
+
+[ADR-0007](ADR-0007-clients-are-generated-from-openapi.md) point 2 defines the generated Swift
+surface as eight tags — `tracks`, `library`, `playlists`, `smart-playlists`, `profiles`, `favorites`,
+`chat` and `queue` — enforced from both ends: the filter in
+`Sources/FamiliarAPI/openapi-generator-config.yaml` and the backend lint in
+`backend/scripts/lint_openapi.py`, so the two cannot drift silently.
+
+[ADR-0013](ADR-0013-the-mac-is-a-management-surface-too.md) puts pending review, proposed changes and
+mixtapes on the Mac. None of those three is reachable from Swift today, so that ADR cannot be
+executed without changing this one. Measured against the current schema:
+
+| tag | endpoints | generated today |
+|---|---|---|
+| `pending-review` | 16 | no |
+| `Proposed Changes` | 12 | no |
+| `mixtapes` | 5 | no — and listed in `NOT_GENERATED` |
+| `smart-playlists` | 10 | **yes** |
+
+Two details matter more than the counts.
+
+**`mixtapes` is excluded on purpose, with a recorded reason.** `NOT_GENERATED` at
+`backend/scripts/lint_openapi.py:56` is `{"ambient", "mixtapes", "outputs"}`, and the comment above it
+cites ADR-0001 point 5 for mixtapes. That justification is exactly what ADR-0013 revisits, so removing
+it from that set is a change of decision rather than a tidy-up, and the comment must be updated to say
+so rather than quietly losing an entry.
+
+**`Proposed Changes` is the only tag with a space and capital letters.** Every other tag in the schema
+is lower-case kebab-case. The generator derives Swift names from operationIds rather than tags, so
+this is not fatal, but it is the sort of inconsistency that produces one oddly-named thing nobody
+later understands — and it is far cheaper to fix before anything generates from it than after.
+
+The `library` tag is already instructive here. `lint_openapi.py` notes that it "stays whole despite
+mixing ~18 listening operations with ~17 management ones (import, dedup, scan, review)", accepting
+"dead generated code rather than a defect", and closes with *"Revisit if they resist typing."* Under
+ADR-0013 those seventeen stop being dead: they are part of what the review surfaces need.
+
+## Decision
+
+1. **Generate three more tags: `pending-review`, `proposed-changes` and `mixtapes`.** The filter in
+   `Sources/FamiliarAPI/openapi-generator-config.yaml` goes from eight tags to eleven.
+
+2. **Rename the backend tag `Proposed Changes` to `proposed-changes` first**, in its route module, so
+   the schema is regenerated with it before any Swift is generated from it. Kebab-case matches every
+   other tag; doing it first means no generated name is ever built on the old spelling.
+
+3. **`mixtapes` leaves `NOT_GENERATED`; `ambient` and `outputs` stay**, with their existing reasons
+   intact — ambient is out of v1 and iOS-only in nature, casting is outside ADR-0001 point 4's scope.
+   The comment gains a line recording that mixtapes left because ADR-0013 brought it into scope, so
+   the set continues to explain itself.
+
+4. **The lint keeps enforcing both ends.** `NOT_GENERATED` and the generator filter are updated in the
+   same change, and the lint's own expectations move with them. A widened surface that only one side
+   knows about is the drift ADR-0007 exists to prevent.
+
+5. **Nothing else is added.** In particular `s3-backup`, `export-import`, `spotify`, `analysis`,
+   `settings` and `admin` stay out: ADR-0013 point 4 keeps them web-only, so generating them would
+   produce exactly the dead code the `library` note tolerates only because tag granularity gives no
+   choice.
+
+6. **No new exceptions to ADR-0007's rules.** If any of the three carries an operationId over 60
+   characters, an undeclared error response, or a non-JSON media type declared as JSON, the backend is
+   corrected rather than the lint relaxed. This is the moment those endpoints are first held to the
+   contract, and some of them predate it.
+
+## Alternatives Considered
+
+**Hand-write Swift clients for the three tags.** Avoids touching the generated surface at all, and for
+33 endpoints it is not unthinkable. Rejected because it reintroduces precisely what ADR-0007 removed:
+a hand-maintained contract that drifts silently, where a renamed response field becomes a runtime
+failure on a device instead of a compile error.
+
+**Generate every tag and stop filtering.** Simplest rule, no list to maintain, no drift possible.
+Rejected because the filter is doing real work — `ambient` and `outputs` are out of scope by
+decision, not by accident, and the recorded reasons in `NOT_GENERATED` are more valuable than the
+convenience. It would also generate S3 backup and Spotify import, which ADR-0013 point 4 explicitly
+keeps web-only.
+
+**Split the `library` tag into listening and management halves.** Tempting while nearby, and it would
+turn the "~18 listening, ~17 management" note into a real boundary. Rejected as a separate concern
+that would balloon this change: it touches every `library` route's decorator and every generated call
+site in the Swift app, for no benefit to the three features ADR-0013 wants. Worth doing on its own if
+those seventeen ever do resist typing.
+
+**Leave `Proposed Changes` spelled as it is.** It works; the generator keys names off operationIds.
+Rejected because it costs one line to fix now and is awkward forever afterwards — and a schema where
+one tag is shaped unlike all the others invites the next person to match the wrong pattern.
+
+## Consequences
+
+- **Positive:** Pending review, proposed changes and mixtapes become reachable from Swift with a
+  compile-time-checked contract, on the same terms as everything else the app talks to.
+- **Positive:** The schema's one inconsistent tag name is fixed while the cost is a rename.
+- **Positive:** Seventeen `library` management operations that were generated as dead code start
+  earning their place.
+- **Tradeoff:** The generated client grows by 33 operations plus their types, lengthening build time
+  and adding surface that only the Mac uses — the iOS target compiles it and never calls it.
+- **Tradeoff:** Endpoints written before ADR-0007's rules now have to satisfy them, which may mean
+  backend corrections that look unrelated to bringing a feature to the Mac.
+- **Follow-up:** If the `library` tag's management half ever does resist typing, split it — the note
+  in `lint_openapi.py` already anticipates this and should be updated to point here.

--- a/docs/decisions/ADR-0015-audio-effects-are-exposed-not-rebuilt.md
+++ b/docs/decisions/ADR-0015-audio-effects-are-exposed-not-rebuilt.md
@@ -1,0 +1,102 @@
+# ADR-0015: Audio Effects Are Exposed, Not Rebuilt
+
+Status: proposed
+
+Date: 2026-08-01
+
+Extends [ADR-0013](ADR-0013-the-mac-is-a-management-surface-too.md).
+
+## Context
+
+The web app has ten audio effects in `packages/web/src/audioEffects/effects/` — EQ, compressor,
+reverb, delay, filter, stereo width, saturation, bitcrusher, chorus and tremolo — built on Web Audio
+nodes and driven by `packages/frontend/src/components/Settings/AudioEffectsSettings.tsx`. The Mac app
+appears to have none.
+
+It has five. `NativeAudioEngine` holds `AVAudioUnitEQ`, `AVAudioUnitReverb`, `AVAudioUnitDelay`, an
+`AVAudioUnitEffect` compressor and the custom `WaveshaperAudioUnit`, and exposes them through methods
+that are already public:
+
+| effect | entry point | line |
+|---|---|---|
+| EQ | `setEQ(lowGain:midGain:highGain:…)` | 1042 |
+| reverb | `setReverb(preset:wetDryMix:enabled:preDelay:)` | 1062 |
+| delay | `setDelay(time:feedback:wetDryMix:enabled:pingPong:)` | 1090 |
+| compressor | `setCompressor(threshold:ratio:attack:release:…)` | 1119 |
+| filter | `setFilter(highpassFreq:lowpassFreq:…)` | 1151 |
+
+They arrived with the engine under [ADR-0001](ADR-0001-native-apple-clients-supersede-capacitor.md)
+point 2 — "all 1,860 lines… move intact" — and nothing has ever called them. This is shipped,
+previously-exercised DSP with no user interface in front of it. The Capacitor app drove these same
+methods across the JS bridge; the bridge was deleted, and the methods were left behind it.
+
+That reframes the work. "Audio effects on the Mac" sounds like a DSP project and is a settings screen.
+
+The five the web has and the engine does not — stereo width, saturation, bitcrusher, chorus, tremolo —
+are a genuinely different proposition. Each would be a new node on the real-time render path, in an
+engine whose `Package.swift` records that Swift 6 strict concurrency already rejects it because of
+"non-Sendable captures in the artwork fetch and the render callbacks", and where the render thread
+"has real isolation requirements that `@MainActor`-by-default would get wrong".
+
+Where the settings live is also already decided by precedent: `audioEffectsStore.ts` is a Zustand
+store with no backend endpoint anywhere — `rg 'audio_effects' backend/app` returns nothing. Effect
+settings have never been server state.
+
+## Decision
+
+1. **Expose the five effects the engine already has** — EQ, reverb, delay, compressor, filter —
+   through a settings surface in the Mac app, calling the existing public methods.
+
+2. **No new DSP, and the render path is not touched.** This adds no nodes to the audio graph and
+   changes no code inside `NativeAudioEngine`'s processing. If exposing an effect appears to require
+   engine changes, that is a signal to stop and reconsider, not to proceed.
+
+3. **Stereo width, saturation, bitcrusher, chorus and tremolo are deferred**, and deliberately so.
+   They are five new real-time nodes in an engine that is explicitly not yet Swift 6 concurrency-clean,
+   for effects whose absence is not what prompted this. Anyone adding them should treat it as its own
+   decision with its own ADR.
+
+4. **Settings stay client-local**, as they are on the web. The Mac keeps its own effect settings in
+   `UserDefaults`; they are not synced, and no server endpoint is added.
+
+5. **Cross-client effect sync is a non-goal.** Effects are a property of *this speaker, in this room*,
+   not of a listener's account. A profile whose EQ follows it from a laptop to a phone to a car would
+   be actively wrong more often than right.
+
+6. **macOS only**, per ADR-0013 point 2. The engine is shared with iOS and the methods are callable
+   there, but no iOS surface is added.
+
+## Alternatives Considered
+
+**Match the web's ten effects.** True parity, and the shape a "bring audio effects to the Mac" request
+most obviously implies. Rejected as a poor trade: five of the ten are already free, and the other five
+cost new real-time audio code in an engine with known concurrency debt. If the missing five turn out
+to matter in use, they can be added knowing exactly what they cost.
+
+**Sync effect settings through the server so all clients agree.** Rejected on the merits rather than
+cost. Effects compensate for output — headphones, car speakers, a desk monitor — so identical settings
+across devices is the wrong default, and it would mean inventing server state for something that has
+never had any.
+
+**Reimplement the web's effects chain in Swift as a port of `EffectsChain.ts`.** Symmetrical, and
+would make the two clients sound identical. Rejected because the engine's nodes are AVFoundation and
+the web's are Web Audio; matching them is approximation, not porting, and the result would be two
+implementations that sound *nearly* the same — which is worse than two that plainly differ.
+
+**Put effects behind the existing web settings and skip the Mac entirely.** The status quo. Rejected
+because effects belong to whichever engine is producing sound: the web's settings cannot alter what
+the native engine is playing, so a listener on the Mac app has no way to reach them at all.
+
+## Consequences
+
+- **Positive:** Five effects arrive for the cost of a settings screen, on DSP that has already shipped
+  and been exercised in the Capacitor app.
+- **Positive:** The engine's real-time path is untouched, so this cannot regress playback — the class
+  of bug that is hardest to find and worst to ship.
+- **Positive:** It closes an odd gap where the Mac app's engine could do something no part of the app
+  could ask it to.
+- **Tradeoff:** The Mac and the web will not sound identical, and five effects exist in one client
+  only. Named here so it reads as a decision rather than an omission.
+- **Tradeoff:** Settings do not follow a listener between clients. Intended — see point 5.
+- **Follow-up:** If the deferred five are wanted, they need their own ADR covering the render-thread
+  and Swift 6 concurrency questions the engine's `Package.swift` already flags.

--- a/docs/decisions/ADR-0015-audio-effects-are-exposed-not-rebuilt.md
+++ b/docs/decisions/ADR-0015-audio-effects-are-exposed-not-rebuilt.md
@@ -1,10 +1,15 @@
 # ADR-0015: Audio Effects Are Exposed, Not Rebuilt
 
-Status: proposed
+Status: accepted
 
 Date: 2026-08-01
 
 Extends [ADR-0013](ADR-0013-the-mac-is-a-management-surface-too.md).
+
+Implementation:
+- Accepted 2026-08-01. Two claims in the proposed draft were corrected against the engine before
+  acceptance rather than after — it is six effects rather than five (saturation is the waveshaper),
+  and the setters are internal rather than public, which is why decision point 3 exists at all.
 
 ## Context
 
@@ -13,17 +18,26 @@ reverb, delay, filter, stereo width, saturation, bitcrusher, chorus and tremolo 
 nodes and driven by `packages/frontend/src/components/Settings/AudioEffectsSettings.tsx`. The Mac app
 appears to have none.
 
-It has five. `NativeAudioEngine` holds `AVAudioUnitEQ`, `AVAudioUnitReverb`, `AVAudioUnitDelay`, an
-`AVAudioUnitEffect` compressor and the custom `WaveshaperAudioUnit`, and exposes them through methods
-that are already public:
+It has six. `NativeAudioEngine` holds `AVAudioUnitEQ`, `AVAudioUnitReverb`, `AVAudioUnitDelay`, an
+`AVAudioUnitEffect` compressor, a second `AVAudioUnitEQ` as a filter, and the custom
+`WaveshaperAudioUnit`, each with a setter already written:
 
 | effect | entry point | line |
 |---|---|---|
 | EQ | `setEQ(lowGain:midGain:highGain:…)` | 1042 |
 | reverb | `setReverb(preset:wetDryMix:enabled:preDelay:)` | 1062 |
 | delay | `setDelay(time:feedback:wetDryMix:enabled:pingPong:)` | 1090 |
+| saturation | `setDistortion(preset:wetDryMix:enabled:drive:)` | 1105 |
 | compressor | `setCompressor(threshold:ratio:attack:release:…)` | 1119 |
 | filter | `setFilter(highpassFreq:lowpassFreq:…)` | 1151 |
+
+plus `setMasterBypass(_:)` at 1167.
+
+**Two corrections to an earlier draft of this ADR, recorded rather than quietly fixed.** It said
+*five* effects and listed saturation among the ones the engine lacks — it has it, as the waveshaper.
+And it called the setters *public*: `class NativeAudioEngine` at line 368 is **internal**, and so are
+they. They are reachable from inside `FamiliarKit` and not from the app target, which decides the
+shape of the work below rather than merely being a detail.
 
 They arrived with the engine under [ADR-0001](ADR-0001-native-apple-clients-supersede-capacitor.md)
 point 2 — "all 1,860 lines… move intact" — and nothing has ever called them. This is shipped,
@@ -32,11 +46,17 @@ methods across the JS bridge; the bridge was deleted, and the methods were left 
 
 That reframes the work. "Audio effects on the Mac" sounds like a DSP project and is a settings screen.
 
-The five the web has and the engine does not — stereo width, saturation, bitcrusher, chorus, tremolo —
-are a genuinely different proposition. Each would be a new node on the real-time render path, in an
-engine whose `Package.swift` records that Swift 6 strict concurrency already rejects it because of
+The four the web has and the engine does not — stereo width, bitcrusher, chorus, tremolo — are a
+genuinely different proposition. Each would be a new node on the real-time render path, in an engine
+whose `Package.swift` records that Swift 6 strict concurrency already rejects it because of
 "non-Sendable captures in the artwork fetch and the render callbacks", and where the render thread
 "has real isolation requirements that `@MainActor`-by-default would get wrong".
+
+One behaviour worth knowing before building on it: **`setMasterBypass(false)` does not restore
+anything.** It clears the flag, but only the `true` branch touches the nodes, so coming out of bypass
+requires re-applying every effect. That is a reasonable design for a method that was always driven by
+a client holding the settings, and it means the settings store — not the engine — is the thing that
+remembers.
 
 Where the settings live is also already decided by precedent: `audioEffectsStore.ts` is a Zustand
 store with no backend endpoint anywhere — `rg 'audio_effects' backend/app` returns nothing. Effect
@@ -44,33 +64,38 @@ settings have never been server state.
 
 ## Decision
 
-1. **Expose the five effects the engine already has** — EQ, reverb, delay, compressor, filter —
-   through a settings surface in the Mac app, calling the existing public methods.
+1. **Expose the six effects the engine already has** — EQ, reverb, delay, saturation, compressor,
+   filter — plus master bypass, through a settings surface in the Mac app.
 
 2. **No new DSP, and the render path is not touched.** This adds no nodes to the audio graph and
    changes no code inside `NativeAudioEngine`'s processing. If exposing an effect appears to require
    engine changes, that is a signal to stop and reconsider, not to proceed.
 
-3. **Stereo width, saturation, bitcrusher, chorus and tremolo are deferred**, and deliberately so.
-   They are five new real-time nodes in an engine that is explicitly not yet Swift 6 concurrency-clean,
-   for effects whose absence is not what prompted this. Anyone adding them should treat it as its own
-   decision with its own ADR.
+3. **The app reaches them through `FamiliarPlayer`, not the engine.** The engine is internal to
+   `FamiliarKit` and stays that way — `FamiliarPlayer` holds it as `private let`, which is what keeps
+   there being exactly one. The player gains a method that takes settings and forwards them. Making
+   the engine public to save that hop would hand every caller the ability to hold a second one.
 
-4. **Settings stay client-local**, as they are on the web. The Mac keeps its own effect settings in
+4. **Stereo width, bitcrusher, chorus and tremolo are deferred**, and deliberately so. They are four
+   new real-time nodes in an engine that is explicitly not yet Swift 6 concurrency-clean, for effects
+   whose absence is not what prompted this. Anyone adding them should treat it as its own decision
+   with its own ADR.
+
+5. **Settings stay client-local**, as they are on the web. The Mac keeps its own effect settings in
    `UserDefaults`; they are not synced, and no server endpoint is added.
 
-5. **Cross-client effect sync is a non-goal.** Effects are a property of *this speaker, in this room*,
+6. **Cross-client effect sync is a non-goal.** Effects are a property of *this speaker, in this room*,
    not of a listener's account. A profile whose EQ follows it from a laptop to a phone to a car would
    be actively wrong more often than right.
 
-6. **macOS only**, per ADR-0013 point 2. The engine is shared with iOS and the methods are callable
+7. **macOS only**, per ADR-0013 point 2. The engine is shared with iOS and the methods are callable
    there, but no iOS surface is added.
 
 ## Alternatives Considered
 
 **Match the web's ten effects.** True parity, and the shape a "bring audio effects to the Mac" request
-most obviously implies. Rejected as a poor trade: five of the ten are already free, and the other five
-cost new real-time audio code in an engine with known concurrency debt. If the missing five turn out
+most obviously implies. Rejected as a poor trade: six of the ten are already free, and the other four
+cost new real-time audio code in an engine with known concurrency debt. If the missing four turn out
 to matter in use, they can be added knowing exactly what they cost.
 
 **Sync effect settings through the server so all clients agree.** Rejected on the merits rather than
@@ -89,14 +114,14 @@ the native engine is playing, so a listener on the Mac app has no way to reach t
 
 ## Consequences
 
-- **Positive:** Five effects arrive for the cost of a settings screen, on DSP that has already shipped
+- **Positive:** Six effects arrive for the cost of a settings screen, on DSP that has already shipped
   and been exercised in the Capacitor app.
 - **Positive:** The engine's real-time path is untouched, so this cannot regress playback — the class
   of bug that is hardest to find and worst to ship.
 - **Positive:** It closes an odd gap where the Mac app's engine could do something no part of the app
   could ask it to.
-- **Tradeoff:** The Mac and the web will not sound identical, and five effects exist in one client
+- **Tradeoff:** The Mac and the web will not sound identical, and four effects exist in one client
   only. Named here so it reads as a decision rather than an omission.
 - **Tradeoff:** Settings do not follow a listener between clients. Intended — see point 5.
-- **Follow-up:** If the deferred five are wanted, they need their own ADR covering the render-thread
+- **Follow-up:** If the deferred four are wanted, they need their own ADR covering the render-thread
   and Swift 6 concurrency questions the engine's `Package.swift` already flags.

--- a/docs/decisions/ADR-0016-embedded-web-surfaces-on-the-mac.md
+++ b/docs/decisions/ADR-0016-embedded-web-surfaces-on-the-mac.md
@@ -1,0 +1,122 @@
+# ADR-0016: Embedded Web Surfaces on the Mac
+
+Status: proposed
+
+Date: 2026-08-01
+
+Extends [ADR-0013](ADR-0013-the-mac-is-a-management-surface-too.md).
+
+## Context
+
+[ADR-0013](ADR-0013-the-mac-is-a-management-surface-too.md) puts Discover and Music Map on the Mac.
+Both exist in the web app and both would be rebuilt in SwiftUI by default — but they are not the same
+size of thing, and treating them the same would be a mistake in one direction or the other.
+
+Measured on 2026-08-01:
+
+| surface | size | renders with |
+|---|---|---|
+| Discover | **2,943 lines across 26 files** (`packages/frontend/src/components/Discovery/`) | ordinary React |
+| Music Map | **690 lines in one file** (`…/Library/browsers/VibeMap/VibeMap.tsx`) | Canvas 2D |
+
+Discover is also the surface most likely to keep moving: it aggregates external sources, and its shape
+follows what those sources make available. A native rebuild is a second implementation to change every
+time the first one does.
+
+**The performance question, answered.** The obvious argument for rebuilding the map natively is speed,
+and it does not hold. `backend/app/api/routes/library_maps.py` caps the map at 200 entities and 500
+maximum (lines 58 and 73). At 200–500 points nothing is near a GPU limit — Canvas 2D, SwiftUI `Canvas`,
+SceneKit and Metal would all be idle between frames. SceneKit or Metal would buy nothing measurable.
+
+What a native map *would* buy is different: no WKWebView resident in memory, real trackpad gestures
+rather than emulated wheel events, and the ability to draw from cached data with no server. And
+SwiftUI's `Canvas` (macOS 12+, iOS 15+) is a close analogue of the Canvas 2D drawing the web version
+already does, so the rebuild is roughly the same 700 lines rather than a research project.
+
+So the deciding axis is **churn and surface size**, not rendering. That reasoning generalises, and is
+worth deciding once rather than re-arguing per feature.
+
+**The constraint that governs any embedding.** `packages/web/src/main.tsx:14` calls
+`registerEngineFactory(() => new WebAudioEngine())` unconditionally. A `WKWebView` running the web app
+therefore stands ready to construct a second audio engine, and any play action inside it would: two
+engines, two queues, two things holding an audio session. That is precisely the failure
+`CarPlayBridge` exists to prevent — its own comment notes "two players would mean two queues, two
+positions and two things holding the audio session" — and it would be far harder to diagnose arriving
+from inside a web view.
+
+## Decision
+
+1. **Embed when a surface is large and moving; build native when it is small and settled.** The test
+   is churn and size, not performance. A surface with many files that tracks external services is a
+   poor candidate for a second implementation; a self-contained one that has found its shape is a
+   good one.
+
+2. **Discover is embedded** in a `WKWebView` pointed at the running server's web app.
+
+3. **Music Map is built native**, drawn with SwiftUI `Canvas`, reading `/library/map` and
+   `/library/map/ego` through the generated client — both carry the `library` tag and are already in
+   the generated surface, so no schema work is needed. The two `*/stream` SSE variants stay outside it,
+   per [ADR-0007](ADR-0007-clients-are-generated-from-openapi.md) point 8.
+
+4. **An embedded surface must never play audio.** This is the load-bearing rule. The embedded page runs
+   browse-only, and every play action is handed to the native `FamiliarPlayer` through a
+   `WKScriptMessageHandler` bridge. No second engine is ever constructed.
+
+5. **The bridge is one-way and narrow**: the page posts an intent — play these track ids, starting at
+   this one — and the native side owns the queue, the playback and the reporting. The web view is
+   never told what is playing and never renders a transport. One player, one queue, one now-playing
+   entry, exactly as with CarPlay.
+
+6. **The web view is given the server URL and profile explicitly** by the native app rather than
+   relying on whatever the embedded app finds in its own storage, so it cannot end up pointed at a
+   different server or acting as a different profile than the window around it.
+
+7. **With no server reachable, an embedded surface shows a native "unavailable" state**, not a browser
+   error page. Embedding is an implementation detail and should fail like the rest of the app.
+
+8. **Embedding is a starting position, not a permanent one.** A surface that settles can be rebuilt
+   native later; this ADR does not need superseding to do that, only the criterion in point 1 applied
+   again.
+
+## Alternatives Considered
+
+**Rebuild Discover natively too.** Consistent, fully native, no web view in the app. Rejected on
+maintenance: 26 files tracking external services is the part of the product most likely to change, and
+a second implementation would have to change with it every time — the kind of duplication that is
+quietly abandoned rather than deliberately removed.
+
+**Embed the Music Map as well, for consistency.** Cheapest possible route for both, and one mechanism
+instead of two. Rejected because the map is small, self-contained and finished, and the things a native
+version gains — trackpad gestures, no resident web view, working from cached data — are exactly what an
+interactive map is judged on. Consistency is not worth much when the two cases genuinely differ.
+
+**Rebuild the map in SceneKit or Metal.** Considered because it was the first instinct, and measured
+rather than assumed. Rejected: with the payload capped at 200–500 entities there is nothing for either
+to accelerate, and both are substantially more machinery than SwiftUI `Canvas` for the same result.
+
+**Let the embedded page play audio through its own `WebAudioEngine`.** Simplest bridge — no bridge at
+all — and Discover would work exactly as it does in a browser. Rejected outright: two engines in one
+process is the defect ADR-0001 and `CarPlayBridge` are both written to avoid, and it would produce two
+queues and a contested audio session with the cause hidden inside a web view.
+
+**Ship a menu item that opens Discover in the default browser.** Honest, trivial, no bridge and no
+duplication. Rejected as not being the request: leaving the app is the friction ADR-0013 exists to
+remove.
+
+## Consequences
+
+- **Positive:** Discover arrives at a fraction of the cost of a rebuild and stays current with the web
+  version automatically, including changes made after this ships.
+- **Positive:** Music Map is genuinely native where that matters — gestures, memory, and drawing from
+  cached data with no server.
+- **Positive:** There is now a stated test for the next feature like this, instead of an argument.
+- **Tradeoff:** The Mac app contains a web view, and will look and feel like one on that screen —
+  scrolling, text selection and focus will not match the rest of the app.
+- **Tradeoff:** Embedded Discover needs the server reachable, so it is the one Mac surface with no
+  offline story at all.
+- **Tradeoff:** The bridge is a new seam between two clients that were previously independent, and a
+  web-app change could break the native app through it. It should be narrow enough — one message
+  shape — that this stays unlikely.
+- **Follow-up:** Decide whether the embedded page should be a purpose-built route that renders only
+  Discover, rather than the full web app with everything else hidden. The narrower route is safer
+  against point 4 but is a change in the web app.


### PR DESCRIPTION
Four ADRs, proposed together with an execution order, bringing **smart playlists, audio effects, pending review, proposed changes, Music Map, mixtapes and Discover** to the macOS app.

This reverses accepted decisions, so it supersedes rather than edits (rule 6). **ADR-0002** made the web app the *sole* home for administration and said outright that parity was "explicitly not a goal"; **ADR-0001 point 5** put most of these out of v1 "possibly permanently". Both were right for what they decided — bounding v1 is what let the native app ship. What changed is the vantage point: a Mac is where this library is actually administered, and the phone never was.

| ADR | Decides |
|---|---|
| **0013** | macOS becomes a management surface. The web app **keeps everything**. iOS stays the listening path. *Supersedes ADR-0002.* |
| **0014** | Widen the generated surface from eight tags to eleven. *Extends ADR-0007.* |
| **0015** | Expose the five audio effects the engine already has; defer the other five. |
| **0016** | Embed vs build native — Discover is embedded, Music Map is native. |

## Three things measurement changed

These are why the work is smaller than the list suggests, and each corrects something the earlier ADRs assumed:

- **The Mac's audio effects already exist.** `NativeAudioEngine` carries `AVAudioUnitEQ`, reverb, delay, a compressor and the custom waveshaper, with **public setters at lines 1042, 1062, 1090, 1119 and 1151**. They moved intact under ADR-0001 point 2 and *nothing has ever called them* — the Capacitor bridge that drove them was deleted and the methods were left behind it. "Audio effects on the Mac" is a settings screen, not a DSP project.
- **Music Map is 690 lines of Canvas 2D in one file**, and its payload is capped at **200 entities (max 500)** in `library_maps.py:58,73`. ADR-0001 point 5's "4,017 lines of three.js" is the **visualizer** — a different feature that was grouped with the map by association rather than measurement. At 200–500 points SceneKit or Metal would accelerate nothing.
- **Much of the API is already generated.** `smart-playlists` is one of ADR-0007's eight tags, so smart playlist CRUD needs no API work at all; the map endpoints carry `library`, likewise. Only pending review, proposed changes and mixtapes need ADR-0014.

## The rule that governs embedding

ADR-0016 decides embed-vs-native **once**, on churn and size rather than performance: embed what is large and moving (Discover — 2,943 lines across 26 files, tracking external services), build native what is small and settled (the map).

Its load-bearing constraint: **an embedded surface must never play audio.** `packages/web/src/main.tsx:14` registers `WebAudioEngine` unconditionally, so a `WKWebView` running the app stands ready to construct a second engine — two queues, two audio sessions, the exact failure `CarPlayBridge` exists to prevent, and far harder to diagnose from inside a web view. The embedded page is browse-only and hands every play intent to the native player over a narrow bridge.

## Also recorded

A contradiction is **noted rather than resolved**: ADR-0002 point 5 says new listening-path features go to native first, while ADR-0005 point 6 designs radio's client half against the web `AmbientCoordinator` — written before native existed. Radio is a listening-path feature, so those disagree. Whoever builds radio should decide deliberately rather than by whichever document they read first.

## Not ADRs

Smart playlist CRUD and the album/artist grids are ordinary work inside ADR-0013's direction. Both depend on nothing and are the fastest visible wins once 0013 is accepted. The grids can reuse what already exists — `ArtworkResolver` caches per album, `AlbumsStore` pages at 100, and albums key on `firstTrackId`, which is exactly what `/tracks/{id}/artwork?size=thumb` takes.

## Review notes

Every figure, path and line number was verified against the repo at write time (rule 4) — including correcting `library_map.py` to `library_maps.py` and the `Proposed Changes` tag, which is the schema's only non-kebab-case tag and should be renamed before anything generates from it.

All four are `Status: proposed` and can be approved independently, in the order in the table.