### PR TITLE
The auto-download toggles said "new tracks" and meant "all of them"

### DIFF
--- a/packages/frontend/src/components/Playlists/FavoritesDetail.tsx
+++ b/packages/frontend/src/components/Playlists/FavoritesDetail.tsx
@@ -244,7 +244,11 @@ export function FavoritesDetail({ onBack: onBackProp }: Props) {
                 ? 'bg-blue-600 hover:bg-blue-500'
                 : 'bg-zinc-700 hover:bg-zinc-600'
             }`}
-            title={autoDownloadEnabled ? 'Disable auto-download' : 'Auto-download new favorites'}
+            title={autoDownloadEnabled
+              ? 'Stop keeping favorites downloaded'
+              // Says what it does. It reads as "only ones I add from now on", and it is not: it
+              // fetches every favorite not already held, then keeps up as the collection changes.
+              : 'Keep favorites downloaded — fetches all that are missing, then keeps up'}
           >
             <RotateCw className="w-4 h-4" />
             <span className="text-sm">Auto</span>

--- a/packages/frontend/src/components/Playlists/PlaylistDetail.tsx
+++ b/packages/frontend/src/components/Playlists/PlaylistDetail.tsx
@@ -583,7 +583,9 @@ export function PlaylistDetail({ playlistId: playlistIdProp, onBack: onBackProp 
                 ? 'bg-blue-600 hover:bg-blue-500'
                 : 'bg-zinc-700 hover:bg-zinc-600'
             }`}
-            title={playlist.auto_download ? 'Disable auto-download' : 'Auto-download new tracks'}
+            title={playlist.auto_download
+              ? 'Stop keeping this playlist downloaded'
+              : 'Keep this playlist downloaded — fetches all that are missing, then keeps up'}
           >
             <RotateCw className="w-4 h-4" />
             <span className="text-sm">Auto</span>

--- a/packages/frontend/src/components/SmartPlaylists/SmartPlaylistDetail.tsx
+++ b/packages/frontend/src/components/SmartPlaylists/SmartPlaylistDetail.tsx
@@ -443,7 +443,9 @@ export function SmartPlaylistDetail({ playlist: playlistProp, onBack: onBackProp
                 ? 'bg-blue-600 hover:bg-blue-500'
                 : 'bg-zinc-700 hover:bg-zinc-600'
             }`}
-            title={playlist.auto_download ? 'Disable auto-download' : 'Auto-download new tracks'}
+            title={playlist.auto_download
+              ? 'Stop keeping this playlist downloaded'
+              : 'Keep this playlist downloaded — fetches all that are missing, then keeps up'}
           >
             <RotateCw className="w-4 h-4" />
             <span className="text-sm">Auto</span>

--- a/packages/frontend/src/hooks/useAutoDownload.ts
+++ b/packages/frontend/src/hooks/useAutoDownload.ts
@@ -1,7 +1,10 @@
 /**
- * Hook for auto-downloading new tracks in playlists/smart playlists.
- * Compares current track IDs against offline tracks and triggers download
- * for any missing tracks when auto-download is enabled.
+ * Keeps a collection downloaded, for playlists, smart playlists and favorites.
+ *
+ * **Not only new tracks**, which is what the controls used to say. It compares the whole current
+ * track list against what is offline and downloads everything missing — so switching it on for a
+ * collection you have never downloaded fetches all of it, not nothing. The labels were corrected to
+ * match; this comment is the reason they had to be.
  */
 import { useEffect, useRef } from 'react';
 import { useDownloadStore } from '../stores/downloadStore';


### PR DESCRIPTION
Three controls — playlists, smart playlists and favorites — described the setting as downloading **new** tracks. `useAutoDownload` compares the whole current track list against what's offline and downloads everything missing, so switching it on for a collection you've never downloaded fetches *all* of it.

The gap matters at the sizes involved: on the live library that's **1,720 favourites**, on the order of 15 GB, offered under a tooltip that reads as "only ones I add from now on".

Found while making the native apps honour the same server setting (`familiar-apple` #45) — the behaviour had to be pinned down before it could be matched, and the label turned out to disagree with the hook it describes.

The hook's own summary made the same claim, so that's corrected too; it's where the next person will check.

960 frontend tests, lint clean (0 errors), bundle builds.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_014P9p2fvFnyiywBxGkv4gfW