### PR TITLE
docs(adr): propose ADR-0030 and ADR-0031 — scrobbling, and casting

### DIFF
--- a/docs/decisions/ADR-0030-the-apple-clients-scrobble.md
+++ b/docs/decisions/ADR-0030-the-apple-clients-scrobble.md
@@ -1,0 +1,141 @@
+# ADR-0030: The Apple Clients Scrobble
+
+Status: proposed
+Date: 2026-08-05
+
+Extends [ADR-0014](ADR-0014-the-generated-surface-widens-to-management.md) and
+[ADR-0004](ADR-0004-listening-feedback-is-event-sourced.md)
+
+## Context
+
+**Playing music in the Mac or iPhone app contributes nothing to Last.fm.** The same album played in
+a browser scrobbles normally. Nothing anywhere says so.
+
+The server has the capability and has had it all along. `backend/app/api/routes/lastfm.py` exposes
+six operations — `/status`, `/auth`, `/callback`, `/disconnect`, `/now-playing`, `/scrobble` — and
+the web client drives them from `hooks/useScrobbling.ts`, which implements Last.fm's rules directly:
+at least 30 seconds played, then a scrobble at `min(duration / 2, 4 minutes)`, once per play, with a
+now-playing update when the track changes.
+
+The Apple clients cannot reach any of it. `lastfm` is not among the eleven tags in
+`Sources/FamiliarAPI/openapi-generator-config.yaml`, so no Swift method exists — and there is no
+generic web view in the app to reach it through either. This is the same shape as the three defects
+ADR-0017 records and the two ADR-0025 closed: **a capability the server has and a client cannot
+reach, failing silently.**
+
+**A premise worth correcting before it is assumed.** `POST /tracks/{id}/play` looks like it might
+scrobble as a side effect — the native reporter calls it, and its docstring talks about scrobble
+thresholds. It does not. It increments `play_count`, updates `last_played_at` and writes a
+`completed` `PlayEvent`; the mention of thresholds is describing *when the client should call it*,
+not what the server then does. Nothing in `backend/app/` calls the Last.fm service except the
+`/lastfm/*` routes themselves.
+
+**The native client reports differently from the web one, and that turns out to help.**
+`ListeningReporter` acts on a completed `PlaybackReport` — `.natural` becomes `recordPlay`, `.user`
+and `.error` become `recordSkip` — where the web runs a mid-playback effect. The report already
+carries `playedSeconds`, `trackDuration`, `completionRatio` and `happenedAt`, which is everything
+Last.fm's threshold needs, and it already flows through `ListeningEventQueue`: an on-disk,
+at-least-once outbox holding up to 1,000 events across launches. The web client had to build a
+separate outbox (`syncService`) to get the same guarantee.
+
+## Decision
+
+1. **The generated surface widens to `lastfm`.** Six operations, following ADR-0014's precedent —
+   the same config change, for the same reason: the client cannot call what is not generated.
+
+2. **A scrobble is derived from the completed play report, not from a mid-track timer.** When
+   `ListeningReporter` sends `recordPlay`, it also sends `/lastfm/scrobble` for the same event.
+   Nothing new observes playback; nothing new has to be kept in sync with the transport.
+
+3. **This is exact rather than approximate, because the endpoint accepts a backdated timestamp.**
+   `lastfm.py` computes `timestamp = request.timestamp or int(time.time())`, so passing the event's
+   `startedAt` records the scrobble at the moment the track began — which is what Last.fm wants and
+   what the web client already sends. Scrobbling after the fact is therefore not a compromise.
+
+4. **Last.fm's thresholds are evaluated against the report, and stay identical to the web's:** at
+   least 30 seconds played, and `playedSeconds >= min(trackDuration / 2, 240)`. Reaching the end of
+   a track is not on its own sufficient — a 20-second interlude played to completion is a play but
+   not a scrobble, and the two counts should not silently disagree between clients.
+
+5. **Now-playing is the exception and fires when a track starts.** It is a statement about the
+   present — "this is playing right now" — and cannot be reconstructed afterwards. `FamiliarPlayer`
+   has `onPlaybackEnded` and no counterpart, so this adds one.
+
+6. **Now-playing is best-effort and is never queued.** A now-playing update replayed from an offline
+   outbox an hour later is a lie about the present, and Last.fm expires it after a few minutes
+   regardless. It is sent if it can be sent and dropped otherwise. Scrobbles go through the queue;
+   these do not.
+
+7. **Nothing is sent, and nothing is queued, unless `/lastfm/status` reports both `configured` and
+   `connected`.** The two are different failures — the server has no API keys, versus this profile
+   has no session — and neither is this client's to fix. Queuing scrobbles for a profile that has
+   never connected would fill a 1,000-event outbox with events that can never drain, evicting real
+   ones. This is ADR-0022 point 3's rule applied to a surface with no interface: **absence means do
+   not send**, not disable a control.
+
+8. **No connect flow, and no settings pane.** Connecting an account is an OAuth round trip through
+   `/lastfm/auth` and `/lastfm/callback` — server configuration a listener does once, which
+   ADR-0013 point 4 keeps in the web app. The Apple clients consume the connection; they do not
+   establish it.
+
+9. **Verification is in three layers.** The threshold rule is pure and unit-tested in `FamiliarKit`
+   against a `PlaybackReport` — including the interlude case from point 4, which is the one a naive
+   implementation gets wrong. The queue-and-drain path extends the existing `ListeningEventQueue`
+   tests. And a real scrobble is confirmed by hand against a connected account, because the failure
+   this fixes is invisible from inside the app: everything looks identical whether or not the
+   scrobble lands.
+
+## Alternatives Considered
+
+**Scrobble server-side when `/tracks/{id}/play` arrives.** By far the most attractive alternative:
+one implementation, and every client — including any future one — gets scrobbling for free without
+touching the generated surface. Rejected because the web client already calls both endpoints itself,
+so the server doing it too would double-scrobble every track played in a browser; fixing that means
+changing the web client in the same breath, which turns a client feature into a cross-client
+migration. It also couples two things ADR-0004 deliberately separates: `recordPlay` is the *taste*
+signal, and its threshold is free to move for reasons that have nothing to do with Last.fm's rules.
+Worth revisiting if a third client ever appears — at that point the duplication argument wins.
+
+**Port `useScrobbling` faithfully — a mid-playback observer with its own timers.** Rejected because
+it needs a new hook into the transport, duplicates threshold logic the report already contains, and
+would need its own persistence to survive a quit. The native app already has the outbox; a
+mid-track observer cannot use it, because there is no completed event to queue.
+
+**Queue now-playing along with scrobbles, for symmetry.** Rejected on the merits: the two have
+different truth conditions. A scrobble is a historical fact and stays true; a now-playing update is
+a claim about this moment and rots in minutes. Sending a stale one would misreport the listener to
+anyone looking.
+
+**Build the Last.fm connect flow natively too.** It is only two endpoints. Rejected because it is an
+OAuth callback — a browser round trip and a redirect target — and ADR-0013 point 4 already draws
+this line: a server has one configuration, and there is no per-client value in a second editor for
+something done once.
+
+**Do nothing; the web app is where scrobbling happens.** The status quo, and defensible if the Mac
+app were incidental. It is not — the Mac and phone are the listening path by ADR-0001, so the
+clients that do almost all the listening are the ones contributing nothing.
+
+## Consequences
+
+- **Positive.** Listening on the Mac and the phone reaches Last.fm, which for a listener with an
+  account is the difference between a scrobble history that reflects what they played and one that
+  reflects which client they happened to use.
+- **Positive.** Offline listening scrobbles when the network returns, at the correct original
+  timestamps, because it rides an outbox that already exists and already survives launches. The web
+  client needed a second mechanism for this; the Apple clients get it free.
+- **Positive.** No new observer of playback. Everything hangs off the report the reporter already
+  receives, so there is nothing extra to keep in step with the transport.
+- **Tradeoff.** A scrobble now arrives when the track *ends* rather than halfway through. The
+  timestamp is correct either way, so the history is identical — but "now playing" and "scrobbled"
+  are further apart in wall-clock time than a Last.fm user may expect, and a track abandoned at 90%
+  scrobbles at that point rather than at the halfway mark.
+- **Tradeoff.** The generated surface grows again. ADR-0014 widened it once for management; this
+  widens it for a single listening integration, and the pattern of "widen for one feature" is worth
+  watching before it becomes the whole schema.
+- **Follow-up.** `lint_openapi.py` carries `NOT_GENERATED = {"ambient", "outputs"}`, which is
+  **declared and never referenced**, and its docstring describes an exclusion set of two when twenty
+  tags are excluded. Nothing compares the backend's `GENERATED_SURFACE` to the Swift config's
+  `filter.tags`; the two claim to enforce each other in comments only. Adding a tag makes that drift
+  worse and is the moment to fix it.
+- **Follow-up.** `queue` remains in the generated surface with **zero callers** after ADR-0028
+  removed queue sync. It should leave when the list is next revised.

