### PR TITLE
Finish adopting UTCDateTime, and add created_at to TrackResponse

### DIFF
--- a/backend/app/api/routes/favorites.py
+++ b/backend/app/api/routes/favorites.py
@@ -9,9 +9,9 @@ from sqlalchemy import func, select
 
 from app.api.deps import DbSession, RequiredProfile
 from app.api.exceptions import TrackNotFoundError
+from app.api.schemas.common import UTCDateTime
 from app.api.schemas.tracks import TrackResponse
 from app.db.models import ProfileFavorite, ProfilePlayHistory, Track
-from app.utils.time import to_rfc3339
 
 logger = logging.getLogger(__name__)
 
@@ -21,7 +21,7 @@ router = APIRouter(prefix="/favorites", tags=["favorites"])
 class FavoriteTrackResponse(TrackResponse):
     """Track in favorites list — full track data plus favorited_at."""
 
-    favorited_at: str = ""
+    favorited_at: UTCDateTime | None = None
 
 
 class FavoritesListResponse(BaseModel):
@@ -106,7 +106,7 @@ async def list_favorites(
         resp = FavoriteTrackResponse.model_validate(
             track, from_attributes=True
         )
-        resp.favorited_at = to_rfc3339(favorite.favorited_at)
+        resp.favorited_at = favorite.favorited_at
         if track.id in play_history_map:
             ph = play_history_map[track.id]
             resp.last_played_at = ph.last_played_at

--- a/backend/app/api/routes/library_discover.py
+++ b/backend/app/api/routes/library_discover.py
@@ -13,6 +13,7 @@ from app.api.routes._external_albums_schemas import (
     ExternalAlbumResponse,
     ExternalAlbumsResponse,
 )
+from app.api.schemas.common import UTCDateTime
 from app.db.models import Artist, ArtistAlias, Track, TrackStatus
 from app.services.app_settings import get_app_settings_service
 from app.services.external_albums_helpers import normalize_artist_name
@@ -20,7 +21,6 @@ from app.services.llm.providers import get_provider
 from app.services.recommendations import RecommendationsService
 from app.services.redis_client import get_redis
 from app.utils.time import utcnow
-from app.api.schemas.common import UTCDateTime
 
 logger = logging.getLogger(__name__)
 

--- a/backend/app/api/routes/library_discover.py
+++ b/backend/app/api/routes/library_discover.py
@@ -20,6 +20,7 @@ from app.services.llm.providers import get_provider
 from app.services.recommendations import RecommendationsService
 from app.services.redis_client import get_redis
 from app.utils.time import utcnow
+from app.api.schemas.common import UTCDateTime
 
 logger = logging.getLogger(__name__)
 
@@ -76,7 +77,7 @@ class CuratedPromptsResponse(BaseModel):
     """AI-generated listening suggestions."""
 
     prompts: list[CuratedPrompt]
-    generated_at: str | None = None
+    generated_at: UTCDateTime | None = None
 
 
 @router.get("/discover/prompts", response_model=CuratedPromptsResponse)
@@ -214,7 +215,7 @@ Respond with ONLY a JSON array, no other text:
             if isinstance(p, dict) and "prompt" in p
         ][:6]
 
-        generated_at = utcnow().isoformat()
+        generated_at = utcnow()
         response = CuratedPromptsResponse(prompts=prompts, generated_at=generated_at)
 
         # Cache in Redis (4 hours)

--- a/backend/app/api/routes/mixtapes.py
+++ b/backend/app/api/routes/mixtapes.py
@@ -79,7 +79,9 @@ def _serialize(mt: MixTape, progress: dict[str, Any] | None = None) -> MixTapeRe
         error_message=mt.error_message,
         duration_seconds=mt.duration_seconds,
         file_size_bytes=mt.file_size_bytes,
-        created_at=mt.created_at if mt.created_at else "",
+        # The column is non-nullable; the empty-string fallback that used to be here
+        # only made sense while this field was a `str`.
+        created_at=mt.created_at,
         completed_at=mt.completed_at if mt.completed_at else None,
         progress=progress,
     )

