### PR TITLE
Propose ADR-0018 and ADR-0019 — the phone gets the Mac's arrangement

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -81,6 +81,12 @@ everything; iOS stays the listening path. Their own order:
 Smart playlist CRUD and the album/artist grids need no ADR — ordinary work inside `0013`'s direction,
 and both depend on nothing, so they were the fastest visible wins once `0013` was accepted.
 
+**`ADR-0018`–`ADR-0019` bring the Mac's arrangement to the phone** (proposed 2026-08-02). `0018`
+replaces the segmented picker and the Collections screen with one root list of destinations; `0019`
+opens that list's Discover row onto the same embedded surface the Mac uses. Neither reverses
+`ADR-0013` point 2 — every destination involved is a way of finding something to play, and the
+management surfaces stay off the phone. `0018` ships without Discover if `0019` is not accepted.
+
 Within `0016`, **Music Map comes before embedded Discover**: the two halves are independent, and the
 map is one self-contained screen against endpoints that already generate, while the embedding half
 carries point 4's rule that an embedded page must never construct a second audio engine.

--- a/docs/decisions/ADR-0012-favorites-are-a-collection-not-a-library-section.md
+++ b/docs/decisions/ADR-0012-favorites-are-a-collection-not-a-library-section.md
@@ -7,6 +7,12 @@ Date: 2026-07-30
 Extends [ADR-0001](ADR-0001-native-apple-clients-supersede-capacitor.md).
 
 Implementation:
+- **Point 1's placement changed on the phone in [ADR-0018](ADR-0018-the-phone-navigates-from-a-root-list.md)**
+  (2026-08-02), and its substance did not. Favorites and Downloads are still one group and still not
+  segments of the browse picker; they are reached from a row in a root list instead of from a toolbar
+  button and a screen. Recorded here rather than edited into the Decision above: the tap this ADR
+  accepted was the price of a button that could not show a number, and a row can — which is what
+  point 1 said it wanted.
 - Accepted 2026-07-30.
 - Execution order, each phase its own branch: (1) `FavoritesSource` and `FavoritesStore` in
   `FamiliarKit`, no networking and no UI; (2) the generated-client half and the Collections group;

