### PR TITLE
Don't offer chat when the server has no provider

### DIFF
--- a/packages/frontend/src/components/AppShell.tsx
+++ b/packages/frontend/src/components/AppShell.tsx
@@ -9,6 +9,7 @@ import { Outlet, useNavigate } from 'react-router-dom';
 import { ScrollContainerContext } from '../hooks/useScrollContainer';
 import { Loader2 } from 'lucide-react';
 import { useLastfmCallback } from '../hooks/useLastfmCallback';
+import { useChatAvailability } from '../hooks/useChatAvailability';
 import { useUIStore } from '../stores/uiStore';
 import { useSelectionStore } from '../stores/selectionStore';
 import { useThemeStore } from '../stores/themeStore';
@@ -54,6 +55,9 @@ export function AppShell() {
   const showSettings = useUIStore((s) => s.showSettings);
   const showFullPlayer = useUIStore((s) => s.showFullPlayer);
   const toggleRightPanel = useUIStore((s) => s.toggleRightPanel);
+  const chatAvailable = useUIStore((s) => s.chatSurfaceAvailable);
+  // Asks the server once and hides chat everywhere if there is no provider (ADR-0022 point 3).
+  useChatAvailability();
   const closeRightPanel = useUIStore((s) => s.closeRightPanel);
   const setShowSettings = useUIStore((s) => s.setShowSettings);
   const setShowFullPlayer = useUIStore((s) => s.setShowFullPlayer);
@@ -137,7 +141,7 @@ export function AppShell() {
               <div className="flex-1 overflow-hidden min-h-0">
                 <Suspense fallback={<LazyLoadSpinner />}>
                   {rightPanel === 'queue' && <QueueView />}
-                  {rightPanel === 'chat' && (
+                  {rightPanel === 'chat' && chatAvailable && (
                     <ChatPanel
                       pendingMessage={pendingChatMessage}
                       onPendingMessageConsumed={() => useUIStore.getState().consumePendingChatMessage()}
@@ -174,7 +178,7 @@ export function AppShell() {
             onExpandClick={() => setShowFullPlayer(true)}
             onQueueToggle={() => toggleRightPanel('queue')}
             isQueueOpen={rightPanel === 'queue'}
-            onChatToggle={() => toggleRightPanel('chat')}
+            onChatToggle={chatAvailable ? () => toggleRightPanel('chat') : undefined}
             isChatOpen={rightPanel === 'chat'}
             onSessionToggle={() => toggleRightPanel('session')}
             isSessionOpen={rightPanel === 'session'}
@@ -235,7 +239,7 @@ export function AppShell() {
         )}
 
         {/* Mobile chat overlay */}
-        {rightPanel === 'chat' && (
+        {rightPanel === 'chat' && chatAvailable && (
           <div className="md:hidden fixed inset-0 z-50 flex">
             <div className="absolute inset-0 bg-black/50" onClick={closeRightPanel} />
             <div className={`relative w-full max-w-md ${resolvedTheme === 'light' ? 'bg-white' : 'bg-zinc-900'} flex flex-col pt-safe pb-safe`}>

--- a/packages/frontend/src/components/Home/HomeScreen.tsx
+++ b/packages/frontend/src/components/Home/HomeScreen.tsx
@@ -224,6 +224,8 @@ export function HomeScreen() {
     setShowFullPlayer(true);
   };
 
+  const chatAvailable = useUIStore((s) => s.chatSurfaceAvailable);
+
   const handlePromptClick = (prompt: string) => {
     useUIStore.getState().triggerChat(prompt);
   };
@@ -350,6 +352,9 @@ export function HomeScreen() {
         );
 
       case 'prompts':
+        // Every card in here opens the chat panel, so without a provider the module is a row of
+        // suggestions that cannot be taken up (ADR-0022 point 3).
+        if (!chatAvailable) return null;
         return (
           <HomeCard
             key={moduleId}
@@ -570,6 +575,7 @@ export function HomeScreen() {
                 <Settings2 className="h-4 w-4" />
                 Customize
               </button>
+              {chatAvailable && (
               <button
                 onClick={() => useUIStore.getState().triggerChat('Help me rediscover my library.')}
                 className="inline-flex items-center gap-2 rounded-lg bg-purple-500 px-3 py-2 text-sm font-medium text-white transition hover:bg-purple-400"
@@ -577,6 +583,7 @@ export function HomeScreen() {
                 <MessageSquare className="h-4 w-4" />
                 Ask Familiar
               </button>
+              )}
             </div>
           </div>
 

--- a/packages/frontend/src/components/Library/AlbumContextMenu.tsx
+++ b/packages/frontend/src/components/Library/AlbumContextMenu.tsx
@@ -1,3 +1,4 @@
+import { useUIStore } from '../../stores/uiStore';
 /**
  * Context menu for album actions.
  *
@@ -46,6 +47,7 @@ export function AlbumContextMenu({
   onAddToPlaylist,
   onMakePlaylist,
 }: AlbumContextMenuProps) {
+  const chatAvailable = useUIStore((s) => s.chatSurfaceAvailable);
   const handleAction = (action: () => void) => {
     action();
     onClose();
@@ -115,12 +117,14 @@ export function AlbumContextMenu({
 
       <MenuDivider />
 
-      {/* AI Actions */}
-      <MenuItem
-        icon={<Sparkles className="w-4 h-4" />}
-        label="Make Playlist From This..."
-        onClick={() => handleAction(onMakePlaylist)}
-      />
+      {/* AI Actions. Absent without a provider: this item only ever opens the chat panel. */}
+      {chatAvailable && (
+        <MenuItem
+          icon={<Sparkles className="w-4 h-4" />}
+          label="Make Playlist From This..."
+          onClick={() => handleAction(onMakePlaylist)}
+        />
+      )}
     </ContextMenuContainer>
   );
 }

--- a/packages/frontend/src/components/Library/TrackContextMenu.tsx
+++ b/packages/frontend/src/components/Library/TrackContextMenu.tsx
@@ -1,3 +1,4 @@
+import { useUIStore } from '../../stores/uiStore';
 /**
  * Context menu for track actions.
  *
@@ -78,6 +79,7 @@ export function TrackContextMenu({
   onDownloadSelectedAnalyses,
   onClearSelection,
 }: TrackContextMenuProps) {
+  const chatAvailable = useUIStore((s) => s.chatSurfaceAvailable);
   const { downloadAnalysis } = useAnalysis();
 
   const handleAction = (action: () => void) => {
@@ -251,12 +253,14 @@ export function TrackContextMenu({
 
       <MenuDivider />
 
-      {/* AI Actions */}
-      <MenuItem
-        icon={<Sparkles className="w-4 h-4" />}
-        label="Make Playlist From This..."
-        onClick={() => handleAction(onMakePlaylist)}
-      />
+      {/* AI Actions. Absent without a provider: this item only ever opens the chat panel. */}
+      {chatAvailable && (
+        <MenuItem
+          icon={<Sparkles className="w-4 h-4" />}
+          label="Make Playlist From This..."
+          onClick={() => handleAction(onMakePlaylist)}
+        />
+      )}
     </ContextMenuContainer>
   );
 }

--- a/packages/frontend/src/components/MobileNav/MobileBottomNav.tsx
+++ b/packages/frontend/src/components/MobileNav/MobileBottomNav.tsx
@@ -24,6 +24,7 @@ export function MobileBottomNav() {
   const showFullPlayer = useUIStore((s) => s.showFullPlayer);
   const rightPanel = useUIStore((s) => s.rightPanel);
   const toggleRightPanel = useUIStore((s) => s.toggleRightPanel);
+  const chatAvailable = useUIStore((s) => s.chatSurfaceAvailable);
   const [showMore, setShowMore] = useState(false);
 
   // Hide when full player is open
@@ -58,6 +59,7 @@ export function MobileBottomNav() {
             </button>
           );
         })}
+        {chatAvailable && (
         <button
           onClick={() => toggleRightPanel('chat')}
           className={`flex flex-col items-center gap-0.5 py-2 px-4 min-w-[64px] transition-colors ${
@@ -69,6 +71,7 @@ export function MobileBottomNav() {
           <MessageSquare className="w-5 h-5" />
           <span className="text-[10px] font-medium">Chat</span>
         </button>
+        )}
         <button
           onClick={() => setShowMore(true)}
           className={`flex flex-col items-center gap-0.5 py-2 px-4 min-w-[64px] transition-colors ${

--- a/packages/frontend/src/hooks/__tests__/useChatAvailability.test.tsx
+++ b/packages/frontend/src/hooks/__tests__/useChatAvailability.test.tsx
@@ -1,0 +1,56 @@
+import { describe, it, expect, beforeEach, vi } from 'vitest';
+import { renderHook, waitFor } from '@testing-library/react';
+import { QueryClient, QueryClientProvider } from '@tanstack/react-query';
+import type { ReactNode } from 'react';
+import { useChatAvailability } from '../useChatAvailability';
+import { useUIStore } from '../../stores/uiStore';
+import { chatApi } from '../../api/chat';
+
+vi.mock('../../api/chat', () => ({ chatApi: { getStatus: vi.fn() } }));
+
+/**
+ * `GET /chat/status` exists so the frontend can avoid showing a chat box that fails on send — and
+ * had no callers anywhere in the web app until this hook. ADR-0022 point 3 refused that on the
+ * native app; these pin the same rule here.
+ */
+describe('useChatAvailability', () => {
+  const wrapper = ({ children }: { children: ReactNode }) => {
+    const client = new QueryClient({ defaultOptions: { queries: { retry: false } } });
+    return <QueryClientProvider client={client}>{children}</QueryClientProvider>;
+  };
+
+  beforeEach(() => {
+    vi.clearAllMocks();
+    useUIStore.setState({ chatSurfaceAvailable: true });
+  });
+
+  it('hides chat when the server has no provider configured', async () => {
+    vi.mocked(chatApi.getStatus).mockResolvedValue({ configured: false, provider: null });
+
+    renderHook(() => useChatAvailability(), { wrapper });
+
+    await waitFor(() => expect(useUIStore.getState().chatSurfaceAvailable).toBe(false));
+  });
+
+  it('leaves chat available when a provider is configured', async () => {
+    vi.mocked(chatApi.getStatus).mockResolvedValue({ configured: true, provider: 'anthropic' });
+
+    renderHook(() => useChatAvailability(), { wrapper });
+
+    await waitFor(() => expect(chatApi.getStatus).toHaveBeenCalled());
+    expect(useUIStore.getState().chatSurfaceAvailable).toBe(true);
+  });
+
+  /**
+   * An unreachable server is not an unconfigured provider. Treating the two the same would make
+   * chat vanish whenever the network hiccuped.
+   */
+  it('leaves the flag alone when the request fails', async () => {
+    vi.mocked(chatApi.getStatus).mockRejectedValue(new Error('offline'));
+
+    renderHook(() => useChatAvailability(), { wrapper });
+
+    await waitFor(() => expect(chatApi.getStatus).toHaveBeenCalled());
+    expect(useUIStore.getState().chatSurfaceAvailable).toBe(true);
+  });
+});

--- a/packages/frontend/src/hooks/useChatAvailability.ts
+++ b/packages/frontend/src/hooks/useChatAvailability.ts
@@ -1,0 +1,38 @@
+import { useEffect } from 'react';
+import { useQuery } from '@tanstack/react-query';
+import { chatApi } from '../api/chat';
+import { useUIStore } from '../stores/uiStore';
+
+/**
+ * Ask the server whether it has a working LLM provider, and hide chat everywhere if it does not.
+ *
+ * **The endpoint was built for this and had never been called.** `GET /chat/status` says in its own
+ * docstring that it exists "so the frontend can show appropriate warnings before the user tries to
+ * chat", and `chatApi.getStatus` had no callers anywhere — so an install with no key configured
+ * showed a chat box that failed on send. ADR-0022 point 3 refused that on the native app; this is
+ * the same defect on the surface that has shipped it all along.
+ *
+ * It reports the *active* provider, so choosing OpenAI without OpenAI credentials is unconfigured
+ * even with `ANTHROPIC_API_KEY` set.
+ *
+ * **A failed request deliberately leaves the flag alone.** An unreachable server is not an
+ * unconfigured provider, and treating the two the same would make chat vanish whenever the network
+ * hiccuped. The cost is the opposite flicker — chat is present until a definite "no" arrives — which
+ * only affects installs that have no provider at all, and only for one request.
+ */
+export function useChatAvailability(): void {
+  const setChatSurfaceAvailable = useUIStore((s) => s.setChatSurfaceAvailable);
+
+  const { data } = useQuery({
+    queryKey: ['chat', 'status'],
+    queryFn: () => chatApi.getStatus(),
+    // Configuring a key happens on the admin page, in another tab. Long enough not to ask on every
+    // mount, short enough that turning chat on does not need a reload to be noticed.
+    staleTime: 1000 * 60 * 5,
+    retry: 1,
+  });
+
+  useEffect(() => {
+    if (data) setChatSurfaceAvailable(data.configured);
+  }, [data, setChatSurfaceAvailable]);
+}

--- a/packages/web/e2e/ai-chat-mocked.spec.ts
+++ b/packages/web/e2e/ai-chat-mocked.spec.ts
@@ -75,9 +75,18 @@ const MOCK_NO_TRACKS_RESPONSE = createMockSSEResponse([
 
 /** Open the chat panel (hidden by default behind a toggle button) */
 async function openChatPanel(page: Page) {
-  const chatButton = page.locator('button[aria-label*="chat" i]').first();
+  const chatButton = chatToggle(page);
+  // Waits rather than clicking straight away: the toggle only exists once `/chat/status`
+  // has answered, so on a slow run it appears a moment after the page does. Clicking the
+  // first match immediately made every test in this file race that request.
+  await chatButton.waitFor({ state: 'visible', timeout: 15000 });
   await chatButton.click();
   await getChatInput(page).waitFor({ timeout: 5000 });
+}
+
+/** The player-bar button that opens chat. Absent entirely when no provider is configured. */
+function chatToggle(page: Page) {
+  return page.locator('button[aria-label*="chat" i]').first();
 }
 
 /** Get the chat input element */
@@ -189,35 +198,36 @@ test.describe('AI Chat (Mocked)', () => {
     await expect(noTracksText).toBeVisible({ timeout: 15000 });
   });
 
-  test('chat shows disabled state when API is not configured', async ({ page }) => {
-    // Override the status mock to indicate not configured
+  /**
+   * With no provider configured there is **no way into chat at all** — not a disabled input and
+   * not a "configure me" notice inside a panel you can still open.
+   *
+   * This test used to assert the opposite, and it is the reason it changed: a surface that opens
+   * and then explains it cannot work is the defect ADR-0022 point 3 refuses. The user has already
+   * gone looking for chat by the time it says no.
+   */
+  test('there is no way into chat when no provider is configured', async ({ page }) => {
     await page.route('**/api/v1/chat/status', async (route) => {
       await route.fulfill({
         status: 200,
         contentType: 'application/json',
-        body: JSON.stringify({ configured: false, provider: 'claude' }),
+        body: JSON.stringify({ configured: false, provider: null }),
       });
     });
 
-    // Reload page to pick up new mock
-    await page.reload();
-    await ensureProfile(page);
-    // Re-open chat panel, waiting for status response (fetched when panel opens)
     await Promise.all([
       page.waitForResponse('**/api/v1/chat/status'),
-      openChatPanel(page),
+      page.reload(),
     ]);
+    await ensureProfile(page);
 
-    // The chat input should be disabled or there's a configuration message
-    const chatInput = getChatInput(page);
-    const configureMessage = page.locator('text=/configure|api key|not configured|unavailable/i').first();
+    // The player bar has to be up, or "absent" would prove only that nothing had rendered.
+    await expect(page.locator('button[aria-label*="queue" i]').first()).toBeVisible({
+      timeout: 15000,
+    });
 
-    // Wait for either condition to be true (up to 5s for UI to reflect status)
-    const isInputDisabled = await chatInput.isDisabled({ timeout: 5000 }).catch(() => false);
-    const hasConfigMessage = await configureMessage.isVisible({ timeout: 5000 }).catch(() => false);
-
-    // Either input is disabled OR there's a config message
-    expect(isInputDisabled || hasConfigMessage).toBe(true);
+    await expect(chatToggle(page)).toHaveCount(0);
+    await expect(getChatInput(page)).toHaveCount(0);
   });
 
   test('queue updates when AI returns tracks', async ({ page }) => {

--- a/packages/web/e2e/helpers.ts
+++ b/packages/web/e2e/helpers.ts
@@ -114,6 +114,9 @@ export async function openChatPanel(page: Page) {
   const desktopButton = page.locator('button[aria-label="Open chat"]');
   const mobileButton = page.locator('nav button:has-text("Chat")');
 
+  // Both toggles are absent until `/chat/status` says a provider is configured, and absent for
+  // good if it says otherwise. The 3s below is therefore waiting on a request, not on a render —
+  // and on a server with no provider this function correctly opens nothing.
   if (await desktopButton.isVisible({ timeout: 3000 }).catch(() => false)) {
     await desktopButton.click();
   } else if (await mobileButton.isVisible({ timeout: 2000 }).catch(() => false)) {


### PR DESCRIPTION
Third of the three you asked for. The web app still shows a chat box that **fails on send** when no LLM provider is configured — the defect ADR-0022 point 3 refused on the native app, still shipping on the surface that has had it all along.

## The endpoint was built for this and never called

`GET /chat/status` says in its own docstring that it exists *"so the frontend can show appropriate warnings before the user tries to chat"*. `chatApi.getStatus` had **no callers anywhere** in the web app.

`useChatAvailability` asks once and drives the `chatSurfaceAvailable` flag #76 introduced, so every way into chat stands down together rather than one at a time:

| Entry point | |
|---|---|
| Player bar chat toggle | hidden |
| Mobile nav "Chat" tab | hidden |
| "Make Playlist From This…" | hidden in **both context menus** — gated in the menus, not at their four call sites, since the item only ever opens the chat panel |
| Home screen "Prompt Onramp" module + rediscover button | hidden |
| Discover's Listening Ideas | already wired to the flag in #76 |
| The panel itself | guarded too, since `rightPanel` can come back from persisted state |

## One deliberate asymmetry

A **failed** status request leaves the flag alone rather than setting it false. An unreachable server is not an unconfigured provider, and treating them alike would make chat disappear whenever the network hiccuped. The cost is the opposite flicker — chat present until a definite "no" arrives — which only affects installs with no provider at all, and only for one request.

## Verification

Headless against the live backend with `/chat/status` intercepted **both ways**, because either direction alone regresses quietly:

- **configured** — the chat toggle is visible, and Discover's Listening Ideas are back (they were only ever hidden in the *embed*, and this confirms it).
- **not configured** — every entry point absent, with the rest of the app rendering normally so "absent" means something.

Three unit tests cover the hook, including the failure case. **977 frontend tests pass**, up from 974; `pnpm build` clean. The 23 pre-existing `tsc` errors are unchanged — same count on a clean tree.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_014P9p2fvFnyiywBxGkv4gfW