### PR TITLE
The buildx layer cache lives on disk, not in RAM

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -616,6 +616,16 @@ jobs:
       - name: Set up Docker Buildx
         uses: docker/setup-buildx-action@v3
 
+      # The cache must live on disk, not under /tmp. /tmp on this runner is a
+      # tmpfs (systemd's default, half of RAM) — a 3.8G cache there was a
+      # quarter of the box's 15.6G, and the rotate below briefly doubles that
+      # against a 7.8G cap. /opt/actions-runner is ext4 with 753G free and is
+      # owned by the runner user.
+      - name: Ensure buildx cache dir exists on disk
+        run: |
+          mkdir -p /opt/actions-runner/_cache
+          test "$(findmnt -no FSTYPE -T /opt/actions-runner/_cache)" != tmpfs
+
       - name: Build Docker image
         uses: docker/build-push-action@v6
         timeout-minutes: 55
@@ -628,14 +638,15 @@ jobs:
           # builds reuse pnpm install, apt-get, uv sync, torch wheels, etc.
           # Without this, setup-buildx-action creates a new isolated builder
           # every run and every layer is rebuilt from scratch.
-          cache-from: type=local,src=/tmp/familiar-buildx-cache
-          cache-to: type=local,dest=/tmp/familiar-buildx-cache-new,mode=max
+          cache-from: type=local,src=/opt/actions-runner/_cache/familiar-buildx
+          cache-to: type=local,dest=/opt/actions-runner/_cache/familiar-buildx-new,mode=max
 
       - name: Rotate buildx cache
         run: |
-          rm -rf /tmp/familiar-buildx-cache
-          if [ -d /tmp/familiar-buildx-cache-new ]; then
-            mv /tmp/familiar-buildx-cache-new /tmp/familiar-buildx-cache
+          rm -rf /opt/actions-runner/_cache/familiar-buildx
+          if [ -d /opt/actions-runner/_cache/familiar-buildx-new ]; then
+            mv /opt/actions-runner/_cache/familiar-buildx-new \
+               /opt/actions-runner/_cache/familiar-buildx
           fi
 
   e2e-test:


### PR DESCRIPTION
`/tmp` on the self-hosted Linux runner is a **tmpfs** — systemd's default `tmp.mount`, sized at half of RAM. The buildx layer cache had grown to **3.8 GiB** there, a quarter of the box's 15.6 GiB. The rotate step doubles peak usage, because `cache-to` writes a complete second copy to `…-new` before the old one is removed: **~7.6 GiB against a 7.8 GiB cap**.

When this was found the machine had **205 MiB free and swap fully consumed** (975/975 MiB). For scale, all 11 Docker containers on that box combined use 2.3 GiB — the build cache alone was larger than every running service put together.

## What changed

Both cache paths move to `/opt/actions-runner/_cache/familiar-buildx`, verified `ext4` with 749 GiB free and already owned by `github-runner` (uid 1001). A new pre-step creates the directory and asserts it is not itself a tmpfs, so a regression back into RAM fails the step rather than quietly costing 3.8 GiB of memory on the machine that also serves the music library.

**The cache is not shrunk or disabled.** A cold build takes ~60 minutes, of which apt-get alone was 26 — the same reasoning as the neighbouring comment warning off `docker system prune -a`. The location was the problem, not the cache.

## Already done on the runner

The existing 3.8 GiB cache was **moved rather than deleted**, so it stays warm and this PR should not trigger a cold rebuild. Ownership was preserved.

| | before | after |
|---|---|---|
| `/tmp` used | 3.8 G | 29.5 M |
| `shared` (tmpfs counted against RAM) | 4.1 Gi | 357 Mi |
| free | 205 Mi | 3.5 Gi |
| available | 8.5 Gi | 11 Gi |

## How to check this worked

**Docker Build on #90 — also a docs-only PR — passed in 3m07s with a warm cache.** This run should land near that. If it comes back at ~60 minutes, the cache did not survive the move and needs repopulating on the new path.

Ignore **macOS Compose Integration**: its keychain failure is environmental and reddens every PR.

## Why now

Nothing was broken — the box still reported 8.6 GiB available. The prompt was `crowcam`, a five-month unattended measurement experiment on the same host that enters a change freeze from mid-December, with Frigate recording continuously. A CI build spiking tmpfs to ~7.6 GiB during that is a real contention risk, and the responses available during a freeze are limited.

Found by the crowcam agent while investigating memory headroom on the shared runner host.

🤖 Generated with [Claude Code](https://claude.com/claude-code)