### PR TITLE
An unavailable chat closes the panel instead of blanking it

### DIFF
--- a/packages/frontend/src/components/AppShell.tsx
+++ b/packages/frontend/src/components/AppShell.tsx
@@ -141,7 +141,7 @@ export function AppShell() {
               <div className="flex-1 overflow-hidden min-h-0">
                 <Suspense fallback={<LazyLoadSpinner />}>
                   {rightPanel === 'queue' && <QueueView />}
-                  {rightPanel === 'chat' && chatAvailable && (
+                  {rightPanel === 'chat' && (
                     <ChatPanel
                       pendingMessage={pendingChatMessage}
                       onPendingMessageConsumed={() => useUIStore.getState().consumePendingChatMessage()}
@@ -239,7 +239,7 @@ export function AppShell() {
         )}
 
         {/* Mobile chat overlay */}
-        {rightPanel === 'chat' && chatAvailable && (
+        {rightPanel === 'chat' && (
           <div className="md:hidden fixed inset-0 z-50 flex">
             <div className="absolute inset-0 bg-black/50" onClick={closeRightPanel} />
             <div className={`relative w-full max-w-md ${resolvedTheme === 'light' ? 'bg-white' : 'bg-zinc-900'} flex flex-col pt-safe pb-safe`}>

--- a/packages/frontend/src/hooks/__tests__/useChatAvailability.test.tsx
+++ b/packages/frontend/src/hooks/__tests__/useChatAvailability.test.tsx
@@ -54,3 +54,47 @@ describe('useChatAvailability', () => {
     expect(useUIStore.getState().chatSurfaceAvailable).toBe(true);
   });
 });
+
+/**
+ * The failure CI caught and a local run did not: the status answer arrives *after* the first
+ * paint, so chat can already be open by the time it turns out to be unavailable. Guarding the
+ * panel's render on availability left an open panel with no input in it — a worse state than the
+ * one the gate exists to prevent, and the reason four E2E tests timed out looking for a chat box
+ * that was on screen but empty.
+ */
+describe('useChatAvailability when chat is already open', () => {
+  const wrapper = ({ children }: { children: ReactNode }) => {
+    const client = new QueryClient({ defaultOptions: { queries: { retry: false } } });
+    return <QueryClientProvider client={client}>{children}</QueryClientProvider>;
+  };
+
+  it('closes the panel when the answer turns out to be no', async () => {
+    useUIStore.setState({ chatSurfaceAvailable: true, rightPanel: 'chat' });
+    vi.mocked(chatApi.getStatus).mockResolvedValue({ configured: false, provider: null });
+
+    renderHook(() => useChatAvailability(), { wrapper });
+
+    await waitFor(() => expect(useUIStore.getState().rightPanel).toBeNull());
+  });
+
+  it('leaves an open panel alone when a provider is configured', async () => {
+    useUIStore.setState({ chatSurfaceAvailable: true, rightPanel: 'chat' });
+    vi.mocked(chatApi.getStatus).mockResolvedValue({ configured: true, provider: 'anthropic' });
+
+    renderHook(() => useChatAvailability(), { wrapper });
+
+    await waitFor(() => expect(chatApi.getStatus).toHaveBeenCalled());
+    expect(useUIStore.getState().rightPanel).toBe('chat');
+  });
+
+  /** The queue must not be closed by a chat answer. */
+  it('does not close a different panel', async () => {
+    useUIStore.setState({ chatSurfaceAvailable: true, rightPanel: 'queue' });
+    vi.mocked(chatApi.getStatus).mockResolvedValue({ configured: false, provider: null });
+
+    renderHook(() => useChatAvailability(), { wrapper });
+
+    await waitFor(() => expect(useUIStore.getState().chatSurfaceAvailable).toBe(false));
+    expect(useUIStore.getState().rightPanel).toBe('queue');
+  });
+});

--- a/packages/frontend/src/hooks/useChatAvailability.ts
+++ b/packages/frontend/src/hooks/useChatAvailability.ts
@@ -33,6 +33,16 @@ export function useChatAvailability(): void {
   });
 
   useEffect(() => {
-    if (data) setChatSurfaceAvailable(data.configured);
+    if (!data) return;
+    setChatSurfaceAvailable(data.configured);
+
+    // **Close the panel rather than leaving it rendering nothing.** The answer arrives after the
+    // first paint, so chat can already be open when it turns out to be unavailable — from a
+    // restored `rightPanel`, or from a toggle pressed in the moment before the request resolved.
+    // Guarding the panel's *render* on availability produced exactly that: an open panel with no
+    // input in it, which is a worse failure than the one the gate exists to prevent.
+    if (!data.configured && useUIStore.getState().rightPanel === 'chat') {
+      useUIStore.getState().closeRightPanel();
+    }
   }, [data, setChatSurfaceAvailable]);
 }


### PR DESCRIPTION
Follow-up to #78, caught by CI on an unrelated docs PR — which is the only reason it was caught at all: **the E2E job is `continue-on-error: true`**, so four failing chat tests never blocked a merge and nothing surfaced them.

## What went wrong

#78 guarded the chat panel's *render* on `chatSurfaceAvailable`, not just the toggle, reasoning that `rightPanel` can come back from persisted state. But the status answer arrives **after the first paint**, so chat can already be open by the time it turns out to be unavailable — from restored state, or from a toggle pressed in the moment before the request resolved.

The guard then left **an open panel with no input in it**. That is a worse state than the one the gate exists to prevent, and it is exactly what the E2E log showed:

```
✓ toggle clicked
✗ locator.waitFor: Timeout 5000ms exceeded
    waiting for input[placeholder*="Ask" i] to be visible
```

A chat box on screen, empty.

## The fix

Guard the entrance; close the room if it disappears.

- The panel renders whatever it is asked to render — no availability check.
- `useChatAvailability` **closes** the panel on a definite no.

## Why my local run missed it

Locally all 8 specs passed in 6.7s, because the mocked status resolves before anything looks for the input. CI is slower and hit the window in between. The three new tests exercise the state directly rather than relying on timing — including that a chat answer must not close the **queue** panel.

## Verification

- **980 frontend tests** pass, up from 977.
- The 8 `ai-chat-mocked` E2E specs pass locally.
- `pnpm build` clean.

**Worth a separate look:** `continue-on-error: true` on the E2E job means it has been advisory this whole time. A green E2E run does exist (run on #81), so the suite works — but nothing enforces it, and that is how four broken chat tests rode along for two merges.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_014P9p2fvFnyiywBxGkv4gfW