### PR TITLE
docs(adr): propose ADR-0032–ADR-0039 — home, visualizer, shuffle, sessions, demo, site

### DIFF
--- a/docs/decisions/ADR-0026-crossfade-is-decided-by-the-player-not-the-engine.md
+++ b/docs/decisions/ADR-0026-crossfade-is-decided-by-the-player-not-the-engine.md
@@ -1,39 +1,51 @@
 # ADR-0026: Crossfade Is Decided by the Player, Not the Engine
 
-Status: proposed
+Status: accepted
 
 Date: 2026-08-05
 
 Extends [ADR-0015](ADR-0015-audio-effects-are-exposed-not-rebuilt.md) and
-[ADR-0025](ADR-0025-the-phone-gets-a-settings-destination.md).
+[ADR-0025](ADR-0025-the-phone-gets-a-settings-destination.md). Constrained by
+[ADR-0031](ADR-0031-casting-is-the-macs-and-excludes-zones.md) point 6.
 
 ## Context
 
 **The native apps do not crossfade, and nothing is broken.** `NativeAudioEngine.executeCrossfade`
-exists, is 80 lines long, ramps two player nodes against each other on a 60fps timer, and is called
-**zero times** in the entire Apple codebase — the only two references are its own declaration and its
-own `print`. Tracks change by `handleTrackEnd` loading the next file when the previous one ends.
+exists at `NativeAudioEngine.swift:1512`, runs 77 lines, ramps two player nodes against each other on
+a 60fps timer, and is called **zero times** in the entire Apple codebase — the only two references are
+its own declaration and its own `print` at :1515. Tracks change by `handleTrackEnd` loading the next
+file when the previous one ends.
 
-This is the third time this exact shape has been found, and the count is the point:
+**This is not quite the shape it looked like.** The first draft of this ADR filed it as a third
+instance of ADR-0015's finding — a capability with no caller — and that is only half right:
 
 | ADR | what was there | what was missing |
 |---|---|---|
 | 0015 | six audio effects, with setters | anything calling them |
 | 0025 | `favorites_auto_download`, read every launch | anything setting it |
-| **0026** | `executeCrossfade`, preload, `isNextReady` | anything deciding *when* |
+| **0026** | `executeCrossfade` | anything deciding *when* |
 
-All three arrived the same way. The Capacitor app drove these methods across a JavaScript bridge;
+`preloadNext` and `isNextReady` do **not** belong in that row. `FamiliarPlayer.primeNext` calls
+`engine.preloadNext` at `FamiliarPlayer.swift:954`, reached from thirteen `primeNeighbours()` call
+sites, so the next track is already downloaded to a temp file at the *start* of every track — earlier
+than the web's 15-second window, not later. Only the fade itself is unreachable. This matters twice
+over: it deletes a tradeoff an earlier draft claimed (crossfade adds no download pressure, because the
+download already happens), and it changes what the preload half of the ported decision is *for* — see
+point 2.
+
+All of it arrived the same way. The Capacitor app drove these methods across a JavaScript bridge;
 [ADR-0001](ADR-0001-native-apple-clients-supersede-capacitor.md) point 2 moved the engine "intact",
-the bridge was deleted, and the methods were left behind it. **The engine is not missing features.
-It is missing callers.**
+the bridge was deleted, and `executeCrossfade` was left behind it while the preload it depends on
+found a new caller.
 
 **The web does crossfade, and its design is the answer to where the decision belongs.** Nothing in
-`WebAudioEngine` decides to fade. `useAudioEngine.ts` watches the clock, and the judgement is four
-pure functions in `player/audio/eventHandlers.ts` — `getCrossfadeTrigger`,
-`getEffectiveCrossfadeDuration`, `shouldHandleEnded`, `getErrorAction` — with 15 assertions against
-the trigger alone in `eventHandlers.test.ts`. The file's own header says why: *"Pure functions
-extracted from useAudioEngine event handlers for testability. These encode the guard/decision logic
-without side effects."*
+`WebAudioEngine` decides to fade. `useAudioEngine.ts:435-476` watches the clock, and the judgement is
+four pure functions in `player/audio/eventHandlers.ts` — `getCrossfadeTrigger`,
+`getEffectiveCrossfadeDuration`, `shouldHandleEnded`, `getErrorAction` — with 12 `expect` calls
+against the trigger alone (17 assertions at run time; one case loops over six values) out of 32 in
+`__tests__/eventHandlers.test.ts`. The file's own header says why: *"Pure functions extracted from
+useAudioEngine event handlers for testability. These encode the guard/decision logic without side
+effects."*
 
 That split is the finding. **Fading two nodes is engine work; knowing when to start is queue work**,
 because it depends on what is playing, what is next, whether the next thing is ready, and whether the
@@ -42,66 +54,138 @@ listener asked for it at all.
 **What the web's rules actually are**, because they are the specification and were learned the hard
 way:
 
-- Two windows, not one. `preload` from `duration + 15s` remaining down to `duration + 1s`;
-  `crossfade` from `duration` remaining down to `0.1s`.
+- Two windows, not one. `preload` from `crossfadeDuration + 15s` remaining down to
+  `crossfadeDuration + 1s`; `crossfade` from `crossfadeDuration` remaining down to `0.1s`.
 - The fade is clamped to `timeRemaining - 0.5`, with a comment saying exactly why: *"so the old
   track's scheduleFile callback doesn't fire mid-crossfade"*. Under 0.5s it is skipped entirely —
   below that there is no meaningful fade, only a glitch.
-- A network output (AirPlay) forces the effective duration to **zero**, so a remote device plays each
-  track to its true end.
+- A network output forces the effective duration to **zero**, so a remote device plays each track to
+  its true end.
 - Guarded on the engine's declared capability, on `isCrossfading()`, on a queue transition already in
   flight, and on a known duration.
 
-**Settings are per-device, and the vocabulary already exists.** `audioSettingsStore.ts` persists
-`crossfadeEnabled` (default **on**) and `crossfadeDuration` (default **3s**, clamped 0–10), with a
-UI in `PlaybackSettings.tsx`. They have never been server state, exactly like the audio effects
-ADR-0015 point 5 keeps local.
+**"Network output" does not mean AirPlay, and an earlier draft of this ADR said it did.** Recorded
+because the mistake inverts the rule. On the web it means a WiiM, Sonos or UPnP target — the local
+engine is muted and the *device* fetches its own stream, so advancing the queue early clips the tail
+on the device. `PlaybackSettings.tsx` says so on screen: *"Crossfade isn't available on network
+outputs (WiiM / Sonos / UPnP)."* AirPlay is the opposite case, and ADR-0031 point 3 excludes it from
+the Apple clients precisely because there the client stays the audio source and the OS routes the
+rendered mix. Suppressing a fade over AirPlay would suppress it on the one route where it is fully
+audible. ADR-0031 point 6 already states the correct rule and names this ADR; point 7 below carries it.
 
-**The engine has one behaviour worth knowing before building on it.** `handleTrackEnd` opens with
+**Settings are per-device, and the vocabulary already exists.** `player/audioSettingsStore.ts`
+persists `crossfadeEnabled` (default **on**) and `crossfadeDuration` (default **3s**, clamped 0–10)
+to `localStorage`, with a UI in `PlaybackSettings.tsx`. They have never been server state, exactly
+like the audio effects ADR-0015 point 5 keeps local. Both platforms now have somewhere to put them:
+ADR-0025 point 2 reversed ADR-0015's macOS-only scope, and `EffectsSettingsView` is already one pane
+used by `SettingsWindow` and `PhoneSettingsView` both.
+
+**Three things about the engine are worth knowing before building on it.**
+
+*The auto-advance guard has never run.* `handleTrackEnd` opens at `NativeAudioEngine.swift:1747` with
 `if isCrossfadingFlag { return }` and a comment explaining that otherwise auto-advance would load the
-next track a second time and "stomp the in-flight fade". That guard has never fired, because the flag
-has never been true. Turning crossfade on turns that code path on for the first time.
+next track a second time and "stomp the in-flight fade". The flag has never been true. Turning
+crossfade on turns that code path on for the first time — and `NativeAudioEngineCrossfadeGuardTests`
+covers the `scheduleFile` and `seek` callbacks but **not this one**.
+
+*`finishCrossfade` notifies nobody.* It swaps the players, promotes `currentTrackId`, clears the
+preload state and calls its `completion` — it never calls `audioEngineDidAutoAdvance`. So the fade
+path bypasses everything `FamiliarPlayer.swift:1139-1171` does on a normal advance: the cursor move,
+`concludeCurrentTrack(reason: .natural)`, `consumePlayedTrack`, `reportingTrack`, the `trackEpoch`
+bump, `publishNowPlaying` and `primeNeighbours`. The last is the sharp edge — `finishCrossfade` clears
+`nextTrackId` but leaves `pendingNextUrl` pointing at the track that just *became* current, so an
+un-re-primed engine would auto-advance that track into itself. And with ADR-0030 scrobbling now
+shipped, a skipped `concludeCurrentTrack` means every crossfaded track goes unreported. This is the
+part of the work that is correctness rather than polish.
+
+*The cast mute cannot be broken by a fade.* Checked rather than assumed, because it looked like a
+collision: `setVolume` writes `engine.mainMixerNode.outputVolume` (`NativeAudioEngine.swift:1163`)
+while the crossfade ramp writes `playerNode.volume` and `nextPlayerNode.volume` (:1574-1575). Separate
+nodes, so a fade cannot leak audio out of a muted Mac. Point 7 exists for the queue-timing reason,
+not for a volume one.
 
 ## Decision
 
 1. **The player decides when to crossfade; the engine only performs it.** `FamiliarPlayer` watches
-   playback position and calls the engine's existing `preloadNext` and `executeCrossfade`. No new DSP,
-   and nothing inside `NativeAudioEngine`'s processing changes — ADR-0015 point 2's rule applies here
-   unchanged.
+   playback position through the `audioEngineDidUpdateTime` delegate it already implements
+   (`FamiliarPlayer.swift:1117`, 4Hz) and calls the engine's existing `preloadNext` and
+   `executeCrossfade`. No new DSP, and nothing inside `NativeAudioEngine`'s processing changes —
+   ADR-0015 point 2's rule applies here unchanged.
 
-2. **The decision is pure, lives in `FamiliarKit`, and mirrors the web's function for function.**
-   `getCrossfadeTrigger` and `getEffectiveCrossfadeDuration` are ported as Swift with the same names,
-   the same windows and the same clamps. Not because sharing is elegant, but because two clients that
-   disagree about when a fade starts would sound different on the same library, and the web's version
-   is the one with fifteen assertions behind it.
+2. **The decision is pure, lives in `FamiliarKit`, and mirrors the web's numbers.** `CrossfadeDecision`
+   ports `getCrossfadeTrigger` and `getEffectiveCrossfadeDuration` with the same windows, the same
+   bounds and the same answers, asserted case for case against the web's suite. Not because sharing
+   is elegant, but because two clients that disagree about when a fade starts would sound different
+   on the same library. **The identifiers are Swift's, not JavaScript's** — `CrossfadeDecision.trigger`
+   and `.effectiveDuration`, matching `QueueAdvance.next` rather than importing `getX` naming into a
+   package that has none. ADR-0021's precedent is that clients share the *vocabulary*; the doc
+   comments name their web counterparts so a search across both repositories still finds the pair.
 
-3. **The 0.5s clamp and the 0.1s floor are carried across as-is**, with the web's reasoning attached.
+3. **The ported `preload` window is a repair, not a preload.** The next track is already primed at
+   track start (see Context), so acting on `preload` the way the web does would be redundant. It is
+   kept for the one case nothing else covers: `preloadNext` gives up after a 10-second timeout
+   (`NativeAudioEngine.swift:1371`), sets `preloadState = .failed`, and **nothing ever retries**. The
+   player acts on the `preload` trigger only when `isNextReady()` is false. The function keeps the
+   web's shape so the boundaries stay comparable; the caller does not.
+
+4. **The 0.5s clamp and the 0.1s floor are carried across as-is**, with the web's reasoning attached.
    They are not tuning constants; they are the boundary either side of which the old track's
-   completion callback fires inside the fade.
+   completion callback fires inside the fade. **They become a third function rather than staying
+   inline.** The web computes the clamp at its call site in `useAudioEngine.ts` and asserts it
+   nowhere, so the two most load-bearing numbers in this ADR are the two with no test behind them.
+   `CrossfadeDecision.fadeDuration` returns the clamped length or nil when what is left is too short
+   to hear, and a swept property test holds it to the invariant the whole clamp exists for: a fade
+   never runs into the audio the trigger measured it against.
 
-4. **Settings are per-device**, in `UserDefaults` alongside the audio effects, offered on both
-   platforms through the surfaces ADR-0025 built. `crossfadeEnabled` defaults **on** and
-   `crossfadeDuration` to **3s**, clamped 0–10, matching the web so a listener moving between clients
-   is not surprised. No server endpoint, for the reason ADR-0015 point 6 gives: this is a property of
-   how this device plays, not of the listener.
+5. **Settings are per-device**, in `UserDefaults` alongside `AudioEffectSettings`, clamped on read for
+   the reason that type's own comment gives — a settings blob written by an older build is not a
+   slider. Offered on both platforms through the shared panes ADR-0025 point 8 built.
+   `crossfadeEnabled` defaults **on** and `crossfadeDuration` to **3s**, clamped 0–10, matching the
+   web so a listener moving between clients is not surprised. No server endpoint, for the reason
+   ADR-0015 point 6 gives: this is a property of how this device plays, not of the listener.
 
-5. **Nothing is synced and no ADR-0003 interaction is introduced.** A crossfade is a rendering
-   decision made locally, at the moment of a transition. The server-owned queue says what plays next,
-   never how the join sounds.
+6. **A completed fade reports itself through the existing auto-advance path.** `finishCrossfade` calls
+   `delegate?.audioEngineDidAutoAdvance(loadedTrackId:)`, and `executeCrossfade`'s completion is left
+   to clear the in-flight flag and handle failure only. One path for "the engine changed track by
+   itself" rather than two, and the player's handler is already written to *follow* rather than lead.
+   That handler gains one change serving both callers: it rebases `lastCountedTime` from
+   `engine.getCurrentTime()` instead of leaving the zero `concludeCurrentTrack` defers
+   (`FamiliarPlayer.swift:762`). On a normal advance that reads ~0 and nothing moves; after a fade the
+   new track is already `crossfadeDuration` seconds in, and the tick guard `delta < 2`
+   (`FamiliarPlayer.swift:1124`) would otherwise discard exactly that much played time from every
+   crossfaded track.
 
