### PR TITLE
ADR-0023: the phone moves to iOS 17

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -120,6 +120,15 @@ Not a disabled row and not an error after the user has typed — that is the "Li
 (`#76`) moved one step later. Accepting `0022` is also what makes `#76` reversible, since `0020`
 point 3's bar for a third bridge message is cleared once a native chat exists to receive the intent.
 
+**`ADR-0023` moves the phone to iOS 17** (accepted 2026-08-03). It extends `0021`, whose point 2 had
+said "iOS is untouched at 15". The prompt was three unavailable APIs while building chat on the
+phone; the finding was that the floor is why **the phone has no swipe-back at all** —
+`NavigationStack(path:)` is iOS 16, so `LibraryView` hand-rolls a `[BrowseRoute]` stack across ten
+push sites behind a custom back bar. 17 rather than 16 because 16 would leave the `onChange`
+compatibility branch alive for one API. **Adopting `NavigationStack` is deliberately not part of it**
+— that is the payoff, recorded as a follow-up, and a navigation rewrite should not ride along with a
+deployment-target bump.
+
 ## Key Directories
 
 ```

--- a/docs/decisions/ADR-0023-the-phone-moves-to-ios-17.md
+++ b/docs/decisions/ADR-0023-the-phone-moves-to-ios-17.md
@@ -1,7 +1,17 @@
 # ADR-0023: The Phone Moves to iOS 17
 
-Status: proposed
+Status: accepted
 Date: 2026-08-03
+
+Implementation:
+- The bump and the cleanups it makes dead shipped together in `familiar-apple` #56: `Package.swift`,
+  both `IPHONEOS_DEPLOYMENT_TARGET` entries, the seven single-parameter `onChange` call sites, and
+  `Artwork.legacyEmbedded` with its `#available` — the last of which had been carrying an iOS 15
+  path since before any of this.
+- Point 4 held: `NavigationStack` was not adopted, and the phone still hand-rolls its stack.
+- The chat composer's single-line fallback and `followsStreamingText` are **not** removed here. They
+  live in `familiar-apple` #55, which was still open — they become dead the moment it merges, and
+  removing them is a separate small change rather than a reason to bundle two branches.
 
 Extends [ADR-0021](ADR-0021-track-lists-on-the-mac-are-sortable-tables.md)
 