--- a/docs/decisions/ADR-0031-casting-is-the-macs-and-excludes-zones.md
+++ b/docs/decisions/ADR-0031-casting-is-the-macs-and-excludes-zones.md
@@ -1,0 +1,183 @@
+# ADR-0031: Casting Is the Mac's, and Excludes Zones
+
+Status: proposed
+Date: 2026-08-05
+
+Extends [ADR-0001](ADR-0001-native-apple-clients-supersede-capacitor.md) and
+[ADR-0014](ADR-0014-the-generated-surface-widens-to-management.md)
+
+## Context
+
+The Apple clients cannot send audio to a Sonos, a WiiM, or a Chromecast. `outputs` is the single
+largest tag missing from the generated surface — **24 operations**, more than any other — and there
+is no generic web view in the app to reach it through.
+
+**ADR-0001 already litigated this, and deliberately left it open.** `outputs` was added to the
+generated surface and removed the next day (2026-07-28, `ffb9251`), with the reason recorded there:
+
+> Casting on the native client is a live question for whenever it enters scope, not a settled
+> inclusion.
+
+This ADR answers that question. Doing so required understanding the mechanism, and the mechanism is
+not what the name suggests.
+
+**"Playing to a Sonos" does not move playback off this device.** The server never proxies or
+transcodes audio; it is a control plane. It hands the speaker a URL and the speaker opens its own
+HTTP connection back to `GET /api/v1/tracks/{id}/stream` — which takes no profile dependency, and
+that is what makes an unauthenticated device fetch possible at all. Meanwhile the client keeps
+fetching, decoding and running the transport clock, and is simply **muted to zero**
+(`useAudioEngine.ts:765-769`, *"Mute local output while casting to a network device (avoids double
+audio); restore on return"*). Two concurrent fetches of the same track exist, and the muted local
+engine remains the timeline authority: end-of-track, queue advance and the resulting push to the
+device all originate from it.
+
+**The subsystem is in worse repair than its endpoint count suggests.**
+
+- **Nine of the twenty-four operations are zones, and zones are dead.** They have no client
+  anywhere. Their state is in-memory and lost on restart — `_persist()` serializes outputs only and
+  `load_persisted()` never reads zones. Fan-out loops members *sequentially*, awaiting each, so
+  members start staggered by the sum of prior devices' connect latencies; this is not synchronised
+  multi-room. And `GET /outputs/zones` is **unreachable**: it is registered at `:304`, after
+  `GET /{output_id}` at `:212`, so Starlette matches `zones` as a UUID path parameter. Verified —
+  it returns **422**, `path.output_id: Input should be a valid UUID … found 'z' at 1`.
+- **There is no server-side notion of who is driving an output.** No outputs endpoint takes
+  `X-Profile-ID`. The registry is a process-wide singleton, so devices, their transport state and
+  their volume are shared by every profile and every client. Selection is the opposite: the web's
+  `activeOutputId` has no persistence, so a reload silently returns to "This Device" while the
+  speaker keeps playing.
+- **Failures are invisible.** Every transport method swallows exceptions and returns `False`; every
+  web call site is `.catch(() => {})`. There are no retries. Sonos never reconnects after
+  construction — if `_connect()` failed at boot, every call returns `False` for the process's
+  lifetime.
+- **A play that reports success is not a play that made sound.** `device_stream_base_url` exists
+  because the browser builds stream URLs from its own origin, which is meaningless to a speaker.
+  Misconfigured, the device is handed a URL it cannot reach, the SOAP or CAST call is still
+  acknowledged, and `play` returns `{"status": "playing"}` over silence.
+- **Discovery mutates global state through a `GET`.** Every discover call auto-registers what it
+  finds and rewrites `data/outputs.json` for everyone.
+
+**A distinction the naming actively hides.** The `airplay` output type and the AirPlay button in the
+app are unrelated mechanisms. `AirPlayButton.tsx:6-9` says so: the button *"presents the iOS system
+route picker … independent of the backend-driven 'Play To' outputs"*. With the OS picker the client
+remains the audio source and iOS re-routes already-decoded output; with the `airplay` output type
+the speaker becomes the source and the client mutes itself. **Nothing prevents both being active at
+once**, and the result is double audio, because the local engine is muted only by `activeOutputId`,
+which the OS route picker never sets.
+
+Finally, the device fetches drive additional concurrent long-lived requests against
+`GET /tracks/{id}/stream` — the endpoint whose own comments record that it exhausted the connection
+pool on 2026-08-02 with 2,416 `QueuePool limit` errors. That is fixed, but casting is the feature
+that multiplies exactly that traffic.
+
+## Decision
+
+1. **The Apple clients adopt casting, narrowly, and the generated surface widens to `outputs`.**
+   ADR-0001's open question is answered yes — casting is part of the listening path, and a client
+   that cannot reach a Sonos is missing it.
+
+2. **Zones are excluded from the generated surface and from the client.** Nine operations that no
+   client calls, whose state does not survive a restart, whose fan-out is sequential rather than
+   synchronised, and one of which is unreachable through a routing shadow. Generating them would
+   produce Swift methods for an API that is partly broken and wholly unused. Fixing zones is a
+   separate decision, on the server, before any client should depend on them.
+
+3. **The `airplay` output type is excluded too, and the OS route picker is the answer instead.**
+   Where the operating system can route audio, letting it do so is strictly better: the client stays
+   the source, so there is no second fetch, no muted decode, no `device_stream_base_url` dependency
+   and no LAN-reachability requirement — and the route survives as OS state that other apps and the
+   system volume respect. This also removes the double-audio trap by construction, because the app
+   never offers two ways to reach one speaker.
+
+4. **What is adopted is therefore: list, discover, and single-output transport** — play, pause,
+   resume, stop, seek, volume — **for `sonos`, `upnp` and `chromecast` only.** These are the devices
+   the OS cannot route to. `browser` is excluded as well: it is a state stub that controls nothing,
+   and its `websocket_id` field is never read by anything.
+
+5. **The client remains the timeline authority, muted, exactly as the web client is.** The queue,
+   end-of-track detection and the advance that pushes the next track to the device all keep running
+   locally. This is not elegant and it is not optional: the server has no queue for the Apple
+   clients to lean on (ADR-0028), so nothing else knows what plays next.
+
+6. **Crossfade is suppressed while casting**, matching the web (`getEffectiveCrossfadeDuration`
+   returns 0 when a network output is active) so a device plays each track to its true end. This
+   constrains [ADR-0026](ADR-0026-crossfade-is-decided-by-the-player-not-the-engine.md) before it is
+   built, and is recorded here so the two are not designed in ignorance of each other.
+
+7. **Casting is macOS-only initially.** The cost of point 5 is a full decode running silently for
+   the length of a listening session, which on a phone is battery and an audio session held for
+   output nobody hears — on the device most likely to be the thing you would AirPlay *from*. This
+   does not reverse ADR-0013 point 2: casting is a listening feature, so the phone is eligible; it
+   is deferred on cost, not on principle, and the ADR that revisits it should measure the drain
+   rather than assume it.
+
+8. **A device is never assumed to be playing because a call succeeded.** The client shows state read
+   back from the device via `get_status`, not the local optimistic assumption, precisely because the
+   `device_stream_base_url` failure returns success over silence. A play that cannot be confirmed is
+   reported as unconfirmed rather than shown as playing.
+
+9. **Discovery is an explicit action, never automatic on opening a screen.** It rewrites global
+   state shared by every profile, and takes up to ten seconds across four protocols. A listener asks
+   for it.
+
+10. **Verification is against real hardware, and the third layer is not optional.** URL construction
+    and the type filtering in point 4 are pure and unit-tested in `FamiliarKit`; the transport
+    calls extend the generated-client tests; and playback to an actual Sonos or WiiM is confirmed by
+    hand, **including the `device_stream_base_url` failure**, because that is the one that reports
+    success over silence and no automated test on this side can see it.
+
+## Alternatives Considered
+
+**Adopt the whole tag, zones included.** The simplest config change, and symmetrical with the web.
+Rejected on measurement: nine of the twenty-four operations have no client, no persistence, and no
+synchronisation, and one of them cannot be called at all. Generating a Swift method for
+`GET /outputs/zones` would produce a call that always returns 422 — a defect shipped as an API.
+
+**Rely on AirPlay alone and skip server-mediated outputs entirely.** Genuinely attractive: it needs
+no schema, no LAN URL, no muted decode, and it is consistent with ADR-0028's local-session grain.
+Some Sonos models even support AirPlay 2. Rejected because Chromecast does not, older Sonos and most
+UPnP renderers do not, and those are exactly the devices the server subsystem exists to reach.
+Point 3 keeps the AirPlay-first half of this argument where it applies.
+
+**Fix the subsystem first — ownership, retries, error reporting — then adopt it.** The most
+defensible sequencing, and what a stricter reading of the evidence argues for. Rejected as the
+enemy of shipping anything: the reliability problems are real but they are *equally* real for the
+web client today, and are not made worse by a second consumer. Points 8 and 9 mitigate the two that
+would be actively misleading on a new surface. An ownership model is recorded as a follow-up rather
+than made a precondition.
+
+**Defer again, as ADR-0001 did.** Rejected because the question has now been examined rather than
+postponed. If the answer were still "not yet", that should be written down as a decision with a
+stated bar, not left as a third deferral.
+
+**Put casting on both platforms from the start.** Rejected on cost, not principle — see point 7.
+The muted-decode requirement is the whole reason, and it is a battery cost that wants measuring
+before it is imposed on a phone.
+
+## Consequences
+
+- **Positive.** ADR-0001's open question is closed, in writing, with the mechanism understood rather
+  than assumed.
+- **Positive.** The Mac can play to the speakers in the house, which is a genuine part of the
+  listening path that the web app has and the native client did not.
+- **Positive.** Excluding zones and `airplay` keeps the generated surface at fifteen operations
+  rather than twenty-four, and keeps the client away from the parts that are broken.
+- **Positive.** Point 3 removes the double-audio failure by construction rather than by guarding
+  against it.
+- **Tradeoff.** The muted local decode is genuinely inelegant: the Mac fetches and decodes audio it
+  will not play, for as long as casting lasts. It is the price of the client owning the queue, and
+  it is the reason point 7 keeps this off the phone for now.
+- **Tradeoff.** Two concurrent fetches of the same track hit `GET /tracks/{id}/stream`, the endpoint
+  that exhausted the connection pool once already. The fix is in and the fetches are sequentialish
+  rather than bulk, but casting is the feature that multiplies that traffic.
+- **Tradeoff.** Adopting `outputs` will trip the OpenAPI linter: its five allowlisted untyped
+  operations are all `outputs/zones/*`, so excluding zones from the *generated* surface must be
+  expressed in the lint's scope too, or the allowlist grows to cover operations no client uses.
+- **Follow-up.** **There is no server-side owner for an output.** Two clients can drive one speaker
+  with neither aware of the other. This is pre-existing and the ADR does not fix it, but a second
+  client makes it likelier to be met.
+- **Follow-up.** `GET /outputs/zones` is unreachable behind `GET /{output_id}`. A one-line
+  reordering fixes it, and should happen whether or not zones are ever used.
+- **Follow-up.** `lint_openapi.py`'s `NOT_GENERATED` names `{"ambient", "outputs"}`, is **declared
+  and never referenced**, and its docstring describes an exclusion set of two when twenty tags are
+  excluded. Removing `outputs` from a constant nothing reads will not change any behaviour — which
+  is the point, and the reason it should be made real. See ADR-0030's identical follow-up.

