### PR TITLE
Asking what audio can do no longer starts audio

### DIFF
--- a/packages/frontend/src/player/audio/__tests__/engineInstance.test.ts
+++ b/packages/frontend/src/player/audio/__tests__/engineInstance.test.ts
@@ -1,0 +1,159 @@
+import { describe, it, expect, beforeEach, vi, afterEach } from 'vitest';
+import type { AudioEngine, AudioEngineCapabilities } from '../types';
+import {
+  registerEngineFactory,
+  resetEngineFactoryForTesting,
+  getDeclaredCapabilities,
+  createEngine,
+} from '../createEngine';
+import {
+  getEngine,
+  getEngineCapabilities,
+  areAudioEffectsAvailable,
+  isVisualizerAvailable,
+  getCurrentMode,
+  getAudioAnalyser,
+  getAudioContext,
+  getGlobalMasterGain,
+  getEngineOutputStream,
+  resetEngineForTesting,
+} from '../engineInstance';
+
+/**
+ * The rule these exist for: **asking what audio can do must not start audio.**
+ *
+ * Every capability helper used to begin with a `getEngine()` call, so a component deciding whether
+ * to draw a visualizer button constructed a `WebAudioEngine` and an `AudioContext` without playing
+ * anything. It went unnoticed in a browser, where an engine is wanted eventually anyway. It matters
+ * for ADR-0016's embedded Mac surface, which reasons that a browse-only page constructs no second
+ * engine — a conclusion that was false precisely because a question was enough to build one.
+ */
+
+const WEB_LIKE: AudioEngineCapabilities = { crossfade: true, visualizer: true, effects: 'web' };
+const NATIVE_LIKE: AudioEngineCapabilities = { crossfade: true, visualizer: false, effects: 'native' };
+
+function fakeEngine(capabilities: AudioEngineCapabilities = WEB_LIKE): AudioEngine {
+  return {
+    capabilities,
+    initialize: () => true,
+    dispose: () => {},
+    load: async () => {},
+    play: async () => {},
+    pause: () => {},
+    seek: () => {},
+    stop: () => {},
+    setVolume: () => {},
+    setNormalizationGain: () => {},
+    getCurrentTime: () => 0,
+    getDuration: () => 0,
+    getLoadedTrackId: () => null,
+    on: () => () => {},
+    updateNowPlaying: () => {},
+  };
+}
+
+describe('engine capabilities', () => {
+  let built: number;
+
+  beforeEach(() => {
+    resetEngineForTesting();
+    resetEngineFactoryForTesting();
+    built = 0;
+  });
+
+  afterEach(() => {
+    resetEngineForTesting();
+    resetEngineFactoryForTesting();
+    vi.restoreAllMocks();
+  });
+
+  function register(capabilities: AudioEngineCapabilities = WEB_LIKE) {
+    registerEngineFactory(() => {
+      built += 1;
+      return fakeEngine(capabilities);
+    }, capabilities);
+  }
+
+  it('answers every capability question without constructing an engine', () => {
+    register();
+
+    expect(getEngineCapabilities()).toEqual(WEB_LIKE);
+    expect(areAudioEffectsAvailable()).toBe(true);
+    expect(isVisualizerAvailable()).toBe(true);
+    expect(getCurrentMode()).toBe('webaudio');
+
+    // The whole point. This was 1 before the split, from the first question asked.
+    expect(built).toBe(0);
+  });
+
+  it('hands out no live audio nodes before anything has played, and builds nothing looking', () => {
+    register();
+
+    expect(getAudioAnalyser()).toBeNull();
+    expect(getAudioContext()).toBeNull();
+    expect(getGlobalMasterGain()).toBeNull();
+    expect(getEngineOutputStream()).toBeNull();
+
+    expect(built).toBe(0);
+  });
+
+  it('constructs exactly one engine, and only when playback asks for it', () => {
+    register();
+    expect(built).toBe(0);
+
+    const first = getEngine();
+    expect(built).toBe(1);
+    expect(getEngine()).toBe(first);
+    expect(built).toBe(1);
+  });
+
+  it('reports no capabilities when nothing is registered, rather than throwing', () => {
+    // An embedded browse-only surface registers no engine. A capability question there has an
+    // answer — "none" — while a request to play does not.
+    expect(getEngineCapabilities()).toEqual({ crossfade: false, visualizer: false, effects: 'none' });
+    expect(areAudioEffectsAvailable()).toBe(false);
+    expect(isVisualizerAvailable()).toBe(false);
+    expect(getAudioAnalyser()).toBeNull();
+
+    expect(() => createEngine()).toThrow(/No audio engine registered/);
+  });
+
+  it('reads native effects as native mode', () => {
+    register(NATIVE_LIKE);
+    expect(getCurrentMode()).toBe('native');
+    expect(areAudioEffectsAvailable()).toBe(true);
+    expect(isVisualizerAvailable()).toBe(false);
+    expect(built).toBe(0);
+  });
+
+  it('remembers what was declared', () => {
+    expect(getDeclaredCapabilities()).toBeNull();
+    register(NATIVE_LIKE);
+    expect(getDeclaredCapabilities()).toEqual(NATIVE_LIKE);
+  });
+
+  /**
+   * The cost of moving capabilities off the instance: two things now state them, and they can drift.
+   * Reported rather than thrown — a mismatch is a developer error, and taking playback down for it
+   * would be worse than the bug.
+   */
+  it('complains loudly if the declaration disagrees with the engine it describes', () => {
+    const error = vi.spyOn(console, 'error').mockImplementation(() => {});
+    // Declares web effects, builds an engine that has none.
+    registerEngineFactory(() => fakeEngine({ crossfade: true, visualizer: true, effects: 'none' }), WEB_LIKE);
+
+    getEngine();
+
+    expect(error).toHaveBeenCalledWith(
+      expect.stringContaining('do not match'),
+      expect.objectContaining({ declared: WEB_LIKE })
+    );
+  });
+
+  it('stays quiet when the declaration is right', () => {
+    const error = vi.spyOn(console, 'error').mockImplementation(() => {});
+    register();
+    getEngine();
+    expect(error).not.toHaveBeenCalled();
+  });
+});

