### PR TITLE
Accept ADR-0017 and give the embedded surface its own entry point

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -85,13 +85,15 @@ Within `0016`, **Music Map comes before embedded Discover**: the two halves are 
 map is one self-contained screen against endpoints that already generate, while the embedding half
 carries point 4's rule that an embedded page must never construct a second audio engine.
 
-**`ADR-0017` (`proposed`) must land before embedded Discover is built.** It extends `0016`. It began
+**`ADR-0017` (`accepted`, web half shipped) governs how embedded Discover boots.** It extends `0016`. It began
 by recording that point 4's conclusion — forbid playback, and no second engine is constructed — did
 not hold, because seven capability helpers constructed one without playing anything. That cause has
 since been fixed, and the ADR records both that and why it still stands: **Discover itself plays
 music** (`DiscoverTrackList` drives `playerStore`), so an embedded copy has real construction paths,
 and the bridge has to catch every one. The **null audio engine** on its own entry point is what makes
-a missed intent inert rather than a second engine.
+a missed intent inert rather than a second engine. The web half is built — `/embed` serves its own
+document registering the null engine. What remains is `familiar-apple`: the `WKWebView`, the
+`WKScriptMessageHandler` that receives the play intent, and the native "unavailable" state.
 
 ## Key Directories
 

--- a/backend/app/main.py
+++ b/backend/app/main.py
@@ -511,6 +511,28 @@ STATIC_DIR = Path(__file__).parent.parent / "static"
 NON_SPA_PREFIXES = ("api/", "docs", "redoc", "openapi.json", "health")
 
 
+async def serve_embed() -> FileResponse:
+    """Serve the embedded surface's own document (ADR-0017).
+
+    A second entry point, not a route inside the single-page app. The Mac app points a `WKWebView`
+    here (ADR-0016 point 2), and the document it gets registers a **null audio engine** — so a play
+    path the bridge fails to intercept is inert rather than a second `WebAudioEngine` competing for
+    the audio session. Serving `index.html` here instead would hand the web view the full app,
+    engine and all, which is the one thing this must not do.
+
+    Defined at module scope for the reason `spa_fallback` records below: as a closure inside the
+    `if STATIC_DIR.exists()` block it would be unreachable from the suite, and that is how a bug this
+    visible survived once already.
+    """
+    embed = STATIC_DIR / "embed.html"
+    if not embed.exists():
+        # A server built before this existed. A typed 404 is better than a `FileResponse` for a
+        # missing path, which surfaces as a 500 with a stack trace in the log and nothing useful in
+        # the web view.
+        raise NotFoundError("This server has no embedded surface build.")
+    return FileResponse(embed)
+
+
 async def spa_fallback(full_path: str) -> FileResponse:
     """Serve index.html for SPA routing (catches all non-API routes).
 
@@ -560,6 +582,10 @@ if STATIC_DIR.exists():
     async def serve_root() -> FileResponse:
         """Serve index.html for root path."""
         return FileResponse(STATIC_DIR / "index.html")
+
+    # Registered before the catch-all below, which would otherwise swallow it and hand the web view
+    # the full app.
+    app.get("/embed", response_model=None)(serve_embed)
 
     # SPA fallback - serve index.html for all non-API routes
     app.get("/{full_path:path}", response_model=None)(spa_fallback)

--- a/backend/tests/test_contract_error_shapes.py
+++ b/backend/tests/test_contract_error_shapes.py
@@ -143,3 +143,46 @@ async def test_spa_fallback_still_serves_the_app_for_client_routes() -> None:
 
     for path in ("", "library", "playlists/abc", "settings/audio"):
         assert isinstance(await spa_fallback(path), FileResponse)
+
+
+async def test_embed_route_serves_its_own_document_not_the_app() -> None:
+    """The embedded surface must never be handed `index.html` (ADR-0017).
+
+    That document registers `WebAudioEngine`, so serving it to the Mac app's web view would put a
+    second audio engine one play button away from the native player — the defect ADR-0016 point 4
+    exists to prevent, arriving from inside a `WKWebView` where it is hardest to diagnose.
+
+    Called directly rather than through `client`, for the same reason as the two above: the route is
+    only registered when a static build exists, and the suite runs without one.
+    """
+    from pathlib import Path
+    from unittest.mock import patch
+
+    from fastapi.responses import FileResponse
+
+    from app import main
+
+    with patch.object(main, "STATIC_DIR", Path(__file__).parent):
+        # `test_contract_error_shapes.py` is beside this file, so a file that exists stands in for
+        # the built document without needing a fixture on disk.
+        with patch.object(Path, "exists", lambda self: True):
+            response = await main.serve_embed()
+
+    assert isinstance(response, FileResponse)
+    assert response.path.name == "embed.html", "the embed route must not serve index.html"
+
+
+async def test_embed_route_404s_when_the_build_predates_it() -> None:
+    """A server built before the embedded surface existed says so, rather than 500ing.
+
+    `FileResponse` on a missing path raises at send time, which surfaces as a stack trace in the log
+    and a blank web view — the least diagnosable combination for a screen inside a native app.
+    """
+    import pytest
+
+    from app.api.exceptions import NotFoundError
+    from app import main
+
+    with pytest.raises(NotFoundError) as caught:
+        await main.serve_embed()
+    assert caught.value.status_code == 404

--- a/backend/tests/test_contract_error_shapes.py
+++ b/backend/tests/test_contract_error_shapes.py
@@ -180,8 +180,8 @@ async def test_embed_route_404s_when_the_build_predates_it() -> None:
     """
     import pytest
 
