### PR TITLE
Let the E2E suite actually fail the build

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -642,13 +642,22 @@ jobs:
     name: E2E Tests (Playwright)
     # Pull requests only — see docker-build. It also depends on docker-build, which does
     # not run on push, so leaving it enabled would leave it permanently skipped anyway.
-    if: github.event_name != 'push'
+    #
+    # `!cancelled()` rather than the default: `needs` is kept purely to *order* these two on the
+    # self-hosted runner, which is also the NAS that serves music — running a Docker build and a
+    # browser suite at once is a bad neighbour. This job downloads nothing from docker-build and
+    # builds its own frontend and backend, so there is no reason for a flaky NAS network to decide
+    # whether the browser tests run.
+    if: ${{ github.event_name != 'push' && !cancelled() }}
     runs-on: [self-hosted, Linux]
     needs: [docker-build]
-    # Advisory only: this job only runs when docker-build succeeds, and
-    # docker-build is itself advisory due to NAS network flakiness. Don't
-    # let skipped/failed E2E mark CI red.
-    continue-on-error: true
+    # **Deliberately not `continue-on-error`.** It was, and the reason was sound: the job inherited
+    # docker-build's flakiness, so a NAS hiccup would have blocked unrelated merges. Decoupling the
+    # two above removes that reason, and the cost of keeping it had become concrete — the chat
+    # specs' `/chat/status` mock never worked in CI, seven of them failed for an unknown length of
+    # time, and nothing went red because nothing could. A suite that cannot fail quietly stops being
+    # true. If NAS flakiness starts blocking merges through *this* job rather than through
+    # docker-build, that is the signal to revisit, and it will be visible rather than silent.
     env:
       UV_HTTP_TIMEOUT: '120'
       NPM_CONFIG_FETCH_RETRIES: '5'


### PR DESCRIPTION
## What it was, and why

```yaml
if: github.event_name != 'push'
needs: [docker-build]
continue-on-error: true   # ← never blocks
```

Two things together meant E2E could fail forever without anything going red: `continue-on-error` made failures non-blocking, and the `if` kept the job off `main` entirely, so there was no "is main green" signal either.

**The original reasoning was sound.** The job `needs: [docker-build]`, docker-build runs on the NAS and is flaky, so making E2E blocking would have let a network hiccup block unrelated merges.

## Why it doesn't survive inspection

That reason is about the *dependency*, not the job. E2E downloads **nothing** from docker-build — no `download-artifact`, no `docker run/pull/load`. It checks out, installs its own toolchain, builds the frontend, starts its own backend, and runs Playwright.

So the dependency is pure **ordering** — worth keeping, because the self-hosted runner is the same NAS that serves your music and a Docker build alongside a browser suite is a bad neighbour. What isn't worth keeping is inheriting its failures.

## The change

- `needs: [docker-build]` **stays** — ordering.
- `if: ${{ github.event_name != 'push' && !cancelled() }}` — runs whether docker-build passed, failed or was skipped.
- `continue-on-error` **removed** — real test failures now block.

## Why now

The cost had stopped being hypothetical. The chat specs' `/chat/status` mock had **never** worked in CI — the built app registers a service worker, and `page.route` can't intercept what one handles (#85). Seven specs failed for an unknown length of time and nothing went red, because nothing could.

A suite that cannot fail quietly stops being true. This one already had.

## The tradeoff, stated

If NAS flakiness starts blocking merges through *this* job rather than through docker-build, that's the signal to revisit — and it will be visible rather than silent, which is the whole point. I left the job PR-only rather than also running it on pushes to `main`: that would add a browser suite to every push on the machine that streams your music, and is a separate call.

Verified: the workflow parses, and the job's resolved `if` / `needs` / `continue-on-error` are as intended.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_014P9p2fvFnyiywBxGkv4gfW