### PR TITLE
Hide Listening Ideas where there is no chat to open

### DIFF
--- a/packages/frontend/src/components/Discovery/CuratedPrompts.tsx
+++ b/packages/frontend/src/components/Discovery/CuratedPrompts.tsx
@@ -35,6 +35,19 @@ interface CuratedPromptsProps {
 }
 
 export function CuratedPrompts({ prompts, loading, onRefresh }: CuratedPromptsProps) {
+  /**
+   * A prompt is a message for the chat and nothing else — there is no other way to act on
+   * "What IDM gems am I sleeping on?". So on a surface with no chat, every card here is dead:
+   * `triggerChat` sets `rightPanel: 'chat'`, only `AppShell` renders that panel, and the embedded
+   * Discover (ADR-0016/0017) deliberately mounts without a shell. Pressing one did nothing at all.
+   *
+   * Hidden rather than disabled, and rather than given a destination. The native app has no chat
+   * surface to bridge to, and building one would contradict a deliberate call that chat is the
+   * lower-value half of Familiar. A section of suggestions that cannot be taken up is worse than
+   * no section.
+   */
+  const chatAvailable = useUIStore((s) => s.chatSurfaceAvailable);
+  if (!chatAvailable) return null;
   if (!loading && prompts.length === 0) return null;
 
   const handleClick = (prompt: CuratedPrompt) => {

--- a/packages/frontend/src/components/Discovery/__tests__/CuratedPrompts.test.tsx
+++ b/packages/frontend/src/components/Discovery/__tests__/CuratedPrompts.test.tsx
@@ -1,0 +1,60 @@
+import { describe, it, expect, beforeEach } from 'vitest';
+import { render, screen, fireEvent } from '@testing-library/react';
+import { CuratedPrompts } from '../CuratedPrompts';
+import { useUIStore } from '../../../stores/uiStore';
+import type { CuratedPrompt } from '../../../api/library';
+
+/**
+ * Written against a real bug Jeff reported: in the embedded Discover surface, the "Listening Ideas"
+ * cards did nothing at all when pressed.
+ *
+ * A prompt is a message for the chat and has no other destination — `triggerChat` sets
+ * `rightPanel: 'chat'`, and only `AppShell` renders that panel. The embed (ADR-0017) mounts Discover
+ * without a shell on purpose, so the state changed and nothing observed it. The third bug of this
+ * exact shape: an affordance in the embedded page whose destination isn't there.
+ *
+ * These pin both halves — that the section is present and live where chat exists, and gone where it
+ * doesn't — because either one alone regresses quietly.
+ */
+describe('CuratedPrompts', () => {
+  const prompts: CuratedPrompt[] = [
+    { prompt: 'What IDM gems am I sleeping on?', icon: 'sparkles' },
+  ] as CuratedPrompt[];
+
+  beforeEach(() => {
+    useUIStore.setState({ chatSurfaceAvailable: true, pendingChatMessage: null, rightPanel: null });
+  });
+
+  it('offers the prompt to the chat where there is one', () => {
+    render(<CuratedPrompts prompts={prompts} loading={false} onRefresh={() => {}} />);
+
+    fireEvent.click(screen.getByText('What IDM gems am I sleeping on?'));
+
+    expect(useUIStore.getState().pendingChatMessage).toBe('What IDM gems am I sleeping on?');
+    expect(useUIStore.getState().rightPanel).toBe('chat');
+  });
+
+  /**
+   * The bug. Rendering these on a surface that cannot open chat shows a row of suggestions that
+   * cannot be taken up — worse than showing nothing, because it reads as broken rather than absent.
+   */
+  it('renders nothing when the surface has no chat to open', () => {
+    useUIStore.setState({ chatSurfaceAvailable: false });
+
+    const { container } = render(
+      <CuratedPrompts prompts={prompts} loading={false} onRefresh={() => {}} />,
+    );
+
+    expect(container.innerHTML).toBe('');
+    expect(screen.queryByText('Listening Ideas')).toBeNull();
+  });
+
+  /** Loading is the state the embed hit first, and it drew the header before any prompt arrived. */
+  it('stays hidden while loading, rather than flashing an empty header', () => {
+    useUIStore.setState({ chatSurfaceAvailable: false });
+
+    const { container } = render(<CuratedPrompts prompts={[]} loading onRefresh={() => {}} />);
+
+    expect(container.innerHTML).toBe('');
+  });
+});

--- a/packages/frontend/src/components/Library/browsers/DiscoverBrowser/DiscoverBrowser.tsx
+++ b/packages/frontend/src/components/Library/browsers/DiscoverBrowser/DiscoverBrowser.tsx
@@ -20,6 +20,7 @@ import { queryKeys } from '../../../../api/queryKeys';
 import { STALE_TIME } from '../../../../api/queryDefaults';
 import type { BrowserProps } from '../../types';
 import { useOfflineStatus } from '../../../../hooks/useOfflineStatus';
+import { useUIStore } from '../../../../stores/uiStore';
 import {
   useLibraryDiscovery,
   DiscoverySectionView,
@@ -47,10 +48,13 @@ export default function DiscoverBrowser({ onGoToArtist, onPlayTrack }: BrowserPr
     staleTime: STALE_TIME.LONG,
   });
 
+  // Generating these costs an LLM call (cached 4h server-side), so a surface that hides the
+  // section should not be asking for it either.
+  const chatAvailable = useUIStore((s) => s.chatSurfaceAvailable);
   const promptsQuery = useQuery({
     queryKey: queryKeys.curatedPrompts.all,
     queryFn: () => libraryApi.getCuratedPrompts(),
-    enabled: !isOffline,
+    enabled: !isOffline && chatAvailable,
     staleTime: STALE_TIME.STATIC, // 30 min client-side; server caches 4h
   });
 

--- a/packages/frontend/src/renderEmbed.tsx
+++ b/packages/frontend/src/renderEmbed.tsx
@@ -5,6 +5,7 @@ import { BrowserRouter } from 'react-router-dom';
 import { initApiOrigin, registerProfileProvider } from './api/base';
 import { profileFromURL } from './services/embedBridge';
 import { EmbedDiscover } from './components/Embed/EmbedDiscover';
+import { useUIStore } from './stores/uiStore';
 
 
 /**
@@ -33,6 +34,11 @@ export function renderEmbed(options?: { onReady?: () => void }): void {
     // does not read would be a no-op dressed up as an action.
     clearSelectedProfile: async () => {},
   });
+
+  // No shell here means no right panel, so `triggerChat` would set a message nothing renders.
+  // Declared rather than inferred: the affordances that lead to chat check this and stand down,
+  // instead of each one having to know it might be inside an embed.
+  useUIStore.getState().setChatSurfaceAvailable(false);
 
   // Its own client, with the app's defaults. The embedded page is a separate document with a
   // separate cache; nothing is shared with a browser tab that happens to have the app open.

--- a/packages/frontend/src/stores/uiStore.ts
+++ b/packages/frontend/src/stores/uiStore.ts
@@ -24,6 +24,15 @@ interface UIState {
   setSidebarCollapsed: (collapsed: boolean) => void;
   setShowFullPlayer: (show: boolean) => void;
   /** Set a pending chat message and open the chat panel */
+  /**
+   * Whether this surface has somewhere for `triggerChat` to go.
+   *
+   * True everywhere `AppShell` renders the right panel — which is the web app. The embedded
+   * surface (ADR-0016) mounts Discover without a shell, so a chat message set here would be
+   * observed by nothing: the prompt would look pressable and do nothing at all.
+   */
+  chatSurfaceAvailable: boolean;
+  setChatSurfaceAvailable: (available: boolean) => void;
   triggerChat: (message: string) => void;
   /** Read and clear the pending chat message */
   consumePendingChatMessage: () => string | null;
@@ -53,6 +62,8 @@ export const useUIStore = create<UIState>()(
       setShowSettings: (show) => set({ showSettings: show }),
       setSidebarCollapsed: (collapsed) => set({ sidebarCollapsed: collapsed }),
       setShowFullPlayer: (show) => set({ showFullPlayer: show }),
+      chatSurfaceAvailable: true,
+      setChatSurfaceAvailable: (available) => set({ chatSurfaceAvailable: available }),
       triggerChat: (message) => set({ pendingChatMessage: message, rightPanel: 'chat' }),
       consumePendingChatMessage: () => {
         const msg = get().pendingChatMessage;


### PR DESCRIPTION
## The report

> the Listening Ideas don't work

In the embedded Discover surface, the "LISTENING IDEAS" cards do nothing at all when pressed.

## Why

A prompt is a message for the chat and has no other destination — there is no way to act on *"What IDM gems am I sleeping on in my collection?"* by playing a track or navigating to an artist.

`CuratedPrompts.handleClick` calls `useUIStore.triggerChat(...)`, which sets `pendingChatMessage` and `rightPanel: 'chat'`. Only `AppShell` renders that panel, and the embed (ADR-0017) mounts Discover **without** a shell on purpose. So the state changed and nothing observed it.

**This is the third bug of the same shape**, after the Unheard spinner and the dead purchase links: an affordance in the embedded page whose destination isn't there. Of the eight `triggerChat` call sites, `CuratedPrompts` is the only one reachable inside the embed.

## Why hidden rather than wired up

The first two bugs were fixed by supplying the missing destination. This one can't be:

- The native app has **no chat surface at all** (nothing matching `chat` in `App/Shared` or `Sources/FamiliarKit`), so there is nothing to bridge to.
- Building one would contradict the deliberate call that the chat box is the lower-value half of Familiar — the value is analysis-driven playlists.
- A third bridge message would exceed ADR-0020 point 2's cap of two and would need its own ADR, which point 3's bar ("the native app already does this better, and the page cannot") does not clear.

A row of suggestions that cannot be taken up is worse than no row: it reads as broken rather than absent.

## The change

- `uiStore` gains `chatSurfaceAvailable` (default true) and a setter. `renderEmbed` declares it false.
- `CuratedPrompts` returns `null` when there is no chat surface. It asks about the *capability*, not about being inside an embed, so anything else that leads to chat can do the same.
- `DiscoverBrowser` gates the prompts query on it too — generating them costs an LLM call (cached 4h server-side), and a surface that hides the section shouldn't be requesting it.
- Not persisted: `partialize` keeps only `sidebarCollapsed`, so a stale `false` can't leak into the web app.

**No ADR.** Ordinary work inside ADR-0017's established direction — the embed's whole point is what it does not mount, and this is one more thing that follows from not mounting the shell.

## Verification

Headless against the live backend (via the dev proxy), both halves, because either alone regresses quietly:

- **Embed** — renders Discover (Unheard / New Releases present), shows no "Listening Ideas", and issues **zero** `curated-prompts` requests.
- **Web app** — `/library/discover` still shows the section.

Three unit tests pin the same pair plus the loading state, which is what the embed hit first — it drew the header before any prompt arrived.

**974 frontend tests pass**, up from 971. The 3 unhandled `window is not defined` errors in the vitest output are pre-existing; clean `main` reports the same.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_014P9p2fvFnyiywBxGkv4gfW