### PR TITLE
The music map draws 500 artists, and the record catches up

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -91,9 +91,10 @@ management surfaces stay off the phone. Both shipped — `0018` in `familiar-app
 Within `0016`, Music Map shipped before embedded Discover (`familiar-apple` #41, then #43): the two
 halves were independent, and the map was one self-contained screen against endpoints that already
 generate, while the embedding half carried point 4's rule that an embedded page must never construct
-a second audio engine. **The map's interaction is still half-wired** — its footer advertises
-scroll-to-zoom that was never implemented, `zoomed(by:toward:)` is only reached through `stepped()`,
-and the drag gesture competes with click-to-focus.
+a second audio engine. **The map's interaction was half-wired and is now finished** — the footer had
+advertised a scroll-to-zoom nothing implemented, so `zoomed(by:toward:)` was reachable only through
+`stepped()`, and a 1pt drag threshold ate click-to-focus. Worth keeping from that: **the footer of a
+canvas is documentation, and nothing checked it against the gestures that existed.**
 
 **`ADR-0017` (`accepted`, shipped both sides) governs how embedded Discover boots.** It extends `0016`. It began
 by recording that point 4's conclusion — forbid playback, and no second engine is constructed — did

--- a/docs/decisions/ADR-0016-embedded-web-surfaces-on-the-mac.md
+++ b/docs/decisions/ADR-0016-embedded-web-surfaces-on-the-mac.md
@@ -17,6 +17,27 @@ Implementation:
   `library_maps.py` caps at 200 and 500 on lines 58 and 73, and `packages/web/src/main.tsx:14` is
   the unconditional `registerEngineFactory` call that point 4 exists to contain.
 - Music Map first, being independent of the embedding half and much the lower risk of the two.
+- **The map's gestures were finished afterwards**, on `familiar-apple` branch
+  `feat/music-map-interaction`. It shipped with a footer advertising "pinch or scroll to zoom" and a
+  comment in the gesture code referring to "the scroll wheel below" — neither of which existed, so
+  the anchored `zoomed(by:toward:)` was reachable only through `stepped()`, which always holds the
+  centre. The map's most-reached-for gesture did nothing.
+
+  Point 3 claims a native map buys "real trackpad gestures" over an embedded one, and that claim was
+  the thing left unbuilt. It holds now: scrolling zooms toward the pointer, pinch does the same
+  toward the pinch (`MagnifyGesture` reports a location where the deprecated `MagnificationGesture`
+  did not), and the zoom curve is exponential so scrolling back returns to exactly the zoom you
+  started at.
+
+  Two defects came out with it. The pan threshold was **1pt**, inside the wobble of an ordinary
+  trackpad click, so a click that moved a pixel became a pan and the click-to-focus never happened —
+  intermittently, looking like a dropped event. And the hover was recomputed only when the *pointer*
+  moved, so zooming without moving the mouse left the tooltip naming the artist that used to be
+  underneath it.
+
+  **The lesson worth keeping is about the footer.** It documented three gestures, one of which had
+  never been written, and it had been on screen since the map shipped. A caption is a claim, and
+  nothing checks captions.
 
 ## Context
 

--- a/packages/frontend/src/components/Library/browsers/VibeMap/VibeMap.tsx
+++ b/packages/frontend/src/components/Library/browsers/VibeMap/VibeMap.tsx
@@ -26,6 +26,23 @@ import { useUIStore } from '../../../../stores/uiStore';
 import { useOfflineStatus } from '../../../../hooks/useOfflineStatus';
 import { usePreviewAudio } from '../../../../hooks/usePreviewAudio';
 
+// How many artists to ask for — the server's maximum.
+//
+// Not a threshold, a count: the server takes every artist with an analysed track, sorts by track
+// count and keeps the top slice (`embedding_map.py`), so what "makes the map" is wherever the
+// cut-off lands for a given library. On the reference library, 200 meant artists with 30+ tracks and
+// covered 12,365 of 26,396 tracks; 500 means 15+ and covers 18,715 — 47% to 71%, measured
+// 2026-08-04. The map was answering "where does this artist sit" for well under half of what anyone
+// would ask it about.
+//
+// 500 is the endpoint's own cap, and the server caches per (entity_type, limit), so both clients
+// asking for the same number is one Redis key rather than two computations.
+const MAP_ENTITY_LIMIT = 500;
+
+// The label threshold, and the map size it was judged against. See `labelZoom` below.
+const LABEL_TUNED_NODE_COUNT = 200;
+const LABEL_ZOOM_AT_TUNED_COUNT = 1.4;
+
 // Lens features in display order, with friendly labels. Only those actually
 // present in the data are shown in the picker.
 const LENS_OPTIONS: { key: string; label: string }[] = [
@@ -109,8 +126,8 @@ export function VibeMap({ onGoToArtist }: BrowserProps) {
 
   // Fetch global similarity map
   const { data, isLoading, error } = useQuery({
-    queryKey: ['library', 'vibe-map', 'artists', 200],
-    queryFn: () => libraryApi.getMusicMap({ entity_type: 'artists', limit: 200 }),
+    queryKey: ['library', 'vibe-map', 'artists', MAP_ENTITY_LIMIT],
+    queryFn: () => libraryApi.getMusicMap({ entity_type: 'artists', limit: MAP_ENTITY_LIMIT }),
     enabled: !isOffline,
     staleTime: STALE_TIME.LONG,
   });
@@ -147,6 +164,18 @@ export function VibeMap({ onGoToArtist }: BrowserProps) {
   const maxTrackCount = useMemo(() => {
     if (!data || data.nodes.length === 0) return 1;
     return Math.max(...data.nodes.map((n) => n.track_count));
+  }, [data]);
+
+  // The zoom past which every name is drawn, scaled to how many there are.
+  //
+  // 1.4 was judged by eye against a 200-artist map. Zooming by z spreads the points over z² the
+  // area, so holding labels-per-screen constant means scaling by the square root of the count —
+  // otherwise raising the limit to 500 draws two and a half times as many names in the same space,
+  // which is the grey rectangle the threshold exists to prevent.
+  const labelZoom = useMemo(() => {
+    const count = data?.nodes.length ?? 0;
+    if (count <= 0) return LABEL_ZOOM_AT_TUNED_COUNT;
+    return LABEL_ZOOM_AT_TUNED_COUNT * Math.sqrt(count / LABEL_TUNED_NODE_COUNT);
   }, [data]);
 
   // Measure container
@@ -308,8 +337,9 @@ export function VibeMap({ onGoToArtist }: BrowserProps) {
         ctx.stroke();
       }
 
-      // Labels for prominent / interesting nodes
-      if (zoom > 1.4 || isHovered || isSelected || isFocused || isNeighbor) {
+      // Labels for prominent / interesting nodes. The ones singled out are always named, at any
+      // zoom; the rest wait for there to be room, which depends on how many there are.
+      if (zoom > labelZoom || isHovered || isSelected || isFocused || isNeighbor) {
         ctx.font = `${isFocused ? 'bold ' : ''}12px system-ui, sans-serif`;
         ctx.fillStyle = isFocused ? '#ffffff' : isSelected ? '#22c55e' : '#a1a1aa';
         ctx.textAlign = 'center';
@@ -336,7 +366,8 @@ export function VibeMap({ onGoToArtist }: BrowserProps) {
     }
   }, [
     data, dimensions, zoom, dataToScreen, hovered, selectedArtists, focusedArtist,
-    adjacency, nodeById, lensFeature, showEdges, maxTrackCount, isLassoing, lassoStart, lassoEnd,
+    adjacency, nodeById, lensFeature, showEdges, maxTrackCount, labelZoom,
+    isLassoing, lassoStart, lassoEnd,
   ]);
 
   useEffect(() => {


### PR DESCRIPTION
Two halves of the same change. The Mac's map work is in seethroughlab/familiar-apple#62; this is the web client keeping step with it, and ADR-0016 saying what was actually built.

## 500 rather than 200

`limit: 200` was not a threshold anyone chose. The server takes every artist with an analysed track, sorts by track count and keeps the top slice (`embedding_map.py:256`), so what "makes the map" is wherever the cut-off happens to land for a given library. Measured 2026-08-04:

| limit | artists | tracks covered | smallest artist on the map |
|---|---|---|---|
| 200 | 200 of 3,475 | 12,365 of 26,396 (46.8%) | 30 tracks |
| **500** | 500 of 3,475 | **18,715 (70.9%)** | 15 tracks |

The map was answering "where does this artist sit" for well under half of what anyone would ask it about. 500 is the endpoint's own cap, and the server caches per `(entity_type, limit)` — so both clients asking for the same number costs one UMAP pass rather than two.

## The label threshold had to move with it

Every name is drawn past 1.4× zoom, a number judged by eye against a 200-artist map. 500 names in the same space is the grey rectangle that rule exists to prevent — and on the Mac side, measurement showed a label is the most expensive thing in the frame, resolved and drawn per label per frame, where the whole map's geometry is under 1.5ms.

Zooming by `z` spreads the points over `z²` the area, so holding labels-per-screen constant means scaling the threshold by the square root of the node count: **2.2× for 500**, the same on-screen density 200 gave at 1.4×. Hovered, selected, focused and neighbour artists are still named at any zoom.

Both numbers are named constants now rather than literals buried in a query key and a draw loop, which is how they drifted apart from what they meant.

## The record

**ADR-0016 and CLAUDE.md both described the map's interaction as half-wired.** It is not any more. Point 3 claims a native map buys "real trackpad gestures" over an embedded one, and that was the part left unbuilt — the footer advertised a scroll-to-zoom nothing implemented, so the anchored zoom was reachable only through the +/− buttons, and a 1pt drag threshold ate click-to-focus.

Kept rather than deleted, because it is the transferable part: the footer documented three gestures, one of which had never been written, and it had been on screen since the map shipped. **A caption is a claim, and nothing checks captions.**

## Testing

980 frontend tests pass, web build and lint clean. No Decision text is edited — the ADR change is an Implementation-block entry, as an accepted ADR's living record is meant to take.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_014P9p2fvFnyiywBxGkv4gfW