--- a/docs/decisions/ADR-0031-casting-is-the-macs-and-excludes-zones.md
+++ b/docs/decisions/ADR-0031-casting-is-the-macs-and-excludes-zones.md
@@ -159,8 +159,10 @@ before it is imposed on a phone.
   than assumed.
 - **Positive.** The Mac can play to the speakers in the house, which is a genuine part of the
   listening path that the web app has and the native client did not.
-- **Positive.** Excluding zones and `airplay` keeps the generated surface at fifteen operations
-  rather than twenty-four, and keeps the client away from the parts that are broken.
+- **Positive.** Excluding zones and `airplay` keeps the generated surface at **nine** operations
+  rather than twenty-four, and keeps the client away from the parts that are broken. *Nine, not the
+  fifteen this originally said: registration is unnecessary because discovery auto-registers, and
+  the four per-protocol discover endpoints are redundant beside `discover_all`.*
 - **Positive.** Point 3 removes the double-audio failure by construction rather than by guarding
   against it.
 - **Tradeoff.** The muted local decode is genuinely inelegant: the Mac fetches and decodes audio it
@@ -169,9 +171,15 @@ before it is imposed on a phone.
 - **Tradeoff.** Two concurrent fetches of the same track hit `GET /tracks/{id}/stream`, the endpoint
   that exhausted the connection pool once already. The fix is in and the fetches are sequentialish
   rather than bulk, but casting is the feature that multiplies that traffic.