-    from app.api.exceptions import NotFoundError
     from app import main
+    from app.api.exceptions import NotFoundError
 
     with pytest.raises(NotFoundError) as caught:
         await main.serve_embed()

--- a/docs/decisions/ADR-0017-the-embedded-surface-gets-a-null-audio-engine.md
+++ b/docs/decisions/ADR-0017-the-embedded-surface-gets-a-null-audio-engine.md
@@ -1,10 +1,24 @@
 # ADR-0017: The Embedded Surface Gets a Null Audio Engine
 
-Status: proposed
+Status: accepted
 
 Date: 2026-08-01
 
 Extends [ADR-0016](ADR-0016-embedded-web-surfaces-on-the-mac.md).
+
+Implementation:
+- Accepted 2026-08-01, together with its web-side half, on `feat/embed-entry-point`. Points 1, 2, 4,
+  6 and 7 are shipped: `packages/web/embed.html` and `src/embed.tsx` register `NullAudioEngine`
+  beside `WebAudioEngine`, `renderEmbed.tsx` mounts Discover with the providers it needs and nothing
+  else, and the server serves the document at `/embed` (`serve_embed` in `backend/app/main.py`).
+- Its first follow-up was done *before* acceptance rather than after, and changed the argument for
+  this ADR rather than the decision — see the Context section on what the fix did and what survived
+  it.
+- Point 5's bridge exists only on the page side so far: `services/embedBridge.ts` posts the play
+  intent, and nothing receives it yet. That is deliberate — the intent being dropped is the correct
+  failure until the Swift half lands, and it is the exact case the null engine makes inert.
+- Not yet built: the `WKWebView` host, the `WKScriptMessageHandler` that receives the intent, and
+  points 3's native "unavailable" state — all of them `familiar-apple` work under ADR-0016.
 
 ## Context
 

