### PR TITLE
Pressing a track in Discover posted no intent and spun forever

### DIFF
--- a/packages/frontend/src/player/__tests__/playbackInterceptor.test.ts
+++ b/packages/frontend/src/player/__tests__/playbackInterceptor.test.ts
@@ -1,0 +1,84 @@
+import { describe, it, expect, beforeEach, afterEach, vi } from 'vitest';
+import {
+  registerPlaybackInterceptor,
+  interceptPlayback,
+  resetPlaybackInterceptorForTesting,
+} from '../playbackInterceptor';
+import type { Track } from '../../types';
+
+/**
+ * The seam that stops the embedded surface playing audio itself.
+ *
+ * Written against a real bug: `EmbedDiscover` wired the bridge to the `onPlayTrack` prop, and
+ * `DiscoverTrackList` never calls it — it drives `usePlayerStore.setQueueByTrackId` directly. So a
+ * track pressed in "Unheard in Your Library" posted no intent, set a local queue, and handed it to a
+ * null audio engine. Correctly silent, and the row spun forever.
+ *
+ * A prop can be missed; the store is where every play path converges. These pin the part that
+ * matters: it is inert unless something registers, and it never lets a start id escape the list.
+ */
+describe('playbackInterceptor', () => {
+  const track = (id: string): Track =>
+    ({ id, title: id, artist: 'A', album: 'B' }) as unknown as Track;
+
+  beforeEach(() => resetPlaybackInterceptorForTesting());
+  afterEach(() => resetPlaybackInterceptorForTesting());
+
+  /**
+   * The case that must never regress: the ordinary web app and the iOS app register nothing, and
+   * a false here is what lets them keep playing their own audio.
+   */
+  it('is inert until something registers', () => {
+    expect(interceptPlayback([track('a')], 'a')).toBe(false);
+  });
+
+  it('hands the whole context and the starting track to the host', () => {
+    const seen: unknown[] = [];
+    registerPlaybackInterceptor((intent) => {
+      seen.push(intent);
+      return true;
+    });
+
+    expect(interceptPlayback([track('a'), track('b'), track('c')], 'b')).toBe(true);
+    expect(seen).toEqual([
+      { tracks: [track('a'), track('b'), track('c')], startingAt: 'b' },
+    ]);
+  });
+
+  /**
+   * A start id outside the list would leave the native side choosing a cursor for a track it was
+   * never given — the same defence the bridge and its Swift parser both already make.
+   */
+  it('falls back to the first track when the start is not in the list', () => {
+    let got: string | undefined;
+    registerPlaybackInterceptor(({ startingAt }) => {
+      got = startingAt;
+      return true;
+    });
+
+    interceptPlayback([track('a'), track('b')], 'nope');
+    expect(got).toBe('a');
+
+    interceptPlayback([track('a'), track('b')], undefined);
+    expect(got).toBe('a');
+  });
+
+  /** Nothing to play is not a request; the host should never be asked about it. */
+  it('does not bother the host with an empty queue', () => {
+    const host = vi.fn(() => true);
+    registerPlaybackInterceptor(host);
+
+    expect(interceptPlayback([], 'a')).toBe(false);
+    expect(host).not.toHaveBeenCalled();
+  });
+
+  /**
+   * A host that declines leaves the app to play normally. Nothing does this today, but the return
+   * value is the contract — if it were ignored, a host that could not deliver would silence
+   * playback instead of falling back.
+   */
+  it('lets the app carry on when the host declines', () => {
+    registerPlaybackInterceptor(() => false);
+    expect(interceptPlayback([track('a')], 'a')).toBe(false);
+  });
+});

--- a/packages/frontend/src/player/playbackInterceptor.ts
+++ b/packages/frontend/src/player/playbackInterceptor.ts
@@ -1,0 +1,56 @@
+import type { Track } from '../types';
+
+/**
+ * Lets a host take over playback instead of this app performing it.
+ *
+ * **Why this exists.** The embedded surface (ADR-0016/0017) runs inside a `WKWebView` in the Mac
+ * app and must never play audio itself — every play action belongs to the native `FamiliarPlayer`.
+ * `EmbedDiscover` wires the `onPlayTrack` prop to the bridge, and that turned out to catch only some
+ * of it: `DiscoverTrackList` never calls `onPlayTrack`, it drives `usePlayerStore.setQueueByTrackId`
+ * directly. So pressing a track in "Unheard in Your Library" posted no intent, set a local queue,
+ * and handed it to a null audio engine — which correctly did nothing, and left the row spinning
+ * forever waiting for a load that would never report.
+ *
+ * A prop can be missed. This cannot: the store is where every play path in the app converges, so
+ * intercepting here catches the ones nobody has written yet. It is the same argument ADR-0020 makes
+ * for the null engine being a floor under the bridge rather than a substitute for it.
+ *
+ * Registration-based, matching `registerEngineFactory` and `registerProfileProvider` — the app's
+ * existing idiom for behaviour only one platform entry point supplies.
+ */
+
+/** What the host is asked to play: the whole context, and where in it to start. */
+export interface PlaybackIntent {
+  tracks: Track[];
+  startingAt: string;
+}
+
+/** Returns true when the host has taken the request and this app should do nothing further. */
+export type PlaybackInterceptor = (intent: PlaybackIntent) => boolean;
+
+let interceptor: PlaybackInterceptor | null = null;
+
+/**
+ * Hand playback to a host. Registered only by the embedded entry point; the ordinary web app and
+ * the iOS app never call this, so `intercept` below is a null check for them.
+ */
+export function registerPlaybackInterceptor(fn: PlaybackInterceptor): void {
+  interceptor = fn;
+}
+
+/**
+ * Offer a play request to the host, if there is one.
+ *
+ * `false` means "nobody took it, carry on" — which is what every ordinary browser and the iOS app
+ * always get.
+ */
+export function interceptPlayback(tracks: Track[], startingAt: string | undefined): boolean {
+  if (!interceptor || tracks.length === 0) return false;
+  const start = startingAt && tracks.some((t) => t.id === startingAt) ? startingAt : tracks[0].id;
+  return interceptor({ tracks, startingAt: start });
+}
+
+/** Test-only. */
+export function resetPlaybackInterceptorForTesting(): void {
+  interceptor = null;
+}