-- **Tradeoff.** Adopting `outputs` will trip the OpenAPI linter: its five allowlisted untyped
-  operations are all `outputs/zones/*`, so excluding zones from the *generated* surface must be
-  expressed in the lint's scope too, or the allowlist grows to cover operations no client uses.
+- ~~**Tradeoff.** Adopting `outputs` will trip the OpenAPI linter.~~ **It does not.** The prediction
+  assumed the surface could only be widened a tag at a time, which would have dragged the zones in;
+  `swift-openapi-generator` filters by operationId as well, so the nine arrive without them. All
+  nine already declare 401/404/422/500, so nothing trips.
+
+  What the linter *did* need was the opposite of a workaround: it restated the generated surface as
+  its own list of tags, with each file's comments claiming the other enforced it while no code
+  compared them. Adding a second way to express the surface would have widened that gap, so the
+  lint now reads the Swift config directly.
 - **Follow-up.** **There is no server-side owner for an output.** Two clients can drive one speaker
   with neither aware of the other. This is pre-existing and the ADR does not fix it, but a second
   client makes it likelier to be met.


### PR DESCRIPTION
Two gaps between the PWA and the Apple clients. Found by measuring the generated surface rather than
by listing features: **119 of 261 backend operations, across 20 tags, are unreachable from Swift** —
and there is no generic web view in the app to reach them through, so the only WebKit surface is the
Discover embed.

