### PR TITLE
Give the embedded surface a scroll container, so its track lists render

### DIFF
--- a/packages/frontend/src/components/Embed/EmbedDiscover.tsx
+++ b/packages/frontend/src/components/Embed/EmbedDiscover.tsx
@@ -1,5 +1,6 @@
-import { lazy, Suspense, useCallback } from 'react';
+import { lazy, Suspense, useCallback, useRef } from 'react';
 import { Loader2 } from 'lucide-react';
+import { ScrollContainerContext } from '../../hooks/useScrollContainer';
 import type { BrowserProps, LibraryFilters } from '../Library/types';
 import { postPlayIntent } from '../../services/embedBridge';
 
@@ -17,6 +18,8 @@ const DiscoverBrowser = lazy(() => import('../Library/browsers/DiscoverBrowser/D
  * main risk of embedding at all.
  */
 export function EmbedDiscover() {
+  const scrollRef = useRef<HTMLDivElement>(null);
+
   /**
    * A play button in Discover posts to the native player and does nothing else.
    *
@@ -62,10 +65,27 @@ export function EmbedDiscover() {
   };
 
   return (
-    <div className="min-h-screen bg-zinc-900 text-zinc-100">
-      <Suspense fallback={<EmbedLoading />}>
-        <DiscoverBrowser {...props} />
-      </Suspense>
+    // **A real scroll container, and a bounded one.** `PlaylistTrackList` virtualises its rows
+    // against whichever element `useScrollContainer` hands it, falling back to its own
+    // `flex-1 min-h-0 overflow-y-auto` wrapper when there is no provider. Neither worked here: the
+    // embed had no provider *and* no height-bounded flex column, so the fallback measured zero and
+    // the virtualiser rendered zero rows. "Unheard in Your Library" and "Deep Cuts" drew their
+    // headers, their counts, and nothing else — not even the empty message, because the lists were
+    // not empty.
+    //
+    // The card grids above them were unaffected, which is what made it look like a data problem
+    // rather than a layout one.
+    //
+    // `h-screen` + `flex flex-col` gives the definite height the chain needs, and providing the
+    // context makes the embedded page scroll as one surface, exactly as `AppShell` does for the app.
+    <div className="h-screen flex flex-col bg-zinc-900 text-zinc-100">
+      <ScrollContainerContext.Provider value={scrollRef}>
+        <div ref={scrollRef} className="flex-1 overflow-y-auto overflow-x-hidden min-h-0">
+          <Suspense fallback={<EmbedLoading />}>
+            <DiscoverBrowser {...props} />
+          </Suspense>
+        </div>
+      </ScrollContainerContext.Provider>
     </div>
   );
 }


### PR DESCRIPTION
"Unheard in Your Library" and "Deep Cuts by Your Favorites" drew their headings, their counts (15 each) and their column headers — and **no rows**. Not even the empty message, because the lists weren't empty: the API returns 15 well-formed tracks for each.

## Cause

`PlaylistTrackList` virtualises rows against whichever element `useScrollContainer` hands it, falling back to its own `flex-1 min-h-0 overflow-y-auto` wrapper when there's no provider in the tree.

The embed had **neither**: no `AppShell`, so no provider — and a plain `min-h-screen` div, so the fallback had no height-bounded flex column to resolve against. The scroll container measured **zero**, the virtualiser saw a zero-height viewport, and rendered zero rows.

The card grids above aren't virtualised, which is why only those two sections were empty — and why it read as a data problem rather than a layout one.

## Fix

`h-screen flex flex-col` gives the chain a definite height, and providing `ScrollContainerContext` makes the embedded page scroll as one surface, exactly as `AppShell` does for the app. That's the arrangement these components were written against; the embed is simply the first place they'd been mounted without it.

Same shape as the lesson CLAUDE.md already records for iOS Safari — a `flex-1` with no bounded ancestor collapses — arriving here through a missing *context* rather than a missing `min-h-0`.

## Verification

Driven headlessly against the dev server with Playwright rather than eyeballed:

```
Unheard in Your Library:      15 rows
Deep Cuts by Your Favorites:  11 rows   (viewport + overscan — correct for virtualisation)
page errors:                  none
```

960 frontend tests, lint clean (0 errors), bundle builds.

## Not fixed here

**Links inside the embed still go nowhere.** That's the separate, known gap: `EmbedDiscover` supplies no-op navigation handlers and the embed router returns to Discover. It's ADR-0017's open follow-up and needs a decision — either a second bridge message so the native app handles navigation, or real routes rendered inside the embed. Deliberately not smuggled into a layout fix.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_014P9p2fvFnyiywBxGkv4gfW