-6. **`handleTrackEnd`'s crossfade guard is treated as untested code, because it is.** It has never run.
-   The first stage of work is a test that puts the engine in `isCrossfadingFlag` and asserts
-   auto-advance declines — before anything can reach that state in the field.
+7. **Crossfade is suppressed while casting, and is not suppressed over AirPlay.** Per ADR-0031
+   point 6, read from `CastController.isCasting` (`Casting.swift:110`) and reaching `FamiliarPlayer`
+   as an injected predicate, in the style of the `downloadedFileURL` and `artworkURL` closures it
+   already takes — `FamiliarKit`'s player does not learn about casting to answer one question. AirPlay
+   is deliberately excluded from the suppression: ADR-0031 point 3 keeps the client the audio source
+   there, so the fade is rendered locally and heard.
 
-7. **Crossfade is off on a network output**, following the web. A device at the end of an AirPlay
-   link has its own buffering and its own idea of when a track ends; overlapping two streams into it
-   produces a fade nobody can predict.
+8. **Nothing is synced and no ADR-0003 interaction is introduced.** A crossfade is a rendering
+   decision made locally, at the moment of a transition. A queue says what plays next, never how the
+   join sounds.
 
-8. **Verification is in three layers, and the third is not optional.** The decision functions are unit
-   tested. The state machine — that a transition cannot both crossfade and auto-advance, and that the
-   two players are never both silent — is unit tested against the engine's own flags. **And then
-   somebody listens**, per ADR-0024 point 9, because no test in this repository can hear a gap. The
-   listen is specified in Consequences rather than left as "try it".
+9. **`handleTrackEnd`'s crossfade guard is treated as untested code, because it is.** It has never
+   run, and the existing suite does not reach it. The first stage of work is a third case in
+   `NativeAudioEngineCrossfadeGuardTests` covering it — asserted against the source text like its two
+   siblings, because `isCrossfadingFlag` and `handleTrackEnd` are both `private` and the engine cannot
+   be driven without hardware. Naming that limit is the point: this ADR does not claim a state test it
+   cannot write.
+
+10. **A pause cancels an in-flight fade rather than suspending it.** Found while building point 1 and
+    recorded here because it is a decision, not a detail: `pause()` pauses `playerNode` and not
+    `nextPlayerNode`, and the ramp measures itself against `Date()` rather than against playback. So
+    a pause during a fade left the incoming track playing on alone, rising to full volume, and
+    promoted it — while the listener believed they had stopped the music. Unreachable until now for
+    the reason this whole ADR exists. Cancelling costs one fade: the outgoing track keeps the
+    transition and hands over normally at its own end.
+
+11. **Verification is in three layers, and the third is not optional.** The decision functions are
+    unit tested against the same numbers as the web's suite. The guards are asserted against the
+    source, per point 9. **And then somebody listens**, per ADR-0024 point 9, because no test in
+    either repository can hear a gap. The listen is specified in Consequences rather than left as
+    "try it".
 
 ## Alternatives Considered
 
@@ -117,11 +201,25 @@ choice for the same reason.
 method exists, shipped in the Capacitor app, and ramps real nodes. This is ADR-0015's finding again —
 "audio effects on the Mac" sounded like a DSP project and was a settings screen.
 