--- a/packages/frontend/src/components/Embed/EmbedDiscover.tsx
+++ b/packages/frontend/src/components/Embed/EmbedDiscover.tsx
@@ -1,0 +1,85 @@
+import { lazy, Suspense, useCallback } from 'react';
+import { Loader2 } from 'lucide-react';
+import type { BrowserProps, LibraryFilters } from '../Library/types';
+import { postPlayIntent } from '../../services/embedBridge';
+
+// Imported directly rather than through `browsers/index.ts`, which registers all nine and would pull
+// the track list, the album grid and the Music Map into a bundle that shows none of them.
+const DiscoverBrowser = lazy(() => import('../Library/browsers/DiscoverBrowser/DiscoverBrowser'));
+
+/**
+ * Discover, alone, for the embedded surface (ADR-0016 point 2, ADR-0017).
+ *
+ * `DiscoverBrowser` takes the full `BrowserProps` because every library browser does, and reads two
+ * of its twenty-two fields. The rest are supplied empty here rather than cast away, so that a field
+ * it starts reading later is a type error at this seam instead of `undefined` at runtime — this file
+ * is the boundary between a 2,943-line surface and a native app, and ADR-0016 names that seam as the
+ * main risk of embedding at all.
+ */
+export function EmbedDiscover() {
+  /**
+   * A play button in Discover posts to the native player and does nothing else.
+   *
+   * Discover hands over one track id, so the intent is a queue of one. That is honest — it is what
+   * was asked for — rather than inventing surrounding context the surface never offered.
+   */
+  const handlePlayTrack = useCallback((trackId: string) => {
+    postPlayIntent({ trackIds: [trackId], startingAt: trackId });
+  }, []);
+
+  const props: BrowserProps = {
+    tracks: [],
+    artists: [],
+    albums: [],
+    isLoading: false,
+
+    // Selection exists to build playlists out of a track list. There is no track list here.
+    selectedTrackIds: new Set<string>(),
+    onSelectTrack: noop,
+    onSelectAll: noop,
+    onClearSelection: noop,
+
+    // Navigation is the open question ADR-0017 leaves as a follow-up: this surface renders Discover
+    // and has nowhere else to go, so these are inert rather than routes to blank screens. The router
+    // in `renderEmbed` sends any internal navigation back here for the same reason.
+    onGoToArtist: noop,
+    onGoToAlbum: noop,
+    onGoToYear: noop,
+    onGoToYearRange: noop,
+    onGoToGenre: noop,
+    onGoToMood: noop,
+
+    onPlayTrack: handlePlayTrack,
+    // Discover has no index to play at, and queueing is a native-side concept here — the bridge is
+    // one message wide (ADR-0016 point 5) and "play" is that message.
+    onPlayTrackAt: (trackId: string) => handlePlayTrack(trackId),
+    onQueueTrack: noop,
+
+    onEditTrack: noop,
+
+    filters: EMPTY_FILTERS,
+    onFilterChange: noop,
+  };
+
+  return (
+    <div className="min-h-screen bg-zinc-900 text-zinc-100">
+      <Suspense fallback={<EmbedLoading />}>
+        <DiscoverBrowser {...props} />
+      </Suspense>
+    </div>
+  );
+}
+
+function EmbedLoading() {
+  return (
+    <div role="status" aria-label="Loading" className="flex items-center justify-center py-20">
+      <Loader2 className="w-8 h-8 animate-spin text-zinc-400" />
+    </div>
+  );
+}
+
+function noop() {}
+
+// Every field on `LibraryFilters` is optional, so this needs no cast — which is the point of
+// building the props out rather than asserting them.
+const EMPTY_FILTERS: LibraryFilters = {};

