### PR TITLE
Widen the generated surface to the management tags (ADR-0014)

### DIFF
--- a/backend/app/api/routes/pending_review.py
+++ b/backend/app/api/routes/pending_review.py
@@ -7,6 +7,7 @@ from uuid import UUID
 
 from fastapi import APIRouter, Query
 from pydantic import BaseModel
+from pydantic import ValidationError as PydanticValidationError
 from sqlalchemy import select, update
 from sqlalchemy.ext.asyncio import AsyncSession
 
@@ -181,6 +182,28 @@ def _folder_name(folder_path: str) -> str:
     return PurePosixPath(folder_path).name
 
 
+def _to_review_info(raw: dict[str, Any] | None) -> ReviewInfo | None:
+    """Read `Track.review_info` out of its JSONB column.
+
+    `None` and `{}` mean different things and both are real: the scanner writes `{}` deliberately —
+    "default to {} so recovery knows it was pending" — for a track awaiting review that has no
+    duplicate. So this only collapses a genuine `None`.
+
+    A row whose shape this model does not describe is logged and dropped rather than raised. The
+    column predates the model, and a track from an older scanner is still reviewable; losing the
+    explanation is a far better outcome than a 500 that hides the whole queue.
+    """
+    if raw is None:
+        return None
+    try:
+        return ReviewInfo.model_validate(raw)
+    # Aliased: `app.api.exceptions` exports a `ValidationError` too, and it is imported below —
+    # an unaliased `except ValidationError` here would catch that one and never Pydantic's.
+    except PydanticValidationError:
+        logger.warning("Unreadable review_info, showing the track without it: %r", raw)
+        return None
+
+
 def _track_to_response(track: Track) -> PendingTrackResponse:
     return PendingTrackResponse(
         id=str(track.id),
@@ -201,7 +224,7 @@ def _track_to_response(track: Track) -> PendingTrackResponse:
         bitrate_mode=track.bitrate_mode,
         codec=track.codec,
         created_at=to_rfc3339(track.created_at),
-        review_info=track.review_info,
+        review_info=_to_review_info(track.review_info),
     )
 
 

--- a/backend/app/api/routes/pending_review.py
+++ b/backend/app/api/routes/pending_review.py
@@ -33,6 +33,40 @@ _REVIEW_STATUSES = {
 # ============================================================================
 
 
+class TrackQuality(BaseModel):
+    """A track's measured quality, as `QualityScore.to_dict()` writes it.
+
+    Typed for ADR-0014: this tag joined the generated Swift surface, and ADR-0007 does not allow
+    an operation in it to hand over an untyped object. Every field is optional because the values
+    are read back out of a JSONB column that predates this model — a row written by an older
+    scanner must still deserialise rather than fail the request.
+    """
+
+    format_tier: int | None = None
+    format_tier_name: str | None = None
+    bitrate: int | None = None
+    sample_rate: int | None = None
+    bit_depth: int | None = None
+    is_lossless: bool | None = None
+    bitrate_mode: str | None = None
+
+
+class ReviewInfo(BaseModel):
+    """Why a track is waiting for review — always a duplicate, currently.
+
+    Written by `detect_duplicate_for_track` and stored in `Track.review_info`. Optional throughout
+    for the same reason as `TrackQuality`: the column holds whatever earlier versions wrote.
+    """
+
+    duplicate_of: str | None = None
+    duplicate_info: str | None = None
+    duplicate_match_type: str | None = None
+    trump_status: str | None = None
+    trump_reason: str | None = None
+    incoming_quality: TrackQuality | None = None
+    existing_quality: TrackQuality | None = None
+
+
 class PendingTrackResponse(BaseModel):
     """A pending track with review_info."""
     id: str
@@ -53,7 +87,7 @@ class PendingTrackResponse(BaseModel):
     bitrate_mode: str | None
     codec: str | None
     created_at: str
-    review_info: dict[str, Any] | None
+    review_info: ReviewInfo | None
 
 
 class PendingGroupResponse(BaseModel):

--- a/backend/app/api/routes/proposed_changes.py
+++ b/backend/app/api/routes/proposed_changes.py
@@ -22,7 +22,11 @@ from app.services.proposed_changes import (
 )
 from app.utils.time import to_rfc3339
 
-router = APIRouter(prefix="/proposed-changes", tags=["Proposed Changes"])
+# Tag is kebab-case like every other one in the schema. It was "Proposed Changes" — the only tag
+# with a space and capitals — until ADR-0014 brought it into the generated Swift surface, where an
+# inconsistent tag produces one oddly-named thing nobody later understands. Renamed before anything
+# generated from it rather than after.
+router = APIRouter(prefix="/proposed-changes", tags=["proposed-changes"])
 
 
 # ============================================================================

--- a/backend/openapi.json
+++ b/backend/openapi.json
@@ -6472,12 +6472,7 @@
             "type": "string"
           },
           "review_info": {
-            "additionalProperties": true,
-            "title": "Review Info",
-            "type": [
-              "object",
-              "null"
-            ]
+            "$ref": "#/components/schemas/ReviewInfo"
           },
           "sample_rate": {
             "title": "Sample Rate",
@@ -6526,8 +6521,7 @@
           "bitrate",
           "bitrate_mode",
           "codec",
-          "created_at",
-          "review_info"
+          "created_at"
         ],
         "title": "PendingTrackResponse",
         "type": "object"