+**Advance the cursor from `executeCrossfade`'s completion closure instead of the delegate** (point 6's
+rejected half). Tempting because it keeps the change on the player's side of the boundary and leaves
+the engine untouched. Rejected because it duplicates the eight-step tail of `audioEngineDidAutoAdvance`
+at a second call site, and the failure mode of the copy drifting from the original is a track that
+scrobbles twice or not at all. `finishCrossfade` promoting a track without telling its delegate is a
+defect on its own terms, whoever calls it.
+
+**Suspend the fade across a pause instead of cancelling it** (point 10's rejected half). The
+listener's intent is arguably "hold everything", and resuming into the middle of a fade is what a
+tape would do. Rejected on cost against benefit: it means pausing the second player *and* rebasing
+the timer's start instant, which is a stopwatch threaded through a 60fps volume ramp — the piece of
+this engine least able to absorb a subtle bug — for a difference nobody can hear. Cancelling loses
+one crossfade at a moment the listener has already interrupted.
+
 **Share the decision code with the web through a common package.** Genuinely tempting given point 2
-copies fifteen tests' worth of logic. Rejected because there is no such package and inventing one for
-two functions would be a build-system change to avoid re-typing forty lines. ADR-0021 set the
-precedent: share the *vocabulary*, keep the implementations separate, and let tests on each side hold
-them to the same numbers.
+copies a tested function. Rejected because there is no such package and inventing one for two
+functions would be a build-system change to avoid re-typing forty lines. ADR-0021 set the precedent:
+share the *vocabulary*, keep the implementations separate, and let tests on each side hold them to the
+same numbers.
 
 **Ship crossfade without a settings control, always on at 3s.** Fewer moving parts, and matches what
 most listeners would want. Rejected because crossfade is genuinely unwanted for some material —
@@ -136,20 +234,53 @@ client crossfades the same library on the same server.
 ## Consequences
 
 - **Positive:** two clients stop sounding different on the same library.
-- **Positive:** an 80-line method that has never run becomes reachable, and `handleTrackEnd`'s guard
-  gets exercised for the first time — point 6 makes that deliberate rather than incidental.
+- **Positive:** a 77-line method that has never run becomes reachable, and `handleTrackEnd`'s guard
+  gets exercised for the first time — point 9 makes that deliberate rather than incidental.
 - **Positive:** the decision arrives with tests, because it is pure. The hard part of crossfade is
   knowing when, and that part is checkable without a speaker.
+- **Positive, and unplanned:** point 3 gives the preload a retry it has never had. A next track whose
+  download timed out at track start currently stays failed until the track ends and the slower
+  `handleTrackEnd` path reloads it from scratch.
+- **Positive:** point 6 fixes a systematic undercount in scrobbling that predates this work in
+  principle and would have shipped with it in practice — every crossfaded track would have reported
+  `crossfadeDuration` seconds fewer than it played.
 - **Tradeoff:** a transition that used to be one code path becomes two, and the second only runs when
   a setting is on. The failure mode is a track that fades into silence rather than into the next one,
   which is worse than a gap.
-- **Tradeoff:** preloading the next track earlier means more downloads in flight on a paged library.
-  Bounded — one track — but it is the same class of pressure that exhausted the server's connection
-  pool on 2026-08-02, and worth remembering rather than rediscovering.
-- **Follow-up, and the specification of the listen point 8 requires.** Confirm continuous playback
+- **Tradeoff:** point 6 changes an engine file this ADR otherwise promises not to touch. It is one
+  delegate call outside the render path, and ADR-0015 point 2's test — "if exposing an effect appears
+  to require engine changes, stop and reconsider" — was applied rather than waved past: the
+  reconsideration is the third alternative above.
+- **Positive, and the one that justifies point 11's middle layer:** building the caller made a
+  latent engine defect reachable and it was caught by reading, not by listening. Pausing mid-fade was
+  on the listen list below as one case among eight; point 10 answers it by construction instead.
+- **Tradeoff, and the finding the listen actually produced.** The first real listen restarted the
+  incoming song: the fade ran, then a hard cut, then the new track from zero. Three places schedule
+  audio whose end should advance the queue — a load, a seek, and the incoming half of a fade — and
+  they carried three *different* subsets of the same three guards. The listen had seeked to near the
+  end of the track, so the live callback was the seek one, which lacked `activePlayerIndex`;
+  `finishCrossfade`'s `playerNode.stop()` fired it, and it reached `handleTrackEnd` while
+  `pendingNextUrl` still named the track the fade had just promoted. A second instance of the same
+  divergence was still silent: the fade's own callback had no seek-token guard, so seeking a track
+  that *arrived* by crossfade would have skipped it. Both are now one factory with one guard set, and
+  `handleTrackEnd` has exactly one caller — which is the invariant worth asserting, and is asserted.
+- **The durable lesson, and it is about the tests rather than the engine.** Two guard tests passed
+  against the broken code. They asserted that each callback *contained* `isCrossfadingFlag`, and each
+  did — what neither asked was whether that flag could still be true when the callback ran. It cannot:
+  `finishCrossfade` clears it before any `DispatchQueue.main.async` body gets a turn, so it only ever
+  catches a callback firing *during* a fade. `activePlayerIndex` is the guard that holds afterwards,
+  because it is a durable fact about which node is live rather than a flag in flight. **A test that a
+  guard exists is worth much less than a test that there is only one way to reach the thing it
+  guards.**
+- **Follow-up, and the specification of the listen point 11 requires.** Confirm continuous playback
   across: a normal track end; a track end with the next track not yet downloaded; skipping *during* a
-  fade; seeking backwards past the trigger point; pausing mid-fade; a queue change mid-fade; the last
-  track in a queue; and a fade with an effect enabled. Each on both platforms. The engine's own
-  comments name the first, third and fourth as the cases that have bitten before.
-- **Follow-up:** whether the phone should crossfade at all on cellular, given the preload it implies.
-  Not answered here; the download work has a precedent in `isDiscretionary` worth reading first.
+  fade; seeking backwards past the trigger point; **pausing mid-fade, which must stop everything and
+  lose the fade rather than keep one player running** (point 10); a queue change mid-fade; the last
+  track in a queue; a fade with an effect enabled; **while casting, which must not fade**; and **over
+  AirPlay, which must**. Each on both platforms, except casting, which is macOS-only per ADR-0031
+  point 7. The engine's own comments name the first, third and fourth as the cases that have bitten
+  before.
+- **Follow-up:** whether the phone should crossfade at all on cellular. Weaker than it looked when
+  this ADR was drafted, since the preload it implies already happens — but a fade means the next
+  track's download must *succeed* rather than merely be attempted, so the question is not empty. The
+  download work's `isDiscretionary` precedent is worth reading first.

--- a/docs/decisions/ADR-0032-the-apple-clients-get-a-home-destination.md
+++ b/docs/decisions/ADR-0032-the-apple-clients-get-a-home-destination.md
@@ -1,0 +1,158 @@
+# ADR-0032: The Apple Clients Get a Home Destination
+
+Status: proposed
+
+Date: 2026-08-06
+
+Extends [ADR-0013](ADR-0013-the-mac-is-a-management-surface-too.md) and
+[ADR-0018](ADR-0018-the-phone-navigates-from-a-root-list.md).
+
+## Context
+
+There is no `Home` anywhere in the Swift app. The phone opens on
+`LibraryNavigation.phone`, which is `LibraryNavigation(root: .menu)` — the root list of
+destinations [ADR-0018](ADR-0018-the-phone-navigates-from-a-root-list.md) built. The Mac opens on
+the Tracks table. Both are indexes: places to *find* something, with nothing on them that starts
+anything.
+
+The web app has had an answer since April. `packages/frontend/src/components/Home/HomeScreen.tsx`
+is the index route — `App.tsx` redirects both `index` and `*` to `/home` — and
+`docs/ENTRY-EXPERIENCE.md` is a full purpose document for it, opening with the aim of *"a single
+coherent entry experience instead of treating the home screen and chat onramp as separate ideas."*
+**That document is not an ADR**, which is why this one exists: the Apple clients cannot inherit a
+decision that was never recorded as one.
+
+**The first instinct was to embed it, and it is worth writing down why that loses**, because
+Discover is embedded and the two look like the same kind of screen.
+
+[ADR-0016](ADR-0016-embedded-web-surfaces-on-the-mac.md) point 1's test is churn and size. All
+three rows re-measured 2026-08-06, so the comparison is like for like:
+
+| surface | lines | files | commits, 6 months | ADR-0016 put it |
+|---|---|---|---|---|
+| Discover | 3,020 | 27 | 14 | embedded |
+| Music Map | 720 | 1 | 2 | native |
+| **Home** | **650** (+ `stores/homeStore.ts`, 177) | **1** | **4** | — |
+
+ADR-0016 measured Discover at 2,943 across 26 files and the map at 690 in one; both have grown
+slightly and the conclusion is unchanged. Home sits on the Music Map's side of that line, not
+Discover's, and by a wide margin on both axes.
+
+Three things settle it beyond the measurement:
+
+1. **The bridge cannot address what Home links to.** Home's Quick Picks and library shortcuts point
+   at Favorites, Downloads, Tracks, Artists, Albums, Music Map and Playlists.
+   [ADR-0020](ADR-0020-the-embedded-surface-can-ask-the-app-to-navigate.md) point 1 carries artist
+   and album and nothing else, and point 2 caps the bridge at two messages until an ADR says
+   otherwise. An embedded Home needs a third message on its first day and a fourth soon after — and
+   ADR-0020 point 4 already ruled year, genre and mood out of scope for exactly this reason.
+
+2. **Home is the root, and the root has to work offline.** ADR-0016 point 7 says an embedded
+   surface with no server shows a native "unavailable" state, and `EmbeddedDiscoverView` phrases it
+   as *"You're offline. This is the one screen here that has no offline version."* That sentence is
+   tolerable about Discover. As the first thing seen on every launch it contradicts
+   [ADR-0028](ADR-0028-the-apple-clients-playback-session-is-local.md), whose whole point is that
+   the app reopens on what it was playing with no network involved.
+
+3. **Embedding would buy no reuse where it matters.** The web Home *starts nothing*. Its Quick
+   Picks are `<Link>`s; nothing on it launches weighted shuffle, radio or ambient. What is being
+   asked for here is quick links to **play options**, which is new work on either side of the
+   embed/native line. Embedding a screen to reuse the half that is not wanted is not a saving.
+
+**What the web version has that this deliberately will not take.** `homeStore.ts` keeps
+per-profile module preferences — show, hide, reorder — behind a "Customize" panel, plus a recents
+list. That is listener preference state, and
+[ADR-0029](ADR-0029-the-server-stores-no-listener-preferences.md) says the server stores none, so
+on the Apple side it would be a third local preference store standing beside the playback session
+and the shuffle modes. For a screen with six rows, that is machinery in search of a problem.
+
+## Decision
+
+1. **Home is a native destination**, by ADR-0016 point 1's own test applied to a third surface. This
+   is an application of an existing rule, not a new one — the rule was written to be reused, and
+   650 lines in one file with 4 commits in six months is the settled end of it.
+
+2. **Home is the landing root on both platforms.** `LibraryNavigation.phone` becomes
+   `LibraryNavigation(root: .home)` and the Mac's initial sidebar selection becomes Home. ADR-0018
+   is not reversed: the phone's root list survives intact as a destination reached *from* Home, and
+   it remains the one mechanism by which every other destination is reached.
+
+3. **Home's rows start playback. They are not links.** This is where the Apple version diverges
+   from the web version rather than porting it, and the divergence is the feature. A row that
+   navigates somewhere you must then press play on is the screen the app already has.
+
+4. **The rows are: Resume, Shuffle Everything, the weighted presets, Favorites, Downloads.** Resume
+   restores from ADR-0028's local snapshot and needs no network. Shuffle Everything is
+   `LibraryView.shuffleLibrary()`, which exists today and is reachable only from a button on the
+   phone's Tracks list. The weighted presets arrive with
+   [ADR-0035](ADR-0035-weighted-shuffle-is-a-preset-the-server-applies.md) and are absent until it
+   lands.
+
+5. **A row whose destination is not reachable is absent, not disabled and not failing.** This is
+   ADR-0022 point 3's rule — the chat destination is absent when no provider is configured — applied
+   again, and it is the correction for the three defects
+   [ADR-0017](ADR-0017-the-embedded-surface-gets-a-null-audio-engine.md) records: an affordance
+   whose destination is not mounted, failing silently. Offline, the server-backed rows are gone and
+   Resume, Favorites and Downloads remain.
+
+6. **No customise panel, no reorder, no per-profile module preferences.** Rejected for the reason in
+   the Context: it is a third preference store for six rows. If the row set turns out to be wrong,
+   the fix is a different row set.
+
+7. **The routing change goes through `LibraryRouting.swift` and nowhere else.** `case home` is added
+   to `SidebarItem` and `LibraryRoot`; `LibraryRoot.init(selecting:)` and `sidebarItem(section:)`
+   then fail to compile until handled, as do the deliberately-exhaustive switches in `LibraryView`
+   (`:405`, `:438`, `:1151`). That file's doc comment already argues that adding a destination
+   anywhere else is how a defect got in, and this ADR takes it at its word.
+
+## Alternatives Considered
+
+**Embed Home in a `WKWebView`, as Discover is.** The fastest route, it stays current with the web
+app for free, and it is what the request first described. Rejected on the three grounds in the
+Context, of which the second is decisive: an embedded root means the first screen of every offline
+launch is an "unavailable" state, in an app that
+[ADR-0009](ADR-0009-offline-downloads-are-background-transfers.md) and ADR-0028 both went to
+considerable trouble to make work with no server. The bridge arithmetic is the second: seven
+destinations that the two permitted messages cannot address, on a screen that is mostly those
+destinations.
+
+**Put the quick-play rows into the existing root list instead of adding a screen.** Cheapest
+possible version — no new destination, no routing change, five rows added to
+`LibraryRootList.swift`. Rejected because the list is a navigation index and this would mix verbs
+into it: a list where "Albums" takes you somewhere and "Shuffle Everything" starts music is two
+mechanisms wearing one appearance, which is the confusion ADR-0018 removed three mechanisms to
+end. It also has no answer for the Mac, whose sidebar is the same index.
+
+**Hybrid: a native shell with the web app's Discovery module embedded inside it.** Keeps the
+offline shell alive while reusing the churniest three columns — recommended artists, unheard
+tracks, deep cuts. Rejected because it costs a second embedded document, a second surface marker
+(`EmbedIntent.surfaceMarker` is a single value, `"embed"`), and a second `WKWebView` host, all for
+three rows whose data comes from `/library/discover` through the generated client anyway. The
+embed machinery is justified by 2,943 lines, not by three rows.
+
+**Port the web Home faithfully, modules and customise panel included.** Consistency across
+clients, and no decisions to make. Rejected because it ports the part that does not work — a home
+screen with no play actions — and adds a preference store to do it. Consistency is worth less than
+the screen being good, and the two clients already differ where it matters (ADR-0028 gave the
+Apple clients a local session the web app does not have).
+
+## Consequences
+
+- **Positive.** The app opens on something that starts music. Resume, which ADR-0028 built and
+  which currently has no affordance beyond the transport, finally has a surface.
+- **Positive.** `shuffleLibrary()` stops being reachable only from a button on one list on one
+  platform.
+- **Positive.** The embed/native test has now been applied three times with three different
+  outcomes, which is what ADR-0016 point 1 was written to allow.
+- **Tradeoff.** The two clients' home screens diverge on purpose: the web app's navigates, the
+  Apple app's plays. Anyone comparing them will find the same name over different screens, and this
+  ADR is the only place that says why.
+- **Tradeoff.** Every destination now has one more tap in front of it on the phone, because the
+  root list moved down a level. That is the cost of point 2 and it is real for anyone whose habit
+  is Library → Artists.
+- **Follow-up.** `docs/ENTRY-EXPERIENCE.md` describes a screen only one client has, and now
+  describes it incompletely for that one. It should either be widened to both or scoped to the web
+  app in its own first paragraph.
+- **Follow-up.** The web Home's Prompt Onramp is hidden when `chatSurfaceAvailable` is false, citing
+  ADR-0022 point 3. If a prompts row is ever wanted here, `/library/discover/prompts` carries the
+  `library` tag and is already generated — the route the phone's chat empty state already takes.

--- a/docs/decisions/ADR-0033-the-embed-bridge-gains-a-return-channel.md
+++ b/docs/decisions/ADR-0033-the-embed-bridge-gains-a-return-channel.md
@@ -1,0 +1,232 @@
+# ADR-0033: The Embed Bridge Gains a Return Channel
+
+Status: proposed
+
+Date: 2026-08-06
+
+Extends [ADR-0016](ADR-0016-embedded-web-surfaces-on-the-mac.md),
+[ADR-0017](ADR-0017-the-embedded-surface-gets-a-null-audio-engine.md) and
+[ADR-0020](ADR-0020-the-embedded-surface-can-ask-the-app-to-navigate.md).
+Amends [ADR-0001](ADR-0001-native-apple-clients-supersede-capacitor.md) point 5 and
+[ADR-0013](ADR-0013-the-mac-is-a-management-surface-too.md) point 4.
+
+## Context
+
+[ADR-0001](ADR-0001-native-apple-clients-supersede-capacitor.md) point 5 put the visualizer
+*"explicitly out of v1, remaining web-only and possibly permanently"*, measuring it at **4,017 lines
+of three.js/React-Three-Fiber across 23 files**. That measurement re-checked on 2026-08-06 holds:
+`packages/frontend/src/components/Visualizer/` is **3,985 lines across 22 TypeScript files**. The
+surface has not grown; ADR-0001's arithmetic was sound. What needs revisiting is the word
+"permanently", and the reason is churn rather than size.
+
+Applying ADR-0016 point 1's test — churn and surface size, not performance — to every screen that
+has been through it:
+
+| surface | lines | files | commits, 6 months | decided |
+|---|---|---|---|---|
+| Discover | 3,020 | 27 | 14 | embedded (ADR-0016 pt 2) |
+| **Visualizer** | **3,985** | **22** | **14** | — |
+| Chat | 965 | 3 | 6 | native (ADR-0022) |
+| Music Map | 720 | 1 | 2 | native (ADR-0016 pt 3) |
+
+The visualizer is the largest surface in the web app and tied for the most active. On the stated
+test it lands on the embedded side more clearly than Discover did.
+
+**But the thing that decides this ADR is not the test.** It is that an embedded visualizer cannot
+work under the rules the embed currently runs by, and the rule it breaks is the one every other
+embed ADR leans on. ADR-0016 point 5:
+
+> The bridge is one-way and narrow: the page posts an intent … the native side owns the queue, the
+> playback and the reporting. **The web view is never told what is playing** and never renders a
+> transport.
+
+A visualizer's entire job is to be told what is playing, sixty times a second.
+
+Inside `/embed` the engine is `NullAudioEngine`, which omits all fifteen optional members of
+`AudioEngine` — including `getAnalyser?()` — and declares `capabilities.visualizer: false`. The
+audio is not merely absent from the page; it is in another process, played by `AVAudioEngine`
+scheduling `AVAudioFile` buffers. There is no Web Audio graph in the web view to analyse and no way
+to make one. Either data flows app → page, or there is no embedded visualizer.
+
+**The DSP is already built, already running, and already discarded.** `NativeAudioEngine`
+installs a tap on `mainMixerNode` in `enableAnalysis()` (`NativeAudioEngine.swift:2125`), runs a
+Hann-windowed FFT off the main actor in `NativeAudioAnalysisProcessor`, throttles to
+`analysisMinInterval = 1.0/60.0`, and hands a `NativeAudioAnalysisFrame` to its delegate. The
+delegate is `FamiliarPlayer.swift:1388`:
+
+```swift
+/// Analysis drives the visualizer, which ADR-0001 point 5 puts out of v1 scope.
+nonisolated func audioEngineDidUpdateAnalysis(
+    frequencyData: [UInt8],
+    timeDomainData: [UInt8],
+    metrics: NativeAudioAnalysisMetrics
+) {}
+```
+
+An empty body. The tap is installed on every `play()`, the FFT runs at 60 Hz, the frame hops to the
+main actor, and it is thrown away — because of the ADR point this one amends. Exposing an FFT here
+is a publishing problem, not a signal-processing problem.
+
+**Both ends of the channel were built once before, for Capacitor, and ADR-0001 deleted the middle.**
+`NativeAudioAnalysisMetrics` still carries an `asDictionary()` — a survival from
+`FamiliarAudioPlugin.swift`, which marshalled exactly this across a JS boundary. On the web side,
+`packages/frontend/src/player/audio/nativeAnalysisBuffers.ts` still exports
+`setNativeAnalysisBuffers` / `clearNativeAnalysisBuffers` / `getNativeAnalysisBuffers`, and
+`useAudioAnalyser.ts` still reads them, because iOS suspends `AudioContext` in the background. The
+shape this ADR proposes is not new; it is the shape that worked, with a different transport.
+
+**The existing contract is a pull, and that matters for the transport.** `useAudioAnalyser.ts` runs
+one shared `requestAnimationFrame` loop that mutates a persistent object; visualizers call
+`getAudioData()` synchronously inside R3F's `useFrame`. Nothing awaits anything per frame. Whatever
+this ADR builds has to land in a buffer the page reads on its own schedule, or every visualizer in
+`docs/VISUALIZER_API.md` has to change.
+
+**One resolution mismatch has to be settled here rather than found later.** The native processor
+uses `fftSize = 256`, giving 128 bins. `WebAudioEngine` uses `fftSize = 1024` — 512 bins — and its
+comment says why: *"finer bass/kick separation; lower smoothing so transients survive for the
+onset/beat detector (0.8 over-averaged the spectrum and starved spectral-flux onset detection)."*
+Feeding 128 bins into a detector tuned on 512 starves it in exactly the way that comment warns
+about.
+
+**And two native tests have never passed.** `NativeAudioAnalysisProcessorTests.swift:54` and `:75`
+are unconditional skips — *"Band edges disagree with the fixture"* and *"Variance ordering does not
+hold; not yet diagnosed"* — and CI never reported it because the iOS job ends
+`| xcpretty || true`. The values in question are `bass`, `mid`, `treble` and `variance` on
+`NativeAudioAnalysisMetrics`: the derived half of the frame, not the spectrum itself.
+
+## Decision
+
+1. **The visualizer is an embedded surface**, by ADR-0016 point 1 applied to the largest and
+   joint-churniest screen in the web app. ADR-0001 point 5's "possibly permanently" is retired for
+   the visualizer specifically. The rest of that point — ambient mode, the settings panels, library
+   import, S3 backup — is untouched. [ADR-0013](ADR-0013-the-mac-is-a-management-surface-too.md)
+   point 4 is amended in the same narrow way: its visualizer bullet gave "no native analogue and no
+   management purpose" as the reasons, and the first of those has stopped being true — the analogue
+   is the FFT quoted above, running on every track.
+
+2. **The bridge gains a direction, not a message.** Page → app stays at exactly two intents and
+   ADR-0020 point 2's cap is not weakened, because nothing is being added to it. App → page is a
+   separate channel with its own contract, its own file and its own tests. Keeping them separate is
+   what lets ADR-0020 point 3's bar go on meaning what it means.
+
+3. **The channel is a coalesced push into a page-side buffer, and the page reads it on its own
+   frame.** The native side calls `evaluateJavaScript` with the latest frame, fire-and-forget, and
+   **never has more than one call in flight** — if a frame is ready while one is outstanding, the
+   newer frame replaces it and the older is dropped. A visualizer rendering at 30 fps must not
+   accumulate a queue of 60 Hz frames it will never draw.
+
+4. **The page-side landing point is `nativeAnalysisBuffers.ts`, unchanged.** The frame is written
+   with `setNativeAnalysisBuffers`, `useAudioAnalyser` reads it, and `getAudioData()` keeps its
+   current signature. Every visualizer in `docs/VISUALIZER_API.md` works without modification,
+   which is most of what embedding is being bought for.
+
+5. **The frame carries the spectrum, not the derived values.** `frequencyData` and
+   `timeDomainData` cross; `bass`, `mid`, `treble`, `beat` and `onset` are derived on the page by
+   `player/audio/analysisMetrics.ts` and the spectral-flux detector in `useAudioAnalyser`, which
+   already exist and are already tuned. This deliberately routes around the two never-passing tests
+   rather than depending on them, and it leaves **one** implementation of the band maths instead of
+   two that are known to disagree.
+
+6. **The native `fftSize` rises from 256 to 1024**, matching `WebAudioEngine`, so the page's
+   detector receives the resolution it was tuned for. Anything less makes point 5 a downgrade
+   dressed as reuse.
+
+7. **Now-playing identity travels on the same channel**: track id, title, artist, album, artwork
+   URL, duration, position, and an explicit `playing` flag. This is the part that plainly reverses
+   ADR-0016 point 5's "never told what is playing", and it is reversed **for this surface only** —
+   embedded Discover is not told, and does not ask.
+
+8. **Lyrics do not travel on the channel.** `GET /api/v1/tracks/{track_id}/lyrics` is tagged
+   `tracks`, is already generated, and returns the synced `lines` the `lyrics` visualizer wants.
+   The page has the server URL and the profile ([ADR-0016](ADR-0016-embedded-web-surfaces-on-the-mac.md)
+   point 6) and can fetch it itself. A channel that carries everything is a channel with no shape.
+
+9. **The null engine is unchanged and still reports `visualizer: false`.** The page reads the
+   buffer; it never asks the engine for an analyser. ADR-0017's guarantee holds exactly as written
+   — a missed play path is inert rather than a second `AudioContext` — and this ADR adds nothing
+   that could construct one.
+
+10. **`disableAnalysis()` runs on `pause()`, so a paused visualizer receives no frames.** The last
+    frame is held and `playing: false` is pushed once. Deciding this now is cheaper than
+    diagnosing it later as a visualizer that looks frozen rather than paused.
+
+11. **The surface needs its own marker.** `EmbedIntent.surfaceMarker` is the single value
+    `"embed"`, probed out of `<meta name="familiar-surface">`. A second embedded document must
+    identify itself distinctly, or the probe that exists to catch a pre-`/embed` server answering
+    from its SPA fallback cannot tell the two surfaces apart.
+
+12. **The frame shape is parsed and formatted in `FamiliarKit`, under test.** `swift test` cannot
+    see `App/`, and a wire format is exactly the kind of decision that belongs in the package —
+    the same reasoning that put `EmbedIntent.parse` there rather than in the message handler.
+
+## Alternatives Considered
+
+**Rebuild the visualizer natively in Metal or SceneKit.** Fully native, no web view, and the FFT is
+already in the right process. Rejected on maintenance, for the reason ADR-0016 rejected a native
+Discover: 3,985 lines across 22 files with 14 commits in six months is the most active surface in
+the product, and a second implementation would have to change with it every time. It would also
+strand the four existing visualizers and the three plugin repositories that target the web API.
+
+**Have the page pull each frame with `WKScriptMessageHandlerWithReply`.** Genuinely attractive: the
+page's `requestAnimationFrame` becomes the clock, so backpressure is automatic and a hidden page
+asks for nothing. Rejected because it inverts a schedule that already exists — the engine throttles
+the tap to 60 Hz and knows when a frame is ready — and it adds an asynchronous round trip per
+rendered frame to fetch data that is already sitting in a buffer. `getAudioData()` is synchronous
+inside `useFrame`; making it await would change the contract every visualizer is written against,
+which is point 4's whole value.
+
+**Push the derived metrics too, since `NativeAudioAnalysisMetrics` already computes them and even
+has `asDictionary()`.** The cheapest possible framing, and it is what the Capacitor bridge did.
+Rejected because the two skipped tests say the band edges and the variance are wrong, and shipping
+them would put unverified numbers into the contract third-party visualizers are written against.
+At 44.1 kHz with `fftSize` 256 the processor's "treble" begins around 11 kHz, which is not what
+anyone drawing a treble bar means. Deriving on the page keeps one tuned implementation.
+
+**Add a third message to the existing `familiar` handler instead of a second channel.** No new
+plumbing, one contract to keep in step. Rejected because it conflates two things ADR-0020 was
+careful to separate: a listener-initiated intent, of which there may be two, and a 60 Hz render
+feed. It would also make ADR-0020 point 2's cap meaningless — "two messages" would come to include
+one that fires sixty times a second — and the bar in point 3 would then have to be argued about
+every future push as well as every future intent.
+
+**Ship only the `lyrics` and `music-video` visualizers, which need metadata but no spectrum.** It
+would need point 7 and not points 3–6, which is most of the work avoided. Rejected because the two
+that need no FFT are the two least worth embedding a web view for, and the channel gets built the
+first time anyone wants `reactive-terrain` — which at 1,311 lines is the default and the largest.
+
+**Leave the visualizer web-only, as ADR-0001 point 5 said.** Still defensible: it is the one
+feature in the product with no functional purpose, and the web app is a browser tab away. Rejected
+because the phone and the Mac are now where the listening happens, the DSP is already running and
+being discarded on every track, and "possibly permanently" was written as a scope boundary for v1
+rather than as a finding.
+
+## Consequences
+
+- **Positive:** The four existing visualizers work on both Apple clients with no changes to any of
+  them, because points 4 and 5 keep `getAudioData()` and its shape intact.
+- **Positive:** An FFT that currently runs 60 times a second and is discarded starts being used.
+- **Positive:** The band maths and the onset detector stop existing in two places that disagree.
+  Point 5 makes `analysisMetrics.ts` the single implementation for every client.
+- **Positive:** Raising `fftSize` to 1024 fixes a resolution mismatch that would otherwise have
+  been discovered as "the beat detection is worse on the Mac".
+- **Tradeoff:** **ADR-0016 point 5 is no longer true as written.** The bridge is one-way for
+  Discover and two-way for the visualizer, and a rule stated in absolute terms now has an
+  exception. Anyone reading ADR-0016 alone will get the wrong answer, which is why point 2
+  separates the directions rather than blurring them.
+- **Tradeoff:** A second embedded document, a second marker, a second entry point in
+  `vite.config.ts`, and a second `serve_*` route registered before the SPA catch-all. ADR-0017
+  already named the first of these as a cost; this doubles it.
+- **Tradeoff:** The seam ADR-0016 called embedding's main risk now has a third contract across it,
+  and like the other two nothing checks the TypeScript half against the Swift half at compile time.
+- **Tradeoff:** 60 `evaluateJavaScript` calls a second is real main-thread work on the native side
+  whenever the visualizer is on screen, on top of the render loop inside the web view.
+- **Follow-up:** The two skipped tests in `NativeAudioAnalysisProcessorTests` are now routed around
+  rather than fixed. They still assert something about a processor this ADR depends on, and
+  `testBrightFixtureDominatesTreble` in particular encodes a disagreement about where treble begins
+  that someone should settle.
+- **Follow-up:** `FullPlayer.tsx` decides what to draw from `isVisualizerAvailable()`. The native
+  full-player has no equivalent decision yet, and where the visualizer is *reached from* on each
+  platform is not settled here.
+- **Follow-up:** With two embedded surfaces, `EmbeddedDiscoverView`'s host, coordinator, navigation
+  policy and probe are no longer Discover-specific. Generalising them is implementation work, but
+  the marker check in point 11 is the part that must not be generalised into a blanket allow.

--- a/docs/decisions/ADR-0034-visualizers-are-drop-in-bundles.md
+++ b/docs/decisions/ADR-0034-visualizers-are-drop-in-bundles.md
@@ -1,0 +1,172 @@
+# ADR-0034: Visualizers Are Drop-In Bundles
+
+Status: proposed
+
+Date: 2026-08-06
+
+Extends [ADR-0033](ADR-0033-the-embed-bridge-gains-a-return-channel.md).
+
+## Context
+
+The ask is that someone could drop a three.js project into the app and have it become a visualizer
+option. **That system was built, and then shelved.** Recording which is the point of this section,
+because the alternative is re-deriving a decision that already has a history.
+
+`dbdef05`, on 2026-03-06, removed 2,114 lines: `services/pluginLoader.ts` (301),
+`services/__tests__/pluginLoader.test.ts` (268), `api/plugins.ts` (100),
+`components/Settings/PluginsSettings.tsx` (378), `backend/app/api/routes/plugins.py` (355),
+`backend/app/services/plugins.py` (480), `backend/app/db/models/plugins.py` (72), and a migration
+dropping the `plugins` table. It was a scope cut, made the same afternoon as `ceeb926`, which
+shelved listening sessions.
+
+**What survived the cut is the whole authoring contract.** `components/Visualizer/types.ts` still
+defines `VisualizerProps`, `VisualizerMetadata`, `visualizerRegistry` and `registerVisualizer`;
+`docs/VISUALIZER_API.md` still documents them; `visualizers/_template/` still holds an
+`ExampleVisualizer.tsx` and a 271-line README; and `visualizers/community/` is still there, empty
+but for a `.gitkeep`. The API is designed, documented and in use by the four built-in visualizers.
+Only the loader is gone.
+
+**Three plugins built against it still exist**, as sibling repositories on disk —
+`familiar-plugin-lyric-pulse`, `familiar-plugin-non-places` and `familiar-plugin-timeline` — each
+with a rollup config, a `dist/`, a README instructing the reader to *"Go to Settings > Plugins"*,
+and a manifest of a settled shape:
+
+```json
+{
+  "name": "Non-Places",
+  "id": "non-places",
+  "version": "0.1.0-alpha.1",
+  "type": "visualizer",
+  "main": "dist/index.js",
+  "familiar": { "apiVersion": 1 },
+  "icon": "Building2"
+}
+```
+
+The shelved loader's own header describes how it worked, and it is the part worth keeping:
+
+> Handles loading external plugins (visualizers and library browsers) from pre-built JavaScript
+> bundles. Exposes a global `window.Familiar` API that plugins use to access React, Three.js,
+> hooks, and registration functions.
+
+React, `three`, `@react-three/fiber` and `@react-three/drei` were handed to the plugin as shared
+globals rather than bundled by it. That is not a convenience: two copies of React in one document
+do not work, and two copies of three.js in one WebGL context is 600 kB of duplicate for nothing.
+
+**The App Store is why this is a decision and not a detail.** A shipped `.app` bundle is
+code-signed and cannot be written to, so "drop it into the application bundle" resolves three ways
+— ship it with the app, put it in a user directory, or fetch it — and only one of them is
+straightforwardly permitted. App Review's position on downloaded interpreted code is that it is
+allowed when it runs in the system's WebKit framework and does not change the app's primary
+purpose. A visualizer bundle executing inside the `WKWebView` that
+[ADR-0033](ADR-0033-the-embed-bridge-gains-a-return-channel.md) introduces satisfies both. The same
+bundle evaluated in native JavaScriptCore would not, and a native plugin format would not even be
+arguable.
+
+So ADR-0033 is not merely the source of the audio data. It is the thing that makes this feature
+permissible at all.
+
+## Decision
+
+1. **A visualizer is a pre-built ES module plus a `familiar-plugin.json` manifest**, in the shape
+   the three existing plugin repositories already use. The format is adopted, not designed — a
+   fourth format would strand three working plugins to gain nothing.
+
+2. **Bundles are evaluated only inside the visualizer web view, never in the app's own process.**
+   This is stated as a rule with its reason attached, because the reason is what makes the feature
+   shippable: interpreted code the app did not ship is acceptable in WebKit and is not acceptable
+   anywhere else in an App Store binary.
+
+3. **The host provides React, three.js, `@react-three/fiber` and `@react-three/drei` on a global,
+   and a bundle must not carry its own.** A manifest whose bundle duplicates them is loaded anyway
+   — nothing can check — but the API contract says it, `_template/` demonstrates it, and the rollup
+   configs in the three existing repositories already externalise them.
+
+4. **Two sources, and only two: shipped and local.** Shipped bundles live in the app bundle's
+   resources and are what a fresh install has. Local bundles live in a `Visualizers/` directory
+   under Application Support, which a button in Settings reveals in Finder or the Files app. There
+   is no third source in this ADR.
+
+5. **Install-from-URL is deferred, not rejected.** It is what the shelved `plugins.py` and
+   `PluginsSettings.tsx` did, and bringing it back means a `plugins` table, a server route, a
+   download path and a trust question about arbitrary JavaScript from a URL. Each of those is a
+   decision, and none of them is this one. Points 1–4 are useful without it and are what "drop a
+   project in" literally asks for.
+
+6. **The API is `VisualizerProps` and `AudioData` as `docs/VISUALIZER_API.md` already documents
+   them**, sourced from ADR-0033's channel rather than from Web Audio. That document stops being a
+   web-app document and becomes the contract for every client, which is what makes a plugin written
+   once run in the browser, on the Mac and on the phone.
+
+7. **`familiar.apiVersion` is enforced.** A manifest declaring a version the host does not
+   implement is refused with a reason shown in the picker, rather than loaded and left to fail
+   somewhere inside a render loop.
+
+8. **A visualizer that throws is unloaded, not fatal.** `AudioVisualizer.tsx` already wraps
+   visualizers in an `ErrorBoundary` and a `Suspense`; a third-party crash falls back to the
+   album-art square the player shows when no visualizer is available, and the picker marks the
+   plugin as failed.
+
+9. **Visualizers only. Library browsers are out of scope.** The shelved loader also registered
+   browsers, and `familiar-plugin-timeline` is one. A browser is a management surface with a play
+   affordance, which on an embedded page means the null engine, the play interceptor and the
+   bridge all have to hold for third-party code — a much larger claim than a visualizer makes, and
+   one [ADR-0013](ADR-0013-the-mac-is-a-management-surface-too.md) would have something to say
+   about.
+
+## Alternatives Considered
+
+**Native visualizer plugins — SwiftUI, Metal or SceneKit.** Would look and perform better than a
+web view, and would not need ADR-0033 at all. Rejected on two independent grounds: there is no safe
+mechanism for loading third-party native code into an App Store app, and it would forfeit the four
+built-in visualizers, the three plugin repositories, the template and the documented API — every
+artefact that exists today.
+
+**Revive install-from-GitHub along with the loader, as it was before the shelving.** It is what the
+READMEs of all three plugin repositories tell people to do, so this ADR leaves them describing a
+button that does not exist. Rejected for now rather than permanently: the server half is 907 lines
+across three files and a table, and the trust question — an app that downloads and runs code from a
+URL the user typed — deserves its own argument rather than riding along with a file format. Point 5
+records this as deferred so it is not read as settled.
+
+**Keep compile-time registration and simply add more built-in visualizers.** Zero new machinery,
+and it is how the four current ones work — `visualizers/index.ts` imports each for its side effect.
+Rejected because it is precisely what the request is not: a visualizer would need a pull request
+against the web app and a redeploy of both clients, which no one outside this repository will do.
+
+**Load bundles from a folder the *server* serves, so one install reaches every client.** Attractive
+for a self-hosted product, and it would put visualizers where the music already is. Rejected
+because it makes the feature depend on the server for a screen that should work while offline
+listening to downloaded tracks, and because it is install-from-URL with the URL fixed — the same
+trust question with a friendlier surface.
+
+**Sandbox each bundle in its own nested iframe.** Stronger isolation, and a crash could not reach
+the host at all. Rejected as the wrong shape for this: the visualizer needs the shared WebGL
+context, the shared three.js and the audio buffer, all of which an isolated frame would have to be
+handed across another boundary — rebuilding ADR-0033's channel a second time, inside the page.
+
+## Consequences
+
+- **Positive:** Three plugins that already exist become usable again, on three clients rather than
+  the one they were written for.
+- **Positive:** A visualizer is written once against a documented API and runs in the browser, on
+  the Mac and on the phone, because point 6 makes the contract shared rather than per-client.
+- **Positive:** The shelving is now recorded with its date and its scope, so the next person to
+  find `visualizers/community/` empty knows why.
+- **Tradeoff:** The app loads and executes code it did not ship. The blast radius is a web view
+  with a null audio engine and no credentials beyond the server URL and profile it was given, but
+  it is a genuine widening of what runs inside the app.
+- **Tradeoff:** Point 3 is a contract nothing enforces. A plugin that bundles its own React will
+  break in ways that look like a host bug, and the only defence is documentation.
+- **Tradeoff:** Point 5 leaves all three plugin READMEs describing an installation route that does
+  not exist. They should be corrected as part of this, or they become the fourth instance of an
+  affordance pointing at a destination that is not mounted.
+- **Tradeoff:** Shipped and local bundles can declare the same `id`. Which wins has to be decided
+  in implementation, and whichever it is will surprise someone.
+- **Follow-up:** Install-from-URL, per point 5 — the shelved `plugins.py`, `api/plugins.ts` and
+  `PluginsSettings.tsx` are the starting point, and the trust question is the actual decision.
+- **Follow-up:** Library-browser plugins, per point 9. `familiar-plugin-timeline` is one and has
+  nowhere to go until that is decided.
+- **Follow-up:** `docs/VISUALIZER_API.md` documents `useAudioAnalyser` as reading a Web Audio
+  `AnalyserNode`. Under ADR-0033 point 4 that is one of three sources, and the document should say
+  so rather than describe the browser case as the only one.

--- a/docs/decisions/ADR-0035-weighted-shuffle-is-a-preset-the-server-applies.md
+++ b/docs/decisions/ADR-0035-weighted-shuffle-is-a-preset-the-server-applies.md
@@ -1,0 +1,146 @@
+# ADR-0035: Weighted Shuffle Is a Preset the Server Applies
+
+Status: proposed
+
+Date: 2026-08-06
+
+Extends [ADR-0027](ADR-0027-shuffle-and-repeat-are-listener-modes.md) and
+[ADR-0029](ADR-0029-the-server-stores-no-listener-preferences.md).
+
+## Context
+
+The web app has four named shuffle modes and the Apple clients have none. Unusually for this set,
+the server half is not merely designed but finished and tested, and nothing needs to be added to the
+generated surface to use it.
+
+`backend/app/services/taste_weighting.py` (145 lines) holds
+`VALID_SHUFFLE_PRESETS = {"rediscover", "fresh_finds", "comfort_zone", "deep_dive"}` and a
+`ShufflePresetWeights` over five axes — `play_count_dir`, `recency_dir`, `newness_dir`,
+`favorites_boost`, `variety_strength`:
+
+| preset | play count | recency | newness | favourites | variety |
+|---|---|---|---|---|---|
+| `rediscover` | +1.0 | −1.0 | 0 | 1.0 | 0.5 |
+| `fresh_finds` | −1.0 | 0 | +1.0 | 1.0 | 0.7 |
+| `comfort_zone` | +1.0 | +0.5 | 0 | 3.0 | 0.2 |
+| `deep_dive` | −1.0 | −1.0 | 0 | 1.0 | 0.8 |
+
+`GET /api/v1/tracks/ids` takes `shuffle_preset` as a query parameter
+(`backend/app/api/routes/tracks/listing.py:51`), outer-joins `ProfilePlayHistory` and
+`ProfileFavorite`, computes a weight per track and draws the order by Efraimidis–Spirakis weighted
+sampling (`:133` onward), then spaces same-artist runs with `apply_artist_variety`.
+
+**The endpoint is tagged `tracks`, and `tracks` is already in
+`Sources/FamiliarAPI/openapi-generator-config.yaml`.** So there is no new tag, no lint burn-down,
+no `openapi.json` re-vendor and nothing for
+[ADR-0014](ADR-0014-the-generated-surface-widens-to-management.md) to widen. The Swift client can
+call this today. That makes it the cheapest thing in the current set of proposals, and worth saying
+plainly so it is not scheduled as though it were large.
+
+The gap is already recorded on the Apple side. `PlaybackSessionSnapshot`'s own comment:
+
+> ADR-0003 point 8 records what losing `queue_source` costs — listening-event context and the
+> weighted shuffle preset — and the Apple client has never had it.
+
+**The part that is not obvious is where the weighting happens, and it is not a free choice.** The
+weights read play counts, last-played timestamps, date-added and favourites *across the whole
+library*, normalised against the maximum play count. The Apple client holds none of that: it pages
+tracks at 50 ([ADR-0021](ADR-0021-track-lists-on-the-mac-are-sortable-tables.md)) and its local
+snapshot deliberately omits the reservoir. A preset is therefore **not a permutation the client can
+compute**. It is an order the client asks for.
+
+That distinguishes it cleanly from what ADR-0027 governs. `isShuffled` permutes a queue the client
+already holds; `QueueShuffle.enabling` shuffles `order[(cursor+1)...]` in memory. A preset chooses
+*which tracks are in the queue at all, and in what order*, before any of that runs. Two mechanisms,
+both called shuffle, and conflating them is how the ADR-0027 defect would arrive in a new place.
+
+## Decision
+
+1. **A weighted shuffle preset is a listener preference, held locally.** Per ADR-0029 the server
+   stores none, so the preset lives beside the ADR-0027 modes on this device. It reaches the server
+   only as a query parameter on a request, never as state.
+
+2. **The preset selects the queue; `isShuffled` permutes it. They are different mechanisms and
+   both can be on at once.** When a queue is built with a preset, `QueueShuffle.enabling` is
+   **not** then applied on top of it. Permuting a weighted order discards the weighting and leaves
+   a control that appears to work and does nothing — the exact shape of the defect ADR-0027 exists
+   to fix.
+
+3. **`logicalQueue` holds the weighted order as given.** `QueueShuffle.disabling` therefore
+   straightens out to the order the server returned, which is an order that really existed. This is
+   ADR-0027 point 2's split honoured rather than re-collapsed: the mode is what the listener chose,
+   the order is a fact about the queue.
+
+4. **The preset applies where a queue is drawn from the library, and nowhere else.** That is
+   `LibraryView.shuffleLibrary()` (`:159`) and `widenQueueToLibrary(startedWith:)` (`:262`), plus
+   the Home row from [ADR-0032](ADR-0032-the-apple-clients-get-a-home-destination.md) point 4.
+   Explicitly **not** playing an album or a playlist: a twelve-track album has nothing to weight,
+   and `LibraryView`'s own comment already gives this reasoning for keeping "shuffle everything" on
+   Tracks only — *"it has an obvious meaning for a list of tracks and none for a list of albums."*
+
+5. **A preset survives a queue change, exactly as the ADR-0027 modes do.** It is a property of the
+   listener. Where ADR-0027 point 6 clears the modes — `clear()` — this clears with them.
+
+6. **With no server there is no weighted order, and the control says so.** The preset is
+   unavailable offline rather than falling back to a plain shuffle, because a plain shuffle looks
+   exactly like the feature working. This is ADR-0032 point 5's rule and the answer to the three
+   silently-failing affordances ADR-0017 records.
+
+7. **The control lives on the transport's shuffle affordance, on both platforms**, mirroring the
+   web app's `ShuffleWeightPopover`. A long-press or a disclosure on the shuffle button, not a
+   Settings pane — a preference nobody finds does not help, which is the reasoning ADR-0005 point 8
+   already used about the insertion interval.
+
+## Alternatives Considered
+
+**Compute the weighting on the client from downloaded metadata.** It would work offline, which is
+the one thing point 6 gives up. Rejected on two counts. The client holds neither the play history
+nor the whole library — the weights normalise against a library-wide maximum play count that a
+50-track page cannot produce. And it would be a second copy of a tuned scorer in a second language,
+which is precisely the outcome [ADR-0005](ADR-0005-one-ranking-engine-serves-ambient-and-radio.md)
+exists to prevent; that ADR rejected forking `ambient.py` for the same reason.
+
+**Send the preset to the server as part of the playback session, in `queue_source`.** It is the
+field designed to carry exactly this, and `PlaybackSessionSnapshot`'s comment names it as what was
+lost. Rejected by ADR-0029 — the server stores no listener preferences — and by
+[ADR-0028](ADR-0028-the-apple-clients-playback-session-is-local.md), which took these clients out
+of the server session entirely. Reintroducing one field would reopen a decision made three ADRs
+ago for one query parameter.
+
+**Model the presets as cases on `FamiliarPlayer` beside `repeatMode` and `isShuffled`.** Tidy, and
+it would make the persistence question answer itself. Rejected because they are not playback
+modifiers: they select a queue before playback starts and have no meaning once one exists. Putting
+them on the player would invite the same category error point 2 is written to prevent.
+
+**Ship one preset — `rediscover` — rather than four.** Defensible: `ambient.py:469` already sets
+`RADIO_TASTE_PRESET = "rediscover"`, so it is the one the product already leans on, and one row is
+easier to place than four. Rejected because the four exist, are tuned, cost nothing extra to
+expose, and differ in ways a listener can actually feel — `comfort_zone` and `deep_dive` are close
+to opposites.
+
+**Wait for [ADR-0006](ADR-0006-offline-ranking-is-precomputed-server-side.md)'s offline manifest so
+the feature works offline from the start.** Rejected as the wrong order: the manifest's variants
+are a larger piece of work, the online path is finished today, and point 6 degrades honestly in
+the meantime.
+
+## Consequences
+
+- **Positive.** Four tuned modes reach the Apple clients with no server change, no schema change
+  and no generator change — the whole cost is client-side.
+- **Positive.** The distinction in point 2 gives the app a defensible answer to "what does shuffle
+  do when a preset is on", which the web app has never had to state because both live in one store.
+- **Positive.** `shuffleLibrary()` and the Home rows share one mechanism, so a preset chosen in the
+  transport is the preset Home uses.
+- **Tradeoff.** The presets do not work offline, making them the second thing after embedded
+  Discover with no offline story. Unlike Discover, this one has a known route to fixing it.
+- **Tradeoff.** Two controls now sit on one button — a mode and a preset — and the difference
+  between them is real but not obvious. Whether one affordance can carry both is a design question
+  this ADR does not settle.
+- **Tradeoff.** `GET /tracks/ids` with a preset does per-track weight computation over the library
+  on every request. It is what the web app already does, but the Apple client will call it from
+  Home, which is a more frequent trigger than a popover.
+- **Follow-up.** ADR-0006's offline manifest carries `variants[]`, each a `(weight profile, filter
+  preset)` combination. Wiring the four presets to those variants is the offline answer to point 6
+  and is its own piece of work.
+- **Follow-up.** ADR-0003 point 8's `queue_source` remains unimplemented on these clients, and now
+  for a second reason. Worth annotating there so nobody reads the gap as an oversight.

--- a/docs/decisions/ADR-0036-listening-sessions-signal-through-familiars-own-server.md
+++ b/docs/decisions/ADR-0036-listening-sessions-signal-through-familiars-own-server.md
@@ -1,0 +1,185 @@
+# ADR-0036: Listening Sessions Signal Through Familiar's Own Server
+
+Status: proposed
+
+Date: 2026-08-06
+
+## Context
+
+Listening sessions — create or join by code, the host streams what they are playing to guests, with
+chat and reactions — are the product's one social feature. They are live in the web app:
+`AppShell.tsx:151` mounts `SessionPanel`, backed by `hooks/useListeningSession.ts` (640 lines),
+`hooks/useWebRTCStreaming.ts` (354), `components/Sessions/SessionPanel.tsx` (366),
+`IceDiagnostics.tsx` (112) and `services/listeningSessionFamiliars.ts` (97). Seven commits in the
+last six months.
+
+**Where the signalling goes is the problem, and it takes a moment to see.**
+
+`ceeb926`, on 2026-03-06, shelved the server half: `backend/app/api/routes/sessions.py` (425 lines,
+already tagged `sessions`, with a `GET /sessions/by-code/{code}`, a `WebSocket /sessions/ws`, and a
+`get_ice_servers()` returning two Google STUN servers plus an optional TURN from settings),
+`backend/app/services/sessions.py` (319), `backend/tests/test_api_sessions.py` (100),
+`docs/LISTENING_SESSIONS.md` (601) and `components/Guest/GuestListener.tsx` (475).
+
+The client half was then rebuilt without it. `useListeningSession.ts:100` reads:
+
+```ts
+function buildWsUrl(): string {
+  let base: string;
+  if (RELAY_URL) {
+    base = RELAY_URL.replace(/^http/, 'ws').replace(/\/$/, '');
+  } else {
+    const proto = window.location.protocol === 'https:' ? 'wss:' : 'ws:';
+    base = `${proto}//${window.location.host}`;
+  }
+  return `${base}/api/v1/sessions/ws`;
+}
+```
+
+`RELAY_URL` comes from `VITE_SESSIONS_RELAY_URL`, defaulting to `''`. Three places set it, all to
+the same value: `docker/Dockerfile:32` (`ARG VITE_SESSIONS_RELAY_URL=https://familiar-sessions.fly.dev`),
+`.github/workflows/release.yml:121`, and `scripts/deploy-dev.sh:34`. So:
+
+- **Every released build signals through `https://familiar-sessions.fly.dev`** — a separate Fly
+  application, outside the user's own server, in a product whose premise is that nothing leaves
+  your network.
+- **Every development build falls back to same-origin `/api/v1/sessions/ws`**, a route deleted five
+  months ago. The panel opens, the socket 404s, and the feature has been broken in `pnpm dev` since
+  the day it was shelved.
+- **Guests never touch the user's server at all.** `buildShareLink` returns
+  `https://familiar-sessions.fly.dev/listen/{code}` when the relay is set, and `/listen/` is not a
+  route in `App.tsx` either way.
+
+That is the finding this ADR exists to act on. It is not a defect in WebRTC or in the session code,
+both of which work. It is that the one feature which involves other people routes through a box the
+listener does not run, and the fallback for anyone who does not set a build argument points at
+nothing.
+
+**The shelving was for scope, not for defects.** `ceeb926`'s message is *"Remove listening
+sessions, WebRTC streaming, and guest listener features. Code preserved on
+feature/listening-sessions branch"*, made the same afternoon as `dbdef05` shelved the plugin
+system. Nothing in either commit says the code was wrong.
+
+**Two properties of the shelved implementation are worth surfacing before it comes back.**
+
+`services/sessions.py` held an in-process `SessionManager`. Sessions did not survive a restart and
+would not be visible across workers. That was acceptable for an ephemeral listening party and it is
+still arguable, but it should be a decision rather than an inheritance.
+
+And `WebSocket /sessions/ws` was the **only** WebSocket route this backend has ever had. Searching
+for one today finds a docstring — `backend/app/services/outputs.py:173` describes signalling *"to
+the frontend via WebSocket"* for browser-based outputs, and there is no such route; the
+multi-room path carries a `websocket_id` field and nothing serves it. So reviving this is not
+adding a socket beside existing ones. It is reintroducing the only one, along with whatever
+deployment characteristics a long-lived connection brings to a server that currently has none.
+
+## Decision
+
+1. **Signalling moves into the Familiar server.** The shelved `sessions.py` and
+   `services/sessions.py` come back rather than being redesigned, because they were removed for
+   scope and there is no finding against them. `GET /sessions/by-code/{code}`, the
+   `WebSocket /sessions/ws` and `get_ice_servers()` return as they were, adjusted only for the
+   contract rules in point 5.
+
+2. **The external relay is retired, and the reason is the product's premise rather than a fault.**
+   `familiar-sessions.fly.dev` works. It is being removed because a self-hosted music player should
+   not route its listeners' session codes, chat and reactions through infrastructure the listener
+   does not run — the same argument the README makes about the library, applied to the one feature
+   that had drifted from it.
+
+3. **`VITE_SESSIONS_RELAY_URL` is deleted, not defaulted.** A build argument that silently sends
+   traffic elsewhere is worse than the same behaviour written down, and leaving it in place with an
+   empty default would restore the broken same-origin path as the fallback for everyone. The
+   `ARG`/`ENV` pair in `docker/Dockerfile`, the line in `release.yml` and the export in
+   `deploy-dev.sh` all go.
+
+4. **The server signals; it never carries audio.** Peers connect directly, as they do today. A
+   listening party must not turn a NAS into a streaming host, and this is the boundary that keeps
+   the feature's cost proportional to running a WebSocket.
+
+5. **The `sessions` tag joins the generated surface, and the WebSocket does not.** The REST half —
+   session lookup, ICE configuration — is typed to
+   [ADR-0007](ADR-0007-clients-are-generated-from-openapi.md)'s rules: typed 2xx JSON, declared 401,
+   404, 422 and 500, `operationId` under 60 characters, entries in both
+   `Sources/FamiliarAPI/openapi-generator-config.yaml` and `VENDORED_TAGS` in
+   `backend/scripts/lint_openapi.py`. The socket is hand-written on every client, for the reason
+   ADR-0007 point 8 already excludes the two SSE map variants: the generator has nothing to
+   generate for it.
+
+6. **ICE stays as the shelved code had it — Google STUN by default, TURN by configuration.**
+   `turn_server_url`, `turn_server_username` and `turn_server_credential` return to `config.py`.
+   Familiar does not run a TURN server and does not promise one.
+
+7. **A session that cannot establish says so, naming the reason.** `IceDiagnostics.tsx` exists
+   because this fails in the field, and behind symmetric NAT with no TURN configured it will fail
+   for reasons no amount of retrying fixes. The failure is reported as a connectivity result, not
+   as a spinner.
+
+8. **Sessions stay in process, and that is stated rather than assumed.** They are ephemeral by
+   nature — a code, some peers, a conversation — and persisting them would mean a table, a
+   lifecycle and a cleanup job for something that ends when everyone leaves. The consequence is
+   that a server restart ends every session, and a multi-worker deployment would need this
+   revisited.
+
+## Alternatives Considered
+
+**Keep the relay and document it.** It works today, it costs nothing to leave alone, and a public
+relay is genuinely easier for a guest who has no account and no access to the host's network —
+which is most guests. Rejected on the premise in point 2, and it should be said that this is a
+values decision rather than a technical one: the relay is not broken, it is just not ours. The
+honest cost is recorded in the Consequences.
+
+**Fix the fallback instead — point same-origin at a revived backend, keep the relay as an
+override.** The smallest change that makes development builds work, and it preserves the guest
+story. Rejected because it leaves two signalling paths, one of which is chosen by a build argument
+nobody sets deliberately, and the difference between them is invisible at runtime. Two paths where
+one is a silent default is how this became hard to see in the first place.
+
+**Signal over polling or SSE instead of a WebSocket, so the backend keeps having no long-lived
+connections.** This was investigated on the strength of `backend/app/services/outputs.py:173`,
+which describes signalling *"to the frontend via WebSocket"* — but that is a docstring for a route
+that does not exist, so there was nothing to reuse and the choice is between a socket and no
+socket. Rejected: WebRTC signalling is a bidirectional negotiation with sub-second latency
+requirements, offer and answer and a stream of ICE candidates in both directions. SSE is one-way
+and polling would make handshake latency the dominant cost of joining. The 12-second handshake
+timeout in `useListeningSession.ts` exists because this is already tight.
+
+**Delete listening sessions properly rather than reviving them.** Defensible: it was shelved once
+for scope, nothing in the repo suggests it is used, and the panel currently 404s in development
+without anyone noticing. Rejected because the feature is being asked for on the Apple clients
+([ADR-0037](ADR-0037-the-apple-clients-host-and-join-listening-sessions.md)), and reviving it
+correctly is the prerequisite for that. If it were not wanted, deleting it would be the right
+answer and this ADR would say so.
+
+**Use a hosted signalling service — Ably, Pusher, a managed WebRTC provider.** Removes the socket,
+the session manager and the TURN question in one step, and is what most products do. Rejected for
+the same reason as the relay, and more strongly: a third-party dependency for the one path that
+carries listeners' identities and messages.
+
+## Consequences
+
+- **Positive:** The one feature routing through infrastructure the listener does not run stops
+  doing so. A self-hosted install becomes self-hosted in full.
+- **Positive:** Development builds stop 404ing. The feature has been broken in `pnpm dev` since
+  2026-03-06 and nothing said so.
+- **Positive:** The Apple clients get a signalling endpoint on the server they are already
+  configured against, with the profile they already hold — which is what makes ADR-0037 tractable.
+- **Positive:** A tag that was already written, already typed and already tested comes back rather
+  than being designed again.
+- **Tradeoff:** **Guests must be able to reach the host's server.** This is the real cost of point
+  2 and it is significant: today a share link works from anywhere, and afterwards it works only for
+  someone who can reach a Familiar instance — over Tailscale, a tunnel, or a public address. For a
+  listener whose server is on a home NAS behind a router, inviting a friend becomes a networking
+  problem.
+- **Tradeoff:** Every host now needs to answer the TURN question themselves. The relay presumably
+  had one; a NAS does not, and point 7 means the failure will be visible rather than mysterious —
+  but it will be more common.
+- **Tradeoff:** Point 8 means a deploy ends every session in progress. On a server that redeploys
+  with `make deploy-dev` during ordinary work, that is not rare.
+- **Follow-up:** `docs/LISTENING_SESSIONS.md` was 601 lines and went with the shelving. Whether it
+  returns, or is replaced by this ADR plus something shorter, is unresolved.
+- **Follow-up:** `/listen/{code}` is not a route in `App.tsx`. A share link needs somewhere to land,
+  and the shelved `GuestListener.tsx` (475 lines) is what used to be there.
+- **Follow-up:** `familiar-sessions.fly.dev` is a second Fly application in the project's
+  footprint. Once nothing points at it, it should be shut down rather than left running — and
+  [ADR-0038](ADR-0038-the-demo-server-is-always-on.md) is where the Fly footprint is accounted for.