--- a/backend/app/api/routes/mixtapes.py
+++ b/backend/app/api/routes/mixtapes.py
@@ -20,6 +20,7 @@ from app.api.exceptions import (
     NotFoundError,
     ValidationError,
 )
+from app.api.schemas.common import UTCDateTime
 from app.config import settings
 from app.db.models import MixTape, Playlist, PlaylistTrack
 from app.services.mixtape_export import (
@@ -29,7 +30,6 @@ from app.services.mixtape_export import (
     run_mixtape_export,
 )
 from app.services.smart_playlists import SmartPlaylistService
-from app.utils.time import to_rfc3339
 
 logger = logging.getLogger(__name__)
 
@@ -61,8 +61,8 @@ class MixTapeResponse(BaseModel):
     error_message: str | None
     duration_seconds: float | None
     file_size_bytes: int | None
-    created_at: str
-    completed_at: str | None
+    created_at: UTCDateTime
+    completed_at: UTCDateTime | None
     progress: dict[str, Any] | None = None
 
 
@@ -79,8 +79,8 @@ def _serialize(mt: MixTape, progress: dict[str, Any] | None = None) -> MixTapeRe
         error_message=mt.error_message,
         duration_seconds=mt.duration_seconds,
         file_size_bytes=mt.file_size_bytes,
-        created_at=to_rfc3339(mt.created_at) if mt.created_at else "",
-        completed_at=to_rfc3339(mt.completed_at) if mt.completed_at else None,
+        created_at=mt.created_at if mt.created_at else "",
+        completed_at=mt.completed_at if mt.completed_at else None,
         progress=progress,
     )
 

--- a/backend/app/api/routes/pending_review.py
+++ b/backend/app/api/routes/pending_review.py
@@ -99,7 +99,7 @@ class PendingGroupResponse(BaseModel):
     duplicate_count: int
     upgrade_count: int
     downgrade_count: int
-    earliest_scan: str
+    earliest_scan: UTCDateTime
     tracks: list[PendingTrackResponse]
 
 

--- a/backend/app/api/routes/pending_review.py
+++ b/backend/app/api/routes/pending_review.py
@@ -13,8 +13,8 @@ from sqlalchemy.ext.asyncio import AsyncSession
 
 from app.api.deps import DbSession, RequiredProfile
 from app.api.exceptions import TrackNotFoundError, ValidationError
+from app.api.schemas.common import UTCDateTime
 from app.db.models import Track, TrackStatus
-from app.utils.time import to_rfc3339
 
 logger = logging.getLogger(__name__)
 
@@ -87,7 +87,7 @@ class PendingTrackResponse(BaseModel):
     bitrate: int | None
     bitrate_mode: str | None
     codec: str | None
-    created_at: str
+    created_at: UTCDateTime
     review_info: ReviewInfo | None
 
 
@@ -223,7 +223,7 @@ def _track_to_response(track: Track) -> PendingTrackResponse:
         bitrate=track.bitrate,
         bitrate_mode=track.bitrate_mode,
         codec=track.codec,
-        created_at=to_rfc3339(track.created_at),
+        created_at=track.created_at,
         review_info=_to_review_info(track.review_info),
     )
 
@@ -381,7 +381,7 @@ async def list_groups(
             duplicate_count=duplicate_count,
             upgrade_count=upgrade_count,
             downgrade_count=downgrade_count,
-            earliest_scan=to_rfc3339(earliest),
+            earliest_scan=earliest,
             tracks=[_track_to_response(t) for t in group_tracks],
         ))
 

--- a/backend/app/api/routes/playlists/crud.py
+++ b/backend/app/api/routes/playlists/crud.py
@@ -9,8 +9,8 @@ from sqlalchemy.orm import selectinload
 
 from app.api.deps import DbSession, RequiredProfile
 from app.api.exceptions import PlaylistNotFoundError