--- a/docs/decisions/ADR-0018-the-phone-navigates-from-a-root-list.md
+++ b/docs/decisions/ADR-0018-the-phone-navigates-from-a-root-list.md
@@ -1,0 +1,131 @@
+# ADR-0018: The Phone Navigates From a Root List
+
+Status: proposed
+
+Date: 2026-08-02
+
+Extends [ADR-0012](ADR-0012-favorites-are-a-collection-not-a-library-section.md) and
+[ADR-0013](ADR-0013-the-mac-is-a-management-surface-too.md).
+
+## Context
+
+The phone reaches its destinations three different ways, and which way depends on an argument nobody
+using it can see.
+
+| destination | how it is reached today |
+|---|---|
+| Tracks, Albums, Artists, Playlists | a segmented picker across the top |
+| Favorites, Downloads | a toolbar button opening `CollectionsView`, which lists both and pushes one |
+| Discover | not on the phone at all |
+
+Each of those was decided well on its own. Together they are three mechanisms for one question —
+*what am I looking at?* — and the reasons they differ are historical rather than legible.
+
+**The picker's four segments are a hard ceiling, and that is the load-bearing constraint.**
+[ADR-0012](ADR-0012-favorites-are-a-collection-not-a-library-section.md) point 1 measured it: a fifth
+segment leaves each about 70pt on a 393pt phone, "which is where the labels abbreviate". So anything
+new has to go somewhere else, and everything new has. That is why there are three mechanisms.
+
+**ADR-0012 point 1 already argued for what this proposes, and could not have it.** Its own words, on
+why the Collections grouping cost a tap:
+
+> a toolbar button cannot show a number, and the number is what makes them read as collections
+> rather than as actions. A sidebar row *can* show one
+
+The Mac later proved that out — `LibrarySidebar` lists Favorites and Downloads with their counts
+beside them, and ADR-0012's note says that is "what that decision wanted in the first place". The
+phone kept the extra screen only because it had no row to put a number on. A root list is that row.
+
+Measured against the live library on 2026-08-02: **26,396 tracks, 3,925 albums, 3,475 artists, 1,720
+favorites.** Downloads is per-device and has no server-side figure.
+
+**What this is not.** [ADR-0013](ADR-0013-the-mac-is-a-management-surface-too.md) point 2 says "iOS
+stays the listening path. The phone is not a management client." Nothing here changes that. Every
+destination below is a way of finding something to play; the management surfaces — smart playlists,
+pending review, proposed changes, mixtapes — stay off the phone, and this ADR does not touch them.
+Discover is discovery, not management, and ADR-0013 point 3 put it "in scope for the Mac" as a way of
+scoping a body of work rather than as a ruling about where it may ever appear.
+
+**The platform constraint.** iOS 15 is the floor (`Package.swift`), so `NavigationSplitView` does not
+exist and neither does the `Layout` protocol. A root list needs neither: it is a `List` of rows that
+push, which iOS has always had, and it is what `CollectionsView` already does for two of these
+destinations.
+
+## Decision
+
+1. **The phone's browse column is rooted on a single list of destinations**, replacing the segmented
+   picker and the Collections screen. One mechanism, one place to look, in the order the Mac sidebar
+   uses so the two clients do not describe the same library differently.
+
+2. **The list is grouped, not flat.** Library — Tracks, Albums, Artists, Playlists, Discover — then
+   Collection: Favorites and Downloads. The grouping is the substance of ADR-0012 point 1 and it
+   survives intact; only the extra screen goes.
+
+3. **Rows carry their counts**, which is the thing ADR-0012 point 1 wanted and could not have from a
+   toolbar button. Favorites shows its total, Downloads shows its size on this device.
+
+4. **This changes where ADR-0012 point 1's entry lives, and not what it decided.** Favorites and
+   Downloads remain one group, still not segments of a browse picker, still per-profile and
+   per-device respectively. They are simply reached from a row instead of from a button and a screen.
+
+5. **It costs a tap to reach Tracks, and that is the price.** The picker put four lists one tap away
+   and everything else two or more; this puts everything at one. The library list is no longer the
+   thing you land on, and for a phone whose most common action is "play something I already know"
+   that is a real cost, accepted for a navigation that holds more than four things.
+
+6. **The management surfaces stay off the phone**, per ADR-0013 point 2, which this does not
+   reverse. If they ever arrive they need their own decision, and the list having room for them is
+   not an argument that they should.
+
+7. **macOS is untouched.** It already has this shape in `LibrarySidebar`, and a 200pt column beside
+   the content is the right form there. This is the phone adopting the Mac's *arrangement*, not its
+   layout.
+
+## Alternatives Considered
+
+**A menu button in the toolbar.** Keeps the phone landing directly on a browse list — no tap
+added — and switches the column in place with no back stack. Rejected because it hides the map of the
+app behind a press: the thing being fixed is that a listener cannot see what the phone can show them,
+and a menu that must be opened to be read does not fix it. It also reproduces the counts problem,
+since a button still cannot show a number.
+
+**A fifth and sixth segment on the picker.** The smallest change, and no new screen. Rejected on the
+measurement ADR-0012 point 1 already made: at six segments each gets about 47pt on a 393pt phone,
+which is not a label but an abbreviation of one. The picker's ceiling is why there are three
+mechanisms, so raising the ceiling is not available.
+
+**A sidebar that slides over from the edge.** Closest to the Mac visually, and keeps the browse list
+as the landing screen. Rejected on cost and fit: iOS 15 has no drawer, so it is a hand-built overlay
+plus a gesture that competes with the system's own interactive back-swipe — and a drawer is a desktop
+idiom borrowed onto a phone, where the platform's own answer to "many destinations" is a list you push
+from.
+
+**A tab bar.** The most conventional iOS answer, and the one Apple Music uses. Rejected because it has
+the same ceiling as the picker — five tabs before it collapses into "More" — and this exists to hold
+seven destinations now and more later. It would also be a third arrangement, agreeing with neither the
+picker it replaces nor the Mac.
+
+**Leave it alone.** The three mechanisms each have a good reason and nothing is broken. Rejected
+because the reasons are invisible from inside the app: what a listener sees is that some destinations
+are segments, one is a button, and Discover is missing — and no amount of individually-sound
+reasoning makes that read as designed.
+
+## Consequences
+
+- **Positive:** One mechanism instead of three, and one that has room. A new destination is a row
+  rather than an argument about which of three places it belongs in.
+- **Positive:** Favorites and Downloads get their counts on the phone, which ADR-0012 point 1 wanted
+  and could not reach. The extra screen it accepted as the price is no longer needed.
+- **Positive:** The two clients describe the same library the same way, so a listener moving between
+  them is not learning a second arrangement.
+- **Tradeoff:** Tracks costs a tap it did not cost before, on the platform where that list is most
+  often what someone wants. Named in point 5 rather than discovered later.
+- **Tradeoff:** `CollectionsView` loses its reason to exist on the phone and should go with it, rather
+  than lingering as a second way into two screens.
+- **Follow-up:** Decide whether the root list should remember and restore the last destination, which
+  would recover most of point 5's cost. Deliberately not decided here: it interacts with state
+  restoration and with the adopted queue (ADR-0003), and it is a smaller question that reads better
+  against a shipped list than against a description of one.
+- **Follow-up:** Discover's row depends on
+  [ADR-0019](ADR-0019-the-embedded-surface-comes-to-the-phone.md). The list ships without it if that
+  is not accepted; the row simply arrives later.