--- a/docs/decisions/ADR-0037-the-apple-clients-host-and-join-listening-sessions.md
+++ b/docs/decisions/ADR-0037-the-apple-clients-host-and-join-listening-sessions.md
@@ -1,0 +1,178 @@
+# ADR-0037: The Apple Clients Host and Join Listening Sessions
+
+Status: proposed
+
+Date: 2026-08-06
+
+Extends [ADR-0036](ADR-0036-listening-sessions-signal-through-familiars-own-server.md) and
+[ADR-0013](ADR-0013-the-mac-is-a-management-surface-too.md).
+
+## Context
+
+[ADR-0036](ADR-0036-listening-sessions-signal-through-familiars-own-server.md) puts signalling back
+on the Familiar server. This ADR decides what the Mac and the phone do with it.
+
+**The embed/native test does not apply here, and that is worth stating once.** Every surface since
+[ADR-0016](ADR-0016-embedded-web-surfaces-on-the-mac.md) has been weighed by churn and size, and
+three have come out differently. This one cannot be weighed at all: ADR-0016 point 4 forbids an
+embedded surface from playing audio, and a listening session *is* audio in both directions. The
+answer is forced. Native, or not at all.
+
+**This brings the first non-Apple dependency into `familiar-apple`.** `Package.swift` currently
+declares three packages, all Apple's: `swift-openapi-generator`, `swift-openapi-runtime` and
+`swift-openapi-urlsession`. There is no first-party WebRTC on any Apple platform, so a binary
+distribution of libwebrtc is the only route. That is the substance of this decision more than the
+feature is — the feature has been built once already, in TypeScript, and works.
+
+**Two engine facts constrain the design, and both are recorded in the engine itself.**
+
+The audio path is `AVAudioEngine` scheduling `AVAudioFile` buffers from files on disk, not a
+streaming player. `NativeAudioEngine` holds two `AVAudioPlayerNode`s for crossfade, an EQ, a
+reverb, a delay, a waveshaper, a compressor and a filter, and it plays *tracks the device has*. A
+guest in a listening session receives a remote audio stream with no track, no file and no
+`streamURL`. Nothing in that graph can accept one.
+
+And the render path is closed on purpose.
+[ADR-0024](ADR-0024-the-audio-engine-is-main-actor-except-where-it-cannot-be.md) point 3 made the
+tap closure `@Sendable` and non-isolated after a Swift 6 runtime check crashed the app on the first
+track played — `Thread 8 Crashed:: Dispatch queue: RealtimeMessenger.mServiceQueue`. The analysis
+tap at `NativeAudioEngine.swift:2148` captures a processor and nothing else, and its comment says
+why in eleven lines. A capture tap for a host's outbound stream sits beside it under exactly the
+same rules.
+
+**The web app's host path is one line of Web Audio.** `WebAudioEngine.getOutputStream()` lazily
+branches `masterGain` into a `MediaStreamAudioDestinationNode` and hands the result to
+`useWebRTCStreaming`. There is no native equivalent of that convenience; the same effect is a
+second `installTap` and an encoder.
+
+**ADR-0013 point 2 has to be addressed rather than routed around.** It says *"iOS stays the
+listening path. The phone is not a management client."* Joining a session is plainly listening.
+Hosting one is less obvious — but it edits nothing, configures nothing and administers nothing.
+It starts a shared listen. On the wording of point 2, hosting is a listening act, and this ADR
+takes it as one.
+
+## Decision
+
+1. **Both platforms host and join.** Hosting is not management under ADR-0013 point 2: it changes
+   nothing about the library or the server, it starts a listen that other people can hear. Scoping
+   hosting to the Mac was considered and is recorded below; the phone is where listening happens,
+   and a listening party you can only start from a desk is a party in the wrong room.
+
+2. **WebRTC arrives as a pinned SPM binary dependency**, and this is recorded as the repository's
+   first non-Apple binary. It must be an exact-version pin rather than a range, it must be
+   reviewable at the version pinned, and the exit is written down before it is added: if the
+   package is abandoned, the feature is removed rather than the dependency forked. A binary
+   framework nobody in this project can rebuild is a liability that should be entered knowingly.
+
+3. **A guest does not play through `NativeAudioEngine`. The engine is stopped for the duration.**
+   The peer connection owns the output while a guest is in a session, and the local player is
+   stopped rather than paused-and-resumed-behind-the-scenes. Two things holding the audio session is
+   the defect `CarPlayBridge` and ADR-0016 point 4 are both written to prevent, and a guest is the
+   easiest place in the product to create one by accident.
+
+4. **A host adds one tap, beside the analysis tap, and nothing else changes.** One engine, one
+   queue, one now-playing entry. The capture closure is `@Sendable`, captures no `self`, and
+   carries its invariant in a comment where it sits — ADR-0024 point 3's rules apply unchanged,
+   because they were written for exactly this shape of code.
+
+5. **A guest's listening produces no play events and no scrobbles.** The tracks are the host's;
+   the guest's server has no ids for them and no reason to believe they were listened to by this
+   profile. [ADR-0004](ADR-0004-listening-feedback-is-event-sourced.md)'s events and
+   [ADR-0030](ADR-0030-scrobbling-is-the-servers-job.md)'s scrobbles both come from the host's
+   playback, as they already do. Feeding a guest's stream into the ranking engine would poison it
+   with someone else's taste.
+
+6. **A guest's queue is the host's, and this is the one exception to
+   [ADR-0028](ADR-0028-the-apple-clients-playback-session-is-local.md).** That ADR made the local
+   session authoritative in both directions; for the length of a session as guest, it is not. The
+   guest's own queue is preserved untouched and restored on leaving. Naming this as an exception is
+   the point — it is the kind of thing that otherwise gets discovered when someone's queue
+   disappears.
+
+7. **Chat and reactions are native.** `SessionPanel.tsx` is 366 lines with a settled shape — join
+   by code, host crown, kick, share link, a 500-character message cap and four reaction kinds — and
+   it sits on the native side of ADR-0016 point 1 by the same measurement that put chat there in
+   [ADR-0022](ADR-0022-chat-is-built-native-and-hidden-without-a-provider.md). It could not be
+   embedded in any case, being attached to a surface that plays audio.
+
+8. **The connection state machine lives in `FamiliarKit`, not in a view.** `swift test` cannot see
+   `App/`, and this is the most stateful thing that will ever be in this app: handshake timeouts,
+   ten reconnect attempts, pending sends, host departure, kick, and ICE failure. `App/` holds the
+   translation, as it does for everything else with a decision in it.
+
+9. **A session that cannot connect fails visibly, with its reason.** ADR-0036 point 7 on the phone
+   and the Mac too. Behind symmetric NAT with no TURN configured this will happen, and a spinner
+   that never resolves is the failure mode this project has now shipped three times.
+
+10. **Interruptions are peer-visible.** `AVAudioSession` interruption handling already exists in the
+    engine and compiles out on macOS. A host who takes a call, and a guest whose app is
+    backgrounded, are states the other side is told about rather than left to infer from silence.
+
+11. **The destination is absent when the server has no sessions endpoint**, read from the
+    generated `sessions` surface. This is ADR-0022 point 3 applied a third time: not a disabled
+    row, not an error after the user has typed a code. An Apple client pointed at a server built
+    before ADR-0036 must not offer this at all.
+
+## Alternatives Considered
+
+**Join only; hosting stays web-only.** Genuinely the narrower and safer half: no capture tap, no
+encoder, no host UI, and it sits more comfortably beside ADR-0013 point 2. It was the alternative
+seriously weighed against point 1. Rejected because a guest-only client is a client that can never
+start anything, and the person most likely to want a listening party is the person with the
+library — who is increasingly on the Mac or the phone rather than in a browser.
+
+**Host only on the Mac, join on both.** Splits the difference and maps cleanly onto ADR-0013's
+division. Rejected on the reading of point 2 in the Context: hosting administers nothing, so the
+management/listening line does not actually fall between hosting and joining. Drawing it there
+would be borrowing a rule's authority for a distinction it does not make.
+
+**Put a guest in a `WKWebView` pointed at the web app's guest page**, which already exists in
+shelved form as `GuestListener.tsx`. No WebRTC dependency at all, and the hardest part — the
+receive path — is already written. Rejected outright by ADR-0016 point 4: it is a web view playing
+audio, which is the one thing embedding is never allowed to do, and it would construct the second
+engine [ADR-0017](ADR-0017-the-embedded-surface-gets-a-null-audio-engine.md) exists to make
+impossible.
+
+**Use the existing casting path from [ADR-0031](ADR-0031-casting-is-the-macs-and-excludes-zones.md)
+instead of WebRTC.** No new dependency, and the Mac can already send audio somewhere else.
+Rejected because casting is same-network output routing to a device, and this is remote
+co-listening with people. Different discovery, different transport, different failure modes, and
+ADR-0031 deliberately excluded zones for reasons that would apply doubly here.
+
+**Stream the host's *queue* rather than the host's *audio*, and have each guest play their own copy
+from their own library.** Elegant for anyone who has the same tracks: no media path at all, no
+WebRTC, just a synchronised cursor over track ids. Rejected because it only works between two
+people with the same library, which is not what a listening party is — and the moment one guest is
+missing a track, the feature silently becomes something else.
+
+**Do not build this on the Apple clients.** The web app works and is a browser tab away, and this
+is the largest and riskiest item proposed. Rejected because it was asked for, and because the whole
+point of ADR-0001 was that listening moves to the native clients — leaving the social half behind in
+the browser splits the feature across two apps.
+
+## Consequences
+
+- **Positive:** The Mac and the phone can start and join a listening session, on a server they are
+  already configured against, with the profile they already hold.
+- **Positive:** Point 3's rule means the guest path cannot produce two things holding the audio
+  session, which is the failure this would otherwise have shipped.
+- **Positive:** Point 5 keeps someone else's listening out of the ranking engine, which
+  [ADR-0005](ADR-0005-one-ranking-engine-serves-ambient-and-radio.md) and ADR-0004 both depend on
+  being honest.
+- **Tradeoff:** **A binary framework enters the build that nobody here can rebuild or audit
+  meaningfully.** Point 2 makes the terms explicit, but the exposure is real and permanent for as
+  long as the feature exists.
+- **Tradeoff:** Point 6 puts a hole in ADR-0028's "the playback session is local, in both
+  directions". It is narrow and bounded by the length of a session, but it is the first one.
+- **Tradeoff:** The engine gains a second tap and a stop-for-guest path, in a file whose complexity
+  is already the subject of two ADRs.
+- **Tradeoff:** Listening sessions are the only feature in the Apple clients with no offline
+  behaviour at all — worse than embedded Discover, which at least fails on one screen.
+- **Follow-up:** The share link a host produces has to open something. On Apple that suggests a
+  universal link into the app and a web fallback, and neither exists — ADR-0036's follow-up about
+  `/listen/{code}` is the other half of it.
+- **Follow-up:** CarPlay. A guest in a session while driving is coherent and completely unspecified;
+  `CarPlayBridge`'s one-player rule is the constraint that would govern it.
+- **Follow-up:** Whether a host can be a guest of themselves across two devices — the phone joining
+  the Mac's session on one profile — is undefined, and the profile-keyed local session makes it
+  plausible enough that someone will try it.