--- a/packages/frontend/src/renderEmbed.tsx
+++ b/packages/frontend/src/renderEmbed.tsx
@@ -1,0 +1,53 @@
+import { StrictMode } from 'react';
+import { createRoot } from 'react-dom/client';
+import { QueryClient, QueryClientProvider } from '@tanstack/react-query';
+import { BrowserRouter } from 'react-router-dom';
+import { initApiOrigin, registerProfileProvider } from './api/base';
+import { getSelectedProfileId, clearSelectedProfile } from './services/profileSelection';
+import { EmbedDiscover } from './components/Embed/EmbedDiscover';
+
+/**
+ * Boots the embedded surface (ADR-0017).
+ *
+ * The sibling of `renderApp`, and deliberately not a variant of it. `App.tsx` is a router with a
+ * shell, a transport, a profile selector and thirteen routes; this renders one screen with the
+ * providers that screen needs and nothing else.
+ *
+ * **The point is what it does not mount.** ADR-0017 rejects "the full web app with its chrome
+ * hidden" because hiding is not preventing — `useAudioEngine` mounts with the player and constructs
+ * an engine whether or not anyone can see it. Reaching that conclusion required a separate entry
+ * point, and this is the shared half of it; the platform half registers the null engine before
+ * calling this.
+ *
+ * A `BrowserRouter` is here despite there being nowhere to navigate: `DiscoverBrowser` calls
+ * `useNavigate`, and several cards below it use `Link`. Without a router in the tree those throw. It
+ * is a real router over a surface with one route, which is cheaper than teasing routing out of a
+ * 2,943-line surface that ADR-0016 embedded precisely to avoid maintaining twice.
+ */
+export function renderEmbed(options?: { onReady?: () => void }): void {
+  registerProfileProvider({ getSelectedProfileId, clearSelectedProfile });
+
+  // Its own client, with the app's defaults. The embedded page is a separate document with a
+  // separate cache; nothing is shared with a browser tab that happens to have the app open.
+  const queryClient = new QueryClient({
+    defaultOptions: {
+      queries: {
+        staleTime: 1000 * 60 * 5,
+        retry: 1,
+      },
+    },
+  });
+
+  initApiOrigin().then(() => {
+    options?.onReady?.();
+    createRoot(document.getElementById('root')!).render(
+      <StrictMode>
+        <QueryClientProvider client={queryClient}>
+          <BrowserRouter>
+            <EmbedDiscover />
+          </BrowserRouter>
+        </QueryClientProvider>
+      </StrictMode>,
+    );
+  });
+}

--- a/packages/frontend/src/services/__tests__/embedBridge.test.ts
+++ b/packages/frontend/src/services/__tests__/embedBridge.test.ts
@@ -1,0 +1,91 @@
+import { describe, it, expect, beforeEach, afterEach, vi } from 'vitest';
+import { isEmbedded, postPlayIntent, BRIDGE_HANDLER, type PlayIntent } from '../embedBridge';
+
+/**
+ * The seam ADR-0016 names as the main risk of embedding: two clients that were independent now share
+ * one message shape, and a change on this side can break the native app through it.
+ *
+ * So these pin the shape, and they pin the two failure modes that matter — inert in a browser, and
+ * inert rather than throwing when the native side misbehaves. "Inert" is the correct failure here:
+ * ADR-0017 puts a null audio engine underneath precisely so that nothing playing is the worst
+ * outcome, rather than a second engine.
+ */
+describe('embedBridge', () => {
+  let posted: unknown[];
+
+  function installHandler(impl?: (message: unknown) => void) {
+    posted = [];
+    (window as unknown as Record<string, unknown>).webkit = {
+      messageHandlers: {
+        [BRIDGE_HANDLER]: {
+          postMessage: impl ?? ((message: unknown) => posted.push(message)),
+        },
+      },
+    };
+  }
+
+  beforeEach(() => {
+    posted = [];
+    delete (window as unknown as Record<string, unknown>).webkit;
+  });
+
+  afterEach(() => {
+    delete (window as unknown as Record<string, unknown>).webkit;
+    vi.restoreAllMocks();
+  });
+
+  it('is inert in an ordinary browser', () => {
+    // This module lives in the shared package, so it is loaded by the web app and the iOS app too.
+    // Posting into nothing must be a no-op, not a crash.
+    expect(isEmbedded()).toBe(false);
+    expect(postPlayIntent({ trackIds: ['a'], startingAt: 'a' })).toBe(false);
+  });
+
+  it('detects a native host and posts the agreed shape', () => {
+    installHandler();
+    expect(isEmbedded()).toBe(true);
+
+    expect(postPlayIntent({ trackIds: ['a', 'b', 'c'], startingAt: 'b' })).toBe(true);
+    expect(posted).toEqual([
+      { type: 'play', trackIds: ['a', 'b', 'c'], startingAt: 'b' } satisfies PlayIntent,
+    ]);
+  });
+
+  /**
+   * A `startingAt` outside the list would leave the native side picking a cursor for a track it was
+   * never given. The first track is the honest default.
+   */
+  it('falls back to the first track when startingAt is not in the list', () => {
+    installHandler();
+    postPlayIntent({ trackIds: ['a', 'b'], startingAt: 'zzz' });
+    expect((posted[0] as PlayIntent).startingAt).toBe('a');
+  });
+
+  it('refuses to post an empty queue', () => {
+    installHandler();
+    expect(postPlayIntent({ trackIds: [], startingAt: 'a' })).toBe(false);
+    expect(posted).toEqual([]);
+  });
+
+  /**
+   * A throwing bridge is a native-side problem. Taking the page down with it would put a stack trace
+   * inside a web view inside an app, which ADR-0016 calls the hardest place to read one.
+   */
+  it('survives a native handler that throws', () => {
+    installHandler(() => {
+      throw new Error('native side blew up');
+    });
+    expect(() => postPlayIntent({ trackIds: ['a'], startingAt: 'a' })).not.toThrow();
+    expect(postPlayIntent({ trackIds: ['a'], startingAt: 'a' })).toBe(false);
+  });
+
+  it('treats a half-installed bridge as absent', () => {
+    // The handler object exists but has no `postMessage` — what a partially wired native side looks
+    // like, and it must read as "no bridge" rather than crashing on the call.
+    (window as unknown as Record<string, unknown>).webkit = {
+      messageHandlers: { [BRIDGE_HANDLER]: {} },
+    };
+    expect(isEmbedded()).toBe(false);
+    expect(postPlayIntent({ trackIds: ['a'], startingAt: 'a' })).toBe(false);
+  });
+});