--- a/packages/frontend/src/player/audio/createEngine.ts
+++ b/packages/frontend/src/player/audio/createEngine.ts
@@ -1,14 +1,39 @@
-import type { AudioEngine } from './types';
+import type { AudioEngine, AudioEngineCapabilities } from './types';
 
 /**
  * Registration-based engine factory.
  * Platform-specific packages (web, ios) register their engine implementation
  * at boot time, before the app renders.
+ *
+ * Capabilities are registered *alongside* the factory, and separately from it, because asking what
+ * an engine can do must not build one. See `engineInstance.ts` for the defect that caused: a
+ * component deciding whether to draw a visualizer button was constructing an `AudioContext`.
  */
 let factory: (() => AudioEngine) | null = null;
+let declared: AudioEngineCapabilities | null = null;
 
-export function registerEngineFactory(f: () => AudioEngine): void {
+/**
+ * @param capabilities What the engine this factory builds will report. Required, and passed here
+ *   rather than read off an instance, so the answer exists before anything is constructed. It is
+ *   checked against the real engine the first time one is built — see `assertCapabilitiesMatch`.
+ */
+export function registerEngineFactory(
+  f: () => AudioEngine,
+  capabilities: AudioEngineCapabilities
+): void {
   factory = f;
+  declared = capabilities;
+}
+
+/**
+ * What the registered engine can do, without building it.
+ *
+ * `null` when nothing has been registered, which callers turn into "can do nothing" rather than
+ * into an error — a capability question has a sensible answer before boot completes, unlike a
+ * request to play something.
+ */
+export function getDeclaredCapabilities(): AudioEngineCapabilities | null {
+  return declared;
 }
 
 export function createEngine(): AudioEngine {
@@ -16,4 +41,33 @@ export function createEngine(): AudioEngine {
     throw new Error('No audio engine registered. Call registerEngineFactory() before rendering the app.');
   }
   return factory();
+}
+
+/**
+ * Catches a declaration that has drifted from the engine it describes.
+ *
+ * The cost of moving capabilities off the instance is that two things now state them, and they can
+ * disagree — a silent, confusing failure where the UI offers effects the engine does not have.
+ * Reported loudly at the one moment both are in hand, rather than thrown: a mismatch is a developer
+ * error, and taking playback down for it would be worse than the bug it reports.
+ */
+export function assertCapabilitiesMatch(engine: AudioEngine): void {
+  if (!declared) return;
+  const actual = engine.capabilities;
+  if (
+    declared.crossfade !== actual.crossfade ||
+    declared.visualizer !== actual.visualizer ||
+    declared.effects !== actual.effects
+  ) {
+    console.error(
+      '[audio] Registered capabilities do not match the engine that was built.',
+      { declared, actual }
+    );
+  }
+}
+
+/** Test-only: forget the registration, so a suite can register a different engine. */
+export function resetEngineFactoryForTesting(): void {
+  factory = null;
+  declared = null;
 }

--- a/packages/frontend/src/player/audio/engineInstance.ts
+++ b/packages/frontend/src/player/audio/engineInstance.ts
@@ -1,5 +1,5 @@
-import type { AudioEngine } from './types';
-import { createEngine } from './createEngine';
+import type { AudioEngine, AudioEngineCapabilities } from './types';
+import { assertCapabilitiesMatch, createEngine, getDeclaredCapabilities } from './createEngine';
 
 // ============================================================================
 // Singleton Engine Instance
@@ -9,55 +9,94 @@ let engine: AudioEngine | null = null;
 
 /**
  * Get the singleton AudioEngine instance. Creates it on first call.
+ *
+ * **This is the only place an engine is ever constructed, and only playback should reach it.** That
+ * was not true until ADR-0017's follow-up: every capability helper below used to start with a
+ * `getEngine()` call, so asking whether effects were available built a `WebAudioEngine` and, with
+ * it, an `AudioContext`. A component deciding whether to draw a visualizer button was starting the
+ * audio stack, having played nothing.
+ *
+ * It mattered most where it was least visible. ADR-0016 point 4 governs embedding a web surface in
+ * the Mac app and reasons that a browse-only page constructs no second engine — which was false for
+ * exactly this reason, since a settings or player component asking a question was enough. The
+ * separation below is what makes that premise true rather than aspirational.
  */
 export function getEngine(): AudioEngine {
   if (!engine) {
     engine = createEngine();
+    assertCapabilitiesMatch(engine);
   }
   return engine;
 }
 
+/**
+ * The engine if one has already been built, and never a new one.
+ *
+ * Everything below that reaches into a live audio graph goes through this. Before anything has
+ * played there are no nodes to hand out, and `null` is the honest answer — building an engine to
+ * discover it has no analyser yet is how the graph came to exist before it was wanted.
+ */
+function existingEngine(): AudioEngine | null {
+  return engine;
+}
+
 // ============================================================================
-// Convenience Getters (used by visualizer, effects, WebRTC, debug)
+// Capabilities — answered from the registration, never by constructing
+// ============================================================================
+
+/** What an unregistered app can do, which is nothing. */
+const NO_CAPABILITIES: AudioEngineCapabilities = {
+  crossfade: false,
+  visualizer: false,
+  effects: 'none',
+};
+
+/**
+ * What the audio engine can do, whether or not one exists yet.
+ *
+ * Reads the descriptor the platform entry point registered beside its factory. A surface that
+ * registers nothing — an embedded browse-only page — gets `NO_CAPABILITIES`, so the UI hides the
+ * controls it cannot honour instead of throwing.
+ */
+export function getEngineCapabilities(): AudioEngineCapabilities {
+  return getDeclaredCapabilities() ?? NO_CAPABILITIES;
+}
+
+export function areAudioEffectsAvailable(): boolean {
+  return getEngineCapabilities().effects !== 'none';
+}
+
+export function isVisualizerAvailable(): boolean {
+  return getEngineCapabilities().visualizer;
+}
+
+export function getCurrentMode(): 'webaudio' | 'native' {
+  return getEngineCapabilities().effects === 'native' ? 'native' : 'webaudio';
+}
+
+// ============================================================================
+// Live audio nodes (used by visualizer, effects, WebRTC, debug)
 // ============================================================================
 
 export function getAudioAnalyser(): AnalyserNode | null {
-  const e = getEngine();
-  return e.getAnalyser?.() ?? null;
+  return existingEngine()?.getAnalyser?.() ?? null;
 }
 
 export function getAudioContext(): AudioContext | null {
-  const e = getEngine();
-  return e.getAudioContext?.() ?? null;
+  return existingEngine()?.getAudioContext?.() ?? null;
 }
 
 export function getGlobalMasterGain(): GainNode | null {
-  const e = getEngine();
-  return e.getMasterGainNode?.() ?? null;
+  return existingEngine()?.getMasterGainNode?.() ?? null;
 }
 
 /**
  * MediaStream branched off the engine's master output, for WebRTC streaming.
- * Returns null when the engine has no implementation (iOS) or audio isn't running yet.
+ * Returns null when the engine has no implementation (iOS), when audio isn't running yet, or when
+ * nothing has been played at all.
  */
 export function getEngineOutputStream(): MediaStream | null {
-  const e = getEngine();
-  return e.getOutputStream?.() ?? null;
-}
-
-export function areAudioEffectsAvailable(): boolean {
-  const e = getEngine();
-  return e.capabilities.effects !== 'none';
-}
-
-export function isVisualizerAvailable(): boolean {
-  const e = getEngine();
-  return e.capabilities.visualizer;
-}
-
-export function getCurrentMode(): 'webaudio' | 'native' {
-  const e = getEngine();
-  return e.capabilities.effects === 'native' ? 'native' : 'webaudio';
+  return existingEngine()?.getOutputStream?.() ?? null;
 }
 
 // ============================================================================

--- a/packages/ios/src/main.tsx
+++ b/packages/ios/src/main.tsx
@@ -20,7 +20,12 @@ if (!nativeAudioV2Enabled) {
 }
 
 // Register Capacitor audio engine
-registerEngineFactory(() => new CapacitorEngine());
+// See the web entry point: declared beside the factory so a capability question constructs nothing.
+registerEngineFactory(() => new CapacitorEngine(), {
+  crossfade: true,
+  visualizer: false,
+  effects: 'none',
+});
 
 // Register ambient synth bridge (deferred — must not block boot)
 import { registerAmbientSynthBridge } from '@familiar/frontend/src/player/ambient/ambientSynthBridge';

--- a/packages/web/src/main.tsx
+++ b/packages/web/src/main.tsx
@@ -11,7 +11,14 @@ declare const __BUILD_TIME__: string;
 console.log(`[App] Build: ${typeof __BUILD_TIME__ !== 'undefined' ? __BUILD_TIME__ : 'dev'}`);
 
 // Register Web Audio engine
-registerEngineFactory(() => new WebAudioEngine());
+// Capabilities are declared here as well as on the engine, so that asking what audio can do never
+// builds an audio graph — see `engineInstance.ts`. They are checked against the real engine the
+// first time one is constructed.
+registerEngineFactory(() => new WebAudioEngine(), {
+  crossfade: true,
+  visualizer: true,
+  effects: 'web',
+});
 
 // Global handler for unhandled promise rejections
 window.addEventListener('unhandledrejection', (event) => {


### PR DESCRIPTION
**Off `main`, independent of the ADR stack** — it's an ordinary defect fix, and it's ADR-0017's own first follow-up.

Every capability helper in `engineInstance.ts` began with `getEngine()`, and `getEngine()` is the only place an engine is ever constructed. So a component deciding whether to draw a visualizer button built a `WebAudioEngine` — and an `AudioContext` — having played nothing. `Settings/index.tsx:106`, four calls across `FullPlayer.tsx`, five in `DebugSettings.tsx`, two in `AudioEffectsSettings.tsx`, all on render.

In a browser this went unnoticed: an engine is wanted eventually anyway, and a context created outside a user gesture is suspended until it isn't. It matters where a *second* engine is the defect — ADR-0016 point 4 concludes that a browse-only embedded page constructs none, which didn't follow, because a question was enough.

## The fix

- **Capabilities are registered beside the factory**, not read off an instance, so the answer exists before anything is built. Both entry points declare theirs. The declaration is checked against the real engine the first time one is constructed — that's the cost of having two sources of the same truth, so it's guarded rather than assumed. Reported loudly, not thrown: taking playback down over a developer error is worse than the error.
- **The live-node getters return what exists and never build.** Before anything has played there is no analyser, and `null` is the honest answer. Every caller already handled it — `useAudioAnalyser` and `useWebRTCStreaming` guard, and their test files were already mocking exactly this.

`getEngine()` is now reached only from playback: `useAudioEngine`, `useAudioControls`, `queueStore`, `useKeyboardShortcuts`, `AmbientCoordinator`.

## Tests

The 8 new tests assert the property directly rather than the symptom: a counter inside the registered factory that must still read **zero** after every capability question and every live-node getter. Two more cover the drift guard in both directions, and one covers the unregistered case — capability questions answer "none" while `createEngine()` still throws, which is the distinction that makes an embedded surface possible without making a registration bug silent.

948 frontend tests pass; both entry points build. The 3 `window is not defined` teardown errors in `useOfflineAlbum.test.ts` are pre-existing — confirmed identical with these changes stashed.

## Knock-on

This changes the argument in **#61 (ADR-0017)**, which I'll update: the finding it was written around is now fixed, but the null engine survives on a different and better argument — `DiscoverTrackList` drives `playerStore` and `DiscoverBrowser` calls `onPlayTrack`, so an embedded Discover has real play paths that still reach `getEngine()`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_014P9p2fvFnyiywBxGkv4gfW