+from app.api.schemas.common import UTCDateTime
 from app.db.models import Playlist, PlaylistTrack, ProfilePlayHistory, Track
-from app.utils.time import to_rfc3339
 
 router = APIRouter()
 
@@ -62,7 +62,7 @@ class TrackInPlaylist(BaseModel):
     album_artist: str | None = None
     album_type: str | None = None
     analysis_version: int | None = None
-    last_played_at: str | None = None
+    last_played_at: UTCDateTime | None = None
     play_count: int | None = None
 
 
@@ -76,8 +76,8 @@ class PlaylistResponse(BaseModel):
     generation_prompt: str | None
     track_count: int
     auto_download: bool = False
-    created_at: str
-    updated_at: str
+    created_at: UTCDateTime
+    updated_at: UTCDateTime
 
 
 class PlaylistDetailResponse(BaseModel):
@@ -90,8 +90,8 @@ class PlaylistDetailResponse(BaseModel):
     generation_prompt: str | None
     tracks: list[TrackInPlaylist]
     auto_download: bool = False
-    created_at: str
-    updated_at: str
+    created_at: UTCDateTime
+    updated_at: UTCDateTime
 
 
 # ============================================================================
@@ -143,8 +143,8 @@ async def list_playlists(
             generation_prompt=playlist.generation_prompt,
             track_count=total_count,
             auto_download=playlist.auto_download,
-            created_at=to_rfc3339(playlist.created_at),
-            updated_at=to_rfc3339(playlist.updated_at),
+            created_at=playlist.created_at,
+            updated_at=playlist.updated_at,
         ))
 
     return responses
@@ -226,8 +226,8 @@ async def create_playlist(
         generation_prompt=playlist.generation_prompt,
         tracks=tracks_added,
         auto_download=playlist.auto_download,
-        created_at=to_rfc3339(playlist.created_at),
-        updated_at=to_rfc3339(playlist.updated_at),
+        created_at=playlist.created_at,
+        updated_at=playlist.updated_at,
     )
 
 
@@ -289,7 +289,7 @@ async def get_playlist(
                 album_artist=pt.track.album_artist,
                 album_type=pt.track.album_type.value if pt.track.album_type else None,
                 analysis_version=pt.track.analysis_version,
-                last_played_at=to_rfc3339(ph.last_played_at) if ph and ph.last_played_at else None,
+                last_played_at=ph.last_played_at if ph and ph.last_played_at else None,
                 play_count=ph.play_count if ph else None,
             ))
 
@@ -301,8 +301,8 @@ async def get_playlist(
         generation_prompt=playlist.generation_prompt,
         tracks=tracks,
         auto_download=playlist.auto_download,
-        created_at=to_rfc3339(playlist.created_at),
-        updated_at=to_rfc3339(playlist.updated_at),
+        created_at=playlist.created_at,
+        updated_at=playlist.updated_at,
     )
 
 
@@ -343,8 +343,8 @@ async def update_playlist(
         generation_prompt=playlist.generation_prompt,
         track_count=track_count,
         auto_download=playlist.auto_download,
-        created_at=to_rfc3339(playlist.created_at),
-        updated_at=to_rfc3339(playlist.updated_at),
+        created_at=playlist.created_at,
+        updated_at=playlist.updated_at,
     )
 
 

--- a/backend/app/api/routes/profiles.py
+++ b/backend/app/api/routes/profiles.py
@@ -17,9 +17,9 @@ from app.api.exceptions import (
     ProfileNotFoundError,
     ValidationError,
 )
+from app.api.schemas.common import UTCDateTime
 from app.config import settings
 from app.db.models import Profile
-from app.utils.time import to_rfc3339
 
 logger = logging.getLogger(__name__)
 
@@ -54,7 +54,7 @@ class ProfileResponse(BaseModel):
     name: str
     color: str | None
     avatar_url: str | None
-    created_at: str
+    created_at: UTCDateTime
     has_lastfm: bool
 
 