--- a/docs/decisions/ADR-0019-the-embedded-surface-comes-to-the-phone.md
+++ b/docs/decisions/ADR-0019-the-embedded-surface-comes-to-the-phone.md
@@ -1,0 +1,114 @@
+# ADR-0019: The Embedded Surface Comes to the Phone
+
+Status: proposed
+
+Date: 2026-08-02
+
+Extends [ADR-0016](ADR-0016-embedded-web-surfaces-on-the-mac.md) and
+[ADR-0017](ADR-0017-the-embedded-surface-gets-a-null-audio-engine.md).
+
+## Context
+
+[ADR-0018](ADR-0018-the-phone-navigates-from-a-root-list.md) gives the phone a list with a Discover
+row in it. This decides what that row opens.
+
+**A premise worth correcting before it is inherited.** It would be natural to say that ADR-0016 made
+embedding macOS-only and that this reverses it. It did not. ADR-0016's Decision has eight points and
+**none of them mentions a platform** — unlike
+[ADR-0015](ADR-0015-audio-effects-are-exposed-not-rebuilt.md), whose point 7 says "macOS only, per
+ADR-0013 point 2" in as many words. The `#if os(macOS)` around `EmbeddedDiscoverView` is
+implementation that followed ADR-0013 point 3 scoping a body of work to the Mac, which is not the same
+as a ruling that the phone may never have it. So this extends ADR-0016 into a question it left open
+rather than overturning an answer it gave.
+
+Likewise [ADR-0013](ADR-0013-the-mac-is-a-management-surface-too.md) point 2 — "iOS stays the
+listening path" — is about management. Discover is how you find something to play, which is the
+listening path, and ADR-0018 point 6 keeps the actual management surfaces off the phone.
+
+**What already exists, verified on 2026-08-02 against the live server.** The whole mechanism is built
+and working on the Mac:
+
+- `/embed` serves its own document, marked `familiar-surface="embed"`, loading an entry point that
+  registers `NullAudioEngine` rather than `WebAudioEngine` (ADR-0017).
+- The page reads its profile from `?profile=` and nothing else (ADR-0016 point 6).
+- A play intent posted through `window.webkit.messageHandlers.familiar` arrives natively and parses:
+  `play(trackIDs: ["t1","t2","t3"], startingAt: "t2")`, start index 1.
+- Discover renders from the live library — 72,853 characters of DOM, no page errors.
+- Pointed at a path an older server answers with the app instead, the marker check refuses it.
+
+`WKWebView` and `WKScriptMessageHandler` are iOS APIs as much as macOS ones, and `EmbedIntent` — the
+parsing and the marker check — is already in `FamiliarKit`, which both platforms compile. What is
+macOS-only is roughly a hundred lines of `NSViewRepresentable`.
+
+**The honest cost, which is not code.** A web view on a 393pt phone is a more noticeable compromise
+than one in a 1,400pt window. ADR-0016 already named this tradeoff — "scrolling, text selection and
+focus will not match the rest of the app" — and everything that makes it noticeable is worse on a
+phone: momentum scrolling inside a scroll view, text selection on long-press where the rest of the app
+has none, and a keyboard that the page rather than the app manages.
+
+## Decision
+
+1. **The phone's Discover row opens the same embedded surface the Mac uses**, pointed at the same
+   `/embed` document on the same server.
+
+2. **Every rule ADR-0016 and ADR-0017 set applies unchanged.** The null engine, the explicit profile,
+   the one-message bridge, the marker check, the native unavailable state. None of them is
+   platform-specific and none is relaxed here.
+
+3. **The representable is the only new code.** `UIViewRepresentable` beside the existing
+   `NSViewRepresentable`, sharing the coordinator, the intent parsing and the marker check — all of
+   which are in `FamiliarKit` already. If this appears to need changes to `EmbedIntent`, that is a
+   signal the two platforms are diverging and worth stopping for.
+
+4. **The bridge stays one message wide**, per ADR-0016 point 5. A phone does not get a second message
+   shape because it is smaller.
+
+5. **Nothing else is embedded on the phone.** This is Discover, because ADR-0018 puts Discover in the
+   list. It is not a precedent for embedding a management surface, which ADR-0013 point 2 keeps off
+   the phone regardless of how it would be rendered.
+
+6. **ADR-0016 point 1's test still decides the next one.** Embed when a surface is large and moving;
+   build native when it is small and settled. That the phone can now host a web view does not lower
+   the bar for using one — the Music Map is still native on both.
+
+## Alternatives Considered
+
+**Build Discover natively for iOS.** No web view on the phone at all, and the compromises above simply
+do not arise. Rejected on the measurement ADR-0016 made and this does not get to re-make: Discover is
+2,943 lines across 26 files that track external services, so a native rebuild is a second
+implementation to change every time the first one does. That argument is not weaker on a phone; if
+anything a third implementation is worse than a second.
+
+**Leave Discover off the phone and ship ADR-0018's list without that row.** Costs nothing, breaks
+nothing, and the list is the thing that was actually asked for. Rejected as a smaller version of the
+problem ADR-0018 exists to fix — the phone would still be missing a destination the Mac has, and the
+list would advertise its own gap. It stays the fallback if this ADR is not accepted, and ADR-0018 is
+written so that it can.
+
+**Open Discover in Safari from the phone.** Honest, trivial, no representable and no bridge. Rejected
+for the reason ADR-0016 rejected the same idea for the Mac: leaving the app is the friction these
+decisions exist to remove, and on a phone the return trip is worse, not better.
+
+**Embed on the phone but without the bridge, browse-only.** Sidesteps the play path entirely — the
+page shows recommendations and the listener finds the track themselves. Rejected because it makes the
+surface an advertisement rather than a way to play something, and because the bridge is the part that
+already works: it is verified on the Mac and needs no new code here.
+
+## Consequences
+
+- **Positive:** Discover arrives on the phone for roughly a hundred lines, because the parsing, the
+  marker check, the null engine and the server route are all already built and verified.
+- **Positive:** One implementation of Discover serves the web app, the Mac and the phone, and stays
+  current with the web version on all three at once.
+- **Tradeoff:** The phone gains a screen that scrolls, selects and focuses unlike the rest of the app,
+  and that is more noticeable at 393pt than it is on a desktop. This is the cost, stated plainly.
+- **Tradeoff:** A `WKWebView` resident on a phone costs memory that a native screen would not — the
+  same objection ADR-0016 weighed for the Music Map and answered differently there, because that
+  surface was small and settled and this one is neither.
+- **Tradeoff:** The seam ADR-0016 named as embedding's main risk now spans two native clients rather
+  than one. A web-app change that breaks the contract breaks both, which raises the value of the
+  marker check and the intent tests rather than changing what they do.
+- **Follow-up:** Decide what an embedded surface does with navigation *inside* it — an artist link in
+  Discover currently goes nowhere on either platform, because `EmbedDiscover` supplies no-op handlers
+  and the embed router returns to Discover. This is ADR-0017's open follow-up, it is now visible on
+  two platforms rather than one, and it is the next thing worth deciding about this surface.


