### PR TITLE
Take the embedded surface's profile from the URL, not from storage

### DIFF
--- a/packages/frontend/src/renderEmbed.tsx
+++ b/packages/frontend/src/renderEmbed.tsx
@@ -3,8 +3,9 @@ import { createRoot } from 'react-dom/client';
 import { QueryClient, QueryClientProvider } from '@tanstack/react-query';
 import { BrowserRouter } from 'react-router-dom';
 import { initApiOrigin, registerProfileProvider } from './api/base';
-import { getSelectedProfileId, clearSelectedProfile } from './services/profileSelection';
+import { profileFromURL } from './services/embedBridge';
 import { EmbedDiscover } from './components/Embed/EmbedDiscover';
+
 
 /**
  * Boots the embedded surface (ADR-0017).
@@ -25,7 +26,13 @@ import { EmbedDiscover } from './components/Embed/EmbedDiscover';
  * 2,943-line surface that ADR-0016 embedded precisely to avoid maintaining twice.
  */
 export function renderEmbed(options?: { onReady?: () => void }): void {
-  registerProfileProvider({ getSelectedProfileId, clearSelectedProfile });
+  const profileId = profileFromURL();
+  registerProfileProvider({
+    getSelectedProfileId: async () => profileId,
+    // Nothing to clear: this surface never selected a profile, it was told one. Clearing storage it
+    // does not read would be a no-op dressed up as an action.
+    clearSelectedProfile: async () => {},
+  });
 
   // Its own client, with the app's defaults. The embedded page is a separate document with a
   // separate cache; nothing is shared with a browser tab that happens to have the app open.

--- a/packages/frontend/src/services/__tests__/embedBridge.test.ts
+++ b/packages/frontend/src/services/__tests__/embedBridge.test.ts
@@ -1,5 +1,12 @@
 import { describe, it, expect, beforeEach, afterEach, vi } from 'vitest';
-import { isEmbedded, postPlayIntent, profileFromURL, BRIDGE_HANDLER, type PlayIntent } from '../embedBridge';
+import {
+  isEmbedded,
+  postPlayIntent,
+  profileFromURL,
+  isEmbedSurfaceDocument,
+  BRIDGE_HANDLER,
+  type PlayIntent,
+} from '../embedBridge';
 
 /**
  * The seam ADR-0016 names as the main risk of embedding: two clients that were independent now share
@@ -111,5 +118,33 @@ describe('profileFromURL', () => {
 
   it('handles ids that need decoding', () => {
     expect(profileFromURL('?profile=a%20b')).toBe('a b');
+  });
+});
+
+/**
+ * The check that stops a native host embedding the wrong document.
+ *
+ * A server predating the `/embed` route answers it from the SPA fallback: HTTP 200, `index.html`,
+ * the full app with `WebAudioEngine` registered. Verified against the live server on 2026-08-01 —
+ * `/embed` returned 200 and `<title>Familiar</title>`. A host that trusted the URL would embed
+ * exactly what ADR-0016 point 4 forbids, and nothing would look wrong.
+ */
+describe('isEmbedSurfaceDocument', () => {
+  function docWith(head: string): Document {
+    return new DOMParser().parseFromString(`<html><head>${head}</head><body></body></html>`, 'text/html');
+  }
+
+  it('recognises the embedded surface', () => {
+    expect(isEmbedSurfaceDocument(docWith('<meta name="familiar-surface" content="embed">'))).toBe(true);
+  });
+
+  it('rejects the app served in its place', () => {
+    // What the live server returns for /embed today, reduced to its head.
+    expect(isEmbedSurfaceDocument(docWith('<title>Familiar</title>'))).toBe(false);
+  });
+
+  it('rejects a marker with the wrong value', () => {
+    expect(isEmbedSurfaceDocument(docWith('<meta name="familiar-surface" content="app">'))).toBe(false);
+    expect(isEmbedSurfaceDocument(docWith('<meta name="familiar-surface">'))).toBe(false);
   });
 });

--- a/packages/frontend/src/services/__tests__/embedBridge.test.ts
+++ b/packages/frontend/src/services/__tests__/embedBridge.test.ts
@@ -1,5 +1,5 @@
 import { describe, it, expect, beforeEach, afterEach, vi } from 'vitest';
-import { isEmbedded, postPlayIntent, BRIDGE_HANDLER, type PlayIntent } from '../embedBridge';
+import { isEmbedded, postPlayIntent, profileFromURL, BRIDGE_HANDLER, type PlayIntent } from '../embedBridge';
 
 /**
  * The seam ADR-0016 names as the main risk of embedding: two clients that were independent now share
@@ -87,5 +87,29 @@ describe('embedBridge', () => {
     };
     expect(isEmbedded()).toBe(false);
     expect(postPlayIntent({ trackIds: ['a'], startingAt: 'a' })).toBe(false);
+  });
+});
+
+describe('profileFromURL', () => {
+  it('reads the profile the native host passed', () => {
+    expect(profileFromURL('?profile=abc123')).toBe('abc123');
+    expect(profileFromURL('?other=1&profile=abc123&x=2')).toBe('abc123');
+  });
+
+  /**
+   * Absent means no profile, never "fall back to storage" (ADR-0016 point 6). A `WKWebView` has its
+   * own empty `localStorage`, so a fallback would either send nothing anyway or — worse, later —
+   * send a previous listener's id, making the surface act as someone other than the window around
+   * it.
+   */
+  it('returns null rather than guessing when nothing was passed', () => {
+    expect(profileFromURL('')).toBeNull();
+    expect(profileFromURL('?other=1')).toBeNull();
+    expect(profileFromURL('?profile=')).toBeNull();
+    expect(profileFromURL('?profile=%20%20')).toBeNull();
+  });
+
+  it('handles ids that need decoding', () => {
+    expect(profileFromURL('?profile=a%20b')).toBe('a b');
   });
 });