@@ -7950,6 +7944,54 @@
           }
         },
         "title": "RestoreRequest",
+        "type": "object"
+      },
+      "ReviewInfo": {
+        "description": "Why a track is waiting for review \u2014 always a duplicate, currently.\n\nWritten by `detect_duplicate_for_track` and stored in `Track.review_info`. Optional throughout\nfor the same reason as `TrackQuality`: the column holds whatever earlier versions wrote.",
+        "properties": {
+          "duplicate_info": {
+            "title": "Duplicate Info",
+            "type": [
+              "string",
+              "null"
+            ]
+          },
+          "duplicate_match_type": {
+            "title": "Duplicate Match Type",
+            "type": [
+              "string",
+              "null"
+            ]
+          },
+          "duplicate_of": {
+            "title": "Duplicate Of",
+            "type": [
+              "string",
+              "null"
+            ]
+          },
+          "existing_quality": {
+            "$ref": "#/components/schemas/TrackQuality"
+          },
+          "incoming_quality": {
+            "$ref": "#/components/schemas/TrackQuality"
+          },
+          "trump_reason": {
+            "title": "Trump Reason",
+            "type": [
+              "string",
+              "null"
+            ]
+          },
+          "trump_status": {
+            "title": "Trump Status",
+            "type": [
+              "string",
+              "null"
+            ]
+          }
+        },
+        "title": "ReviewInfo",
         "type": "object"
       },
       "RuleFieldInfo": {
@@ -10375,6 +10417,62 @@
           }
         },
         "title": "TrackMetadataUpdateRequest",
+        "type": "object"
+      },
+      "TrackQuality": {
+        "description": "A track's measured quality, as `QualityScore.to_dict()` writes it.\n\nTyped for ADR-0014: this tag joined the generated Swift surface, and ADR-0007 does not allow\nan operation in it to hand over an untyped object. Every field is optional because the values\nare read back out of a JSONB column that predates this model \u2014 a row written by an older\nscanner must still deserialise rather than fail the request.",
+        "properties": {
+          "bit_depth": {
+            "title": "Bit Depth",
+            "type": [
+              "integer",
+              "null"
+            ]
+          },
+          "bitrate": {
+            "title": "Bitrate",
+            "type": [
+              "integer",
+              "null"
+            ]
+          },
+          "bitrate_mode": {
+            "title": "Bitrate Mode",
+            "type": [
+              "string",
+              "null"
+            ]
+          },
+          "format_tier": {
+            "title": "Format Tier",
+            "type": [
+              "integer",
+              "null"
+            ]
+          },
+          "format_tier_name": {
+            "title": "Format Tier Name",
+            "type": [
+              "string",
+              "null"
+            ]
+          },
+          "is_lossless": {
+            "title": "Is Lossless",
+            "type": [
+              "boolean",
+              "null"
+            ]
+          },
+          "sample_rate": {
+            "title": "Sample Rate",
+            "type": [
+              "integer",
+              "null"
+            ]
+          }
+        },
+        "title": "TrackQuality",
         "type": "object"
       },
       "TrackResponse": {
@@ -25720,7 +25818,7 @@
         },
         "summary": "List Changes",
         "tags": [
-          "Proposed Changes"
+          "proposed-changes"
         ]
       },
       "post": {
@@ -25800,7 +25898,7 @@
         },
         "summary": "Create Change",
         "tags": [
-          "Proposed Changes"
+          "proposed-changes"
         ]
       }
     },
