### PR TITLE
docs(adr): propose ADR-0027 and ADR-0028 — shuffle as a mode, and writing the session back

### DIFF
--- a/docs/decisions/ADR-0027-shuffle-and-repeat-are-listener-modes.md
+++ b/docs/decisions/ADR-0027-shuffle-and-repeat-are-listener-modes.md
@@ -1,0 +1,130 @@
+# ADR-0027: Shuffle and Repeat Are Listener Modes
+
+Status: proposed
+Date: 2026-08-05
+
+Extends [ADR-0003](ADR-0003-server-owns-the-playback-queue.md)
+
+## Context
+
+Shuffle switches itself off when you click a track. Reported from the Mac, and true on every
+surface: `FamiliarPlayer.play(_:startingAt:)` sets `isShuffled = false`
+(`FamiliarPlayer.swift:153`), and all **twelve** call sites that start playback from a list go
+through it — the library, favourites, downloads, browse, chat and the embedded Discover surface.
+
+Nothing decided this. The method's documentation does not mention shuffle at all; the assignment is
+part of installing a fresh queue in the order it was handed. That falls out of how the flag is
+modelled: `isShuffled` is documented as "whether `queue` is a shuffled view of `logicalQueue`"
+(`FamiliarPlayer.swift:26`). It is a statement about the *current queue*, not about the listener.
+Build a new queue and there is nothing shuffled about it, so the toggle is off — correctly, by its
+own definition, which is why no test caught it and no comment flags it.
+
+**A premise from ADR-0003 needs correcting here, because it reads as if it settled this.** That ADR
+says shuffle "is consumed as order rather than reimplemented as a mode", and its phase 4 bullet
+says the Swift player "has no `shuffle`, `repeat`, `consume` or reservoir concept". Both were true
+and neither is now. The first was a statement about *reading* the server's session — flattening
+`shuffle_order` into a play order so a reader need not reconstruct the mode — and it says nothing
+about what the toggle should mean to someone using it. The second has simply been overtaken:
+`isShuffled` (`:27`), `repeatMode` (`:29`) and `consume` (`:31`) all exist natively today.
+
+The server has never agreed with the client here. `PlaybackSessionWrite` carries `shuffle`,
+`repeat` and `consume` as fields in their own right, *alongside* `shuffle_order` and
+`shuffle_index`. The mode and the order are separate things in the schema, and the web client sends
+both (`packages/frontend/src/services/queueSyncService.ts:94`). Only the Apple client collapses them.
+
+The behaviour is also inconsistent with itself. `toggleShuffle()` deliberately preserves the
+listener's intent across a queue change — `logicalQueue` exists solely so that switching shuffle off
+can straighten an album out again, and `QueueShuffle.disabling` reconstructs the original order.
+Considerable care went into shuffle surviving one kind of change, and none into it surviving the
+most common one.
+
+## Decision
+
+1. **Shuffle, repeat and consume are properties of the listener, not of a queue.** They persist
+   across queue replacement. Starting playback from a list no longer clears them; a listener who
+   turned shuffle on stays in shuffle until they turn it off.
+
+2. **`isShuffled` splits into a mode and a fact.** The published mode is what the toggle sets and
+   what survives. Whether `queue` currently *is* a permutation of `logicalQueue` stays as it is —
+   internal, derived, and what `QueueShuffle.disabling` needs to straighten an album out. Collapsing
+   the two is what caused this, so the fix must not re-collapse them under a new name.
+
+3. **Starting playback with shuffle on shuffles the remainder, not the choice.** Clicking a track
+   plays *that* track and permutes what follows, as `toggleShuffle()` already does mid-listen. It
+   does not re-randomise the opening track: the listener picked it, and honouring that pick is the
+   whole point of clicking a row rather than pressing Shuffle.
+
+4. **`playShuffled(_:)` keeps its distinct meaning and now also sets the mode.** Pressing Shuffle on
+   an album should still surprise you with the opening track, which is why it exists separately from
+   `play(_:startingAt:)` plus a toggle. What changes is that it leaves the mode on afterwards rather
+   than describing only the queue it built.
+
+5. **An adopted queue still claims nothing.** ADR-0003's reasoning stands unchanged: a session
+   arrives flattened, so this device cannot tell whether the order it received was shuffled, and
+   asserting a mode would offer to "un-shuffle" into an order the server never had. Adoption
+   continues to record the order as the order it is. It may now *read* the session's `shuffle` field
+   to set the mode, because that field says what the listener chose rather than what the order looks
+   like — but the order itself is still taken as given.
+
+6. **Clearing the queue clears the modes.** `clear()` returns the player to its initial state, and a
+   listener who has stopped everything and emptied the queue is not mid-session. This is the one
+   place the modes do not survive, and it is deliberate rather than an oversight.
+
+7. **The modes are not yet persisted anywhere.** They survive queue changes within a launch and
+   nothing more. Where they are stored across launches is [ADR-0028](ADR-0028-the-apple-client-writes-its-playback-session-back.md)'s
+   decision, and deliberately not this one — this ADR is executable on its own and fixes the
+   reported defect on its own.
+
+## Alternatives Considered
+
+**Leave it: clicking a track is a deliberate exit from shuffle.** There is a real argument that
+picking a specific track means "play this, in order, from here" — and it has the merit of being
+what the code does today. Rejected because it is not discoverable in the slightest: the toggle
+silently changes state as a side effect of an unrelated action, with no indication that it was the
+click that did it. If it were the intent, the toggle would be disabled or the change announced.
+Neither happens, and the behaviour was reported as a bug by the person who built the app.
+
+**Make `play(_:startingAt:)` preserve the flag without splitting the concept.** The one-line fix:
+capture `isShuffled` and restore it. Rejected because the flag would then be lying — it would claim
+`queue` is a shuffled view of `logicalQueue` when it is not, and `toggleShuffle()` reads exactly
+that to decide whether to straighten out. The next person to call `QueueShuffle.disabling` on that
+state gets an order that never existed. The concept has to split or the bug moves rather than
+leaves.
+
+**Reimplement shuffle as the server models it, with `shuffle_order` maintained client-side.** This
+is what the web client does, and it would make write-back (ADR-0028) a direct mapping instead of a
+translation. Rejected as the wrong order of work: ADR-0003 found that consuming the order rather
+than reconstructing the mode was "the one observation that made the phase tractable instead of a
+port of `queueStore.ts`", and that remains true. Maintaining a permutation and an index alongside
+the queue is a substantial rewrite of working code, justified only if write-back proves it
+necessary — and ADR-0028 argues it does not.
+
+**Persist the modes in `UserDefaults` as part of this change.** Tempting, because it is small and
+gets most of what was asked for. Rejected because it would put playback state in a second place
+that launch-time adoption already writes from (`LibraryView.swift:904`), and two sources of truth
+for what is playing is precisely the hazard ADR-0028 exists to resolve. Doing it here would
+pre-empt that decision by making the wrong half irreversible.
+
+## Consequences
+
+- **Positive.** The reported defect goes away, and shuffle behaves the way it does in every other
+  player: a mode the listener sets, not a property of whatever list they last touched.
+- **Positive.** The client stops disagreeing with its own server. `shuffle`, `repeat` and `consume`
+  have been fields in `PlaybackSessionWrite` all along; after this the Apple client has something
+  truthful to put in them, which is what makes ADR-0028 possible.
+- **Positive.** The split in point 2 makes the invariant testable in `FamiliarKit`:
+  the mode is a published property with defined behaviour across queue replacement, and
+  `QueueShuffle` is already pure and covered.
+- **Tradeoff.** Twelve call sites change behaviour at once, and none of them asked to. A listener
+  who has grown used to clicking a track as a way *out* of shuffle loses that gesture, and the
+  replacement — the toggle — is one they may never have used.
+- **Tradeoff.** Point 3 means clicking a track in shuffle produces a queue whose order depends on
+  where you clicked, which is harder to reason about than "the list, shuffled". It is the same rule
+  `toggleShuffle()` already follows mid-listen, so the inconsistency being removed is larger than
+  the one being introduced.
+- **Follow-up.** The transport gives no indication that shuffle is a persistent mode rather than a
+  per-queue state. Now that it survives, it is worth checking that the control reads as on when it
+  is on, across all three surfaces.
+- **Follow-up.** ADR-0003's phase 4 bullet should be annotated to record that its "no `shuffle`,
+  `repeat`, `consume`" premise has expired, so nobody re-derives the deferral from it. Its Decision
+  is not edited; the note belongs with the implementation record.