--- a/docs/decisions/ADR-0023-the-phone-moves-to-ios-17.md
+++ b/docs/decisions/ADR-0023-the-phone-moves-to-ios-17.md
@@ -1,0 +1,108 @@
+# ADR-0023: The Phone Moves to iOS 17
+
+Status: proposed
+Date: 2026-08-03
+
+Extends [ADR-0021](ADR-0021-track-lists-on-the-mac-are-sortable-tables.md)
+
+## Context
+
+[ADR-0021](ADR-0021-track-lists-on-the-mac-are-sortable-tables.md) point 2 moved the Mac to
+macOS 14 and said plainly that **"iOS is untouched at 15"**, on the grounds that
+[ADR-0001](ADR-0001-native-apple-clients-supersede-capacitor.md)'s reasoning about not regressing the
+Capacitor app's devices "applies to the phone, not to a Mac app that has never shipped to anyone."
+Reversing that needs a decision of its own, which is this one.
+
+**The prompt was small and the finding was not.** Building the chat surface on the phone
+([ADR-0022](ADR-0022-chat-is-built-native-and-hidden-without-a-provider.md) point 7) ran into three
+unavailable APIs and degraded the composer to a single line to avoid them. That looked like the whole
+cost. It is not.
+
+**The floor is why the phone has no swipe-back.** `LibraryView` holds
+`@State private var path: [BrowseRoute]` (line 59) and drives it by hand: `path.append(…)` at ten
+call sites, `path.popLast()` behind a custom `backBar` whose own comment says it "Stands in for a
+navigation bar neither platform provides here" (line 493). There is no `NavigationLink` and no
+`NavigationStack` anywhere in the app, because `NavigationStack(path:)` is iOS 16. The result on the
+phone is a hand-rolled stack with a hand-drawn back button and **no interactive pop gesture** — the
+single most-used navigation gesture on the platform, absent from a listening app whose whole job is
+browsing. `LibraryView`'s header comment and `LibrarySidebar`'s both record the floor as the reason.
+
+What else the floor currently costs, all of it verified in the tree at write time:
+
+| Wanted | Available from | Worked around by |
+|---|---|---|
+| `NavigationStack(path:)` | iOS 16 | a hand-rolled `[BrowseRoute]` stack and `backBar` |
+| `TextField(axis:)`, `lineLimit(1...6)` | iOS 16 | the phone's chat composer is one line |
+| `onChange(of:initial:)` | iOS 17 | `followsStreamingText` in `ChatView`, plus 8 deprecated `onChange(of:perform:)` call sites |
+| `AVAsset.load(_:)` | iOS 16 | `#available` in `Sources/FamiliarKit/Artwork.swift:122` |
+
+**The device cost is nil.** The only paired device is an **iPhone 13 Pro** (`iPhone14,2`), which runs
+current iOS; TestFlight distribution is to the author. ADR-0001's argument was about not regressing
+devices the Capacitor app already served — a real concern then, and an empty one now that the
+audience is one phone the author holds.
+
+## Decision
+
+1. **The iOS deployment target moves from 15 to 17**, in `Package.swift` and both
+   `IPHONEOS_DEPLOYMENT_TARGET` entries in `Familiar.xcodeproj`. macOS stays at 14; the floor is per
+   platform, as ADR-0021 point 2 established.
+
+2. **17 rather than 16, because 16 is a partial fix.** 16 buys the two that matter most —
+   `NavigationStack` and the composer — but leaves `followsStreamingText` and eight deprecated
+   `onChange` call sites in place, which is a compatibility branch kept alive for one API. 17 clears
+   every branch currently in the tree, and there is no device between the two to protect.
+
+3. **Not higher than 17.** Nothing in the table above needs 18, and a floor is easier to raise again
+   than to justify in advance. This ADR is the precedent for raising it when a named API earns it,
+   not a licence to track the latest SDK.
+
+4. **Adopting `NavigationStack` is separate work, not part of this decision.** This ADR makes it
+   possible; it does not do it. Replacing a hand-rolled stack that ten call sites push onto is a
+   change to how the phone navigates, with its own risk, and bundling it into a deployment-target
+   bump would make both harder to review and to revert. The mechanical cleanups in the table —
+   composer, `followsStreamingText`, the `onChange` sites, the `Artwork` guard — ship with the bump
+   because they only remove code the bump makes dead.
+
+5. **The floor is a floor, not a target.** Raising it does not oblige any surface to adopt a newer
+   API; it removes the availability question. Existing code keeps working unchanged.
+
+## Alternatives Considered
+
+**Leave the floor at 15 and keep working around it.** The status quo, and defensible while the
+workarounds were small. Rejected on what the survey turned up: the workaround is no longer a one-line
+branch but the phone's entire navigation model, and the user-visible cost is a missing swipe-back
+gesture rather than a slightly plainer composer. Continuing to pay it buys nothing — there is no
+device on 15 or 16 to serve.
+
+**Move to 16 rather than 17.** The conservative choice, and it delivers the two most valuable APIs.
+Rejected because the remaining branch — `followsStreamingText` and eight deprecated `onChange` calls
+— exists solely to span iOS 15/16 and macOS 14, and would survive a bump to 16 unchanged. Paying the
+cost of a floor raise and keeping the compatibility code is the worst of both.
+
+**Adopt `NavigationStack` in this same change.** Tempting, since it is the reason for the ADR.
+Rejected as decision point 4 says: it is a navigation rewrite touching ten push sites and a custom
+back affordance, and a deployment-target bump should be revertible on its own.
+
+**Keep 15 and adopt `NavigationStack` behind `if #available(iOS 16)`.** Would restore swipe-back on
+modern devices without a floor change. Rejected because it means maintaining two navigation models in
+one app — the hand-rolled stack has to stay for the fallback — which is more code and more divergence
+than the thing it avoids, in service of devices nobody owns.
+
+## Consequences
+
+- **Positive.** `NavigationStack` becomes available, which is the prerequisite for the phone getting
+  system navigation — swipe-back, system titles, large-title collapse — instead of a hand-drawn bar.
+- **Positive.** Every iOS availability branch currently in the tree becomes dead code and is removed
+  in the same change, including the `Artwork` guard that predates all of this.
+- **Positive.** The phone's chat composer can grow to multiple lines, which is what
+  ADR-0022's Implementation block recorded as the cost of the floor.
+- **Tradeoff.** Devices that cannot run iOS 17 — anything older than an iPhone XS — can no longer
+  install the app. Nobody is affected today, and this is the decision that would have to be revisited
+  if the app were ever distributed more widely.
+- **Tradeoff.** The precedent cuts both ways: a floor that moves when an API earns it is a floor that
+  will be asked to move again. Point 3 is the guard, and it is only as good as the next ADR.
+- **Follow-up:** Adopt `NavigationStack(path:)` on the phone, retiring `backBar` and the manual
+  `path.popLast()`. This is the payoff and it is deliberately not in this change.
+- **Follow-up:** Reconsider `LibrarySidebar`'s and `LibraryView`'s header comments once
+  `NavigationStack` lands — both explain a shape chosen because of the floor, and both will be
+  describing history rather than a constraint.


