### PR TITLE
Accept ADR-0027 to ADR-0031 — their work has shipped

### DIFF
--- a/docs/decisions/ADR-0026-crossfade-is-decided-by-the-player-not-the-engine.md
+++ b/docs/decisions/ADR-0026-crossfade-is-decided-by-the-player-not-the-engine.md
@@ -8,7 +8,18 @@ Extends [ADR-0015](ADR-0015-audio-effects-are-exposed-not-rebuilt.md) and
 [ADR-0025](ADR-0025-the-phone-gets-a-settings-destination.md). Constrained by
 [ADR-0031](ADR-0031-casting-is-the-macs-and-excludes-zones.md) point 6.
 
-## Context
+Implementation:
+- Accepted 2026-08-05, shipped in `familiar-apple` #76 on 2026-08-06. `CrossfadeDecision` is in
+  `FamiliarKit`, asserted case for case against the web's `eventHandlers.test.ts`;
+  `FamiliarPlayer.considerCrossfade` runs on the existing 4 Hz tick; `CrossfadeSettings` is
+  per-device in `UserDefaults` beside the audio effects, on both platforms through the panes
+  ADR-0025 built.
+- ADR-0031 point 6 arrived with it rather than after it: `CrossfadeDecision` takes `isCasting` and
+  returns no fade, so a speaker plays each track to its true end.
+- The engine changes and the defects building the caller made reachable are recorded in the
+  Consequences below, which were written against what the build found rather than what it planned.
+- **The follow-up listen is not complete.** The Consequences specify ten cases on both platforms;
+  the first real listen produced the `handleTrackEnd` finding and the rest have not been walked.
 
 **The native apps do not crossfade, and nothing is broken.** `NativeAudioEngine.executeCrossfade`
 exists at `NativeAudioEngine.swift:1512`, runs 77 lines, ramps two player nodes against each other on

--- a/docs/decisions/ADR-0027-shuffle-and-repeat-are-listener-modes.md
+++ b/docs/decisions/ADR-0027-shuffle-and-repeat-are-listener-modes.md
@@ -1,9 +1,28 @@
 # ADR-0027: Shuffle and Repeat Are Listener Modes
 
-Status: proposed
+Status: accepted
 Date: 2026-08-05
 
 Extends [ADR-0003](ADR-0003-server-owns-the-playback-queue.md)
+
+Implementation:
+- Accepted 2026-08-05 and shipped in `familiar-apple` #70, alongside
+  [ADR-0028](ADR-0028-the-apple-clients-playback-session-is-local.md) — the two were built together
+  because point 7's deferral only holds if the thing it defers to lands in the same change.
+- Point 2's split is in `Sources/FamiliarKit/FamiliarPlayer.swift`. `play(_:startingAt:)` no longer
+  assigns `isShuffled = false`; the doc comment at `:216` now records that shuffle survives it and
+  why it used to not.
+- Point 5's reading of an adopted session is moot in practice: ADR-0028 removed adoption entirely
+  in the same PR. `adoptLogicalOrder` remains and still sets `isShuffled = false` (`:358`), which is
+  what `restoreSession` must *not* call — a local snapshot's play order is not a flattened server
+  order, and restoring through the adoption path would give back a shuffled queue that can never be
+  straightened out again. That distinction is the point-2 split doing its job on the first thing
+  that touched it.
+- Point 7's persistence question is answered by ADR-0028's cold file, which carries `repeatMode` and
+  `consume` with a defaulting decoder so a snapshot written before those fields existed still loads.
+- Point 4's `playShuffled(_:)` keeps its meaning and now leaves the mode on (`:255`).
+- **Follow-ups not done:** the transport-affordance check across all three surfaces, and the
+  annotation on ADR-0003's phase 4 bullet.
 
 ## Context
 

--- a/docs/decisions/ADR-0028-the-apple-clients-playback-session-is-local.md
+++ b/docs/decisions/ADR-0028-the-apple-clients-playback-session-is-local.md
@@ -1,11 +1,32 @@
 # ADR-0028: The Apple Client's Playback Session Is Local
 