--- a/packages/frontend/src/services/embedBridge.ts
+++ b/packages/frontend/src/services/embedBridge.ts
@@ -25,6 +25,24 @@ export interface PlayIntent {
 export const BRIDGE_HANDLER = 'familiar';
 
 /**
+ * The marker `embed.html` carries so a native host can tell this document from the app's.
+ *
+ * Load-bearing rather than cosmetic. A server built before the `/embed` route existed answers that
+ * path from its single-page-app fallback — HTTP 200, `index.html`, the whole web app with
+ * `WebAudioEngine` registered. A native host that trusted the URL would embed the very thing
+ * ADR-0016 point 4 forbids, and nothing would look wrong: the page would just play audio itself and
+ * never use the bridge.
+ */
+export const SURFACE_MARKER = 'embed';
+export const SURFACE_META_NAME = 'familiar-surface';
+
+/** Whether the document currently loaded is the embedded surface. */
+export function isEmbedSurfaceDocument(doc: Document = document): boolean {
+  const meta = doc.querySelector(`meta[name="${SURFACE_META_NAME}"]`);
+  return meta?.getAttribute('content') === SURFACE_MARKER;
+}
+
+/**
  * The profile this surface acts as, taken from the URL and nowhere else (ADR-0016 point 6).
  *
  * The native app appends `?profile=…` when it points its web view here. Reading it from the query

--- a/packages/frontend/src/services/embedBridge.ts
+++ b/packages/frontend/src/services/embedBridge.ts
@@ -24,6 +24,26 @@ export interface PlayIntent {
 /** The handler name the native side installs. */
 export const BRIDGE_HANDLER = 'familiar';
 
+/**
+ * The profile this surface acts as, taken from the URL and nowhere else (ADR-0016 point 6).
+ *
+ * The native app appends `?profile=…` when it points its web view here. Reading it from the query
+ * string rather than from storage is the whole of that decision: a `WKWebView` has its own
+ * `localStorage`, separate from any browser, so whatever it found there would be either empty or
+ * left over from a previous listener — and a surface acting as a different profile than the window
+ * around it is a bug nobody would think to look for.
+ *
+ * Absent means **no profile**, not "fall back to storage". Falling back would reintroduce exactly
+ * the failure this prevents, and do it silently.
+ *
+ * The server URL needs no equivalent: the document is served *by* that server, so relative API
+ * paths can only reach the one it came from. Point 6 is satisfied for the URL by construction.
+ */
+export function profileFromURL(search: string = window.location.search): string | null {
+  const value = new URLSearchParams(search).get('profile');
+  return value !== null && value.trim() !== '' ? value : null;
+}
+
 interface WebKitBridgeWindow {
   webkit?: {
     messageHandlers?: Record<string, { postMessage: (message: unknown) => void } | undefined>;

--- a/packages/web/embed.html
+++ b/packages/web/embed.html
@@ -6,6 +6,14 @@
     <meta name="theme-color" content="#18181b" />
     <meta name="description" content="Familiar — embedded discovery surface" />
 
+    <!-- How the native host proves it got *this* document and not the app.
+         A server built before this existed has no `/embed` route, and its single-page-app fallback
+         answers that path with `index.html` — HTTP 200, the full web app, `WebAudioEngine` and all.
+         That is the one thing ADR-0016 point 4 exists to prevent, and it would happen silently: the
+         page would play audio itself and the bridge would simply never be used.
+         So the native side reads this marker after load and refuses anything without it. -->
+    <meta name="familiar-surface" content="embed" />
+
     <!-- Deliberately no manifest and no apple-itunes-app banner: this document is only ever loaded
          inside the Mac app's web view (ADR-0016), where an install prompt or a "get the app"
          banner would be advertising the app to itself. -->


### PR DESCRIPTION
A gap in #64, found while starting the Swift half.

`renderEmbed` registered the storage-backed profile provider. A `WKWebView` has its own `localStorage`, separate from any browser — so inside the Mac app it would have been empty, and every request would have gone without `X-Profile-ID`.

ADR-0016 point 6 says the native app gives the web view its profile explicitly *"rather than relying on whatever the embedded app finds in its own storage, so it cannot end up pointed at a different server or acting as a different profile than the window around it."* This is that: `?profile=…`, read once at boot.

**Absent means no profile, not "fall back to storage."** A fallback would reintroduce precisely the failure that point prevents, and silently. The empty case is harmless today; a listener who had used the surface before would leave an id behind for the next one to inherit.

The server URL needs no equivalent, and that's worth stating rather than leaving the asymmetry looking like an oversight: the document is served *by* that server, so relative API paths can only reach the one it came from. Point 6 is satisfied for the URL by construction.

`profileFromURL` lives in `embedBridge.ts` — the module that already holds this surface's contract with its native host — and takes the query string as a parameter, so it's testable without pulling React DOM into a test.

957 frontend tests (was 954), lint clean (0 errors), both bundles build.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_014P9p2fvFnyiywBxGkv4gfW