@@ -69,7 +69,7 @@ def profile_to_response(profile: Profile, has_lastfm: bool) -> ProfileResponse:
         name=profile.name,
         color=profile.color,
         avatar_url=avatar_url,
-        created_at=to_rfc3339(profile.created_at),
+        created_at=profile.created_at,
         has_lastfm=has_lastfm,
     )
 

--- a/backend/app/api/routes/proposed_changes.py
+++ b/backend/app/api/routes/proposed_changes.py
@@ -13,6 +13,7 @@ from sqlalchemy.ext.asyncio import AsyncSession
 
 from app.api.deps import get_db
 from app.api.exceptions import NotFoundError, ValidationError
+from app.api.schemas.common import UTCDateTime
 from app.db.models import ChangeSource, ChangeStatus
 from app.services.proposed_changes import (
     ApplyResult,
@@ -20,7 +21,6 @@ from app.services.proposed_changes import (
     ChangeStats,
     ProposedChangesService,
 )
-from app.utils.time import to_rfc3339
 
 # Tag is kebab-case like every other one in the schema. It was "Proposed Changes" — the only tag
 # with a space and capitals — until ADR-0014 brought it into the generated Swift surface, where an
@@ -50,8 +50,8 @@ class ProposedChangeResponse(BaseModel):
     reason: str | None
     scope: str
     status: str
-    created_at: str
-    applied_at: str | None
+    created_at: UTCDateTime
+    applied_at: UTCDateTime | None
     target_description: str | None = None
 
 
@@ -129,8 +129,8 @@ def _change_to_response(
         reason=change.reason,
         scope=change.scope.value if hasattr(change.scope, "value") else change.scope,
         status=change.status.value if hasattr(change.status, "value") else change.status,
-        created_at=to_rfc3339(change.created_at) if change.created_at else None,
-        applied_at=to_rfc3339(change.applied_at) if change.applied_at else None,
+        created_at=change.created_at if change.created_at else None,
+        applied_at=change.applied_at if change.applied_at else None,
         target_description=target_description,
     )
 

--- a/backend/app/api/routes/smart_playlists.py
+++ b/backend/app/api/routes/smart_playlists.py
@@ -10,10 +10,10 @@ from sqlalchemy import select
 
 from app.api.deps import DbSession, RequiredProfile
 from app.api.exceptions import NotFoundError, ValidationError, sanitize_error_for_client
+from app.api.schemas.common import UTCDateTime
 from app.api.schemas.tracks import TrackResponse
 from app.db.models import ProfilePlayHistory
 from app.services.smart_playlists import SmartPlaylistService
-from app.utils.time import to_rfc3339
 
 router = APIRouter(prefix="/smart-playlists", tags=["smart-playlists"])
 
@@ -63,10 +63,10 @@ class SmartPlaylistResponse(BaseModel):
     order_direction: str
     max_tracks: int | None
     cached_track_count: int
-    last_refreshed_at: str | None
+    last_refreshed_at: UTCDateTime | None
     auto_download: bool = False
-    created_at: str
-    updated_at: str
+    created_at: UTCDateTime
+    updated_at: UTCDateTime
 
 
 class SmartPlaylistTracksResponse(BaseModel):
@@ -89,10 +89,10 @@ def playlist_to_response(playlist: Any) -> SmartPlaylistResponse:
         order_direction=playlist.order_direction,
         max_tracks=playlist.max_tracks,
         cached_track_count=playlist.cached_track_count,
-        last_refreshed_at=to_rfc3339(playlist.last_refreshed_at) if playlist.last_refreshed_at else None,
+        last_refreshed_at=playlist.last_refreshed_at if playlist.last_refreshed_at else None,
         auto_download=playlist.auto_download,
-        created_at=to_rfc3339(playlist.created_at),
-        updated_at=to_rfc3339(playlist.updated_at),
+        created_at=playlist.created_at,
+        updated_at=playlist.updated_at,
     )
 
 