@@ -25886,7 +25984,7 @@
         },
         "summary": "Batch Apply",
         "tags": [
-          "Proposed Changes"
+          "proposed-changes"
         ]
       }
     },
@@ -25962,7 +26060,7 @@
         },
         "summary": "Scan For Proposals",
         "tags": [
-          "Proposed Changes"
+          "proposed-changes"
         ]
       }
     },
@@ -26034,7 +26132,7 @@
         },
         "summary": "Get Stats",
         "tags": [
-          "Proposed Changes"
+          "proposed-changes"
         ]
       }
     },
@@ -26122,7 +26220,7 @@
         },
         "summary": "Get Track Changes",
         "tags": [
-          "Proposed Changes"
+          "proposed-changes"
         ]
       }
     },
@@ -26210,7 +26308,7 @@
         },
         "summary": "Delete Change",
         "tags": [
-          "Proposed Changes"
+          "proposed-changes"
         ]
       },
       "get": {
@@ -26292,7 +26390,7 @@
         },
         "summary": "Get Change",
         "tags": [
-          "Proposed Changes"
+          "proposed-changes"
         ]
       }
     },
@@ -26376,7 +26474,7 @@
         },
         "summary": "Apply Change",
         "tags": [
-          "Proposed Changes"
+          "proposed-changes"
         ]
       }
     },
@@ -26460,7 +26558,7 @@
         },
         "summary": "Preview Change",
         "tags": [
-          "Proposed Changes"
+          "proposed-changes"
         ]
       }
     },
@@ -26544,7 +26642,7 @@
         },
         "summary": "Reject Change",
         "tags": [
-          "Proposed Changes"
+          "proposed-changes"
         ]
       }
     },
@@ -26628,7 +26726,7 @@
         },
         "summary": "Undo Change",
         "tags": [
-          "Proposed Changes"
+          "proposed-changes"
         ]
       }
     },

--- a/backend/scripts/lint_openapi.py
+++ b/backend/scripts/lint_openapi.py
@@ -37,6 +37,12 @@ GENERATED_SURFACE = {
     # Radio and offline ranking (ADR-0005, ADR-0006). Native clients consume these
     # directly — the whole point of ADR-0006 is that they carry no ranking code.
     "queue",
+    # Management surfaces the Mac app now has (ADR-0013, generated per ADR-0014). Not on
+    # iOS, which ADR-0013 point 2 keeps on the listening path — but the generated client is
+    # shared by both targets, so iOS compiles these and never calls them.
+    "pending-review",
+    "proposed-changes",
+    "mixtapes",
 }
 
 # Tags deliberately NOT generated, with the reason. Recorded rather than merely absent,
