### PR TITLE
Two follow-ups: the chown and the cache export

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -613,14 +613,30 @@ jobs:
           docker system prune -f || true
           df -h || true
 
+      # A *named* builder that outlives the job. Its layer cache lives in the
+      # buildkit container's own volume under /var/lib/docker — on disk, and
+      # updated in place, so nothing has to be exported and copied anywhere.
+      #
+      # This is what replaces `cache-to: type=local,mode=max`, which rewrote the
+      # entire 3.8G cache on every build — 5m03s of a 17m30s run measured on
+      # 2026-08-05, and paid in full even on docs-only PRs where not one layer
+      # changed.
+      #
+      # `cleanup: false` is what keeps it between runs. Note that "Clean up
+      # dangling resources" above removes *stopped* containers, so a builder
+      # that ever stops is recreated empty next run. That is survivable rather
+      # than costly because cache-from below still seeds it from disk.
       - name: Set up Docker Buildx
         uses: docker/setup-buildx-action@v3
+        with:
+          name: familiar-persistent
+          cleanup: false
 
       # The cache must live on disk, not under /tmp. /tmp on this runner is a
       # tmpfs (systemd's default, half of RAM) — a 3.8G cache there was a
-      # quarter of the box's 15.6G, and the rotate below briefly doubles that
-      # against a 7.8G cap. /opt/actions-runner is ext4 with 753G free and is
-      # owned by the runner user.
+      # quarter of the box's 15.6G. Nothing writes here any more, but the
+      # assert stays: this path silently becoming tmpfs would cost memory on
+      # the machine that also serves the music library.
       - name: Ensure buildx cache dir exists on disk
         run: |
           mkdir -p /opt/actions-runner/_cache
@@ -634,20 +650,26 @@ jobs:
           file: docker/Dockerfile
           push: false
           tags: familiar:test
-          # Persist buildx layer cache to a runner-local path so subsequent
-          # builds reuse pnpm install, apt-get, uv sync, torch wheels, etc.
-          # Without this, setup-buildx-action creates a new isolated builder
-          # every run and every layer is rebuilt from scratch.
+          # Read-only floor. The persistent builder above holds the live cache;
+          # this directory is a fixed snapshot that seeds it whenever the
+          # builder has been recreated, so losing the builder costs seconds
+          # rather than the ~60m a fully cold build takes. There is deliberately
+          # no cache-to: exporting is the 5m03s this change removes.
           cache-from: type=local,src=/opt/actions-runner/_cache/familiar-buildx
-          cache-to: type=local,dest=/opt/actions-runner/_cache/familiar-buildx-new,mode=max
 
-      - name: Rotate buildx cache
+      # Bound the builder's cache, which is the job the rotate used to do — the
+      # local exporter could not prune in place, so a full rewrite was the only
+      # way to drop stale layers. Pruning does it directly and incrementally.
+      #
+      # The flag is `--max-used-space`; buildx v0.33 on this runner has no
+      # `--keep-storage`, whatever older documentation says. Failure is reported
+      # rather than swallowed, because a prune that silently never runs looks
+      # exactly like one that works until the disk fills.
+      - name: Bound the builder cache
+        if: always()
         run: |
-          rm -rf /opt/actions-runner/_cache/familiar-buildx
-          if [ -d /opt/actions-runner/_cache/familiar-buildx-new ]; then
-            mv /opt/actions-runner/_cache/familiar-buildx-new \
-               /opt/actions-runner/_cache/familiar-buildx
-          fi
+          docker buildx prune --builder familiar-persistent --max-used-space=20GB -f \
+            || echo "::warning::buildx prune failed — the builder cache is unbounded"
 
   e2e-test:
     name: E2E Tests (Playwright)

--- a/docker/Dockerfile
+++ b/docker/Dockerfile
@@ -102,32 +102,47 @@ RUN apt-get update && apt-get install -y --no-install-recommends \
 # Install Deno - required by yt-dlp for YouTube JS challenge solving
 RUN curl -fsSL https://deno.land/install.sh | DENO_INSTALL=/usr/local sh
 
+# Create the non-root user here rather than at the end, because every COPY
+# below uses --chown and that needs the user to already exist. This ordering
+# is what keeps the venv out of a recursive chown — see the note further down.
+RUN useradd --create-home --shell /bin/bash familiar
+
 # Copy Python virtual environment from deps stage
-COPY --from=python-deps /app/.venv /app/.venv
+COPY --from=python-deps --chown=familiar:familiar /app/.venv /app/.venv
 
 # Copy backend application code
-COPY backend/app ./app
+COPY --chown=familiar:familiar backend/app ./app
 
 # Copy smoke test script for post-build verification
-COPY backend/scripts/smoke_test_clap.py ./scripts/smoke_test_clap.py
+COPY --chown=familiar:familiar backend/scripts/smoke_test_clap.py ./scripts/smoke_test_clap.py
 
 # Copy Alembic configuration
 # Note: migrations/ instead of alembic/ to avoid shadowing the alembic package