**Execution order is 0030 then 0031.** Scrobbling is small, closes a silent gap, and widens the
generated surface once so the second widening has a precedent.

---

## ADR-0030 — the Apple clients scrobble

Playing an album on the Mac or the phone contributes **nothing** to Last.fm. The same album in a
browser scrobbles normally. Nothing anywhere says so.

**A premise corrected before anyone assumes it:** `POST /tracks/{id}/play` looks like it might
scrobble as a side effect — the native reporter calls it and its docstring mentions scrobble
thresholds. It does not. That sentence describes *when the client should call it*. Nothing in
`backend/app/` touches the Last.fm service except the `/lastfm/*` routes.

**The load-bearing point is where the scrobble comes from.** The web runs a mid-playback timer; the
native reporter acts on a completed `PlaybackReport` that already carries `playedSeconds`,
`trackDuration` and `happenedAt` — everything Last.fm's threshold needs — and already rides
`ListeningEventQueue`, an on-disk at-least-once outbox of 1,000 events surviving launches. So:

- no second observer of playback, nothing new to keep in step with the transport
- **offline listening scrobbles when the network returns, at correct original timestamps, for free** —
  the web needed a whole separate outbox for that

This is exact rather than approximate because `lastfm.py` computes
`timestamp = request.timestamp or int(time.time())`.