--- a/docs/decisions/ADR-0038-the-demo-server-is-always-on.md
+++ b/docs/decisions/ADR-0038-the-demo-server-is-always-on.md
@@ -1,0 +1,162 @@
+# ADR-0038: The Demo Server Is Always On
+
+Status: proposed
+
+Date: 2026-08-06
+
+## Context
+
+`docs/TEST-SERVER.md` opens with the reason this matters:
+
+> Apple App Store review requires a working backend server with test data.
+
+An App Store reviewer opens Familiar, is asked for a server, and has nothing to type. Without a
+reachable server the app is a setup screen, and a submission that reaches a reviewer in that state
+is rejected on functionality regardless of what shipped in it. That makes this a prerequisite for
+every Apple-facing decision in the current set, not a piece of infrastructure housekeeping.
+
+**The server exists. It is off, and what shipped is not what was designed.** Checked 2026-08-06:
+
+| `docs/TEST-SERVER.md` specifies | `deploy/fly/fly.toml` does |
+|---|---|
+| app `familiar-test` | app `familiar-demo` |
+| always-on `performance-2x`, 4 CPU / 8 GB, ~$55/month | `shared` CPU × 1, 1 GB |
+| `auto_stop_machines = "off"`, `min_machines_running = 1` | `auto_stop_machines = 'stop'`, `min_machines_running = 0` |
+| `fly.toml` at the repo root, built from `docker/Dockerfile` | `deploy/fly/fly.toml`, its own `deploy/fly/Dockerfile` |
+| `fly/seed-music.sh` | does not exist |
+| `.github/workflows/deploy-fly.yml` | shipped as `fly-deploy-demo.yml` |
+
+And that workflow is `workflow_dispatch` only. Its `push:` block is commented out, above the line:
+
+```
+# Auto-deploy on push disabled while demo is offline.
+```
+
+So the server the submission depends on is scaled to zero, deploys only when someone remembers, and
+— were it on — would cold-start under a reviewer against a health check with a 30-second grace
+period.
+
+**The document is not wrong so much as unreconciled**, and that is the failure worth recording: a
+design document and an implementation that diverged in every particular, with nothing comparing
+them, is how this became invisible for months. Anyone reading `TEST-SERVER.md` today would conclude
+there is an always-on 8 GB machine called `familiar-test`.
+
+**The parts that do work are the expensive ones.** `demo-library/` holds **32 CC-licensed tracks**
+— Kevin MacLeod, Jahzzar, Hussalonia and Nicolas Falcon, CC-BY / CC-BY-SA / public domain, sourced
+from the Internet Archive, with a generated `ATTRIBUTIONS.md`. Three scripts support it:
+`scripts/fetch-demo-library.sh` fetches them, `scripts/analyze-demo-library.sh` (274 lines) runs a
+full analysis pass against a throwaway local Docker stack, and `scripts/seed-demo-library.sh`
+`pg_dump`s the result into Neon. `deploy/fly/entrypoint.sh` already ensures `pgvector` and runs
+`alembic upgrade head` on boot. There is **no `DEMO_MODE` code path anywhere** in the backend or
+the frontend, and there should not be — "demo" here is seeded data plus a separate deployment, not
+a branch in the product.
+
+**One env var deserves a second look.** `fly.toml` sets `DISABLE_CLAP_EMBEDDINGS = 'true'`, which
+is what makes a 1 GB machine plausible — the CLAP model is ~1.5 GB. Reading
+`backend/app/services/background/analysis.py`, that flag gates **computing** embeddings during
+analysis, not using them. A database seeded from `analyze-demo-library.sh` already contains the
+vectors, so similarity search and the Music Map work on the demo without the model ever being
+loaded. That is a considerably better position than it looks from the flag name, and it should be
+written down before someone "fixes" it by turning the flag off and running out of memory.
+
+## Decision
+
+1. **The demo server runs continuously.** `min_machines_running = 1` and `auto_stop_machines` off.
+   A reviewer who hits a cold machine sees timeouts, and one rejection costs more in calendar time
+   than the machine costs in a year.
+
+2. **The size stays modest and the reason is recorded.** The 32-track library needs no analysis
+   capacity, `DISABLE_CLAP_EMBEDDINGS` stays `true`, and the embeddings arrive pre-computed in the
+   seed. `TEST-SERVER.md`'s `performance-2x` was sized for a machine that would analyse; this one
+   never analyses. The monthly figure goes in the document, not in this ADR, because it is the
+   thing most likely to change.
+
+3. **`docs/TEST-SERVER.md` is corrected to as-built** — the app name, the machine, the file
+   locations, the workflow name, and the seeding path that actually exists. A design document kept
+   as intent after the implementation diverged is worse than no document, because it is read as
+   fact.
+
+4. **Auto-deploy from `main` returns.** The commented-out `push:` trigger is restored, scoped to
+   `backend/**`, `deploy/fly/**` and the workflow itself. A demo that drifts from `main` is a demo
+   that disproves the submitted build.
+
+5. **The demo library is seeded from a dump and reset on a schedule.** Reviewers and anyone with
+   the link share one profile, so play counts, favourites and playlists accumulate from strangers.
+   The Neon dump produced by `seed-demo-library.sh` is the source of truth and the volume is
+   disposable; a scheduled reset restores it. (Whatever runs that reset must connect to Neon's
+   **direct** host — the pooler ignores `ALTER ROLE SET search_path`, and a restore against the
+   pooler will not find the schema.)
+
+6. **The review account is recorded where the submission is prepared, not rediscovered.** The
+   server URL and the profile a reviewer types belong beside the App Store Connect metadata, in
+   the repository, with the demo credentials. Every submission otherwise begins by working out what
+   they were.
+
+7. **This is a review and demonstration server. It is not hosted Familiar.** No user accounts, no
+   uploads, no expectation of durability, and no growth into a service. Familiar is self-hosted
+   software; the moment this becomes something people rely on, it is a different product with a
+   different set of decisions.
+
+8. **The Fly footprint is accounted for as a whole.** `familiar-demo` is not the only Fly
+   application in this project — `familiar-sessions.fly.dev` is the signalling relay that
+   [ADR-0036](ADR-0036-listening-sessions-signal-through-familiars-own-server.md) retires. Once
+   nothing points at it, it is shut down rather than left running and forgotten, which is how it
+   came to be load-bearing without appearing in any decision.
+
+## Alternatives Considered
+
+**Keep scale-to-zero and accept the cold start.** Cheapest, and Fly's cold starts are usually a few
+seconds. Rejected because "usually" is doing too much work: the health check has a 30-second grace
+period, the container runs `alembic upgrade head` on boot, and the first request also has to warm
+Postgres. A reviewer with a stopwatch and a rejection form is the wrong audience for a machine that
+is *usually* quick.
+
+**Run the demo on the NAS behind Tailscale, as everything else is tested.** No new hosting, no new
+cost, and the library is real rather than 32 tracks. Rejected because Apple cannot reach it —
+Tailscale is the whole point of that setup — and because the NAS is also this project's CI runner,
+where heavy jobs already contend with streaming music. Adding an audience that can reject the app
+to that machine is not a trade worth making.
+
+**Ship a fixture or offline mode in the app so review needs no server at all.** Genuinely
+attractive: no hosting, no cost, no cold start, and it would work for a reviewer with no network.
+Rejected because it is a second code path through the client, built for an audience of one, and it
+would exercise none of the thing under review — the app's entire behaviour is what it does against
+a server. It would also be the first `DEMO_MODE` branch in a codebase that has deliberately never
+had one.
+
+**Bring the machine up by hand around each submission.** It is what happens now, and it is not
+absurd — submissions are infrequent. Rejected because it is precisely the arrangement that produced
+the current state: a manual step that was skipped once, a `push:` trigger commented out to match,
+and a server that has been off long enough for the comment explaining why to become the
+documentation.
+
+**Use a hosted demo from a template — a Fly Postgres plus the published `ghcr.io` image, no
+repository config.** Fewer files to keep in step. Rejected because the deploy would then exist only
+in someone's shell history, which is a worse version of the divergence this ADR is written to fix.
+
+## Consequences
+
+- **Positive:** An App Store submission has a server to point a reviewer at, which unblocks every
+  other Apple-facing decision currently proposed.
+- **Positive:** A working public demo also exists — the thing the site has never been able to link
+  to.
+- **Positive:** A design document and its implementation are reconciled, and the reason they
+  diverged is on record.
+- **Positive:** The Fly footprint becomes two applications counted rather than one counted and one
+  forgotten.
+- **Tradeoff:** A recurring monthly cost, forever, for a machine that is idle almost all the time.
+  That is the honest shape of point 1.
+- **Tradeoff:** A publicly reachable Familiar instance with one shared profile is a small attack
+  surface and a certain source of odd data. Point 5's reset bounds the damage; it does not remove
+  it.
+- **Tradeoff:** `DISABLE_CLAP_EMBEDDINGS` means the demo can never analyse anything new. A reviewer
+  or a visitor who adds music — if that is even reachable — gets a track with no features and no
+  embedding, which looks like a bug.
+- **Follow-up:** CI/E2E against a real environment was the second reason `TEST-SERVER.md` gave for
+  building this, and it has never happened. A demo that is always on makes it possible; whether
+  tests should run against the same instance a reviewer might be using is its own question.
+- **Follow-up:** The reset schedule in point 5 needs a mechanism. Fly has no cron; a scheduled
+  GitHub Action against the direct Neon host is the obvious candidate and is not built.
+- **Follow-up:** `deploy/fly/Dockerfile` and `docker/Dockerfile` are now two build definitions for
+  one application. Whether the demo should build from the same image the release publishes is worth
+  deciding rather than inheriting.

