### PR TITLE
Release dates that cannot be true no longer lead "new releases"

### DIFF
--- a/backend/app/services/new_releases.py
+++ b/backend/app/services/new_releases.py
@@ -37,6 +37,57 @@ logger = logging.getLogger(__name__)
 DISCOVERY_CONTEXT = "artist_new_release"
 
 
+
+# How far ahead of today a release date can be before it is certainly wrong.
+#
+# Generous on purpose. MusicBrainz legitimately carries announced future releases — an album due in
+# three months is real and should appear. Nothing, though, is released more than a year out, so this
+# only catches data that cannot be true.
+MAX_RELEASE_DATE_LOOKAHEAD = timedelta(days=366)
+
+
+def plausible_release_date(
+    value: datetime | None, *, now: datetime | None = None
+) -> datetime | None:
+    """A release date, or `None` when the source gave one that cannot be true.
+
+    **This exists because two of 589 cached releases claimed 2913 and 2209**, both year-only dates
+    from MusicBrainz where someone typed a digit wrong. They parse cleanly — `2913-01-01` is valid
+    ISO — so nothing rejected them, and because this list is ordered by date descending they sorted
+    *above every real release*. The two most prominent cards in Discover were the two worst rows in
+    the table.
+
+    Returning `None` rather than dropping the release keeps the album discoverable — these are real
+    compilations with a typo attached — while removing the claim that is wrong. The query orders
+    `nullslast`, so a release with no trustworthy date stops leading a list called "new releases".
+
+    Only the future bound is checked. An old first-release date is a different question: a reissue
+    can legitimately carry one, and deciding what that means for this feature is not this function's
+    business.
+    """
+    if value is None:
+        return None
+
+    # Written out rather than folded into a conditional expression: the aware/naive distinction
+    # decides whether the subtraction below raises, and `a or b if c else d` binds in a way that
+    # reads as the opposite of what it does.
+    if now is not None:
+        reference = now
+    elif value.tzinfo is not None:
+        reference = datetime.now(tz=value.tzinfo)
+    else:
+        reference = datetime.now()
+
+    # The stored column is naive and a caller's `now` may not be. Comparing the two raises, and a
+    # crash in a background sync is a worse outcome than trusting one odd date.
+    if (value.tzinfo is None) != (reference.tzinfo is None):
+        return value
+
+    if value - reference > MAX_RELEASE_DATE_LOOKAHEAD:
+        return None
+    return value
+
+
 class NewReleasesService:
     """Service for discovering new releases from artists in the user's library."""
 

--- a/backend/app/services/tasks/new_releases.py
+++ b/backend/app/services/tasks/new_releases.py
@@ -156,6 +156,7 @@ async def _check_artist_against_musicbrainz(
         get_artist_releases_recent,
         search_artist,
     )
+    from app.services.new_releases import plausible_release_date
 
     mb_id_to_use = mb_artist_id
     releases_for_artist: list[dict[str, Any]] = []