Now-playing is the exception: it is a claim about the present, so it fires at track start and is
**never queued** — one replayed from an outbox an hour later is a lie.

The most attractive rejected alternative is server-side scrobbling on `recordPlay`: one
implementation, every client free. Rejected because the web already calls both endpoints, so the
server doing it too would double-scrobble every browser play — and ADR-0004 keeps `recordPlay` as
the *taste* signal, whose threshold should move independently of Last.fm's rules.

---

## ADR-0031 — casting is the Mac's, and excludes zones

ADR-0001 added `outputs` to the generated surface, removed it the next day, and left the question
open **in writing**:

> Casting on the native client is a live question for whenever it enters scope, not a settled
> inclusion.

This answers it — and understanding the mechanism changed the answer.

**"Playing to a Sonos" does not move playback off this device.** The server is a control plane: it
hands the speaker a URL, the speaker opens its own connection to `GET /tracks/{id}/stream`, and the
client keeps fetching and decoding while **muted to zero**. Two concurrent fetches of the same
track. The muted local engine stays the timeline authority — and that is not optional, because after
ADR-0028 the server has no queue for these clients to lean on.

**Nine of the 24 operations are zones, and zones are dead:** no client anywhere, state lost on
restart, fan-out that loops members *sequentially* rather than synchronising them — and
`GET /outputs/zones` is **unreachable**, shadowed by `GET /{output_id}` registered 90 lines earlier.
Verified:

```
GET /api/v1/outputs/zones -> 422
path.output_id: Input should be a valid UUID … found 'z' at 1
```

**The `airplay` output type is excluded too.** It is not the AirPlay button — `AirPlayButton.tsx`
says so itself, *"independent of the backend-driven 'Play To' outputs"*. With the OS picker the
client stays the source; with the output type the speaker does and the client mutes. Nothing
currently prevents both at once, and the result is double audio. Point 3 removes that by
construction.

So fifteen operations are adopted, for `sonos`/`upnp`/`chromecast` only, **macOS only** — point 7
defers the phone on measured cost, not principle, since a muted full decode for a listening session
is battery on the device you would usually AirPlay *from*.

Two points exist because the subsystem lies: point 8 (a play that returns success is not a play that
made sound — the `device_stream_base_url` failure acknowledges over silence) and point 9 (discovery
is a `GET` that rewrites global state for every profile).

---

## Verification

Every factual claim in both ADRs was checked mechanically, not read:

- 24 outputs operations, 9 of them zones — counted
- `/{output_id}` registered before `/zones`, and the 422 reproduced against a TestClient
- `websocket_id` appears exactly once — declared, never read
- local engine muted rather than stopped (`useAudioEngine.ts:765-769`)
- `lastfm` = 6 operations, absent from the 11 generated tags
- `recordPlay` does not touch Last.fm
- web thresholds (30s floor, 4-minute cap) read from `useScrobbling.ts`
- outbox capacity 1,000; `onPlaybackEnded` exists with no start counterpart
- both ADR-0001 and `AirPlayButton` quotations confirmed **verbatim** against source

Both start `proposed`. Both carry the same follow-up: `lint_openapi.py`'s `NOT_GENERATED` is
declared and never referenced, and nothing compares the backend's `GENERATED_SURFACE` to the Swift
config's tag list — they claim to enforce each other in comments only.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_014P9p2fvFnyiywBxGkv4gfW