### PR DESCRIPTION
The phone reaches its destinations **three different ways**:

| destination | how it's reached today |
|---|---|
| Tracks, Albums, Artists, Playlists | a segmented picker |
| Favorites, Downloads | a toolbar button → `CollectionsView` → push |
| Discover | not on the phone at all |

Each was decided well on its own. Together they're three mechanisms for one question — *what am I looking at?* — and the reasons they differ are historical, not legible from inside the app.

**#0018** makes it one root list. **#0019** decides its Discover row opens the same embedded surface the Mac uses. They're separate because 0018 ships without Discover if 0019 isn't accepted.

## Neither reverses anything — but the record had to be checked to say so

- **ADR-0013 point 2** — "iOS stays the listening path… not a management client" — is about *management*. Every destination here is a way of finding something to play. Smart playlists, pending review, proposed changes and mixtapes stay off the phone, and 0018 point 6 says so.
- **ADR-0016's Decision has eight points and none mentions a platform.** Compare ADR-0015 point 7, which says *"macOS only, per ADR-0013 point 2"* in as many words. The `#if os(macOS)` is implementation that followed ADR-0013 point 3 scoping a body of *work* to the Mac — not a ruling that the phone may never have it. So 0019 extends a question 0016 left open.

## 0018 is mostly ADR-0012 point 1 getting what it asked for