--- a/docs/decisions/ADR-0028-the-apple-client-writes-its-playback-session-back.md
+++ b/docs/decisions/ADR-0028-the-apple-client-writes-its-playback-session-back.md
@@ -1,0 +1,147 @@
+# ADR-0028: The Apple Client Writes Its Playback Session Back
+
+Status: proposed
+Date: 2026-08-05
+
+Extends [ADR-0003](ADR-0003-server-owns-the-playback-queue.md) and
+[ADR-0027](ADR-0027-shuffle-and-repeat-are-listener-modes.md)
+
+## Context
+
+Quit the Mac app and everything about what you were listening to is gone: the queue, the position
+in it, the position in the track. Relaunch and you are on an empty player. The request was simply
+"I'd like the app to preserve state between launches".
+
+There is already a launch-time restore path, and it does not come from disk.
+`queueAdopter.adoptOnce(into: player)` (`LibraryView.swift:904`, implemented at
+`QueueAdoption.swift:76`) fetches the server's playback session and adopts it. So the Apple client
+*does* start from stored state — the server's. What it never does is contribute to it.
+`queueGetPlaybackSession` has exactly one caller (`ServerQueueSource.swift:17`);
+`queuePutPlaybackSession` has **zero**, despite being generated and available, because the `queue`
+tag is in the generator's filter list.
+
+That asymmetry is not an oversight either. ADR-0003 phase 4 states the reason:
+
+> Read-only by decision: the player has no `shuffle`, `repeat`, `consume` or reservoir concept, and
+> a write would flatten a 1,732-track shuffled queue the web client was actively using. Handoff is
+> the value; two-way sync waits for those concepts to exist natively.
+
+**That condition has been met, and nothing revisited it.** `isShuffled`, `repeatMode` and `consume`
+are all published properties of `FamiliarPlayer` today (`:27`, `:29`, `:31`), and ADR-0027 makes
+them mean what the server's fields of the same names mean. The deferral was conditional and the
+condition expired quietly, which is exactly the kind of thing an ADR set is supposed to catch.
+
+The consequence is worse than a missing feature. Because the Mac adopts but never writes, an hour
+of listening on the Mac leaves the server holding whatever the web app last pushed. The next device
+to adopt — including the Mac itself, next launch — restores a session that is stale by however long
+the Mac was in use. The Mac is not merely failing to save its state; it is being silently overwritten
+by a less recently used client.
+
+The web client is the existence proof that the other half works. `queueSyncService.ts` both pushes
+(`:130`) and adopts (`:159`), reconciles on load (`:211`), and coalesces writes through an outbox so
+that calling it often is cheap. Its payload (`:94`) already carries everything needed to resume:
+`track_ids`, `cursor`, `shuffle_order`, `shuffle_index`, `shuffle`, `repeat`, `consume`,
+`queue_source`, `position_seconds`, `version` and `updated_at`. **No schema work is required.** This
+is a second implementation of an existing contract, not a new one.
+
+## Decision
+
+1. **Resume-across-launches is the server session, not a local snapshot.** The Apple client gains no
+   private store of what was playing. It already restores from the server on launch; this ADR makes
+   that restore meaningful by ensuring the server holds what this device did.
+
+2. **The Apple client writes the playback session, completing ADR-0003 phase 4's deferred half.**
+   `queuePutPlaybackSession` is called with the same fields the web client sends, on the same
+   optimistic-concurrency contract — `version` in, conflict handled, as
+   `familiar.queueSync.adoptedVersion.<profile>` already tracks for reads.
+
+3. **Writes are coalesced and driven by change, not by a clock.** A signature over the queue,
+   cursor and modes decides whether anything is worth sending, as the web client's outbox does.
+   `position_seconds` is the exception and stays coarse — ADR-0003 already records as a follow-up
+   that a handoff "can resume a few seconds" off, and that is a better trade than a write every
+   tick.
+
+4. **Nothing is written while the queue is adopted-but-untouched.** A device that adopts a session
+   and does not play must not immediately write it back: that would bump `version` and let an idle
+   client win a conflict against an active one. The first write follows the first change *this
+   listener* made.
+
+5. **Shuffle is still written as order, and now also as mode.** `shuffle_order` and `shuffle_index`
+   are populated from the queue as it stands; `shuffle`, `repeat` and `consume` come from ADR-0027's
+   modes. ADR-0003's observation — that a reader can flatten the order and skip the bookkeeping —
+   is unaffected, because it governs reading and this governs writing.
+
+6. **A conflict is resolved by taking the server's session, not by merging.** Two devices editing
+   one queue has no correct merge, and the web client does not attempt one. The losing device adopts
+   and continues from what the server had.
+
+7. **Offline, nothing is queued for later.** A write that cannot be sent is dropped, not spooled.
+   The state it described will be superseded by the next successful write, and a stale session
+   replayed after a gap is worse than no write at all — it would resurrect a queue the listener
+   abandoned hours ago. This is deliberately narrower than the web client's offline outbox, which
+   exists for actions that must not be lost; a playback position is not one.
+
+8. **With queue sync disabled, none of this happens and nothing is preserved.** The existing
+   `familiar.queueSync.enabled` setting (`ServerConfiguration.swift:48`) governs writes as it governs
+   reads. A listener who has turned sync off has asked for this device not to participate, and
+   inventing local persistence for them would be answering a question they did not ask — see the
+   alternatives.
+
+9. **Verification is against a real server, in three layers.** The payload construction is pure and
+   unit-tested in `FamiliarKit`; the conflict and adoption paths extend the existing
+   `QueueAdopterTests`; and a launch-quit-relaunch cycle is checked by hand against the live server,
+   because the failure this fixes is only visible across a process boundary.
+
+## Alternatives Considered
+
+**Persist to `UserDefaults` or a local file, and leave sync alone.** Much smaller, works offline,
+and needs no server round trip. Rejected because launch-time adoption already exists and already
+writes the player's state from the server — so a local snapshot creates two sources of truth that
+disagree on exactly the launch where it matters, and something must arbitrate. It also fixes the
+symptom while leaving the cause: the Mac would still be silently overwriting itself on the server,
+and the phone and web app would still be adopting a stale session after an hour of Mac listening.
+
+**Write only `position_seconds`, treating the queue as the web client's to own.** Cheap, and would
+deliver most of "resume where I left off" for a listener who uses the Mac alone. Rejected because
+the queue is the part that is actually lost — a position into a queue nobody restored is not useful
+— and because it entrenches the asymmetry rather than resolving it.
+
+**Reimplement the web client's `queueStore.ts` shuffle bookkeeping first, so the payload is a direct
+mapping.** Rejected for the reason ADR-0003 gives: consuming order rather than reconstructing mode
+was "the one observation that made the phase tractable instead of a port of `queueStore.ts`". The
+write direction can populate `shuffle_order` from the queue it has without maintaining a permutation
+continuously, so the rewrite buys symmetry with the web client and nothing a listener would notice.
+
+**Wait for a real conflict-resolution design before writing at all.** The safest option, and the
+status quo. Rejected because the status quo is not neutral — it is a client that loses its own state
+every launch and degrades the shared session for every other client. Point 6 adopts the same
+last-writer-wins rule the web client has run on since ADR-0003 phase 3, which is a known quantity
+rather than a new risk.
+
+## Consequences
+
+- **Positive.** The Mac resumes where it left off, which is what was asked for — and so does the
+  phone, and so does handoff between all three, because they resume from the same place.
+- **Positive.** The Apple client stops silently degrading the shared session. This is the larger
+  defect and it was invisible: nothing on any surface indicates that the Mac's listening was never
+  recorded.
+- **Positive.** No schema, no new endpoint, no generator change. `PlaybackSessionWrite` and
+  `queuePutPlaybackSession` already exist and are already generated; the write is a second consumer
+  of a contract with a working reference implementation to check against.
+- **Positive.** ADR-0003 phase 4's deferral is closed rather than left as a conditional that
+  quietly expired. That the condition had been met for some time, unnoticed, is the argument for
+  writing this down.
+- **Tradeoff.** Two clients now write one session, so conflicts become real rather than theoretical.
+  Point 6 resolves them by discarding one side's recent listening — correct, and still a loss.
+- **Tradeoff.** Point 8 means the request is not granted for anyone who has turned queue sync off:
+  they get no persistence at all. That is defensible and it is not obvious, and it may be the point
+  reviewers most want to push on.
+- **Tradeoff.** Point 3's coarse `position_seconds` means a resumed track can start a few seconds
+  from where it stopped. ADR-0003 already carries this as a follow-up; this ADR inherits it rather
+  than fixing it.
+- **Follow-up.** Point 4's rule — do not write an adopted-but-untouched session — is the kind of
+  invariant that is easy to state and easy to violate later. It wants a test that fails if adoption
+  alone produces a write.
+- **Follow-up.** If point 8 proves too strict in use, the answer is a local cache *behind* the same
+  restore path, not beside it: one source of truth on launch, with the server preferred when both
+  exist.