-Status: proposed
+Status: accepted
 Date: 2026-08-05
 
 Extends [ADR-0027](ADR-0027-shuffle-and-repeat-are-listener-modes.md) and
 [ADR-0029](ADR-0029-the-server-stores-no-listener-preferences.md).
 Retires ADR-0003 phase 4 for the Apple clients.
+
+Implementation:
+- Accepted 2026-08-05 and shipped in `familiar-apple` #70, with
+  [ADR-0027](ADR-0027-shuffle-and-repeat-are-listener-modes.md).
+- Points 2 and 4 are done by deletion: `QueueAdopter`, `QueueAdoptionText`, `ServerQueueSource`,
+  `QueueSyncStatus`, the `familiar.queueSync.enabled` switch and both settings surfaces are gone
+  from the repository. `PlaybackSessionSnapshot` survives as point 6 specifies, now `Codable` and
+  carrying `repeatMode` and `consume`.
+- Point 7's two files shipped as designed, and the reasons written into it were each load-bearing.
+  The signature is SHA256 rather than `hashValue` — Swift seeds `Hasher` per process, so a stored
+  hash never matches on the next launch and restore would have silently done nothing forever.
+  Beyond what the ADR anticipated, three further failures were only avoided by being looked for:
+  the writer must attach strictly *after* restore, or it saves an empty player over the session
+  before anything reads it; `restoreSession` must not route through `adoptQueue`, for the reason in
+  ADR-0027's record; and the writer is a `@StateObject`, because its only other reference is a weak
+  Combine subscription and a plain `let` on a re-created view struct would deallocate it mid-session
+  with playback carrying on unsaved.
+- Point 8's third layer — launch, quit, relaunch with the network off — was performed.
+- **Both follow-ups stand.** The `queue` tag is still in the generator's filter list with no
+  callers, and `Tests/FamiliarAPITests/QueueSessionTests.swift` still exercises an endpoint this
+  client no longer calls.
 
 ## Context
 

--- a/docs/decisions/ADR-0029-the-server-stores-no-listener-preferences.md
+++ b/docs/decisions/ADR-0029-the-server-stores-no-listener-preferences.md
@@ -1,10 +1,38 @@
 # ADR-0029: The Server Stores No Listener Preferences
 
-Status: proposed
+Status: accepted
 Date: 2026-08-05
 
 Extends [ADR-0013](ADR-0013-the-mac-is-a-management-surface-too.md) and
 [ADR-0015](ADR-0015-audio-effects-are-exposed-not-rebuilt.md)
+
+Implementation:
+- Accepted 2026-08-05. Points 1, 2, 3, 5 and 6 describe the codebase as it already was, so the only
+  executable part was point 4 — which shipped on both clients the same day: `familiar` #99 and
+  `familiar-apple` #71.
+- **The migration needed a seed, and the seed needed a guard.** Both clients read
+  `GET /favorites/auto-download` exactly once per profile to carry the old value across; without it,
+  anyone who had the setting on stops getting downloads after the update and rightly calls it a bug.
+  A failed read is not an answer — nothing is marked seeded and the next load tries again. And the
+  seed must not resurrect a value the listener has since changed, or the toggle appears to undo
+  itself on reload.
+- **Both endpoints survive, marked `deprecated` with the reason in the docstring**
+  (`backend/app/api/routes/favorites.py`). They can go once every client has seeded; note that
+  `familiar-apple` commits `openapi.json` verbatim, so removing them means regenerating the Swift
+  client in the same change. Until then `Profile.settings` is not yet the empty bag the last
+  follow-up describes.
+- The web keys the setting by profile *inside* the store, unlike `familiar-queue-sync`, which was a
+  rollout gate and genuinely per-device-only. Favourites belong to a listener, so two people sharing
+  one browser must not share the answer.
+- Two things fell out of the move that the ADR did not predict. The Mac gained a Downloads tab in
+  Settings: both native apps had *read* `favorites_auto_download` since they shipped and only the
+  phone could write it, so the Mac had been silently obeying a setting with nothing anywhere to
+  change it (the gap ADR-0025 point 5 recorded). And the launch read stopped failing silently — it
+  was wrapped in `catch { return }`, so offline, the one condition where having files on disk
+  matters most, the setting simply did not apply.
+- **All four follow-ups stand**: the five `normalization_*` fields, re-scoping
+  `playlist_discovery_mode` and `community_cache_contribute`, the playlist `auto_download` flags,
+  and what becomes of `Profile.settings`.
 
 ## Context
 