--- a/packages/frontend/src/player/queueStore.ts
+++ b/packages/frontend/src/player/queueStore.ts
@@ -1,6 +1,7 @@
 import { create } from 'zustand';
 import type { Track, QueueItem } from '../types';
 import { usePlaybackStore, normalizeAdvanceReason } from './playbackStore';
+import { interceptPlayback } from './playbackInterceptor';
 import type { AdvanceReason } from './playbackStore';
 import { persistCombinedState, _setQueueStateGetter } from './persistenceAdapter';
 import {
@@ -292,6 +293,9 @@ export const useQueueStore = create<QueueState & QueueActions>((set, get) => ({
   },
 
   playTrack: (track, options) => {
+    // A host may own playback (the embedded surface hands it to the native player, ADR-0016
+    // point 5). No-op in an ordinary browser and on iOS, where nothing registers.
+    if (interceptPlayback([track], track.id)) return;
     const reason = normalizeAdvanceReason(options?.reason);
     log.info('playTrack', { id: track.id, title: track.title });
     const currentTrack = usePlaybackStore.getState().currentTrack;
@@ -505,6 +509,10 @@ export const useQueueStore = create<QueueState & QueueActions>((set, get) => ({
   },
 
   setQueue: (tracks, startIndex = 0, source?: QueueSource, options?: { preservePlaybackState?: boolean; reason?: AdvanceReason; preserveReservoir?: boolean }) => {
+    // The funnel: `setQueueByTrackId` and every "play this list from here" path arrive here, which
+    // is why the host is offered the request at this point rather than at each call site. One of
+    // those call sites is `DiscoverTrackList`, which never touches the `onPlayTrack` prop.
+    if (interceptPlayback(tracks, tracks[startIndex]?.id)) return;
     // Callers are queue rebuilds, hydration and profile switches — not listener actions.
     const reason = normalizeAdvanceReason(options?.reason ?? 'system');
     const requestedTrackId = tracks[startIndex]?.id;

--- a/packages/web/src/embed.tsx
+++ b/packages/web/src/embed.tsx
@@ -1,5 +1,7 @@
 import '@familiar/frontend/src/index.css';
 import { registerEngineFactory } from '@familiar/frontend/src/player/audio/createEngine';
+import { registerPlaybackInterceptor } from '@familiar/frontend/src/player/playbackInterceptor';
+import { postPlayIntent } from '@familiar/frontend/src/services/embedBridge';
 import { renderEmbed } from '@familiar/frontend/src/renderEmbed';
 import { NullAudioEngine } from './NullAudioEngine';
 
@@ -24,5 +26,17 @@ registerEngineFactory(() => new NullAudioEngine(), {
   visualizer: false,
   effects: 'none',
 });
+
+// Every play path in the app converges on the queue store, so this is where the surface hands
+// playback to the native player — not at a prop.
+//
+// The prop wiring in `EmbedDiscover` was not enough and this is the record of why:
+// `DiscoverTrackList` never calls `onPlayTrack`, it calls `setQueueByTrackId`. Pressing a track in
+// "Unheard in Your Library" therefore posted no intent, set a local queue, and handed it to the
+// null engine — which correctly made no sound, and left the row spinning forever waiting for a load
+// that would never report. Silence was right; the spinner was the bug.
+registerPlaybackInterceptor(({ tracks, startingAt }) =>
+    postPlayIntent({ trackIds: tracks.map((t) => t.id), startingAt })
+);
 
 renderEmbed();


### PR DESCRIPTION
Reported from use: clicking a song in "Unheard in Your Library" spun indefinitely. Native half: `familiar-apple` #52.

## Why my earlier fix was incomplete

`EmbedDiscover` wires the bridge to the **`onPlayTrack` prop**, which the *card* items use. But `DiscoverTrackList` **never calls it** — it drives `usePlayerStore.setQueueByTrackId` directly. So a track pressed in those lists posted **no intent at all**, set a local queue, and handed it to the null audio engine.

The null engine did its job — no second engine, no sound, which is the half of ADR-0017 that matters. What was missing is that nothing told the page, so the row waited on a load that would never report. **Silence was correct; the spinner was the bug.**

## The fix, and why it's at the store

A prop can be missed. The store is where every play path in the app converges — so interception moves there:

- `registerPlaybackInterceptor` in the player layer
- checked by **`setQueue`** (the funnel `setQueueByTrackId` and every "play this list from here" path arrive through) and by **`playTrack`**
- registered only by the embedded entry point; the ordinary web app and iOS register nothing and are unaffected — the case the first test pins

This is the same argument ADR-0020 makes for the null engine being a *floor* under the bridge rather than a substitute: the bridge has to catch every play path in a 2,943-line surface, and one chokepoint beats the call sites that happen to exist today.

Registration-based, matching `registerEngineFactory` and `registerProfileProvider`.

## Tests

5 new, including a start id outside the list falling back to the first — the same defence the bridge and its Swift parser already make — and an empty queue never reaching the host. 971 frontend tests, lint clean, bundle builds.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_014P9p2fvFnyiywBxGkv4gfW