### PR TITLE
Propose ADR-0022 — chat is built native, and hidden without a provider

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -109,7 +109,7 @@ server's sort allowlist. `0021`'s load-bearing point is that the Tracks list sor
 it pages at 50, and sorting the loaded page would repeat the library-shuffle defect on a surface
 where a wrong order looks like an order.
 
-**`ADR-0022` builds chat natively (proposed 2026-08-02).** It extends `0016` by applying that ADR's
+**`ADR-0022` builds chat natively (accepted 2026-08-02).** It extends `0016` by applying that ADR's
 point 1 test to a third surface: chat is 965 lines against Discover's 2,828 and has had 6 commits in
 six months against 15, so it lands on the **native** side rather than being embedded. The bridge
 settles it independently — a chat response carries `queued_tracks` and `playback_action`, so an

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -109,6 +109,17 @@ server's sort allowlist. `0021`'s load-bearing point is that the Tracks list sor
 it pages at 50, and sorting the loaded page would repeat the library-shuffle defect on a surface
 where a wrong order looks like an order.
 
+**`ADR-0022` builds chat natively (proposed 2026-08-02).** It extends `0016` by applying that ADR's
+point 1 test to a third surface: chat is 965 lines against Discover's 2,828 and has had 6 commits in
+six months against 15, so it lands on the **native** side rather than being embedded. The bridge
+settles it independently — a chat response carries `queued_tracks` and `playback_action`, so an
+embedded chat would need both, against `0020` point 2's cap of two. Its load-bearing point is point
+3: **the destination is absent when the active provider is not configured**, read from
+`GET /chat/status`, which already exists for that purpose and which the web app has never called.
+Not a disabled row and not an error after the user has typed — that is the "Listening Ideas" defect
+(`#76`) moved one step later. Accepting `0022` is also what makes `#76` reversible, since `0020`
+point 3's bar for a third bridge message is cleared once a native chat exists to receive the intent.
+
 ## Key Directories
 
 ```

--- a/docs/decisions/ADR-0022-chat-is-built-native-and-hidden-without-a-provider.md
+++ b/docs/decisions/ADR-0022-chat-is-built-native-and-hidden-without-a-provider.md
@@ -1,0 +1,158 @@
+# ADR-0022: Chat Is Built Native, and Hidden Without a Provider
+
+Status: proposed
+Date: 2026-08-02
+
+Extends [ADR-0016](ADR-0016-embedded-web-surfaces-on-the-mac.md)
+
+## Context
+
+[ADR-0001](ADR-0001-native-apple-clients-supersede-capacitor.md) point 4 put AI chat in the native v1 scope
+and it is the last item there still unbuilt. Nothing has decided *how* it is built:
+[ADR-0016](ADR-0016-embedded-web-surfaces-on-the-mac.md) settled embed-versus-native for Discover and
+Music Map only, and chat is a third surface its point 1 has never been applied to.
+
+The question arrived from the other end. `familiar` #76 removed the "Listening Ideas" cards from the
+embedded Discover surface because pressing one did nothing: a curated prompt is a message for the
+chat and has no other destination, `triggerChat` sets `rightPanel: 'chat'`, only `AppShell` renders
+that panel, and the embed mounts Discover without a shell. It was the third defect of that shape,
+after the Unheard spinner and the dead purchase links, and the only one that could not be fixed by
+supplying the destination — because there is no chat anywhere in the native app to supply.
+
+**A premise worth recording, because it cuts against building this at all.** Chat was deprioritised
+on 2026-07-31 on the evidence of real use: *"AI chat is becoming less of a priority through usage. I
+just didn't end up using it as much as I thought. I still like the idea of the CLAP and other
+analysis for creating playlists, but the actual chat is a lower priority for now."* That judgement is
+not overturned here. What changed is that the native app now has surfaces that *lead* to chat and
+cannot complete the journey, so the choice is between building the destination and permanently
+removing the paths to it. Point 2 below is shaped by the deprioritisation: the parts worth showing
+are the tool calls that build playlists, not the prose.
+
+Four facts about the server, verified against the repo and the running instance at write time:
+
+- **`chat` is already a generated tag.** `openapi-generator-config.yaml` lists it among the eleven,
+  so `POST /api/v1/chat` and `GET /api/v1/chat/status` already exist in the Swift client. Unlike
+  ADR-0014, this needs no widening of the generated surface.
+- **`GET /chat/status` already answers the capability question**, returning `configured` and
+  `provider`. Its docstring says it exists "so the frontend can show appropriate warnings before the
+  user tries to chat". Nothing in the web app has ever called it — `chatApi.getStatus`
+  (`packages/frontend/src/api/chat.ts:174`) has no callers. It reports the **active** provider, so
+  selecting `openai` without OpenAI credentials returns `configured: false` even when
+  `ANTHROPIC_API_KEY` is set.
+- **Both chat endpoints raise `LLMNotConfiguredError`** when the active provider is unconfigured
+  (`backend/app/api/routes/chat.py:140` and `:179`), so an unguarded surface fails at the moment the
+  user has already typed something.
+- **The server holds no conversation.** `ChatRequest.history` carries up to 100 messages on every
+  request, and the web app's history lives in the browser's IndexedDB (`db.chatSessions`, via
+  `services/chatService.ts`). There is nothing server-side for a second client to read.
+
+Applying ADR-0016 point 1's test — churn and size — to the chat surface as it stands, counting
+components and hooks and excluding tests:
+
+| | Chat | Discover (embedded) |
+|---|---|---|
+| Lines | 965 (`ChatPanel` 637, `ChatHistoryPanel` 327, `index` 1) | 2,828 |
+| Commits since 2026-02-01 | 6 | 15 |
+
+Chat's transport and persistence add 466 lines beyond that — `services/chatService.ts` (269) and
+`api/chat.ts` (197) — of which the native app reimplements only the SSE reader, taking the rest from
+the generated client. Discover's equivalent lives in the shared `api/library.ts` and is not counted
+on either side.
+
+## Decision
+
+1. **Chat is built native, not embedded.** ADR-0016 point 1's test is churn and size, and chat is a
+   third of Discover's UI with under half its churn — small and settled, which is the native side of
+   that test. Embedding it would also put the bridge under pressure it was explicitly capped against:
+   a chat response carries `queued_tracks` and `playback_action`, so the surface whose entire product
+   is queueing tracks and controlling playback would need messages for both, against
+   [ADR-0020](ADR-0020-the-embedded-surface-can-ask-the-app-to-navigate.md) point 2's cap of two.
+   Native, the generated `ChatResponse` is handed straight to `FamiliarPlayer` and there is no bridge
+   at all.
+
+2. **It streams, through a hand-rolled `URLSession` reader rather than the generated client.**
+   `POST /chat/stream` is a `text/event-stream`, which [ADR-0007](ADR-0007-clients-are-generated-from-openapi.md)
+   point 8 already keeps outside generation — the same carve-out audio streaming and the two
+   `/library/map/*/stream` variants use. The non-streaming endpoint would be simpler and is already
+   generated, but tool execution takes real time and it returns nothing until every tool has run.
+   **The `tool_call` and `tool_result` events are the point, not the prose**: "Searching your
+   library", "Creating playlist" is the analysis-driven work that holds the value here, and a surface
+   that sits silent for twenty seconds and then prints a paragraph shows none of it.
+
+3. **The destination is absent when the active provider is not configured.** The app reads
+   `GET /chat/status` at launch and on foreground; when `configured` is false the chat destination
+   does not appear in the root list or the sidebar at all. Not a disabled row, not a greyed control,
+   and not an error raised after the user has typed a message — showing a surface that cannot work is
+   the defect this ADR exists to stop repeating, and doing it one step later is not a fix.
+
+4. **A configuration that changes underneath is handled as an unavailable state, not a crash.** The
+   status check races the server: a key can be removed after launch, and `LLMNotConfiguredError` can
+   arrive on a send from a surface that was legitimately shown. That response puts the open surface
+   into the native unavailable state of ADR-0016 point 7, and the destination goes away on the next
+   status read.
+
+5. **Queued tracks and playback actions from a chat response go to the native player directly.** One
+   player, one queue, one now-playing entry — as with CarPlay and with the embedded surface. Chat is
+   another way of asking for something to play, not a second playback path.
+
+6. **Conversations are per-device and are not synced.** The server holds no history and the web's
+   lives in IndexedDB, so the native app keeps its own. Presenting the two as one history would mean
+   inventing server-side storage, which is a larger decision than this one and belongs in its own
+   ADR if it is ever wanted.
+
+7. **Both platforms, Mac first.** Chat is a way of finding something to play, so it is a legitimate
+   destination on the phone under [ADR-0018](ADR-0018-the-phone-navigates-from-a-root-list.md) and
+   does not touch [ADR-0013](ADR-0013-the-mac-is-a-management-surface-too.md) point 2's line about
+   management surfaces. It ships on the Mac first and the phone second, the same order Discover took
+   through ADR-0016/0017 and then ADR-0019.
+
+## Alternatives Considered
+
+**Embed the chat panel in the `WKWebView`, as Discover is.** The consistent choice, and it would
+reuse 965 lines rather than reimplementing them. Rejected on ADR-0016 point 1's own test: chat is
+small and settled where Discover is large and moving, so the criterion points the other way. The
+bridge is the stronger objection — chat's output is `queued_tracks` and `playback_action`, so an
+embedded chat needs the app to play and to control playback on its behalf, and ADR-0017 is the record
+of how many construction paths a bridge misses on a surface far less playback-centric than this one.
+
+**Use the non-streaming `POST /chat`.** Already generated, no SSE reader, and it returns the same
+tool calls and queued tracks in one structured response — a genuinely smaller build. Rejected because
+it returns them only after every tool has finished. The wait is the tool execution, so the endpoint
+that hides tool execution is the one that makes the wait worst, on the surface with the least
+goodwill to spend.
+
+**Show chat always, and report "no provider configured" when the first message fails.** How the web
+app behaves today. Rejected: it is the Listening Ideas defect moved one step later — the user has
+composed a message before learning the feature does not work here. The endpoint that would prevent it
+has existed, unused, the whole time.
+
+**Add the `settings` tag to the generated surface to read the provider configuration.** Rejected for
+the reason the queue-sync pane was: filtering to a tag generates its writes as well as its reads, so
+this would make server configuration editable from the app, which ADR-0013 point 4 forbids.
+`/chat/status` answers the question from a tag that is already generated.
+
+**Leave chat web-only and delete the paths to it.** The honest minimum, and #76 is exactly this done
+for one surface. Rejected as a direction because ADR-0001 point 4 put chat in native v1 scope, and
+because the paths keep appearing: Listening Ideas is one, and every "ask about this artist" affordance
+in the web app is another.
+
+## Consequences
+
+- **Positive.** The native app gains the last unbuilt item in ADR-0001 point 4's v1 scope, and gains
+  it in the form that shows the analysis work rather than the chat box.
+- **Positive.** `familiar` #76's removal becomes reversible on a rule already written. ADR-0020 point
+  3's bar for a third bridge message is "the native app already does this better, and the page
+  cannot" — which a chat prompt fails today only because there is no native chat. Once there is, a
+  `chat` intent clears that bar exactly, and Listening Ideas can return to the embedded surface.
+- **Tradeoff.** A second chat implementation to keep working. Point 1's test says this is the cheap
+  case, but 6 commits in six months is not 0, and each one is now a question about two clients.
+- **Tradeoff.** The SSE reader is hand-written and untyped, outside the generation that ADR-0007
+  exists to guarantee. It parses a documented event set — `text`, `tool_call`, `tool_result`,
+  `queue`, `playback`, `done`, `error` — that nothing enforces against the server.
+- **Tradeoff.** Conversations do not follow the user between the web app and the Mac, and the Mac and
+  the phone do not share one either.
+- **Follow-up.** The web app should gate on `GET /chat/status` too. It has never called it, so a web
+  install with no provider configured shows a chat box that fails on send — the same defect this ADR
+  refuses on native, still present on the surface that has it today.
+- **Follow-up.** Restoring Listening Ideas needs its own ADR under ADR-0020 point 3, after the native
+  chat surface exists to receive the intent.

--- a/docs/decisions/ADR-0022-chat-is-built-native-and-hidden-without-a-provider.md
+++ b/docs/decisions/ADR-0022-chat-is-built-native-and-hidden-without-a-provider.md
@@ -1,6 +1,6 @@
 # ADR-0022: Chat Is Built Native, and Hidden Without a Provider
 
-Status: proposed
+Status: accepted
 Date: 2026-08-02
 
 Extends [ADR-0016](ADR-0016-embedded-web-surfaces-on-the-mac.md)


### PR DESCRIPTION
> ok I guess we need a chat surface in the native app - but if there is NO LLM API key, we shouldn't show something that doesn't work

Follows #76, which removed the dead "Listening Ideas" cards from embedded Discover because there was no chat anywhere in the native app to send a prompt to.

**`Status: proposed`** — nothing is built here. This is the decision to approve or reject first.

## What was already decided, and what wasn't

ADR-0001 point 4 put AI chat in native v1 scope and it is **the last item there still unbuilt**. So "should there be one" is settled; **how** is not. ADR-0016 answered embed-vs-native for Discover and Music Map only, and chat is a third surface its point 1 has never been applied to.

## Two things that turned out better than expected

- **`chat` is already a generated tag.** `POST /chat`, `POST /chat/stream` and `GET /chat/status` already exist in the Swift client. Unlike ADR-0014, no widening of the generated surface is needed.
- **The capability endpoint you asked for already exists.** `GET /chat/status` returns `configured` and `provider`, and its docstring says it is there "so the frontend can show appropriate warnings before the user tries to chat." **Nothing has ever called it** — `chatApi.getStatus` (`api/chat.ts:174`) has no callers. It reports the *active* provider, so selecting `openai` without OpenAI credentials returns `configured: false` even with `ANTHROPIC_API_KEY` set.

## The size test, applied

ADR-0016 point 1: *embed when a surface is large and moving; build native when it is small and settled.* Components and hooks, excluding tests:

| | Chat | Discover (embedded) |
|---|---|---|
| Lines | 965 | 2,828 |
| Commits since 2026-02-01 | 6 | 15 |

**Native.** And the bridge settles it independently: a chat response carries `queued_tracks` and `playback_action`, so the surface whose entire product is queueing tracks would need messages for both — against ADR-0020 point 2's cap of two. Native, the generated `ChatResponse` goes straight to `FamiliarPlayer` and there is no bridge at all.

## The seven points

1. Built native, not embedded.
2. **Streams**, through a hand-rolled `URLSession` SSE reader — ADR-0007 point 8 already keeps streaming outside generation. The `tool_call` events are the point, not the prose.
3. **The destination is absent when the provider is not configured.** Not disabled, not an error on send.
4. A configuration that changes underneath degrades to ADR-0016 point 7's native unavailable state.
5. Queued tracks go to the native player. One queue.
6. Conversations are per-device — the server holds no history, the web's is in IndexedDB.
7. Both platforms, Mac first — the order Discover took.

## Where I pushed back on myself

The Context records the premise that **cuts against building this at all**: you deprioritised chat on 2026-07-31 on the evidence of real use. That judgement isn't overturned here — what changed is that native surfaces now *lead* to chat and can't finish the journey, so the choice is building the destination or permanently removing the paths. It's also why point 2 streams: the analysis is worth showing even if the chat box isn't.

Alternatives rejected with reasons include embedding it (fails point 1's own test), the simpler non-streaming endpoint (hides the tool execution that *is* the wait), and generating the `settings` tag to read the key (would generate settings *writes*, which ADR-0013 point 4 forbids).

## Consequence worth noting

**Accepting this makes #76 reversible.** ADR-0020 point 3's bar for a third bridge message is "the native app already does this better, and the page cannot" — which a chat prompt fails today only because no native chat exists. Once one does, Listening Ideas can come back. That needs its own small ADR.

**Follow-up flagged, not fixed:** the web app should gate on `/chat/status` too. A web install with no provider shows a chat box that fails on send — the same defect this ADR refuses on native, still present where it ships today.

## Verification

Every path, line number and metric re-checked against the repo (ADR rule 4) — which caught three wrong ADR filenames, a line number off by one, and a Discover line count of 2,943 taken from an existing comment that measures something else. Live server confirms `{"configured":true,"provider":"anthropic"}`.

Stacked behind #75 and #76 only by branch order; touches different files, no conflicts.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_014P9p2fvFnyiywBxGkv4gfW