### PR DESCRIPTION
Two things noticed while using the Mac app: **shuffle turns itself off when you click a track**, and
**nothing survives a relaunch**. One theme, two decisions, so two ADRs — `CLAUDE.md` rule 1. They
have an execution order: **0027 first**, and it stands alone.

## ADR-0027 — shuffle and repeat are listener modes

`FamiliarPlayer.play(_:startingAt:)` sets `isShuffled = false` (`:153`), and all **twelve** call
sites that start playback from a list go through it. Nothing decided this — the method's own
documentation does not mention shuffle. It falls out of how the flag is modelled: `isShuffled` means
*"is `queue` a shuffled view of `logicalQueue`"*, a statement about the queue rather than about the
listener. Build a new queue and there is nothing shuffled about it, so the toggle is correctly off
by its own definition. That is why no test caught it.

**The server has never agreed.** `shuffle`, `repeat` and `consume` are fields in
`PlaybackSessionWrite` in their own right, *alongside* `shuffle_order` and `shuffle_index`, and the
web client sends both. Only the Apple client collapses mode into order.

Point 2 is the load-bearing one: the flag **splits** into a mode and a fact. Preserving the existing
flag across a queue change would be the one-line fix and would make it lie — `toggleShuffle()` reads
it to decide whether to straighten an album out, so the next call to `QueueShuffle.disabling` would
produce an order that never existed. The bug would move rather than leave.