-COPY backend/alembic.ini ./
-COPY backend/migrations ./migrations
+COPY --chown=familiar:familiar backend/alembic.ini ./
+COPY --chown=familiar:familiar backend/migrations ./migrations
 
 # Copy built frontend
-COPY --from=frontend-builder /app/packages/web/dist ./static
+COPY --from=frontend-builder --chown=familiar:familiar /app/packages/web/dist ./static
 
 # Download silero-vad ONNX model (~2MB) for voice activity detection
 RUN mkdir -p /app/data/models \
     && curl -fsSL -o /app/data/models/silero_vad.onnx \
        https://github.com/snakers4/silero-vad/raw/master/src/silero_vad/data/silero_vad.onnx
 
-# Create non-root user and directories
-RUN useradd --create-home --shell /bin/bash familiar \
-    && mkdir -p /data/music /data/art /data/videos /data/mixtapes /app/data \
-    && chown -R familiar:familiar /app /data
+# Runtime data directories.
+#
+# The recursive chown here deliberately covers only /data (empty at build time)
+# and /app/data (~2MB of models). Everything large under /app already arrived
+# owned by familiar via COPY --chown above, which costs nothing because the
+# ownership is set as the files are written.
+#
+# This step used to be `chown -R familiar:familiar /app /data`, and it took
+# 9m12s of a 17m30s CI build on 2026-08-05 — /app/.venv is a CPU torch build
+# with analysis extras, and walking it dominated the image. Do not reintroduce
+# a recursive chown over /app; add --chown to the COPY instead.
+RUN mkdir -p /data/music /data/art /data/videos /data/mixtapes /app/data \
+    && chown familiar:familiar /app /app/VERSION \
+    && chown -R familiar:familiar /data /app/data
 
 # Copy entrypoint script
 COPY docker/entrypoint.sh /entrypoint.sh


### PR DESCRIPTION
Supersedes #95, which GitHub auto-closed when #92's branch was deleted on merge. Same two commits, rebased onto `main`.

These are the two follow-ups measured out of #92's build log, which ran 17m30s against a 3m07s warm baseline. Between them they account for **14m15s of that 17m30s**. Neither is the cache location #92 fixed; both were already there and only became visible once the log was read step by step.

## 1. `chown -R` over a torch venv — 9m12s

```
#37 [production 11/13] RUN useradd … && mkdir -p … && chown -R familiar:familiar /app /data
#37 DONE 551.9s
```

The single most expensive step in the image — more than `apt-get`, `uv sync` and the frontend build put together. `/app/.venv` is a CPU torch build with the analysis extras, and walking it dominates.

Nothing about the result needed a recursive pass. Every large path under `/app` arrives via `COPY`, and `COPY --chown` sets ownership as it writes, for free. So the user is created *before* the copies, each `COPY` is tagged, and the recursive chown is left covering only `/data` (empty at build time) and `/app/data` (~2 MB of models).

**The end state is identical.** The one thing worth checking was whether a parent directory created by `COPY --chown` — `/app/scripts`, which no `COPY` names directly — lands owned by the user or by root. Verified against a minimal image: it is owned by the user, so the scoped chown leaves no gap.

## 2. Exporting the cache — 5m03s

```
#40 exporting cache to client directory
#40 preparing build cache for export 267.5s done
```

`cache-to: type=local,mode=max` rewrites the **entire** 3.8 G cache every build, paid in full on docs-only PRs where not one layer changed — and rewriting 3.8 G to the SSD each time is its own cost.

The builder is now named and kept (`cleanup: false`), so its cache lives in the buildkit container's own volume and is updated **in place**. Nothing is exported, so the rotate goes with it, and so does the 2× peak that made this dangerous back when the cache lived in tmpfs.

`cache-from` stays as a **read-only floor**. "Clean up dangling resources" removes stopped containers, so the builder can be lost; when that happens the next build seeds from the snapshot in seconds rather than rebuilding cold for ~60 minutes. That is the deliberate answer to the one real risk here.

**The prune uses `--max-used-space`.** buildx v0.33 on this runner has no `--keep-storage` — the command in the original report would have failed. It reports failure rather than swallowing it, because a prune that silently never runs looks exactly like one that works until the disk fills.

## What to expect

This PR's own build is **not** the clean measurement: both commits invalidate the layers they touch, so expect one slower run. The comparison to watch is the run *after* it.

| | before | expected after |
|---|---|---|
| `chown` step | 9m12s | seconds |
| cache export | 5m03s | gone |
| warm build | 3m07s + export | ~3m |

If the persistent builder turns out not to survive between runs on this box, the symptom is every build seeding from `cache-from` and taking a few extra minutes — visible, not silent, and revertible by restoring `cache-to` plus the rotate.

Once this settles, `/opt/actions-runner/_cache/familiar-buildx` stops being updated and can either be refreshed deliberately or dropped.

🤖 Generated with [Claude Code](https://claude.com/claude-code)