That point accepted an extra tap, and said exactly why:

> a toolbar button cannot show a number, and the number is what makes them read as collections rather than as actions. A sidebar row **can** show one

The Mac's sidebar proved it out. The phone kept the extra screen only because it had no row to put a number on. A root list is that row — the grouping survives untouched, only the screen goes. Recorded in ADR-0012's `Implementation:` block rather than edited into its Decision, per rule 6.

## Costs, stated rather than discovered later

- **Tracks gains a tap**, on the platform where that list is most often what someone wants (0018 point 5).
- **A web view is more noticeable at 393pt** than in a 1,400pt window — momentum scrolling, long-press selection, a page-managed keyboard (0019).

## Verification

Counts checked against the live library on 2026-08-02: **26,396 tracks, 3,925 albums, 3,475 artists, 1,720 favourites**. An earlier sketch of the list guessed 412 favourites — worth checking rather than shipping.

0019's "what already exists" section is the end-to-end probe run from #43, so its cost estimate rests on a mechanism that's verified working, not assumed.

## Also captured

0019 records where **Discover's dead links** belong: an artist link inside the embed goes nowhere on *either* platform, because `EmbedDiscover` supplies no-op handlers and the embed router returns to Discover. That's ADR-0017's open follow-up, now visible on two platforms, and the next thing worth deciding about this surface.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_014P9p2fvFnyiywBxGkv4gfW