--- a/backend/app/api/routes/tracks/playback.py
+++ b/backend/app/api/routes/tracks/playback.py
@@ -22,8 +22,9 @@ from sqlalchemy import select
 
 from app.api.deps import DbSession, RequiredProfile
 from app.api.exceptions import TrackNotFoundError
+from app.api.schemas.common import UTCDateTime
 from app.db.models import PlayEvent, ProfilePlayHistory, Track
-from app.utils.time import to_naive_utc, to_rfc3339, utcnow
+from app.utils.time import to_naive_utc, utcnow
 
 logger = logging.getLogger(__name__)
 
@@ -163,7 +164,7 @@ class TopTrackStat(BaseModel):
     artist: str | None = None
     play_count: int
     total_play_seconds: float
-    last_played_at: str | None = None
+    last_played_at: UTCDateTime | None = None
 
 
 class ProfilePlayStatsResponse(BaseModel):
@@ -356,7 +357,7 @@ async def get_play_stats(
             artist=track.artist,
             play_count=ph.play_count,
             total_play_seconds=ph.total_play_seconds,
-            last_played_at=to_rfc3339(ph.last_played_at) if ph.last_played_at else None,
+            last_played_at=ph.last_played_at if ph.last_played_at else None,
         )
         for ph, track in rows[:limit]
     ]

--- a/backend/app/api/schemas/tracks.py
+++ b/backend/app/api/schemas/tracks.py
@@ -45,6 +45,10 @@ class TrackResponse(BaseModel):
     format: str | None
     status: str = "active"
     analysis_version: int
+    # When the scanner first saw the file. `from_attributes` fills it straight off
+    # `Track.created_at`, which is what ADR-0021's `dateAdded` column sorts by — the sort
+    # shipped without the field, so the column was built, seen blank on every row, and removed.
+    created_at: UTCDateTime | None = None
     features: TrackFeaturesResponse | None = None
     # Play history (profile-specific, populated when profile header is present)
     last_played_at: UTCDateTime | None = None

--- a/backend/openapi.json
+++ b/backend/openapi.json
@@ -2876,6 +2876,7 @@
         "description": "AI-generated listening suggestions.",
         "properties": {
           "generated_at": {
+            "format": "date-time",
             "title": "Generated At",
             "type": [
               "string",
@@ -3731,6 +3732,14 @@
               "null"
             ]
           },
+          "created_at": {
+            "format": "date-time",
+            "title": "Created At",
+            "type": [
+              "string",
+              "null"
+            ]
+          },
           "disc_number": {
             "title": "Disc Number",
             "type": [
@@ -3746,9 +3755,12 @@
             ]
           },
           "favorited_at": {
-            "default": "",
+            "format": "date-time",
             "title": "Favorited At",
-            "type": "string"
+            "type": [
+              "string",
+              "null"
+            ]
           },
           "features": {
             "$ref": "#/components/schemas/TrackFeaturesResponse"
@@ -5781,6 +5793,7 @@
             ]
           },
           "completed_at": {
+            "format": "date-time",
             "title": "Completed At",
             "type": [
               "string",
@@ -5788,6 +5801,7 @@
             ]
           },
           "created_at": {
+            "format": "date-time",
             "title": "Created At",
             "type": "string"
           },
@@ -6432,6 +6446,7 @@
             ]
           },
           "created_at": {
+            "format": "date-time",
             "title": "Created At",
             "type": "string"
           },
@@ -6966,6 +6981,7 @@
             "type": "boolean"
           },
           "created_at": {
+            "format": "date-time",
             "title": "Created At",
             "type": "string"
           },
@@ -7003,6 +7019,7 @@
             "type": "array"
           },
           "updated_at": {
+            "format": "date-time",
             "title": "Updated At",
             "type": "string"
           }
@@ -7063,6 +7080,7 @@
             "type": "boolean"
           },
           "created_at": {
+            "format": "date-time",
             "title": "Created At",
             "type": "string"
           },