## ADR-0028 — the Apple client writes its playback session back

The client already restores from stored state on launch — `queueAdopter.adoptOnce(into: player)`
(`LibraryView.swift:904`) adopts the **server's** session. What it never does is contribute:
`queueGetPlaybackSession` has one caller, `queuePutPlaybackSession` has **zero**, though it is
generated and available.

That was deliberate, and ADR-0003 phase 4 said why:

> Read-only by decision: the player has no `shuffle`, `repeat`, `consume` or reservoir concept, and
> a write would flatten a 1,732-track shuffled queue the web client was actively using.

**The condition has been met and nothing revisited it** — `isShuffled`, `repeatMode` and `consume`
are all published properties today. A conditional deferral expired quietly, which is the sort of
thing the ADR set exists to catch.

**The defect is worse than a missing feature.** Because the Mac adopts but never writes, an hour of
listening on the Mac leaves the server holding whatever the web app last pushed — so the next device
to adopt, including the Mac next launch, restores a stale session. The Mac is not just failing to
save its own state; it is being silently overwritten by a less recently used client.

No schema work: `PlaybackSessionWrite` already carries `track_ids`, `cursor`, `shuffle_order`,
`shuffle_index`, `shuffle`, `repeat`, `consume`, `position_seconds`, `version` and `updated_at`, and
`queueSyncService.ts` is a working reference implementation to check against.

## What review should push on

- **0028 point 8** — with queue sync off, nothing is preserved at all. Defensible, not obvious, and
  probably the point most worth arguing about. The alternative (a local snapshot) is rejected in
  both ADRs for the same reason: launch-time adoption already writes the player's state from the
  server, so a second store disagrees on exactly the launch where it matters.
- **0027 point 3** — clicking a track in shuffle shuffles *the remainder*, keeping your pick. It
  matches `toggleShuffle()` mid-listen, but it means the resulting order depends on where you
  clicked.
- **0028 point 6** — conflicts resolve last-writer-wins, discarding one side's recent listening.
  Same rule the web client has run since ADR-0003 phase 3, and still a real loss.

## Verification

Every path, line number and quotation was checked against the repos at write time:

- eight cited `familiar-apple` locations re-read and confirmed at those exact lines
- four cited `queueSyncService.ts` locations confirmed
- both ADR-0003 quotations confirmed **verbatim** against the source
- `queuePutPlaybackSession` confirmed generated (`queue` tag is in the generator filter) with zero
  callers in `App/` and `Sources/`
- twelve `startingAt:` call sites counted, not estimated

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_014P9p2fvFnyiywBxGkv4gfW