@@ -44,16 +50,19 @@ GENERATED_SURFACE = {
 #
 #   ambient   — ADR-0001 point 5 puts ambient/generative mode out of v1, and it is iOS-only
 #               anyway (`ambientSynthBridge`: "Web never registers").
-#   mixtapes  — ADR-0001 point 5, same list.
 #   outputs   — casting does not appear in ADR-0001 point 4's v1 scope. Removing it also
 #               restores the invariant ADR-0001's readiness audit claimed: the five
 #               allowlisted untyped operations that were inside the surface are all
 #               `outputs/zones/*`, so every allowlisted entry is now genuinely out of scope.
 #
+# `mixtapes` left this set in ADR-0014. It was here under ADR-0001 point 5, which ADR-0013
+# revisited: the Mac is a management surface now, and mixtapes are one of the things it gained.
+#
 # `library` stays whole despite mixing ~18 listening operations with ~17 management ones
 # (import, dedup, scan, review). Tag granularity cannot express that split, and the cost of
-# the extra 17 is dead generated code rather than a defect. Revisit if they resist typing.
-NOT_GENERATED = {"ambient", "mixtapes", "outputs"}
+# the extra 17 was dead generated code rather than a defect — under ADR-0013 those 17 stop
+# being dead, since the review surfaces need them.
+NOT_GENERATED = {"ambient", "outputs"}
 
 # Error statuses every in-scope operation must declare, so a generated client can model
 # failures. 422 is the important one: FastAPI emits HTTPValidationError for it automatically,

--- a/docs/decisions/ADR-0014-the-generated-surface-widens-to-management.md
+++ b/docs/decisions/ADR-0014-the-generated-surface-widens-to-management.md
@@ -1,11 +1,22 @@
 # ADR-0014: The Generated Surface Widens to Management
 
-Status: proposed
+Status: accepted
 
 Date: 2026-08-01
 
 Extends [ADR-0007](ADR-0007-clients-are-generated-from-openapi.md).
 Depends on [ADR-0013](ADR-0013-the-mac-is-a-management-surface-too.md).
+
+Implementation:
+- Accepted and executed 2026-08-01. Eleven tags; **33 operations** added to the generated client.
+  `Proposed Changes` renamed to `proposed-changes` first, before anything generated from it.
+- Point 6 earned its place immediately. The lint refused the widened surface over
+  `PendingTrackResponse.review_info`, a bare `dict[str, Any]` that would have generated as `Any`.
+  It was typed rather than allowlisted, as that point requires — `ReviewInfo` and `TrackQuality` in
+  `backend/app/api/routes/pending_review.py`, every field optional because the values are read back
+  out of a JSONB column older than the model and a row written by an earlier scanner must still
+  deserialise. `reviewInfo` now generates as `Components.Schemas.ReviewInfo`.
+- Backend: 64 tests over the three tags pass. Swift: 378 tests, both targets building.
 
 ## Context
 


### PR DESCRIPTION
Eleven tags instead of eight. `pending-review`, `proposed-changes` and `mixtapes` become reachable from Swift — the prerequisite ADR-0013 needs to put the review queues and mixtapes on the Mac.

Paired with `familiar-apple` **#38**, which carries the filter change and the refreshed schema.

## What moved

- **`mixtapes` left `NOT_GENERATED`.** It was excluded under ADR-0001 point 5 — the list ADR-0013 revisited — so the comment above that set now records *why* it left rather than quietly losing an entry.
- **`Proposed Changes` → `proposed-changes`, first**, before anything generated from it. It was the schema's only tag with a space and capitals; a rename costs one line now against one oddly-named thing forever afterwards.

## ADR-0014 point 6 earned its place immediately

That point says an endpoint predating ADR-0007's rules gets **fixed in the backend rather than allowlisted**. The lint refused the widened surface on the first run:

```
PendingTrackResponse.review_info: field generates as Any in the generated surface.
Type it, or add it to ALLOWED_LOOSE_FIELDS with a reason.
```

So `ReviewInfo` and `TrackQuality` now type it. **Every field is optional on purpose:** the values are read back out of a JSONB column older than the model, and a row written by an earlier scanner has to deserialise rather than fail the request. `reviewInfo` generates as `Components.Schemas.ReviewInfo` instead of an untyped container.

The note in `lint_openapi.py` about `library` carrying "~17 management operations" as tolerated dead code is updated too — under ADR-0013 those seventeen are what the review surfaces will use.

## Verification

- `lint_openapi.py`: **OK, 261 operations, 11 tags in the generated surface**
- backend: **64 tests** across the three tags pass (local DB needed migrations first — unrelated)
- Swift: **33 operations** generated, 378 tests, macOS and iOS both building

## Not here

Nothing consumes the new operations yet. The review, proposed-changes and mixtapes screens are their own work; this is the prerequisite landing alone, as ADR-0014 is scoped.