--- a/packages/frontend/src/services/embedBridge.ts
+++ b/packages/frontend/src/services/embedBridge.ts
@@ -1,0 +1,73 @@
+/**
+ * The page half of the embedded surface's bridge to the native player (ADR-0016 point 5).
+ *
+ * One message shape, one direction. The page posts an intent — play these track ids, starting at
+ * this one — and the native side owns the queue, the playback and the reporting. Nothing comes back:
+ * the web view is never told what is playing and never renders a transport, so there is one player,
+ * one queue and one now-playing entry, exactly as with CarPlay.
+ *
+ * Narrow on purpose. ADR-0016 records the tradeoff this creates — a new seam between two clients
+ * that were previously independent, where a web-app change could break the native app — and argues
+ * it stays unlikely only if the seam is one message wide. Adding a second shape is a decision, not a
+ * detail.
+ */
+
+/** What the native side receives. Keep this in step with the Swift `WKScriptMessageHandler`. */
+export interface PlayIntent {
+  type: 'play';
+  /** The full context to queue, in order. */
+  trackIds: string[];
+  /** Which of them to start on. Always a member of `trackIds`. */
+  startingAt: string;
+}
+
+/** The handler name the native side installs. */
+export const BRIDGE_HANDLER = 'familiar';
+
+interface WebKitBridgeWindow {
+  webkit?: {
+    messageHandlers?: Record<string, { postMessage: (message: unknown) => void } | undefined>;
+  };
+}
+
+/**
+ * Whether a native host is listening.
+ *
+ * False in an ordinary browser, which is the case that matters: this module is in the shared package
+ * and must be inert everywhere except inside the Mac app's web view.
+ */
+export function isEmbedded(): boolean {
+  const w = window as unknown as WebKitBridgeWindow;
+  return typeof w.webkit?.messageHandlers?.[BRIDGE_HANDLER]?.postMessage === 'function';
+}
+
+/**
+ * Hand a play intent to the native player.
+ *
+ * Returns whether it was delivered. A `false` means nothing will play — which is the correct failure
+ * for an unbridged page, and why ADR-0017 puts a null engine underneath: the alternative to silence
+ * is a second audio engine, not success.
+ */
+export function postPlayIntent(intent: Omit<PlayIntent, 'type'>): boolean {
+  if (intent.trackIds.length === 0) return false;
+  const w = window as unknown as WebKitBridgeWindow;
+  const handler = w.webkit?.messageHandlers?.[BRIDGE_HANDLER];
+  if (!handler || typeof handler.postMessage !== 'function') return false;
+
+  const message: PlayIntent = {
+    type: 'play',
+    trackIds: intent.trackIds,
+    // Defended rather than trusted: a `startingAt` outside the list would leave the native side
+    // choosing a cursor for a track it was not given, and the first track is the honest default.
+    startingAt: intent.trackIds.includes(intent.startingAt) ? intent.startingAt : intent.trackIds[0],
+  };
+
+  try {
+    handler.postMessage(message);
+    return true;
+  } catch {
+    // A throwing bridge is a native-side problem, and taking the page down with it would put a
+    // stack trace inside a web view inside an app — the hardest place to read one.
+    return false;
+  }
+}