--- a/docs/decisions/ADR-0039-the-website-is-rebuilt-in-place.md
+++ b/docs/decisions/ADR-0039-the-website-is-rebuilt-in-place.md
@@ -1,0 +1,148 @@
+# ADR-0039: The Website Is Rebuilt in Place
+
+Status: proposed
+
+Date: 2026-08-06
+
+## Context
+
+`https://familiar.seethroughlab.com/` is live and serves `site/index.html` — **364 lines** of
+hand-written HTML, beside `privacy.html`, an `assets/` directory (`site.css` at 15 kB, `icon.svg`,
+`app-store-badge.svg`, a 485 kB `og-image.png`) and a gitignored `screenshots` symlink to the repo
+root. Thirteen commits in the last six months, the most recent 2026-07-26. It is maintained, not
+abandoned.
+
+Its current shape is ten stacked sections: hero, intro, "Who Familiar is for", "How Familiar
+compares", Features, "Ask Familiar…", Install, "Listen from anywhere", FAQ, Screenshots, and beta
+feedback. It reads as a very good README that has been given a stylesheet — which is what it is,
+since `README.md` embeds the same fifteen screenshots from the same directory.
+
+**There is a documentation conflict to record before touching anything.** `site/README.md` says:
+
+> Published via GitHub Pages on push to `main` … The Pages workflow copies `site/` plus the
+> repo-root `screenshots/` directory into `_site/`, writes the CNAME, and deploys. DNS:
+> `familiar.seethroughlab.com` CNAME → `seethroughlab.github.io`.
+
+None of that is true. `.github/workflows/pages.yml` assembles `_site/` and deploys through
+`cloudflare/pages-action@v1` to a Cloudflare Pages project named `familiar-site`, using
+`CF_API_TOKEN` and `CF_ACCOUNT_ID`. No CNAME file is written anywhere in the repository. The
+workflow is still called `pages.yml` and its job is still called Pages, which is presumably how the
+README survived the migration.
+
+**The reference point for the rebuild is `git-fork.com`**, and it is worth naming what is being
+borrowed. Fork's landing page is: a thin nav (Home / Release Notes / Blog / About), a hero whose
+entire content is two download buttons with system requirements and price, a screenshot carousel
+per platform, four feature callouts each pairing a sentence with an image, two feature matrices, a
+short section introducing the two people who make it, a repeated download call to action, and a
+footer. Generous whitespace, plain typography, and screenshots doing the persuading rather than
+abstract graphics.
+
+Two things transfer and one does not. What transfers is the **information architecture** — the
+install path is above the fold and repeated at the bottom, and the product is shown rather than
+described. What does not transfer is the visual register: Fork is deliberately neutral, and
+Familiar is a self-hosted music player with a name that invites illustration. Black cats, crows,
+witchy but playful is a real differentiator against a category of self-hosted software that all
+looks like a dashboard.
+
+**What the current page gets wrong by that measure** is that "Install" is the seventh section. A
+self-hosted product's landing page is an install page with an argument attached; this one is an
+argument with an install section some distance down it.
+
+## Decision
+
+1. **The site stays static, in `site/`, deployed to Cloudflare Pages.** No generator, no build
+   step, no new dependency, no `packages/` workspace. Two HTML files and a stylesheet do not
+   justify a toolchain, and the deployment path already works.
+
+2. **The structure is rebuilt around the install path**, taking Fork's architecture: nav, hero with
+   the install command and the app links immediately visible, screenshots close behind, feature
+   callouts, a comparison table, FAQ, and a repeated install call to action before the footer. The
+   existing sections are reordered and rewritten rather than replaced wholesale — the content is
+   good, its ordering is not.
+
+3. **Familiar's hero is a `docker run` and two app links, not a price.** Fork's hero sells a
+   purchase; this one sells a five-minute install of MIT-licensed software plus the Apple clients.
+   Requirements — Docker, 2 GB RAM, x86_64 or ARM64 — belong there, as Fork puts its OS
+   requirements there.
+
+4. **An illustration set is commissioned or drawn once, named, and used consistently.** Black cats,
+   crows, and witchy-but-playful marks. SVG, inline where small, and theme-aware so the site can
+   have a dark mode without a second set of files. This is called out as a decision because an
+   illustration style adopted for a hero and then abandoned for every other section is worse than
+   having none — the inconsistency reads as unfinished in a way plain typography never does.
+
+5. **Screenshots stay generated.** `packages/web/e2e/screenshots.spec.ts` writes `screenshots/`,
+   `README.md` embeds them and `pages.yml` copies them into `_site/`. The site does not acquire its
+   own copies to drift, and a screenshot that goes stale is fixed by re-running the spec.
+
+6. **Release notes, a blog and rendered docs are out of scope, and that is what would reverse point
+   1.** Fork has all three and they are why Fork would need a generator. Familiar has
+   `CHANGELOG.md` and a `docs/` directory of unbuilt Markdown; the moment either wants to be a
+   section of the site with an index and permalinks, this decision should be made again rather than
+   worked around with hand-written pages.
+
+7. **`site/README.md` is corrected to describe Cloudflare Pages**, including the project name and
+   the two secrets, and the DNS claim is removed or replaced with what is actually configured.
+
+8. **The Apple clients get a place on the page.** `app-store-badge.svg` has been sitting in
+   `assets/` since April in anticipation. Once
+   [ADR-0038](ADR-0038-the-demo-server-is-always-on.md) provides a public instance, the demo gets a
+   link too — the first time the site has been able to show the product rather than picture it.
+
+## Alternatives Considered
+
+**Adopt Astro or 11ty.** It is the obvious modern answer, it would let `docs/` and `CHANGELOG.md`
+become real pages with an index, and both are cheap to run. Rejected *for now* and only for now:
+the site is one landing page and a privacy page, and a build step for two documents is a
+maintenance cost paid every time a dependency needs updating, on a repository that already carries
+a pnpm workspace, a Python backend and a Swift package. Point 6 names the trigger that would change
+this, which is release notes — not aesthetics.
+
+**Redesign the visuals and leave the structure alone.** Cheapest real option, and it addresses the
+part that is most obviously dated. Rejected because the structure is the weaker half: burying
+Install seven sections down is the substantive problem, and a prettier version of the same ordering
+fixes nothing that matters. The Fork reference was offered for its architecture as much as its
+look.
+
+**Move the site into `packages/` as a workspace and build it with Vite like the app.** One
+toolchain across the repository, and shared design tokens with the product. Rejected because it
+shares nothing real with the app — no components, no state, no routing — and would inherit a pnpm
+install and a build for two static files. It would also couple the site's deployment to the app's
+dependency tree, so a Vite upgrade could break the marketing page.
+
+**Serve the site from the Familiar server itself, alongside the app.** No Cloudflare, no second
+deployment, and `backend/app/main.py` already serves static files with an SPA fallback. Rejected
+because the marketing site must be up when nobody's server is — it is what someone reads *before*
+they have one — and because it would put a public-facing page inside the application that
+[ADR-0038](ADR-0038-the-demo-server-is-always-on.md) point 7 is careful to keep from becoming a
+service.
+
+**Use an off-the-shelf template.** Fast, competent, and free. Rejected because the illustration set
+in point 4 is the entire point of the exercise, and a template's value is that it looks like every
+other site built from it — which is the position the self-hosted-software category is already in.
+
+## Consequences
+
+- **Positive:** The install path — the one thing a visitor needs — moves to the top and is repeated
+  at the bottom, which is the change most likely to matter.
+- **Positive:** No new dependency, no new CI step, and the deployment that works keeps working.
+- **Positive:** A documentation conflict that has been misdescribing the deployment since the
+  Cloudflare migration gets fixed, before someone follows it to a GitHub Pages setting that does
+  nothing.
+- **Positive:** The Apple clients and, once ADR-0038 lands, a live demo get somewhere to be
+  announced.
+- **Tradeoff:** Hand-written HTML means every section is duplicated markup, and a nav change is a
+  change in two files. That is the accepted cost of point 1 and it grows with every page added —
+  which is exactly why point 6 names the reversal condition.
+- **Tradeoff:** An illustration set is real work with no functional payoff, and it is the part most
+  likely to be left half-done. Point 4 is written to make that visible rather than to prevent it.
+- **Tradeoff:** The site continues to depend on `screenshots/` being regenerated by hand after
+  significant UI changes. Nothing checks that they are current, and several predate the Apple
+  clients entirely.
+- **Follow-up:** There are no screenshots of the native Mac or iOS apps at all — `screenshots/`
+  contains the web app and its mobile layout. The Apple clients cannot be shown until something
+  captures them, and `screenshots.spec.ts` is a Playwright spec that cannot.
+- **Follow-up:** `og-image.png` is 485 kB, which is most of the page weight. Worth regenerating
+  with the new illustration set rather than carrying forward.
+- **Follow-up:** The workflow is named `pages.yml` and its job "Deploy Pages" while deploying to
+  Cloudflare. Renaming it would prevent the next version of the conflict this ADR is fixing.