--- a/docs/decisions/ADR-0030-scrobbling-is-the-servers-job.md
+++ b/docs/decisions/ADR-0030-scrobbling-is-the-servers-job.md
@@ -1,9 +1,32 @@
 # ADR-0030: Scrobbling Is the Server's Job
 
-Status: proposed
+Status: accepted
 Date: 2026-08-05
 
 Extends [ADR-0004](ADR-0004-listening-feedback-is-event-sourced.md)
+
+Implementation:
+- Accepted 2026-08-05 and shipped the same day. Server half on `familiar` #103; point 6's client
+  call on `familiar-apple` #74.
+- Point 2's threshold rule is `backend/app/services/scrobble_policy.py` — pure, 40 lines, covered by
+  `backend/tests/test_scrobble_policy.py` including the 60%-then-skipped case that distinguishes
+  this design from the first draft. Point 4's out-of-band guarantee is
+  `backend/app/services/scrobble_dispatch.py`, called from `/played` and `/skipped` in
+  `api/routes/tracks/playback.py`. Point 6's `POST /tracks/{id}/started` is at `playback.py:346`.
+- Point 5 was paid: `useScrobbling.ts` lost its scrobble call, and **six tests went with it rather
+  than being made to pass**. The file records where that coverage moved and why, which is the part
+  worth keeping — a deleted test is otherwise indistinguishable from a forgotten one.
+- Point 8 held exactly: the Apple clients got scrobbling with no scrobbling code at all, and the
+  start signal was one call on a tag they already had. On the client it is keyed on `trackEpoch`
+  rather than the track id — the counter ADR-0031 added — because under `repeat one`, and in a queue
+  holding one track twice in a row, the id never changes though the track genuinely restarts, and an
+  id-keyed task falls silent in exactly those cases. Point 7's "never queued" is honoured by the
+  reporter sending it directly rather than through `ListeningEventQueue`.
+- Point 10's third layer was performed against the real account, in both directions: a `/started`
+  call put a track up as NOW PLAYING, and scrobbles landed. The account's last scrobble before this
+  was 31 July, which is the measure of what the gap cost.
+- **Follow-ups.** `POST /tracks/{id}/started` still has one consumer. The Apple track-start hook
+  the second follow-up asked for is now wired, via `trackEpoch` as predicted.
 
 ## Context
 

--- a/docs/decisions/ADR-0031-casting-is-the-macs-and-excludes-zones.md
+++ b/docs/decisions/ADR-0031-casting-is-the-macs-and-excludes-zones.md
@@ -1,10 +1,37 @@
 # ADR-0031: Casting Is the Mac's, and Excludes Zones
 
-Status: proposed
+Status: accepted
 Date: 2026-08-05
 
 Extends [ADR-0001](ADR-0001-native-apple-clients-supersede-capacitor.md) and
 [ADR-0014](ADR-0014-the-generated-surface-widens-to-management.md)