### PR DESCRIPTION
Phase 2. The implementation is `familiar-apple` #56.

## The prompt was small; the finding was not

Building chat on the phone hit three unavailable APIs and I degraded the composer to one line. That looked like the whole cost of the iOS 15 floor. Then I looked properly:

**The floor is why the phone has no swipe-back.** `NavigationStack(path:)` is iOS 16, so `LibraryView` holds `@State private var path: [BrowseRoute]` and drives it by hand — ten `path.append(…)` sites, `path.popLast()` behind a custom `backBar` whose own comment reads *"Stands in for a navigation bar neither platform provides here."* There is no `NavigationLink` and no interactive pop gesture anywhere in a browsing app.

| Wanted | From | Currently worked around by |
|---|---|---|
| `NavigationStack(path:)` | iOS 16 | a hand-rolled stack + `backBar` |
| `TextField(axis:)`, `lineLimit(1...6)` | iOS 16 | the phone's chat composer is one line |
| `onChange(of:initial:)` | iOS 17 | `followsStreamingText` + 7 deprecated call sites |
| `AVAsset.load(_:)` | iOS 16 | `#available` in `Artwork.swift` |

## Why 17, and why not more

**17 rather than 16** because 16 is a partial fix: it buys `NavigationStack` and the composer but leaves the `onChange` compatibility branch alive for a single API. Paying for a floor raise and keeping the compat code is the worst of both.

**Not higher than 17** — nothing here needs 18. The ADR is a precedent for raising the floor when a named API earns it, not for tracking the latest SDK.

**Device cost is nil.** The only paired device is an iPhone 13 Pro; TestFlight is you. ADR-0001's argument was about not regressing devices the *Capacitor* app already served — real then, empty now.

## What this ADR deliberately does not do

**Adopting `NavigationStack` is point 4: separate work.** It's the reason for the ADR and it is not in it. Replacing a hand-rolled stack that ten sites push onto is a navigation rewrite; a deployment-target bump should be revertible on its own. It's recorded as the follow-up, and it's the actual payoff.

Also flagged: the composer fallback and `followsStreamingText` live in the still-open #55, so they are **not** removed by #56 — they become dead the moment #55 merges, which is a separate one-line change rather than a reason to bundle two branches.

## Alternatives

Real ones, including keeping 15 and adopting `NavigationStack` behind `if #available(iOS 16)` — rejected because it means maintaining *two* navigation models in one app, in service of devices nobody owns.

Every count and line reference verified (rule 4) — which caught "eleven push sites" that is actually ten.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_014P9p2fvFnyiywBxGkv4gfW