### PR DESCRIPTION
Eight decisions covering six features that exist in the PWA and in no form in `familiar-apple`, plus the two pieces of infrastructure an App Store submission depends on. All `Status: proposed`; each is executable on its own, and the test applied while writing them was whether any one could be approved while the other seven are still proposed.

| ADR | Decides |
|---|---|
| 0032 | Home is **native**, becomes the landing root, and its rows *play* rather than link |
| 0033 | The visualizer is embedded, and the bridge gains a **direction** — not a third message |
| 0034 | Visualizers are drop-in ESM bundles, loaded only inside the web view |
| 0035 | A weighted preset selects the queue; `isShuffled` permutes it — never both |
| 0036 | Listening sessions signal through our own server; the Fly relay retires |
| 0037 | The Apple clients host and join, on the first non-Apple binary dependency |
| 0038 | The demo server runs continuously, because review needs it to |
| 0039 | The site is rebuilt in place, static, around the install path |

**Execution order is deliberately not the numbering:** `0038` → `0035` → `0032` → `0033` → `0034` → `0039` → `0036` → `0037`. Submission blockers first, then server-side work every client inherits, then client work, and the newest dependency last.

## Four findings that shaped the arguments

- **The native FFT already runs and is discarded.** `FamiliarPlayer.swift:1388` is an empty delegate body whose comment cites ADR-0001 point 5; the tap is installed on every `play()` and throttled to 60 Hz. ADR-0033 is a publishing decision, not a signal-processing one.
- **Listening sessions route through infrastructure we do not run.** `docker/Dockerfile:32` bakes `https://familiar-sessions.fly.dev` into every released build. Dev builds fall back to same-origin `/api/v1/sessions/ws`, deleted in `ceeb926` on 2026-03-06 — so the feature has been broken in `pnpm dev` for five months, silently.
- **The plugin system and listening sessions were shelved the same afternoon**, `dbdef05` and `ceeb926`, for scope rather than for defects. "Drop a three.js project in" is that system returning, and ADR-0034 says so rather than inviting someone to re-derive the shelving.
- **Two documents describe things that are not true.** `docs/TEST-SERVER.md` specifies an always-on `familiar-test` on 8 GB; `deploy/fly/fly.toml` is a scale-to-zero 1 GB `familiar-demo` whose auto-deploy is commented out. `site/README.md` claims GitHub Pages; `pages.yml` deploys to Cloudflare. Correcting both is a numbered decision point, not a quiet edit.

## Two corrections carried into the commit

- **The visualizer has not grown.** An earlier count said ~30% since ADR-0001; it included `car.glb`. It is 3,985 lines across 22 files against ADR-0001's 4,017 across 23 — essentially flat. ADR-0033's case now rests on churn (14 commits in six months, tied with Discover), which is what ADR-0016 point 1 actually tests.
- **There is no existing outputs WebSocket.** `outputs.py:173` is a docstring for a route that does not exist, so `/sessions/ws` would be the backend's only socket. The strawman alternative was replaced with a real one (SSE/polling, rejected on handshake latency).

## What this PR deliberately does not do

The `familiar-apple` README's ADR index is **not** updated. That table indexes what governs the repo, and a proposed ADR governs nothing — ADR-0026–0031 are missing from it too, all shipped. Worth its own pass, along with 0027/0028/0030/0031 still reading `proposed` after their code landed.

Every cited path, line number, line count and six-month commit count was re-verified against both repos on 2026-08-06. All `Extends` links and inline `ADR-NNNN` references resolve.

🤖 Generated with [Claude Code](https://claude.com/claude-code)