@@ -206,6 +207,11 @@ async def _check_artist_against_musicbrainz(
                 release_date = datetime.fromisoformat(raw_date)
             except Exception:
                 release_date = None
+
+        # A date that cannot be true is worse than no date here, because this list is ordered by
+        # date descending — a release claiming 2913 sorts above everything real. See
+        # `plausible_release_date`; two rows in the live cache did exactly that.
+        release_date = plausible_release_date(release_date)
 
         saved = await service.save_discovered_release(
             artist_name=artist_name,

--- a/backend/migrations/versions/20260802_implausible_release_dates.py
+++ b/backend/migrations/versions/20260802_implausible_release_dates.py
@@ -1,0 +1,59 @@
+"""Clear cached release dates that cannot be true.
+
+Two of 589 rows in `external_album_cache` claimed release dates of **2913** and **2209** — year-only
+dates from MusicBrainz with a digit typed wrong. They parse cleanly, so nothing rejected them on the
+way in, and because the new-releases list is ordered by `release_date DESC NULLS LAST` they sorted
+above every real release. The two most prominent cards in Discover were the two worst rows in the
+table.
+
+`plausible_release_date` now rejects these at ingestion, but that alone would never heal these rows:
+`save_discovered_release` returns early when a `release_id` already exists and never updates it, so
+a bad row is permanent until something rewrites it. This is that something.
+
+The date is cleared rather than the row deleted. These are real compilations with a typo attached —
+keeping them discoverable while dropping the claim that is wrong is the smaller loss, and
+`NULLS LAST` then stops them leading a list called "new releases".
+
+Only the future bound is checked, matching the helper: an old first-release date can legitimately
+belong to a reissue, and that is a different question.
+
+Revision ID: 20260802_bad_release_dates
+Revises: 20260727_playback_sessions
+Create Date: 2026-08-02
+"""
+
+from collections.abc import Sequence
+
+from alembic import op
+
+from migrations.helpers import column_exists, table_exists
+
+revision: str = "20260802_bad_release_dates"
+down_revision: str | None = "20260727_playback_sessions"
+branch_labels: str | Sequence[str] | None = None
+depends_on: str | Sequence[str] | None = None
+
+
+def upgrade() -> None:
+    if not table_exists("external_album_cache"):
+        return
+    if not column_exists("external_album_cache", "release_date"):
+        return
+
+    # The same 366-day window `plausible_release_date` uses. Written as an interval rather than a
+    # literal year so a migration run later does not clear dates the application would keep.
+    op.execute(
+        """
+        UPDATE external_album_cache
+        SET release_date = NULL
+        WHERE release_date IS NOT NULL
+          AND release_date > (NOW() + INTERVAL '366 days')
+        """
+    )
+
+
+def downgrade() -> None:
+    # One-way: the cleared values were wrong and there is nowhere to restore them from — the source
+    # they came from is the thing that had them wrong. Re-running the new-releases sync repopulates
+    # dates for anything MusicBrainz can still answer for, now filtered.
+    pass

--- a/backend/tests/test_new_release_dates.py
+++ b/backend/tests/test_new_release_dates.py
@@ -1,0 +1,76 @@
+"""A release date the source could not possibly mean.
+
+Two of 589 cached releases claimed **2913** and **2209** — year-only dates from MusicBrainz with a
+digit typed wrong. They parse cleanly (`2913-01-01` is valid ISO), so nothing rejected them, and
+because the list is ordered by date descending they sorted above every real release. The two most
+prominent cards in Discover were the two worst rows in the table.
+
+These run without a database: `plausible_release_date` is a pure function, which is most of why it
+is one.
+"""
+
+from datetime import datetime, timedelta
+
+from app.services.new_releases import (
+    MAX_RELEASE_DATE_LOOKAHEAD,
+    plausible_release_date,
+)
+
+NOW = datetime(2026, 8, 2)
+
+
+def test_the_two_dates_found_in_the_live_cache_are_rejected() -> None:
+    assert plausible_release_date(datetime(2913, 1, 1), now=NOW) is None
+    assert plausible_release_date(datetime(2209, 1, 1), now=NOW) is None
+
+
+def test_an_announced_future_release_is_kept() -> None:
+    """MusicBrainz legitimately carries releases that have not happened yet.
+
+    Rejecting those would empty the feature of the thing it is for — an album due in three months is
+    exactly what "new releases from your artists" means.
+    """
+    assert plausible_release_date(datetime(2026, 11, 1), now=NOW) == datetime(2026, 11, 1)
+    assert plausible_release_date(NOW + timedelta(days=300), now=NOW) is not None
+
+
+def test_the_boundary_is_inclusive_and_just_beyond_it_is_not() -> None:
+    edge = NOW + MAX_RELEASE_DATE_LOOKAHEAD
+    assert plausible_release_date(edge, now=NOW) == edge
+    assert plausible_release_date(edge + timedelta(seconds=1), now=NOW) is None
+
+
+def test_old_dates_are_left_alone() -> None:
+    """Only the future bound is checked.
+
+    A reissue can legitimately carry an old first-release date, and deciding what that means for
+    this feature is a different question from rejecting a date that cannot be true.
+    """
+    assert plausible_release_date(datetime(1913, 1, 1), now=NOW) == datetime(1913, 1, 1)
+    assert plausible_release_date(datetime(1970, 6, 1), now=NOW) == datetime(1970, 6, 1)
+
+
+def test_no_date_stays_no_date() -> None:
+    assert plausible_release_date(None, now=NOW) is None
+
+
+def test_a_mixed_awareness_comparison_does_not_raise() -> None:
+    """The stored column is naive; a caller's clock may not be.
+
+    Subtracting one from the other raises, and a crash inside a background sync is a worse outcome
+    than trusting one odd date — so the mismatch is a pass, not an error.
+    """
+    from datetime import UTC
+
+    aware = datetime(2913, 1, 1, tzinfo=UTC)
+    assert plausible_release_date(aware, now=NOW) == aware
+
+    naive_far_future = datetime(2913, 1, 1)
+    aware_now = datetime(2026, 8, 2, tzinfo=UTC)
+    assert plausible_release_date(naive_far_future, now=aware_now) == naive_far_future
+
+
+def test_it_defaults_to_the_real_clock() -> None:
+    """Called with no `now` in production, so the default path is the one that runs."""
+    assert plausible_release_date(datetime(2913, 1, 1)) is None
+    assert plausible_release_date(datetime(2020, 1, 1)) == datetime(2020, 1, 1)


### PR DESCRIPTION
Chasing the two odd cards in the Discover screenshot. They're real, and the damage was worse than cosmetic.

```
2913-01-01   Various Artists   Chilled – The Collection
2209-01-01   Various Artists   Ρεμπέτικες ουσίες 2: Απαγορευμένα ρεμπέτικα
```

Two of **589** cached releases — year-only dates from MusicBrainz with a digit typed wrong.

They parse cleanly (`2913-01-01` is valid ISO, so `datetime.fromisoformat` accepts it) and nothing rejected them. And because the list is ordered `release_date DESC NULLS LAST`, **they sorted above every real release** — the two most prominent cards in Discover were the two worst rows in the table.

## Three parts, because the first alone wouldn't have worked

1. **`plausible_release_date`** rejects anything more than 366 days ahead. Generous on purpose: MusicBrainz legitimately carries announced future releases, and an album due in three months is exactly what this feature is *for*. Only the future bound is checked — a reissue can legitimately carry an old first-release date, and what that means here is a separate question.
2. **The ingestion path applies it**, so no more accumulate.
3. **A migration clears the two already stored** — because ingestion would never have healed them. `save_discovered_release` returns early when a `release_id` already exists and **never updates it**, so a bad row is permanent until something rewrites it. That's the part worth a second look: it means any data defect that gets into this cache is there for good.

The date is cleared rather than the row deleted. These are real compilations with a typo attached; keeping them discoverable while dropping the wrong claim is the smaller loss, and `NULLS LAST` then stops them leading a list called "new releases".

## Verification

7 tests, no database needed — the helper is pure, which is most of why it is one. They pin the two real values, the announced-future case that must survive, the boundary either side of 366 days, and the naive/aware mismatch that would otherwise raise inside a background sync.

Migration lint passes (45 validated), ruff and mypy clean.

**Not yet run against the live database** — the migration is what fixes your two rows, and that happens on the next `deploy-dev`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_014P9p2fvFnyiywBxGkv4gfW