+
+Implementation:
+- Accepted 2026-08-05 and shipped in `familiar-apple` #73. The OpenAPI lint change the last
+  follow-up asked for landed first, on `familiar` #102.
+- **Points 2, 3 and 4 are expressed as an `operations:` list, not a tag**, in
+  `Sources/FamiliarAPI/openapi-generator-config.yaml`. The generator filters by `operationId` as
+  well as by tag, so the exclusion is exact — and the trap worth naming is that the filter keys are
+  a **union**: adding `outputs` to `tags:` would re-admit all 24 operations including the nine this
+  list exists to exclude. Verified as 141 → 150 generated methods, exactly +9, with zero `Zone`
+  schemas. A typo is a build failure, not a silent omission.
+- The client is `Sources/FamiliarKit/Casting.swift` and `CastCommand.swift`, with
+  `App/Shared/ServerCastOutputsSource.swift` behind `#if os(macOS)` — point 7 enforced by the
+  compiler rather than by convention. The UI is in `NowPlayingBar.swift`. Tests:
+  `CastControllerTests`, `CastReducerTests`, `TrackEpochTests`.
+- **Point 5 needed a signal that did not exist.** The client is the timeline authority, so casting
+  has to know when a track *begins* in order to hand the speaker the next URL, and
+  `onPlaybackEnded` had no counterpart. Notifying on a track-id change is wrong twice over — under
+  `repeat one`, and in a queue holding one track twice in a row, the id does not change though the
+  track restarts. `trackEpoch` is a counter instead, and ADR-0030's now-playing call keys on it too.
+- Point 6 is live: `CrossfadeDecision` takes `isCasting` and returns no fade, so
+  [ADR-0026](ADR-0026-crossfade-is-decided-by-the-player-not-the-engine.md) was built already
+  constrained rather than corrected afterwards.
+- Point 10's third layer — real hardware, including the `device_stream_base_url` failure that
+  reports success over silence — is the one that cannot be automated and is the one to re-run
+  whenever the transport changes.
+- **Follow-ups.** No server-side owner for an output, and `GET /outputs/zones` is still unreachable
+  behind `GET /{output_id}`; a second client now makes the first likelier to be met.
 
 ## Context
 


### PR DESCRIPTION
Five ADRs were still `proposed` with their implementations merged on both sides — the state the convention exists to prevent, where an ADR read months later looks like a live proposal when it is a description of the running app.

| ADR | shipped in |
|---|---|
| `0027`, `0028` | `familiar-apple` #70 |
| `0029` point 4 | `familiar` #99, `familiar-apple` #71 |
| `0030` | `familiar` #103, `familiar-apple` #74 |
| `0031` | `familiar-apple` #73, lint half on `familiar` #102 |

`ADR-0026` was already accepted but had no `Implementation:` block at all despite shipping in `familiar-apple` #76. It gets one, kept short because its Consequences were written against what the build found rather than what it planned.

### Three records worth more than the status change

**`ADR-0029` point 4 is not finished the way the ADR describes it, and the block says so.** `Profile.settings` is not yet the empty bag its last follow-up imagines: both `/favorites/auto-download` endpoints survive, marked `deprecated` with the reason in the docstring, because every client reads the old value exactly once to carry it across. They can go once every client has seeded — and `familiar-apple` commits `openapi.json` verbatim, so removing them means regenerating the Swift client in the same change.

**`ADR-0028` point 7 anticipated one silent failure; the build found three more.** The stored signature is SHA256 rather than `hashValue` because Swift seeds `Hasher` per process, so a stored hash never matches on the next launch and restore would have done nothing, forever. Beyond that: the writer must attach strictly *after* restore or it saves an empty player over the session; `restoreSession` must not route through `adoptQueue`, which sets `isShuffled = false` and would return a shuffled queue that can never be straightened out; and the writer is a `@StateObject` because its only other reference is a weak Combine subscription.

**`ADR-0031`'s exclusion of zones is an `operations:` list, not a tag**, and the trap is named where it lives: the generator's filter keys are a *union*, so adding `outputs` to `tags:` would re-admit all 24 operations including the nine the list exists to exclude. Verified as 141 → 150 generated methods, exactly +9, with zero `Zone` schemas.

Every path, symbol and count cited was checked against both repositories at write time.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_014P9p2fvFnyiywBxGkv4gfW