--- a/packages/web/embed.html
+++ b/packages/web/embed.html
@@ -1,0 +1,20 @@
+<!doctype html>
+<html lang="en">
+  <head>
+    <meta charset="UTF-8" />
+    <meta name="viewport" content="width=device-width, initial-scale=1.0, viewport-fit=cover" />
+    <meta name="theme-color" content="#18181b" />
+    <meta name="description" content="Familiar — embedded discovery surface" />
+
+    <!-- Deliberately no manifest and no apple-itunes-app banner: this document is only ever loaded
+         inside the Mac app's web view (ADR-0016), where an install prompt or a "get the app"
+         banner would be advertising the app to itself. -->
+    <link rel="icon" type="image/svg+xml" href="/icons/icon.svg" />
+
+    <title>Discover</title>
+  </head>
+  <body>
+    <div id="root"></div>
+    <script type="module" src="/src/embed.tsx"></script>
+  </body>
+</html>

--- a/packages/web/src/NullAudioEngine.ts
+++ b/packages/web/src/NullAudioEngine.ts
@@ -1,0 +1,87 @@
+import type { AudioEngine, AudioEngineCapabilities, EngineEvent } from '@familiar/frontend/src/player/audio/types';
+
+/**
+ * An `AudioEngine` that does nothing, for the embedded surface (ADR-0017).
+ *
+ * **This exists to be absent.** It will look like dead code to anyone who finds it without the ADR,
+ * so: the embedded Discover surface runs inside a `WKWebView` in the Mac app, and the one thing it
+ * must never do is become a second audio engine — two engines in one process means two queues and
+ * two things holding an audio session, which is the defect
+ * [ADR-0001](../../../docs/decisions/ADR-0001-native-apple-clients-supersede-capacitor.md) and
+ * `CarPlayBridge` are both written to avoid.
+ *
+ * ADR-0016 point 4 assumed that forbidding playback was enough to prevent construction. It was not,
+ * for two separate reasons. One is fixed: capability queries used to construct an engine, and no
+ * longer do. The other is intrinsic — **Discover plays music.** `DiscoverTrackList` wires
+ * `setQueueByTrackId` to a row's play button and `DiscoverBrowser` calls `onPlayTrack`, both of which
+ * reach `getEngine()`. ADR-0016 point 5 hands those intents to the native player over a bridge, and
+ * this is the floor under that bridge: a *missed* intent is inert rather than a second engine.
+ *
+ * Every method is deliberately silent rather than throwing. A `throw` here would surface as a crash
+ * inside a web view inside a native app, which ADR-0016 itself calls the hardest place in the product
+ * to diagnose anything — and the wanted behaviour for an unbridged play is nothing happening, not a
+ * stack trace.
+ *
+ * Only the 15 required members of `AudioEngine` are implemented. All 15 optional ones are omitted, so
+ * `preloadNext?.()`, `getAnalyser?.()` and the rest are `undefined` and their callers already fall
+ * back — which is how the visualizer and the effects chain stay away from a surface that has neither.
+ */
+export class NullAudioEngine implements AudioEngine {
+  /**
+   * Declared here *and* registered beside the factory in `embed.tsx`, because the two are read at
+   * different times: the registration answers before anything is built, and this answers if anything
+   * ever is. They must agree, and `assertCapabilitiesMatch` says so out loud if they drift.
+   */
+  readonly capabilities: AudioEngineCapabilities = {
+    crossfade: false,
+    visualizer: false,
+    effects: 'none',
+  };
+
+  // Lifecycle
+  initialize(): boolean {
+    // `true` — "there is an engine and it is ready" is accurate. It is ready to do nothing.
+    return true;
+  }
+
+  dispose(): void {}
+
+  // Playback. Silent, per the note above.
+  async load(): Promise<void> {}
+  async play(): Promise<void> {}
+  pause(): void {}
+  seek(): void {}
+  stop(): void {}
+
+  // Volume & normalization
+  setVolume(): void {}
+  setNormalizationGain(): void {}
+
+  // State. Zeroes and nulls, which is what "nothing is loaded" looks like everywhere else.
+  getCurrentTime(): number {
+    return 0;
+  }
+
+  getDuration(): number {
+    return 0;
+  }
+
+  getLoadedTrackId(): string | null {
+    return null;
+  }
+
+  /**
+   * Never emits.
+   *
+   * The unsubscribe function is still real, so callers that hold it and call it on unmount behave
+   * exactly as they do with a live engine. Returning a no-op that was not callable would turn this
+   * into a different kind of bug than the one it prevents.
+   */
+  on(_handler: (event: EngineEvent) => void): () => void {
+    return () => {};
+  }
+
+  // Media session / Now Playing. The native app owns the now-playing entry (ADR-0016 point 5), and
+  // an embedded page writing to `MediaSession` would put a second one on the lock screen.
+  updateNowPlaying(): void {}
+}