@@ -7097,6 +7115,7 @@
             "type": "integer"
           },
           "updated_at": {
+            "format": "date-time",
             "title": "Updated At",
             "type": "string"
           }
@@ -7295,6 +7314,7 @@
             ]
           },
           "created_at": {
+            "format": "date-time",
             "title": "Created At",
             "type": "string"
           },
@@ -7351,6 +7371,7 @@
         "description": "Response model for a proposed change.",
         "properties": {
           "applied_at": {
+            "format": "date-time",
             "title": "Applied At",
             "type": [
               "string",
@@ -7366,6 +7387,7 @@
             "type": "number"
           },
           "created_at": {
+            "format": "date-time",
             "title": "Created At",
             "type": "string"
           },
@@ -8766,6 +8788,7 @@
             "type": "integer"
           },
           "created_at": {
+            "format": "date-time",
             "title": "Created At",
             "type": "string"
           },
@@ -8781,6 +8804,7 @@
             "type": "string"
           },
           "last_refreshed_at": {
+            "format": "date-time",
             "title": "Last Refreshed At",
             "type": [
               "string",
@@ -8818,6 +8842,7 @@
             "type": "array"
           },
           "updated_at": {
+            "format": "date-time",
             "title": "Updated At",
             "type": "string"
           }
@@ -9617,6 +9642,7 @@
             "type": "string"
           },
           "last_played_at": {
+            "format": "date-time",
             "title": "Last Played At",
             "type": [
               "string",
@@ -9936,6 +9962,7 @@
             "type": "string"
           },
           "last_played_at": {
+            "format": "date-time",
             "title": "Last Played At",
             "type": [
               "string",
@@ -10502,6 +10529,14 @@
           },
           "artist": {
             "title": "Artist",
+            "type": [
+              "string",
+              "null"
+            ]
+          },
+          "created_at": {
+            "format": "date-time",
+            "title": "Created At",
             "type": [
               "string",
               "null"

--- a/backend/openapi.json
+++ b/backend/openapi.json
@@ -6292,6 +6292,7 @@
             "type": "integer"
           },
           "earliest_scan": {
+            "format": "date-time",
             "title": "Earliest Scan",
             "type": "string"
           },

--- a/backend/tests/test_timestamp_wire_format.py
+++ b/backend/tests/test_timestamp_wire_format.py
@@ -1,0 +1,64 @@
+"""The wire format must not move when a timestamp field gains its type.
+
+ADR-0007's follow-up called this "a wire-compatible schema change", and it only stays that way
+because `UTCDateTime` serialises through `to_rfc3339` — the same function the producers used to
+call by hand. These assert the bytes, not the annotation: a naive ISO string without an offset is
+rejected outright by Swift's decoder and silently read as *local time* by JavaScript, which is the
+defect `to_rfc3339` exists to prevent.
+"""
+
+from datetime import UTC, datetime
+
+import pytest
+from pydantic import BaseModel
+
+from app.api.schemas.common import UTCDateTime
+
+NAIVE = datetime(2026, 1, 25, 23, 40, 43, 980516)
+AWARE = datetime(2026, 1, 25, 23, 40, 43, 980516, tzinfo=UTC)
+EXPECTED = "2026-01-25T23:40:43.980516Z"
+
+
+class _Model(BaseModel):
+    at: UTCDateTime
+    maybe: UTCDateTime | None = None
+
+
+def test_naive_utc_serialises_with_a_z():
+    """The database columns are TIMESTAMP WITHOUT TIME ZONE, so naive is the normal case."""
+    assert _Model(at=NAIVE).model_dump(mode="json")["at"] == EXPECTED
+
+
+def test_aware_utc_serialises_identically():
+    assert _Model(at=AWARE).model_dump(mode="json")["at"] == EXPECTED
+
+
+def test_it_never_emits_a_bare_naive_isoformat():
+    """`utcnow().isoformat()` was what `CuratedPromptsResponse.generated_at` shipped, and it is
+    exactly what a client misreads as local time."""
+    emitted = _Model(at=NAIVE).model_dump(mode="json")["at"]
+    assert emitted != NAIVE.isoformat()
+    assert emitted.endswith("Z")
+
+
+def test_none_stays_none():
+    assert _Model(at=NAIVE).model_dump(mode="json")["maybe"] is None
+
+
+def test_the_schema_declares_the_format():
+    """`WithJsonSchema` is what makes a generated client decode these as dates rather than strings.
+
+    Asserted in serialization mode because that is the direction responses travel, and it is the
+    mode `PlainSerializer` would otherwise degrade to a bare string.
+    """
+    schema = _Model.model_json_schema(mode="serialization")
+    assert schema["properties"]["at"]["format"] == "date-time"
+
+
+@pytest.mark.parametrize("offset_hours", [0, 5, -8])
+def test_any_offset_normalises_to_utc(offset_hours):
+    """A client may send an offset-aware value; what goes back out is always UTC."""
+    from datetime import timedelta, timezone
+
+    local = AWARE.astimezone(timezone(timedelta(hours=offset_hours)))
+    assert _Model(at=local).model_dump(mode="json")["at"] == EXPECTED


### PR DESCRIPTION
Phase 3. The Swift half is `familiar-apple` #57.

## The follow-up was better than it looked

ADR-0007 asked for typing "the 49 timestamp fields still declared as plain `string`". The survey found that **`UTCDateTime` already exists** in `api/schemas/common.py` — `Annotated[datetime, PlainSerializer(to_rfc3339), WithJsonSchema({format: date-time})]` — purpose-built for this, and adopted by **three files**. So this isn't "type 49 fields", it's "finish adopting the type that was already built."

**Fields typed as `date-time`: 8 → 27.**

## Wire-compatible by construction, not by luck

The producers already called `to_rfc3339` by hand at 47 sites. The annotation just moves that call into the serialiser, so the bytes are identical. `tests/test_timestamp_wire_format.py` pins it: naive and aware both emit `...Z`, any offset normalises to UTC, `None` stays `None`, and the **serialization-mode** schema still carries `format: date-time` — the last being exactly what `PlainSerializer` would otherwise silently degrade to a bare string.

That mattered: naively switching these to `datetime` would have emitted naive ISO **without** the `Z`, which Swift rejects outright and JavaScript reads as *local time*.

## A real bug found on the way

`CuratedPromptsResponse.generated_at` was `utcnow().isoformat()`. Verified against the live server:

```
generated_at = '2026-08-03T11:15:48.143190'   ← no offset
```

That is the exact defect `to_rfc3339`'s docstring exists to describe, on an endpoint carried by the `library` tag — so it reaches the generated client. Now a `UTCDateTime`.

## Deliberately not migrated

This is a classification job, not a mechanical pass:

- **`library_artists.release_date`** — a release date out of a scraped dict, not an instant.
- **`library_sync.started_at`** — comes from a progress dict.

Typing either would declare a format their values don't keep. `favorites.favorited_at` was the third hazard — it defaulted to `""`, which is not a valid date-time and would have broken a strict decoder at runtime.

## `created_at` on `TrackResponse`

ADR-0021 records that the `dateAdded` column was built, seen blank on every row, and removed because `TrackResponse` carried no such field. It does now, and the generated Swift has `createdAt: Foundation.Date?`. Restoring the column is Phase 4.

## Known asymmetry, stated rather than hidden

`favorited_at` becomes **nullable**, because the response is built by `model_validate(track)` and only then assigned — a required field would fail validation there. The server always populates it in the one endpoint that returns it, but the web's TS type still says `string`. Worth reconciling; not silently.

## Verification

- 8 new wire-format tests pass; `ruff` clean.
- Schema regenerated via `make openapi` and vendored to `familiar-apple`, where **both schemes build** and 507 Swift tests pass against the regenerated client.
- The DB-backed suite needs a local postgres I don't have; CI covers it, and the contract tests are the ones that would catch a wire regression.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_014P9p2fvFnyiywBxGkv4gfW