### PR TITLE
Block the service worker in E2E, so mocked GETs actually get mocked

### DIFF
--- a/packages/web/playwright.config.ts
+++ b/packages/web/playwright.config.ts
@@ -13,6 +13,17 @@ export default defineConfig({
     baseURL: process.env.BASE_URL || 'http://localhost:4400',
     trace: 'on-first-retry',
     screenshot: 'only-on-failure',
+    // CI builds the app and serves `dist/` from the backend, so the PWA service worker is
+    // registered — locally these run against the dev server, where it is not. `page.route` does not
+    // intercept requests a service worker handles, and Workbox's runtime caching handles **GET**s,
+    // so a mocked GET silently reached the real backend while a mocked POST did not.
+    //
+    // That asymmetry hid itself until a GET started mattering: the chat specs' `/chat/status` mock
+    // had never applied in CI, and nobody noticed while the chat toggle was unconditional. Once the
+    // toggle depended on that endpoint, CI's provider-less backend answered "not configured", the
+    // toggle correctly disappeared, and seven specs failed against an app that was behaving exactly
+    // as designed.
+    serviceWorkers: 'block',
   },
   projects: [
     {


### PR DESCRIPTION
Diagnosed from the CI artifacts after the chat specs kept failing on a **docs-only** PR (#83) — which is what made it clear the cause wasn't in the diff.

## The asymmetry

CI **builds** the web app and serves `dist/` from the backend, so the **PWA service worker is registered**. These specs run locally against the **dev server**, where it is not.

`page.route` does not intercept requests a service worker handles, and Workbox's runtime caching handles **GET**s. So in CI:

| | |
|---|---|
| mocked `POST /chat/stream` | intercepted normally |
| mocked `GET /chat/status` | **silently reached the real backend** |

That hid itself for as long as no GET mattered. The `/chat/status` mock had *never* applied in CI; nobody noticed while the chat toggle was unconditional.

## Why it surfaced now

#78 made the toggle depend on that endpoint. CI's backend has no LLM provider, so it answered "not configured", the toggle correctly vanished, and seven specs failed **against an app behaving exactly as designed**.

The page snapshot in the report is what settled it — the player bar rendered:

```
button "Open queue"
button "Open session"
button "Select audio output"
```

…and no "Open chat". The gate working, not breaking.

It also explains the two symptoms I chased before: the panel opening blank (pre-#84) and then closing under the test (post-#84) are both just the status answer arriving late and saying "no".

## The fix

`serviceWorkers: 'block'` in the Playwright config makes `page.route` authoritative for every method.

## Verification, honestly weighted

The 8 `ai-chat-mocked` specs still pass locally with it set — but that's the weak half, since locally there was no service worker to block. **The CI run is the real check**, and I'll confirm it on the next run rather than claim it now.

Worth noting separately: the E2E job is `continue-on-error: true`, which is why a mock that never worked in CI went unnoticed for however long it has been that way.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_014P9p2fvFnyiywBxGkv4gfW