### PR TITLE
Propose ADR-0021 — track lists on the Mac are sortable tables

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -95,6 +95,14 @@ a missed intent inert rather than a second engine. The web half is built — `/e
 document registering the null engine. What remains is `familiar-apple`: the `WKWebView`, the
 `WKScriptMessageHandler` that receives the play intent, and the native "unavailable" state.
 
+**`ADR-0020`–`ADR-0021` are proposed 2026-08-02.** `0020` widens the embed bridge by one message so
+Discover's links open the app's own artist and album screens, and states the bar for a third. `0021`
+turns the Mac's track lists into sortable tables with a column chooser, bumps the **macOS floor to
+14** for `TableColumnCustomization` (iOS stays at 15), and adds `playCount`/`dateAdded` to the
+server's sort allowlist. `0021`'s load-bearing point is that the Tracks list sorts **server-side** —
+it pages at 50, and sorting the loaded page would repeat the library-shuffle defect on a surface
+where a wrong order looks like an order.
+
 ## Key Directories
 
 ```

--- a/backend/app/api/routes/tracks/__init__.py
+++ b/backend/app/api/routes/tracks/__init__.py
@@ -8,6 +8,7 @@ import logging
 from typing import Any
 
 from fastapi import APIRouter
+from sqlalchemy import Float, cast, nulls_last
 
 from app.api.schemas.tracks import (  # noqa: F401 — re-export for sub-routers
     BatchTracksRequest,
@@ -17,7 +18,7 @@ from app.api.schemas.tracks import (  # noqa: F401 — re-export for sub-routers
     TrackListResponse,
     TrackResponse,
 )
-from app.db.models import ProfilePlayHistory, Track
+from app.db.models import ProfilePlayHistory, Track, TrackAnalysis
 
 logger = logging.getLogger(__name__)
 
@@ -36,8 +37,18 @@ SORT_FIELD_MAP: dict[str, Any] = {
     'genre': Track.genre,
     'trackNum': Track.track_number,
     'format': Track.format,
+    'dateAdded': Track.created_at,
     'lastPlayed': ProfilePlayHistory.last_played_at,
+    'playCount': ProfilePlayHistory.play_count,
 }
+
+# Sort fields that live on the *listener's* play history rather than on the track.
+#
+# They need the per-profile join, and they are meaningless without a profile — "how often have you
+# played this" has no answer when there is no you. Ordering by one anyway would leave SQLAlchemy to
+# invent a cross join against every row of `profile_play_history`, which is a wrong answer served
+# slowly rather than an error.
+PROFILE_SORT_FIELDS = {'lastPlayed', 'playCount'}
 
 # Analysis features that need JSONB extraction
 SORT_FEATURE_FIELDS = {
@@ -75,6 +86,58 @@ AUDIO_MIME_TYPES = {
 # Aggregate sub-routers into top-level router
 # ---------------------------------------------------------------------------
 
+def apply_track_sort(
+    query: Any,
+    *,
+    sort_by: str | None,
+    sort_order: str,
+    profile: Any | None,
+    has_feature_filter: bool,
+) -> Any:
+    """Order a track query, or leave it to the caller's default when the request cannot be honoured.
+
+    Shared by `/tracks` and `/tracks/ids` because they had the same twenty lines twice, and the two
+    must agree: `/tracks/ids` builds the queue that `/tracks` paginates the metadata for, so an
+    order that differs between them would hand the player a queue in one order and titles in
+    another.
+
+    Returns `None` when the sort was not applied, so the caller can fall back to its own default
+    ordering rather than this function having to know what that is.
+    """
+    if not sort_by:
+        return None
+
+    if sort_by in SORT_FIELD_MAP:
+        # A play-history field with nobody to attribute it to. Falling back beats ordering by a
+        # column from a table that was never joined — see `PROFILE_SORT_FIELDS`.
+        if sort_by in PROFILE_SORT_FIELDS and profile is None:
+            return None
+
+        sort_col = SORT_FIELD_MAP[sort_by]
+        if sort_by in PROFILE_SORT_FIELDS:
+            query = query.outerjoin(
+                ProfilePlayHistory,
+                (ProfilePlayHistory.track_id == Track.id)
+                & (ProfilePlayHistory.profile_id == profile.id),
+            )
+        sort_expr = sort_col.desc() if sort_order == 'desc' else sort_col.asc()
+    elif sort_by in SORT_FEATURE_FIELDS:
+        if not has_feature_filter:
+            query = query.outerjoin(TrackAnalysis, Track.id == TrackAnalysis.track_id)
+        sort_col_attr = getattr(TrackAnalysis, sort_by, None)
+        expr = cast(sort_col_attr, Float) if sort_col_attr is not None else TrackAnalysis.bpm
+        sort_expr = expr.desc() if sort_order == 'desc' else expr.asc()
+    else:
+        return None
+
+    # `Track.id` last so the total order is unique. Without it, 866 tie groups covering 2,846 rows
+    # share an ordering key, and OFFSET paging over a non-unique order may repeat or skip rows
+    # between pages.
+    return query.order_by(
+        nulls_last(sort_expr), Track.artist, Track.album, Track.track_number, Track.id
+    )
+
+
 from app.api.routes.tracks.discovery import router as discovery_router  # noqa: E402
 from app.api.routes.tracks.identification import router as identification_router  # noqa: E402
 from app.api.routes.tracks.listing import list_tracks  # noqa: E402
@@ -94,3 +157,4 @@ router.include_router(discovery_router)
 router.include_router(playback_router)
 router.include_router(metadata_router)
 router.include_router(identification_router)
+

--- a/backend/app/api/routes/tracks/listing.py
+++ b/backend/app/api/routes/tracks/listing.py
@@ -29,6 +29,7 @@ from . import (
     TrackIdsResponse,
     TrackListResponse,
     TrackResponse,
+    apply_track_sort,
 )
 
 router = APIRouter()
@@ -196,28 +197,16 @@ async def list_track_ids(
     # --- Standard shuffle/sort path ---
     if shuffle:
         query = query.order_by(func.random())
-    elif sort_by and (sort_by in SORT_FIELD_MAP or sort_by in SORT_FEATURE_FIELDS):
-        if sort_by in SORT_FIELD_MAP:
-            sort_col = SORT_FIELD_MAP[sort_by]
-            if sort_by == 'lastPlayed' and profile:
-                query = query.outerjoin(
-                    ProfilePlayHistory,
-                    (ProfilePlayHistory.track_id == Track.id) &
-                    (ProfilePlayHistory.profile_id == profile.id),
-                )
-            if sort_order == 'desc':
-                query = query.order_by(nulls_last(sort_col.desc()), Track.artist, Track.album, Track.track_number, Track.id)
-            else:
-                query = query.order_by(nulls_last(sort_col.asc()), Track.artist, Track.album, Track.track_number, Track.id)
-        else:
-            if not has_feature_filter:
-                query = query.outerjoin(TrackAnalysis, Track.id == TrackAnalysis.track_id)
-            sort_col_attr = getattr(TrackAnalysis, sort_by, None)
-            sort_expr = cast(sort_col_attr, Float) if sort_col_attr is not None else TrackAnalysis.bpm
-            if sort_order == 'desc':
-                query = query.order_by(nulls_last(sort_expr.desc()), Track.artist, Track.album, Track.track_number, Track.id)
-            else:
-                query = query.order_by(nulls_last(sort_expr.asc()), Track.artist, Track.album, Track.track_number, Track.id)
+    elif (
+        sorted_query := apply_track_sort(
+            query,
+            sort_by=sort_by,
+            sort_order=sort_order,
+            profile=profile,
+            has_feature_filter=has_feature_filter,
+        )
+    ) is not None:
+        query = sorted_query
     else:
         # `Track.id` last for the same reason as `list_tracks`, so this endpoint's order and the
         # paged list's order are the same total order rather than two orders that agree on ties
@@ -382,28 +371,16 @@ async def list_tracks(
     total = await db.scalar(count_query) or 0
 
     # Apply ordering
-    if sort_by and (sort_by in SORT_FIELD_MAP or sort_by in SORT_FEATURE_FIELDS):
-        if sort_by in SORT_FIELD_MAP:
-            sort_col = SORT_FIELD_MAP[sort_by]
-            if sort_by == 'lastPlayed' and profile:
-                query = query.outerjoin(
-                    ProfilePlayHistory,
-                    (ProfilePlayHistory.track_id == Track.id) &
-                    (ProfilePlayHistory.profile_id == profile.id)
-                )
-            if sort_order == 'desc':
-                query = query.order_by(nulls_last(sort_col.desc()), Track.artist, Track.album, Track.track_number, Track.id)
-            else:
-                query = query.order_by(nulls_last(sort_col.asc()), Track.artist, Track.album, Track.track_number, Track.id)
-        else:
-            if not has_feature_filter:
-                query = query.outerjoin(TrackAnalysis, Track.id == TrackAnalysis.track_id)
-            sort_col_attr = getattr(TrackAnalysis, sort_by, None)
-            sort_expr = cast(sort_col_attr, Float) if sort_col_attr is not None else TrackAnalysis.bpm
-            if sort_order == 'desc':
-                query = query.order_by(nulls_last(sort_expr.desc()), Track.artist, Track.album, Track.track_number, Track.id)
-            else:
-                query = query.order_by(nulls_last(sort_expr.asc()), Track.artist, Track.album, Track.track_number, Track.id)
+    if (
+        sorted_query := apply_track_sort(
+            query,
+            sort_by=sort_by,
+            sort_order=sort_order,
+            profile=profile,
+            has_feature_filter=has_feature_filter,
+        )
+    ) is not None:
+        query = sorted_query
     else:
         # `Track.id` last so the total order is unique. Without it, 866 tie groups covering
         # 2,846 rows share an ordering key, and OFFSET paging over a non-unique order may

--- a/backend/tests/test_track_sorting.py
+++ b/backend/tests/test_track_sorting.py
@@ -1,0 +1,111 @@
+"""Ordering for the track list, checked by compiling SQL rather than by running it.
+
+No database needed: `apply_track_sort` builds a query, and what it built can be read off the compiled
+statement. That keeps the two things worth guarding — which fields are sortable, and what happens
+when one cannot be honoured — under test in a suite that runs anywhere.
+
+Both `/tracks` and `/tracks/ids` go through this. They have to agree: `/tracks/ids` builds the queue
+that `/tracks` paginates metadata for, so an order that differed between them would hand the player a
+queue in one order and titles in another.
+"""
+
+from types import SimpleNamespace
+from uuid import uuid4
+
+from sqlalchemy import select
+
+from app.api.routes.tracks import (
+    PROFILE_SORT_FIELDS,
+    SORT_FIELD_MAP,
+    apply_track_sort,
+)
+from app.db.models import Track
+
+PROFILE = SimpleNamespace(id=uuid4())
+
+
+def compiled(sort_by: str | None, *, order: str = "asc", profile=PROFILE) -> str | None:
+    query = apply_track_sort(
+        select(Track.id),
+        sort_by=sort_by,
+        sort_order=order,
+        profile=profile,
+        has_feature_filter=False,
+    )
+    if query is None:
+        return None
+    return str(query.compile(compile_kwargs={"literal_binds": True}))
+
+
+def test_the_two_fields_the_mac_needed_are_sortable() -> None:
+    """Play count and date-added answer "what do I listen to" and "what is new here".
+
+    Both columns existed and neither was reachable from any client, including the web.
+    """
+    assert "playCount" in SORT_FIELD_MAP
+    assert "dateAdded" in SORT_FIELD_MAP
+
+    assert "play_count" in (compiled("playCount") or "")
+    assert "created_at" in (compiled("dateAdded") or "")
+
+
+def test_a_play_history_sort_joins_the_listeners_own_rows() -> None:
+    sql = compiled("playCount") or ""
+    assert "JOIN profile_play_history" in sql
+    # Scoped to one listener rather than joined on the track alone — otherwise the ordering would
+    # be by *everyone's* plays, which is a different and much less useful question.
+    assert "profile_play_history.profile_id" in sql
+
+
+def test_a_play_history_sort_without_a_profile_is_declined() -> None:
+    """"How often have you played this" has no answer when there is no you.
+
+    Ordering by the column anyway would leave SQLAlchemy to invent a cross join against every row of
+    `profile_play_history` — a wrong answer served slowly, rather than an error. Declining lets the
+    caller fall back to its own default order.
+    """
+    for field in sorted(PROFILE_SORT_FIELDS):
+        assert compiled(field, profile=None) is None, f"{field} must decline without a profile"
+
+    # A track-owned field is unaffected by having no profile.
+    assert compiled("artist", profile=None) is not None
+
+
+def test_unknown_and_missing_fields_are_declined_rather_than_guessed() -> None:
+    assert compiled(None) is None
+    assert compiled("") is None
+    assert compiled("nonsense") is None
+    assert compiled("DROP TABLE tracks") is None
+
+
+def test_every_sort_ends_in_a_unique_total_order() -> None:
+    """`Track.id` last, on every path.
+
+    Without it 866 tie groups covering 2,846 rows share an ordering key, and OFFSET paging over a
+    non-unique order may repeat or skip rows between pages — silently omitting tracks from anything
+    that pages the whole library.
+    """
+    for field in ["artist", "album", "dateAdded", "playCount", "bpm", "energy"]:
+        sql = compiled(field) or ""
+        assert sql, f"{field} should have produced a query"
+        order_by = sql.split("ORDER BY", 1)[1]
+        assert order_by.rstrip().endswith("tracks.id"), f"{field} does not end in a unique key"
+
+
+def test_direction_is_honoured_on_both_kinds_of_field() -> None:
+    for field in ["dateAdded", "playCount", "bpm"]:
+        assert "DESC" in (compiled(field, order="desc") or "")
+        ascending = compiled(field, order="asc") or ""
+        first_key = ascending.split("ORDER BY", 1)[1].split(",")[0]
+        assert "DESC" not in first_key
+
+
+def test_nulls_sort_last_whichever_direction() -> None:
+    """A track nobody has played should not lead a list ordered by play count."""
+    for order in ("asc", "desc"):
+        assert "NULLS LAST" in (compiled("playCount", order=order) or "")
+
+
+def test_a_feature_sort_joins_the_analysis_table() -> None:
+    sql = compiled("bpm") or ""
+    assert "track_analysis" in sql

--- a/docs/decisions/ADR-0021-track-lists-on-the-mac-are-sortable-tables.md
+++ b/docs/decisions/ADR-0021-track-lists-on-the-mac-are-sortable-tables.md
@@ -1,0 +1,142 @@
+# ADR-0021: Track Lists on the Mac Are Sortable Tables
+
+Status: proposed
+
+Date: 2026-08-02
+
+Extends [ADR-0013](ADR-0013-the-mac-is-a-management-surface-too.md).
+
+## Context
+
+Every track list in the Mac app is the same two-line row: a title, then `artist · album` underneath,
+with a duration on the right. It cannot be sorted, and most of what the library knows about a track
+cannot be seen at all — play count, when it was added, year, genre, bitrate, tempo, key. A library of
+26,396 tracks is browsed through a shape that shows four fields and orders them one way.
+
+The web app answered this long ago. `columnStore.ts` defines **fifteen columns** with visibility,
+order and width, persisted to `localStorage` as `familiar-columns`, and `PlaylistTrackList` renders a
+header row whose cells sort. Three of those columns are on by default; the rest are there when
+wanted. This ADR is the Mac catching up, and the web's arrangement is the model.
+
+**The part that does not transfer, and is the reason this needs deciding rather than copying.** The
+web sorts *in the browser*, with `useSortedTracks` over the rows it happens to hold. On a list that
+pages, that sorts the loaded page and nothing else. `LibraryStore` pages the Mac's Tracks list at
+**50**, so a client-side sort there would order fifty rows out of 26,396 and present the result as
+the library's order.
+
+That is not a hypothetical: it is the defect the library shuffle already shipped and had to fix.
+`LibraryView.shuffleLibrary` records it — *"that made shuffle look like it played nothing but artists
+beginning with 'A'. The order was random; the pool was fifty tracks deep."* Sorting has exactly the
+same failure available to it, and would be harder to notice, because a wrong order looks like an
+order.
+
+**The server can already do it, mostly.** `/tracks` accepts `sort_by` and `sort_order`
+(`backend/app/api/routes/tracks/listing.py:68`), against an allowlist of nine fields — artist, album,
+title, duration, year, genre, trackNum, format, lastPlayed — plus twelve audio features
+(`backend/app/api/routes/tracks/__init__.py:30-47`).
+
+**Two of the columns most worth having are missing from it**, and both exist in the schema:
+`ProfilePlayHistory.play_count` and `Track.created_at`. Play count and date-added are the two fields
+that answer "what do I actually listen to" and "what is new here", and neither can be sorted by
+today on any client.
+
+**Which lists page, and which do not.** The distinction decides where sorting happens:
+
+| list | loading | sort belongs |
+|---|---|---|
+| Tracks | paged, 50 at a time | server |
+| Album, artist, playlist, smart playlist | fetched whole per entity | client |
+| Favorites | whole — `limit: 10_000` against 1,720 (ADR-0012 point 3) | client |
+| Downloads | on-device index | client |
+
+**The platform constraint, and what it costs.** SwiftUI's `Table` gives sorting, resizing and
+reordering from macOS 12. The built-in column chooser — `TableColumnCustomization`, which persists
+visibility and order itself — is macOS 14. The Mac app currently targets **macOS 13.0**
+(`Familiar.xcodeproj` and `Package.swift`), so the choice is a floor bump or a hand-built chooser
+duplicating what the system offers.
+
+## Decision
+
+1. **Track lists on the Mac become `Table`s**, with a header row whose columns sort, resize and
+   reorder, and a column chooser for what is shown.
+
+2. **The Mac's deployment target moves to macOS 14.** This is the load-bearing cost of point 1, and
+   it is stated as its own point because everything after it inherits the freedom: any later Mac code
+   may use macOS 14 APIs without an availability check. **iOS is untouched at 15** — the floor is per
+   platform, and ADR-0001's reasoning about not regressing the Capacitor app's devices applies to the
+   phone, not to a Mac app that has never shipped to anyone.
+
+3. **Sorting is done by whoever holds the whole list.** The Tracks list sorts through the server's
+   `sort_by`/`sort_order`, and resorting refetches from the first page. Every other list is fetched
+   whole and sorts on the device. A list must never sort the pages it happens to have.
+
+4. **The server's sort allowlist gains `playCount` and `dateAdded`**, mapping to
+   `ProfilePlayHistory.play_count` and `Track.created_at`. `lastPlayed` already joins the play-history
+   table per profile, so play count needs no new join — only an entry.
+
+5. **Column choice, order and width are per-device and not synced.** They follow ADR-0015 points 5
+   and 6: a display preference belongs to the screen it is displayed on. A 13-inch laptop and a
+   34-inch monitor want different columns, and a column set that followed a listener between machines
+   would be wrong more often than right. `TableColumnCustomization` persists them itself.
+
+6. **The column identifiers match the web's**, so the two clients name the same things — `artist`,
+   `album`, `duration`, `year`, `genre`, `trackNum`, `format`, `lastPlayed`, `bpm`, `key`, and the
+   audio features. The stores stay separate; only the vocabulary is shared.
+
+7. **In scope: every main track list** — Tracks, album, artist, playlist, smart playlist, favorites,
+   downloads. One table component, one column preference across them.
+
+8. **Out of scope: the queue.** Its order *is* the playback order, so a sortable queue either
+   reorders playback or displays an order that is not the one playing. Both are worse than a list.
+   The now-playing bar and the full player are transport, not browsing, and are untouched.
+
+## Alternatives Considered
+
+**Stay on macOS 13 and hand-build the column chooser.** No floor bump, and `Table` still gives
+sorting and resizing — only the show/hide chooser would be ours, as a toolbar menu backed by
+`UserDefaults`. Rejected on cost against benefit: it is a persisted preference model, a menu, and the
+plumbing to rebuild the table's columns from it, written to avoid raising a floor on an app that has
+never been released. If the app had users on macOS 13 this would be the answer.
+
+**Build the whole thing by hand, mirroring `PlaylistTrackList`.** Maximum control, matches the web
+exactly, and could share column definitions conceptually. Rejected because it reimplements sorting,
+resizing, reordering and keyboard behaviour that `Table` provides and that Mac users already know
+from Finder and Mail — and every one of those is a place to be subtly worse than the system.
+
+**Sort everything client-side, as the web does.** Simplest, one code path, no server work. Rejected
+outright: it would ship the shuffle bug again on a surface where it is harder to see. Sorting 50 of
+26,396 tracks by play count produces a plausible-looking list that is wrong, which is worse than a
+list that cannot be sorted at all.
+
+**Load the whole library and sort it locally.** `/tracks/ids` already returns all 26,396 ids in one
+request, so the precedent exists. Rejected because ids are not rows: sorting by play count needs the
+play counts, and fetching 26,396 full track rows to sort them on the device is a great deal of work
+to avoid an `ORDER BY` the database is already able to do.
+
+**Sync column preferences through the server, as one profile-wide layout.** Consistent across
+machines, and there is precedent for profile settings. Rejected for the reason ADR-0015 gives about
+audio effects: it is a property of the screen, not of the listener. It would also invent server state
+for something that has never had any.
+
+## Consequences
+
+- **Positive:** The library becomes answerable — most played, recently added, longest, by year — on
+  the platform ADR-0013 made the management surface.
+- **Positive:** Sorting the Tracks list is correct rather than plausible, because it happens where the
+  whole library is.
+- **Positive:** `playCount` and `dateAdded` become sortable for every client, including the web,
+  which cannot sort by them today either.
+- **Tradeoff:** Macs on macOS 13 can no longer run the app. Named in point 2 rather than discovered
+  at a build failure.
+- **Tradeoff:** Two sorting paths — server for one list, client for the rest — and the rule for which
+  is which lives in point 3 rather than being obvious from a call site. The alternative was one wrong
+  path.
+- **Tradeoff:** A table is denser and less forgiving than a two-line row. Long titles truncate where
+  they previously wrapped to a second line, and the phone keeps the row shape, so the two clients now
+  present the same list differently.
+- **Follow-up:** Whether the *phone* should gain sorting without columns — a sort menu rather than a
+  table, since a 393pt screen has no room for a header row. It is the same question ADR-0018 answered
+  for navigation, and the answer here may well be different.
+- **Follow-up:** The web sorts client-side over loaded rows and has the defect described above. This
+  ADR does not fix it; it only avoids repeating it. Worth its own change once the server allowlist is
+  wider.


### PR DESCRIPTION
Every track list on the Mac is the same two-line row — title over `artist · album`, duration on the right. Unsortable, and showing four of the fields the library knows. The web answered this long ago (`columnStore.ts`: fifteen columns with visibility, order and width, persisted to `localStorage`), and this is the Mac catching up with that as the model.

## The part that doesn't transfer, and why this needed deciding rather than copying

The web sorts **in the browser**, over the rows it happens to hold. `LibraryStore` pages the Mac's Tracks list at **50** — so the same approach would order fifty rows out of 26,396 and present the result as the library's order.

That isn't hypothetical. It's the defect the library shuffle already shipped and had to fix, recorded in `shuffleLibrary`:

> that made shuffle look like it played nothing but artists beginning with "A". The order was random; the pool was fifty tracks deep.

Sorting has the same failure available, and it's *harder* to notice — a wrong order still looks like an order.

**So: sorting happens wherever the whole list is.** Server for Tracks; on-device for every other list, all of which are fetched whole (album/artist/playlist per entity, favorites at `limit: 10_000` against 1,720, downloads local).

## Two findings from the investigation

- **The server can already sort** — `sort_by`/`sort_order`, allowlist of 9 fields + 12 audio features.
- **But not play count or date added.** Both columns exist (`ProfilePlayHistory.play_count`, `Track.created_at`); neither is reachable from *any* client, including the web. They're the two fields that answer "what do I actually listen to" and "what's new here", so point 4 adds them.

## The floor bump, stated as its own point

`Table` gives sorting from macOS 12, but `TableColumnCustomization` — the chooser, persisted by the system — is **macOS 14**. The app targets 13 today.

Point 2 moves the Mac to 14 and says so separately because everything after it inherits the freedom: later Mac code can use macOS 14 APIs without an availability check. **iOS is untouched at 15** — the floor is per platform, and ADR-0001's argument about not regressing the Capacitor app's devices is about the phone, not a Mac app that has never shipped to anyone.

The alternative — staying on 13 and hand-building the chooser — is recorded, and would be the answer if there were users on macOS 13.

## Out of scope, deliberately

**The queue.** Its order *is* the playback order, so sorting it either reorders playback or shows an order that isn't the one playing. Both are worse than a list.

## Follow-ups it names rather than solves

- Whether the **phone** should get sorting without columns — a sort menu, since 393pt has no room for a header row.
- **The web has the client-side sorting defect described above.** This ADR avoids repeating it; it doesn't fix it.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_014P9p2fvFnyiywBxGkv4gfW