### PR TITLE
The embedded surface can ask the app to navigate (ADR-0020)

### DIFF
--- a/docs/decisions/ADR-0020-the-embedded-surface-can-ask-the-app-to-navigate.md
+++ b/docs/decisions/ADR-0020-the-embedded-surface-can-ask-the-app-to-navigate.md
@@ -1,0 +1,126 @@
+# ADR-0020: The Embedded Surface Can Ask the App to Navigate
+
+Status: proposed
+
+Date: 2026-08-02
+
+Extends [ADR-0016](ADR-0016-embedded-web-surfaces-on-the-mac.md) and
+[ADR-0017](ADR-0017-the-embedded-surface-gets-a-null-audio-engine.md).
+
+## Context
+
+Embedded Discover shipped with every link in it dead. Tapping an artist, an album or "See all" does
+nothing at all — not an error, not a wrong screen, nothing. It was reported twice from use before
+being decided, which is the honest reason this ADR exists.
+
+That was deliberate, and recorded at the time.
+[ADR-0017](ADR-0017-the-embedded-surface-gets-a-null-audio-engine.md)'s final follow-up says:
+*"Decide what an embedded surface does with navigation inside it — an artist link in Discover
+currently goes nowhere on either platform, because `EmbedDiscover` supplies no-op handlers and the
+embed router returns to Discover."* This is that decision.
+
+**The rule being amended, and why it was right to begin with.**
+[ADR-0016](ADR-0016-embedded-web-surfaces-on-the-mac.md) point 5:
+
+> The bridge is one-way and narrow: the page posts an intent — play these track ids, starting at
+> this one — and the native side owns the queue, the playback and the reporting.
+
+and in its consequences:
+
+> **Tradeoff:** The bridge is a new seam between two clients that were previously independent, and a
+> web-app change could break the native app through it. It should be narrow enough — one message
+> shape — that this stays unlikely.
+
+That reasoning holds. The seam is the main risk of embedding, and every message added is surface a
+web-app change can break the native app through. So this widens it by exactly one, and says what the
+bar is for a third.
+
+**What makes navigation different from the other things the page could ask for.** The native app
+already has artist and album screens, reached from four other places, and they are better than the
+web equivalents would be inside a web view — native scrolling, native context menus, artwork from
+the same cache the rest of the app uses. Discover's links are the only route into them that does not
+work. So this is not new capability; it is connecting a surface that was left unconnected.
+
+The alternative shape — rendering artist and album routes *inside* the embed — is what
+ADR-0017 point 1 rejected in a different guise. It rejected "the full web app with its chrome
+hidden" because hiding is not preventing; growing the embed one route at a time arrives at the same
+place more slowly, and each route added is another chance for a play affordance to appear on a
+surface whose engine is deliberately null.
+
+**A constraint the native side already carries.** Albums and artists are addressed *by name*,
+because that is what the API offers. Names containing a slash cannot be addressed at all — there are
+**79 such artists** in this library (`backend/app/main.py:546`), and `BrowseDetailView` already
+degrades to a filtered track list for them rather than failing. Navigation from the embed inherits
+that behaviour rather than inventing a second answer to it.
+
+## Decision
+
+1. **The bridge carries a second message: `navigate`.** The page posts an intent to open an artist
+   or an album; the native app pushes its own screen for it. The bridge stays one-way — nothing is
+   sent back, and the web view is never told what the app is showing.
+
+2. **Two messages is the cap until an ADR says otherwise.** ADR-0016 point 5's argument is unchanged
+   and this is not a licence to grow. A third message needs a decision of its own, and the test it
+   must pass is the one in point 3.
+
+3. **The bar for a message is: the native app already does this better, and the page cannot.**
+   Navigation clears it — the artist screen exists, is native, and Discover cannot reach it. A
+   message that merely saves the page some work does not clear it.
+
+4. **Navigation targets are limited to artist and album.** They are what Discover links to, they are
+   what the native app has screens for, and they are addressed by name through paths the app already
+   uses. Anything else — a playlist, a settings pane, an external URL — is out of scope and would
+   need point 3 applied again.
+
+5. **An unroutable name degrades rather than fails.** A name the path-keyed API cannot address
+   already lands on a filtered track list with a note saying so; navigation from the embed reaches
+   the same place. It does not silently do nothing, which is the behaviour this ADR exists to end.
+
+6. **The page keeps no navigation state.** It does not know whether the app honoured the intent, and
+   it does not change what it shows. There is one navigation stack and it is the app's, exactly as
+   there is one queue.
+
+7. **Both platforms, once each has the surface.** This is a property of the bridge rather than of a
+   window, so it applies to the Mac now and to the phone if
+   [ADR-0019](ADR-0019-the-embedded-surface-comes-to-the-phone.md) is accepted.
+
+## Alternatives Considered
+
+**Render artist and album routes inside the embed.** No bridge change, no native work, and the links
+would work today. Rejected as ADR-0017 point 1's rejection arriving by instalments: it rejected the
+full app with its chrome hidden because hiding is not preventing, and adding routes one at a time
+reaches the same surface area with the same hazard — a play affordance on a page whose engine is
+deliberately null. It would also give the app two artist screens that drift.
+
+**Leave the links dead and remove them from the embedded page.** Honest, and cheaper than either
+alternative: a surface with no links cannot have broken ones. Rejected because the links are most of
+what Discover *is* — a recommendation you cannot open is a poster, not a discovery surface — and
+because stripping them means a purpose-built variant of the page, which is the maintenance cost
+ADR-0016 embedded Discover to avoid.
+
+**Open the artist in the default browser.** Trivial, no bridge. Rejected for the reason ADR-0016
+rejected it for Discover itself: leaving the app is the friction ADR-0013 exists to remove, and it
+is worse from a screen already inside the app.
+
+**Make the bridge generic — let the page post any route and have the app interpret it.** One message
+forever, no future ADRs about a third. Rejected because it inverts the seam: an open-ended route
+string means the web app decides what the native app can be asked to do, and a typo becomes a silent
+no-op on a client that cannot be debugged from the page. Two named intents can be exhaustively
+handled in Swift and tested; a route string cannot.
+
+## Consequences
+
+- **Positive:** Discover's links work, and land on native screens rather than web ones — the artist
+  page you reach from a recommendation is the same one you reach from the library.
+- **Positive:** The embed stays a single screen. Nothing about the null engine or the browse-only
+  rule is weakened, because navigation leaves the web view rather than deepening it.
+- **Positive:** There is now a stated bar for a third message, instead of a precedent that the
+  bridge grows whenever something is inconvenient.
+- **Tradeoff:** The seam ADR-0016 named as embedding's main risk is twice as wide. Two shapes to
+  keep in step across a TypeScript half and a Swift half that no compiler checks against each other.
+- **Tradeoff:** A link that lands on a degraded track list, for one of the 79 slash-named artists,
+  looks like a worse result than the web app would give — the web app has the same limitation but
+  reaches it by a different route.
+- **Follow-up:** Decide what "See all" should do. It is a link to a *list* rather than to an entity,
+  and the native app has no screen for "all new releases" — so it is out of scope here and is the
+  most likely candidate for testing point 3 in earnest.