--- a/packages/web/src/embed.tsx
+++ b/packages/web/src/embed.tsx
@@ -1,0 +1,28 @@
+import '@familiar/frontend/src/index.css';
+import { registerEngineFactory } from '@familiar/frontend/src/player/audio/createEngine';
+import { renderEmbed } from '@familiar/frontend/src/renderEmbed';
+import { NullAudioEngine } from './NullAudioEngine';
+
+/**
+ * The embedded surface's entry point (ADR-0017 point 1).
+ *
+ * A second entry beside `main.tsx`, not a mode of it. The whole decision rests on this file being
+ * the only thing that boots the embedded page: it registers an engine that cannot make sound, so a
+ * play path the bridge fails to intercept is inert rather than a second `WebAudioEngine` competing
+ * with the native player for the audio session.
+ *
+ * Registering *nothing* was the obvious alternative and is rejected by ADR-0017 point 4:
+ * `createEngine()` throws when no factory is registered, which would turn a missed play intent into
+ * a crash inside a web view inside a native app.
+ *
+ * No service worker is registered here. `main.tsx` reloads the page when a new one takes control,
+ * which inside a native web view would be a screen refreshing itself for reasons no one watching
+ * could see.
+ */
+registerEngineFactory(() => new NullAudioEngine(), {
+  crossfade: false,
+  visualizer: false,
+  effects: 'none',
+});
+
+renderEmbed();

--- a/packages/web/vite.config.ts
+++ b/packages/web/vite.config.ts
@@ -2,6 +2,7 @@ import { defineConfig } from 'vite'
 import react from '@vitejs/plugin-react'
 import tailwindcss from '@tailwindcss/vite'
 import { VitePWA } from 'vite-plugin-pwa'
+import { resolve } from 'node:path'
 
 const isCapacitorBuild = process.env.BUILD_TARGET === 'capacitor';
 
