### PR TITLE
Stop the embedded surface registering a service worker

### DIFF
--- a/packages/web/src/main.tsx
+++ b/packages/web/src/main.tsx
@@ -44,6 +44,18 @@ window.addEventListener('unhandledrejection', (event) => {
 
 // Service worker update check (web only — no SW in native apps)
 if ('serviceWorker' in navigator) {
+  // Registered here rather than by the PWA plugin's injected script. That injection is per-*build*
+  // and not per-entry, so it also landed in `embed.html` — and the embedded surface is the one
+  // document that must not have a worker (see `vite.config.ts`).
+  //
+  // Registered directly rather than through `virtual:pwa-register`, which pulls in `workbox-window`
+  // — a dependency this app does not have and does not need for this. The generated worker already
+  // carries `skipWaiting` and `clientsClaim` (`registerType: 'autoUpdate'`), and the reload that
+  // follows from them is handled below, by hand, and has been since before this change.
+  navigator.serviceWorker.register('/sw.js').catch((error) => {
+    log.error('SW: registration failed', error);
+  });
+
   // With registerType: 'autoUpdate' a new SW activates in the background, but an
   // already-open page (especially a docked PWA) keeps running the old in-memory
   // bundle until it's reloaded. Reload once the new SW takes control so deploys

--- a/packages/web/vite.config.ts
+++ b/packages/web/vite.config.ts
@@ -47,6 +47,13 @@ export default defineConfig({
     // Skip PWA/service worker for Capacitor builds — native app doesn't need it
     ...(!isCapacitorBuild ? [VitePWA({
       registerType: 'autoUpdate',
+      // Registered by hand in `main.tsx` rather than injected, because injection is per-*build*
+      // and not per-entry: the plugin puts `registerSW.js` into every HTML document it emits,
+      // which silently included `embed.html`. The embedded surface must not register a service
+      // worker — it runs inside a `WKWebView` in the Mac app, where a worker would serve that
+      // window cached assets on a schedule nobody watching could see, and ADR-0017 gives it its
+      // own entry point precisely so it shares nothing it does not need.
+      injectRegister: null,
       includeAssets: ['icons/*.png', 'icons/*.svg'],
       manifest: false, // Using our custom manifest.json
       workbox: {


### PR DESCRIPTION
Found by checking the deployed output rather than the source: `embed.html` was loading `registerSW.js`.

`embed.tsx` says in a comment *"No service worker is registered here"* — and that was false. VitePWA's `injectRegister` is per-**build**, not per-entry, so the plugin put its registration script into every HTML document it emitted, `embed.html` included.

It matters where that document runs. The embedded surface lives inside a `WKWebView` in the Mac app, and a worker there would serve that window cached assets on a schedule nobody watching could see — ADR-0017 gives the surface its own entry point precisely so it shares nothing it doesn't need.

## The fix

`injectRegister: null`, and `main.tsx` registers the worker itself.

Registered with a plain `navigator.serviceWorker.register('/sw.js')` rather than through `virtual:pwa-register`, which pulls in `workbox-window` — a dependency this app doesn't have, and adding one to move a single line would be the wrong trade. Nothing about the app's behaviour changes: the generated worker already carries `skipWaiting` and `clientsClaim` from `registerType: 'autoUpdate'`, and the controller-change reload was already handled by hand in `main.tsx` directly below.

Verified in the built output, since that's where the problem was invisible from the source:

- `embed.html` no longer references `registerSW.js`
- `dist/sw.js` is still generated
- the app's entry chunk still contains the registration

960 frontend tests, lint clean (0 errors).

## Known and not fixed here

`embed.html` still preloads **`vendor-three`** — three.js, for a surface with no 3D in it. It arrives through `DiscoverBrowser` → `PlaylistRow`, so it's pre-existing chunking that the app carries too; the embed just makes it conspicuous. Untangling those imports is its own change and shouldn't ride along with a service-worker fix.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_014P9p2fvFnyiywBxGkv4gfW