--- a/packages/frontend/src/components/Embed/EmbedDiscover.tsx
+++ b/packages/frontend/src/components/Embed/EmbedDiscover.tsx
@@ -2,7 +2,7 @@ import { lazy, Suspense, useCallback, useRef } from 'react';
 import { Loader2 } from 'lucide-react';
 import { ScrollContainerContext } from '../../hooks/useScrollContainer';
 import type { BrowserProps, LibraryFilters } from '../Library/types';
-import { postPlayIntent } from '../../services/embedBridge';
+import { postNavigateIntent, postPlayIntent } from '../../services/embedBridge';
 
 // Imported directly rather than through `browsers/index.ts`, which registers all nine and would pull
 // the track list, the album grid and the Music Map into a bundle that shows none of them.
@@ -30,6 +30,14 @@ export function EmbedDiscover() {
     postPlayIntent({ trackIds: [trackId], startingAt: trackId });
   }, []);
 
+  const handleGoToArtist = useCallback((artistName: string) => {
+    postNavigateIntent({ to: 'artist', artist: artistName });
+  }, []);
+
+  const handleGoToAlbum = useCallback((artistName: string, albumName: string) => {
+    postNavigateIntent({ to: 'album', artist: artistName, album: albumName });
+  }, []);
+
   const props: BrowserProps = {
     tracks: [],
     artists: [],
@@ -42,11 +50,14 @@ export function EmbedDiscover() {
     onSelectAll: noop,
     onClearSelection: noop,
 
-    // Navigation is the open question ADR-0017 leaves as a follow-up: this surface renders Discover
-    // and has nowhere else to go, so these are inert rather than routes to blank screens. The router
-    // in `renderEmbed` sends any internal navigation back here for the same reason.
-    onGoToArtist: noop,
-    onGoToAlbum: noop,
+    // Handed to the *app*, not followed in the page (ADR-0020). The native artist and album screens
+    // already exist and are better than a web equivalent inside a web view; these links were the
+    // only route into them that did nothing.
+    onGoToArtist: handleGoToArtist,
+    onGoToAlbum: handleGoToAlbum,
+    // Still inert, and named as such by ADR-0020 point 4: these open *lists* — a year, a genre, a
+    // mood region — and the native app has no screen for any of them. A message that leads nowhere
+    // on the other side would be worse than a link that does nothing.
     onGoToYear: noop,
     onGoToYearRange: noop,
     onGoToGenre: noop,

--- a/packages/frontend/src/services/__tests__/embedBridge.test.ts
+++ b/packages/frontend/src/services/__tests__/embedBridge.test.ts
@@ -3,6 +3,7 @@ import {
   isEmbedded,
   postPlayIntent,
   profileFromURL,
+  postNavigateIntent,
   isEmbedSurfaceDocument,
   BRIDGE_HANDLER,
   type PlayIntent,
@@ -146,5 +147,80 @@ describe('isEmbedSurfaceDocument', () => {
   it('rejects a marker with the wrong value', () => {
     expect(isEmbedSurfaceDocument(docWith('<meta name="familiar-surface" content="app">'))).toBe(false);
     expect(isEmbedSurfaceDocument(docWith('<meta name="familiar-surface">'))).toBe(false);
+  });
+});
+
+/**
+ * The second message (ADR-0020), and the reason it is the last one for now.
+ *
+ * ADR-0016 point 5 called the bridge the main risk of embedding and kept it to one shape. This
+ * widens it by exactly one, so both shapes must fail identically — inert in a browser, inert rather
+ * than throwing when the host misbehaves — or the next message inherits whichever half was
+ * remembered.
+ */
+describe('postNavigateIntent', () => {
+  let posted: unknown[];
+
+  function installHandler(impl?: (m: unknown) => void) {
+    posted = [];
+    (window as unknown as Record<string, unknown>).webkit = {
+      messageHandlers: { familiar: { postMessage: impl ?? ((m: unknown) => posted.push(m)) } },
+    };
+  }
+
+  beforeEach(() => {
+    posted = [];
+    delete (window as unknown as Record<string, unknown>).webkit;
+  });
+  afterEach(() => {
+    delete (window as unknown as Record<string, unknown>).webkit;
+  });
+
+  it('posts an artist intent without an album key', () => {
+    installHandler();
+    expect(postNavigateIntent({ to: 'artist', artist: 'Boards of Canada' })).toBe(true);
+    expect(posted).toEqual([{ type: 'navigate', to: 'artist', artist: 'Boards of Canada' }]);
+  });
+
+  it('posts an album intent with both names', () => {
+    installHandler();
+    expect(postNavigateIntent({ to: 'album', artist: 'Interpol', album: 'Antics' })).toBe(true);
+    expect(posted).toEqual([
+      { type: 'navigate', to: 'album', artist: 'Interpol', album: 'Antics' },
+    ]);
+  });
+
+  it('trims, and refuses a target it cannot address', () => {
+    installHandler();
+    expect(postNavigateIntent({ to: 'artist', artist: '  M83  ' })).toBe(true);
+    expect((posted[0] as { artist: string }).artist).toBe('M83');
+
+    expect(postNavigateIntent({ to: 'artist', artist: '   ' })).toBe(false);
+    expect(postNavigateIntent({ to: 'album', artist: 'Interpol' })).toBe(false);
+    expect(postNavigateIntent({ to: 'album', artist: 'Interpol', album: ' ' })).toBe(false);
+    expect(posted).toHaveLength(1);
+  });
+
+  /**
+   * A slash-named artist is passed through unchanged. There are 79 of them, the path-keyed API
+   * cannot address any, and the native side already degrades to a filtered track list — inventing a
+   * second answer here would give two behaviours for one limitation.
+   */
+  it('passes through names the path-keyed API cannot address', () => {
+    installHandler();
+    expect(postNavigateIntent({ to: 'artist', artist: 'Kruder & Dorfmeister/K&D' })).toBe(true);
+    expect((posted[0] as { artist: string }).artist).toBe('Kruder & Dorfmeister/K&D');
+  });
+
+  it('is inert in an ordinary browser, like the play intent', () => {
+    expect(postNavigateIntent({ to: 'artist', artist: 'M83' })).toBe(false);
+  });
+
+  it('survives a throwing host, like the play intent', () => {
+    installHandler(() => {
+      throw new Error('native side blew up');
+    });
+    expect(() => postNavigateIntent({ to: 'artist', artist: 'M83' })).not.toThrow();
+    expect(postNavigateIntent({ to: 'artist', artist: 'M83' })).toBe(false);
   });
 });

--- a/packages/frontend/src/services/embedBridge.ts
+++ b/packages/frontend/src/services/embedBridge.ts
@@ -12,6 +12,22 @@
  * detail.
  */
 
+/**
+ * Open an artist or an album in the *app*, not in the page (ADR-0020).
+ *
+ * Addressed by name because that is what the API offers — `/library/artists/{artist_name}` and
+ * `/library/albums/{artist_name}/{album_name}`. Names containing a slash cannot be addressed, and
+ * the native side already degrades those to a filtered track list rather than failing; this inherits
+ * that rather than inventing a second answer.
+ */
+export interface NavigateIntent {
+  type: 'navigate';
+  to: 'artist' | 'album';
+  artist: string;
+  /** Present only for `to: 'album'`. */
+  album?: string;
+}
+
 /** What the native side receives. Keep this in step with the Swift `WKScriptMessageHandler`. */
 export interface PlayIntent {
   type: 'play';
@@ -86,20 +102,52 @@ export function isEmbedded(): boolean {
  * for an unbridged page, and why ADR-0017 puts a null engine underneath: the alternative to silence
  * is a second audio engine, not success.
  */
+/**
+ * Ask the app to open an artist or album.
+ *
+ * The second and — per ADR-0020 point 2 — final message shape until an ADR says otherwise. It earns
+ * its place by that ADR's point 3: the native app already has these screens, they are better than a
+ * web equivalent inside a web view, and the page cannot reach them.
+ *
+ * Returns whether it was delivered. A `false` in an ordinary browser is correct: this module ships
+ * in the web app and the iOS app too, and must be inert outside a native host.
+ */
+export function postNavigateIntent(intent: Omit<NavigateIntent, 'type'>): boolean {
+  const artist = intent.artist?.trim();
+  if (!artist) return false;
+  if (intent.to === 'album' && !intent.album?.trim()) return false;
+
+  return post({
+    type: 'navigate',
+    to: intent.to,
+    artist,
+    ...(intent.to === 'album' ? { album: intent.album!.trim() } : {}),
+  } satisfies NavigateIntent);
+}
+
 export function postPlayIntent(intent: Omit<PlayIntent, 'type'>): boolean {
   if (intent.trackIds.length === 0) return false;
-  const w = window as unknown as WebKitBridgeWindow;
-  const handler = w.webkit?.messageHandlers?.[BRIDGE_HANDLER];
-  if (!handler || typeof handler.postMessage !== 'function') return false;
 
-  const message: PlayIntent = {
+  return post({
     type: 'play',
     trackIds: intent.trackIds,
     // Defended rather than trusted: a `startingAt` outside the list would leave the native side
     // choosing a cursor for a track it was not given, and the first track is the honest default.
     startingAt: intent.trackIds.includes(intent.startingAt) ? intent.startingAt : intent.trackIds[0],
-  };
+  } satisfies PlayIntent);
+}
 
+/**
+ * The one place a message actually crosses.
+ *
+ * Shared so the two shapes cannot fail differently — with the bridge now two messages wide
+ * (ADR-0020), "inert in a browser" and "survives a throwing host" have to mean the same thing for
+ * both, or the next one to be added inherits whichever half was remembered.
+ */
+function post(message: PlayIntent | NavigateIntent): boolean {
+  const w = window as unknown as WebKitBridgeWindow;
+  const handler = w.webkit?.messageHandlers?.[BRIDGE_HANDLER];
+  if (!handler || typeof handler.postMessage !== 'function') return false;
   try {
     handler.postMessage(message);
     return true;


### PR DESCRIPTION
> Based on **#70** (both touch `EmbedDiscover`). Merge that first. Native half: `familiar-apple` #49.

Every link in embedded Discover was dead — not an error, not a wrong screen, nothing. Reported twice from use before being decided, which is the honest reason ADR-0020 exists. ADR-0017's final follow-up named it.

## What's being amended, and why it was right before

ADR-0016 point 5 kept the bridge to **one message shape**, and called the seam embedding's main risk: *"a web-app change could break the native app through it. It should be narrow enough — one message shape — that this stays unlikely."*

That reasoning still holds, so this widens it by **exactly one** and states the bar for a third:

> **The native app already does this better, and the page cannot.**

Navigation clears it — the artist screen exists, is native, and Discover was the only route into it that did nothing. "A message that merely saves the page some work" does not clear it.

## The shape that was rejected

Rendering artist and album routes *inside* the embed. That's ADR-0017 point 1's rejection arriving by instalments: it turned down "the full web app with its chrome hidden" because hiding is not preventing, and adding routes one at a time reaches the same surface area with the same hazard — a play affordance on a page whose engine is deliberately null. It would also give the app two artist screens that drift.

## Deliberately still dead

`onGoToYear`, `onGoToYearRange`, `onGoToGenre`, `onGoToMood`. ADR-0020 point 4: they open **lists**, and the native app has no screen for a year or a mood region. A message leading nowhere on the other side is worse than a link that does nothing.

"See all" is left as the ADR's follow-up — it's a link to a list too, and the most likely candidate for testing point 3 in earnest.

## Details

- Both shapes now cross through one `post`, so "inert in a browser" and "survives a throwing host" can't mean different things for each — otherwise a third message inherits whichever half was remembered.
- Slash-named artists pass through unchanged: 79 of them can't be addressed by the path-keyed API, and the native side already degrades to a filtered track list.

966 frontend tests (18 on the bridge), lint clean, bundle builds.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_014P9p2fvFnyiywBxGkv4gfW