@@ -13,6 +14,18 @@ export default defineConfig({
   build: {
     manifest: true,
     rollupOptions: {
+      // Two documents, not one. `embed.html` is the embedded surface ADR-0017 gives its own entry
+      // point, and naming `index.html` here is required as soon as `input` is set at all — Vite's
+      // default single entry stops applying.
+      //
+      // Not built for Capacitor: the iOS app is the listening path (ADR-0013 point 2) and embeds
+      // nothing, so the second document would be dead weight in the bundle it ships.
+      input: isCapacitorBuild
+        ? { index: resolve(__dirname, 'index.html') }
+        : {
+            index: resolve(__dirname, 'index.html'),
+            embed: resolve(__dirname, 'embed.html'),
+          },
       output: {
         manualChunks(id) {
           // Vendor chunks - split large dependencies


### PR DESCRIPTION
The web half of ADR-0017, accepted in the same PR — the shape #59 used for ADR-0014.

A second Vite entry (`embed.html` → `src/embed.tsx`) that registers a **`NullAudioEngine`** instead of `WebAudioEngine`, and a server route at `/embed` serving that document rather than the app's.

## Why a separate document, not a mode of the app

ADR-0017 rejects "the full web app with its chrome hidden" because **hiding is not preventing**: `useAudioEngine` mounts with the player and constructs an engine whether or not anyone can see it. So `renderEmbed` mounts Discover with the providers Discover needs — a query client, and a router because `DiscoverBrowser` calls `useNavigate` — and nothing else.

## Why a *null* engine, not no engine

`createEngine()` throws when nothing is registered, which would turn a missed play intent into a crash inside a web view inside a native app. **Silence is the wanted failure.** All 15 required `AudioEngine` members are no-ops; all 15 optional ones are omitted, so the visualizer and effects chain stay away from a surface that has neither.

`NullAudioEngine` lives in `packages/web` per point 7, which means it can't have a unit test — that package has no runner, and having `@familiar/frontend` import it would invert the dependency. Its completeness is enforced by `implements AudioEngine` at build time instead. Said rather than papered over.

## Details worth a look

- **`EmbedDiscover` builds the full `BrowserProps`** rather than casting a partial one. This file is the boundary between a 2,943-line surface and a native app, and ADR-0016 names that seam as embedding's main risk — a field `DiscoverBrowser` starts reading later should be a type error *here*, not `undefined` at runtime. (`LibraryFilters` needed no cast at all: every field on it is optional.)
- **`embedBridge.ts` is the page half of ADR-0016 point 5, and nothing receives it yet.** Deliberate — a dropped intent is the correct failure until the Swift half lands, and it's exactly the case the null engine makes inert. 6 tests pin the message shape and the two failure modes that matter: inert in an ordinary browser, inert rather than throwing when the native side misbehaves.
- **`serve_embed` is at module scope**, for the reason `spa_fallback` records beside it: as a closure inside `if STATIC_DIR.exists()` it'd be invisible to the suite, and that's how a bug this visible survived once already. A build predating this answers a typed 404 rather than a `FileResponse` for a missing path — otherwise a stack trace in the log and a blank web view.
- **`embed.html` is excluded from the Capacitor bundle** — verified, `packages/ios/dist` has only `index.html`. iOS is the listening path (ADR-0013 point 2) and embeds nothing.

## Verification

954 frontend tests (was 948), lint clean (0 errors), web and Capacitor bundles both build. The 2 new backend tests pass; the 11 errors in that file locally are SQLAlchemy connection failures with no Postgres running, and are pre-existing.

**Not verified: the page has not been loaded in a browser or a web view.** There's no `WKWebView` host yet, so `/embed` has never actually been rendered. That's the first thing the Swift half will show.

## What's left of ADR-0016/0017

The `WKWebView`, the `WKScriptMessageHandler` that receives the play intent, and the native "unavailable" state — all `familiar-apple`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_014P9p2fvFnyiywBxGkv4gfW