### PR TITLE
Accept ADR-0016 — Discover embeds, the map is built native

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -68,18 +68,22 @@ ranking engine, precomputed offline ranking, and OpenAPI-generated clients.
 The ordering principle: **server-side work that every client inherits comes before client work**, and
 anything that accumulates data over time starts as early as possible.
 
-**`ADR-0013`–`ADR-0016` bring management surfaces to the Mac app** (proposed 2026-08-01). `0013`
-supersedes `0002`: macOS becomes a management surface alongside the web app, which keeps everything;
-iOS stays the listening path. Their own order:
+**`ADR-0013`–`ADR-0016` bring management surfaces to the Mac app** (all four accepted 2026-08-01).
+`0013` supersedes `0002`: macOS becomes a management surface alongside the web app, which keeps
+everything; iOS stays the listening path. Their own order:
 
 | # | ADR | Why here |
 |---|---|---|
 | 1 | `0013` | Framing only, and the one that supersedes. Nothing else is coherent without it. |
 | 2 | `0014` | Widens the generated surface to eleven tags. Cheap, and unblocks pending review, proposed changes and mixtapes. |
-| 3 | `0015`, `0016` | Independent of each other. `0015` exposes five effects the engine already has; `0016` decides embed-vs-native and covers Discover and Music Map. |
+| 3 | `0015`, `0016` | Independent of each other. `0015` exposes six effects the engine already has; `0016` decides embed-vs-native and covers Discover and Music Map. |
 
 Smart playlist CRUD and the album/artist grids need no ADR — ordinary work inside `0013`'s direction,
-and both depend on nothing, so they are the fastest visible wins once `0013` is accepted.
+and both depend on nothing, so they were the fastest visible wins once `0013` was accepted.
+
+Within `0016`, **Music Map comes before embedded Discover**: the two halves are independent, and the
+map is one self-contained screen against endpoints that already generate, while the embedding half
+carries point 4's rule that an embedded page must never construct a second audio engine.
 
 ## Key Directories
 

--- a/docs/decisions/ADR-0016-embedded-web-surfaces-on-the-mac.md
+++ b/docs/decisions/ADR-0016-embedded-web-surfaces-on-the-mac.md
@@ -1,10 +1,22 @@
 # ADR-0016: Embedded Web Surfaces on the Mac
 
-Status: proposed
+Status: accepted
 
 Date: 2026-08-01
 
 Extends [ADR-0013](ADR-0013-the-mac-is-a-management-surface-too.md).
+
+Implementation:
+- Accepted 2026-08-01. One citation in the proposed draft was corrected against the repo before
+  acceptance rather than after: Discover's **2,943 lines across 26 files** is right, but it is not
+  all in `packages/frontend/src/components/Discovery/`. That directory holds 22 files and 2,458
+  lines; the remaining 4 files and 485 lines are in
+  `packages/frontend/src/components/Library/browsers/DiscoverBrowser/`. The size that decided
+  point 2 is unchanged — the address was incomplete, not the measurement.
+- The other figures were re-checked and hold: `VibeMap.tsx` is 690 lines,
+  `library_maps.py` caps at 200 and 500 on lines 58 and 73, and `packages/web/src/main.tsx:14` is
+  the unconditional `registerEngineFactory` call that point 4 exists to contain.
+- Music Map first, being independent of the embedding half and much the lower risk of the two.
 
 ## Context
 
@@ -18,6 +30,12 @@ Measured on 2026-08-01:
 |---|---|---|
 | Discover | **2,943 lines across 26 files** (`packages/frontend/src/components/Discovery/`) | ordinary React |
 | Music Map | **690 lines in one file** (`…/Library/browsers/VibeMap/VibeMap.tsx`) | Canvas 2D |
+
+Discover's row is two directories, not one, and the row above understated that: 22 files and 2,458
+lines in `components/Discovery/`, plus 4 files and 485 lines in
+`components/Library/browsers/DiscoverBrowser/`. Corrected here rather than quietly, because anyone
+checking the figure would otherwise find 2,458 at the address given and conclude the ADR was wrong
+about the size — when it is the split that was missing.
 
 Discover is also the surface most likely to keep moving: it aggregates external sources, and its shape
 follows what those sources make available. A native rebuild is a second implementation to change every


### PR DESCRIPTION
The last of the ADR-0013 set. Discover goes in a `WKWebView`; Music Map is rebuilt in SwiftUI `Canvas`. The deciding axis is churn and surface size, not rendering — the performance argument for a native map does not survive the payload being capped at 200–500 entities.

**One citation corrected before acceptance rather than after.** Discover's *2,943 lines across 26 files* is right, but it is not all at the address the draft gave. `components/Discovery/` holds 22 files and 2,458 lines; the other 4 files and 485 lines are in `components/Library/browsers/DiscoverBrowser/`. The measurement that decided point 2 is unchanged, so this is recorded in the Context and the Implementation block rather than quietly patched — a reader who checked the figure at the stated path would find 2,458 and conclude the ADR had the size wrong, when what was missing is the split.

Everything else re-checked and holds: `VibeMap.tsx` is 690 lines, `library_maps.py` caps at 200 and 500 on lines 58 and 73, and `packages/web/src/main.tsx:14` is the unconditional `registerEngineFactory` call that point 4 exists to contain.

CLAUDE.md picks up two stale things while it is open: the 0013–0016 set is no longer `proposed`, and 0015 exposes **six** effects rather than five — corrected at that ADR's own acceptance, never carried across.

Execution note added: **Music Map before embedded Discover.** The halves are independent, and the map is one self-contained screen against endpoints that already generate.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_014P9p2fvFnyiywBxGkv4gfW