### PR TITLE
Make the runner fix reproducible, and stop starving the frontend tests

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -78,6 +78,25 @@ jobs:
     steps:
       - uses: actions/checkout@v4
 
+      # Fails in a second with the remedy, instead of four minutes later inside a Docker
+      # build with an error message that blames a locked keychain. `svc.sh install`
+      # rewrites this key on every runner reinstall, so the fix is one `svc.sh` away from
+      # being silently undone — and the symptom is nowhere near the cause.
+      - name: Check the runner can reach the keychain
+        run: |
+          for plist in "$HOME/Library/LaunchAgents"/actions.runner.seethroughlab.*.plist; do
+            [ -f "$plist" ] || continue
+            value=$(plutil -extract SessionCreate raw "$plist" 2>/dev/null || echo absent)
+            if [ "$value" = "true" ]; then
+              echo "::error::$(basename "$plist" .plist) has SessionCreate=true, so the runner"
+              echo "::error::sits in its own security session and cannot reach the login keychain."
+              echo "::error::Docker Desktop's credential service will fail during the build."
+              echo "::error::Fix on the runner host: ./scripts/fix-macos-runner-session.sh"
+              exit 1
+            fi
+          done
+          echo "Runner session is shared with the login session; the keychain is reachable."
+
       - name: Prepare keychain-free Docker config
         run: |
           rm -rf "$DOCKER_CONFIG"

--- a/packages/frontend/vitest.config.ts
+++ b/packages/frontend/vitest.config.ts
@@ -7,5 +7,20 @@ export default defineConfig({
     // spurious "window is not defined" errors. These are harmless teardown
     // artifacts, not real test failures.
     dangerouslyIgnoreUnhandledErrors: true,
+    // Vitest's default is 5s, and that is too tight for the machines this runs on.
+    //
+    // CI is two self-hosted runners that do other work: a NAS that also streams music
+    // and builds Docker images, and a Mac that is somebody's desktop. On 2026-08-06 a
+    // run took 4m21s where it normally takes 31s — an 8x slowdown — and two tests hit
+    // the 5s ceiling. **Both were synchronous**: a `render` followed by `getByRole`
+    // with no awaiting anywhere, so nothing in them was hanging. The render itself was
+    // starved of CPU.
+    //
+    // 15s keeps roughly 3x headroom over that observed worst case while still failing
+    // a genuinely hung test in a reasonable time. Raising this rather than pinning the
+    // job to one runner is deliberate: either machine can be busy, so placement moves
+    // the flake rather than removing it.
+    testTimeout: 15_000,
+    hookTimeout: 15_000,
   },
 });

--- a/scripts/fix-macos-runner-session.sh
+++ b/scripts/fix-macos-runner-session.sh
@@ -1,0 +1,121 @@
+#!/usr/bin/env bash
+#
+# Make this repo's self-hosted macOS Actions runner able to reach the login keychain.
+#
+# Run after installing or reinstalling the runner: `svc.sh install` writes
+# `SessionCreate = true` into the LaunchAgent every time, and that one key is what
+# breaks `macOS Compose Integration`.
+#
+#   ./scripts/fix-macos-runner-session.sh                 # this repo's runner
+#   ./scripts/fix-macos-runner-session.sh <label> [...]   # named runners
+#
+# ## Why
+#
+# `SessionCreate = true` tells launchd to put the runner in its **own security
+# session**, separate from the GUI login session. `securityd` will not release a
+# keychain item to a session that cannot present a prompt, so Docker Desktop's
+# credential service — which resolves registry auth during a build, and which ignores
+# `DOCKER_CONFIG` entirely — fails with:
+#
+#     error getting credentials - err: exit status 1, out: `keychain cannot be accessed
+#     because the current session does not allow user interaction. The keychain may be
+#     locked; unlock it by running "security -v unlock-keychain ..." and try again`
+#
+# That message misleads twice. The keychain is **not locked** — `security
+# show-keychain-info ~/Library/Keychains/login.keychain-db` reports `no-timeout` — and
+# unlocking it would not help, because the problem is the session rather than the lock.
+# Removing the key is the fix; there is nothing to unlock.
+#
+# See `.github/workflows/ci.yml` (macos-compose-integration) for the full history,
+# including the second, independent bug this one was hiding.
+#
+# **Scoped on purpose.** This machine hosts runners for more than one project, and a
+# script in this repository has no business reconfiguring somebody else's. Defaults to
+# `actions.runner.seethroughlab.*`; pass labels explicitly to go wider.
+#
+# Idempotent: safe to run repeatedly, and does nothing if the key is already absent.
+
+set -euo pipefail
+
+AGENTS="$HOME/Library/LaunchAgents"
+DEFAULT_PREFIX="actions.runner.seethroughlab."
+
+shopt -s nullglob
+
+if [ $# -gt 0 ]; then
+    plists=()
+    for label in "$@"; do
+        candidate="$AGENTS/${label%.plist}.plist"
+        if [ -f "$candidate" ]; then
+            plists+=("$candidate")
+        else
+            echo "error   no LaunchAgent at $candidate" >&2
+            exit 1
+        fi
+    done
+else
+    plists=("$AGENTS/$DEFAULT_PREFIX"*.plist)
+fi
+
+if [ ${#plists[@]} -eq 0 ]; then
+    echo "No runner LaunchAgents matching '${DEFAULT_PREFIX}*' under $AGENTS."
+    echo "Nothing to do — is the runner installed as a service?"
+    exit 0
+fi
+
+# Reload an agent, waiting for the unload to land before bootstrapping.
+#
+# **`bootout` returns before the job is gone**, so bootstrapping immediately after it
+# races and can fail — leaving the runner unloaded and the machine quietly short one
+# runner. Learned the hard way: the first version of this script did exactly that.
+reload() {
+    local label="$1" plist="$2" domain="gui/$(id -u)"
+
+    launchctl bootout "$domain/$label" 2>/dev/null || true
+    for _ in $(seq 1 50); do
+        launchctl print "$domain/$label" >/dev/null 2>&1 || break
+        sleep 0.2
+    done
+
+    launchctl bootstrap "$domain" "$plist"
+
+    for _ in $(seq 1 50); do
+        if launchctl print "$domain/$label" 2>/dev/null | grep -q "state = running"; then
+            echo "        $label is running in $domain"
+            return 0
+        fi
+        sleep 0.2
+    done
+
+    echo "error   $label did not come back up. Restore with:" >&2
+    echo "          launchctl bootstrap $domain $plist" >&2
+    return 1
+}
+
+changed=0
+
+for plist in "${plists[@]}"; do
+    label=$(basename "$plist" .plist)
+
+    if ! plutil -extract SessionCreate raw "$plist" >/dev/null 2>&1; then
+        echo "ok      $label — no SessionCreate key"
+        continue
+    fi
+
+    value=$(plutil -extract SessionCreate raw "$plist")
+    if [ "$value" != "true" ]; then
+        echo "ok      $label — SessionCreate is $value"
+        continue
+    fi
+
+    echo "fixing  $label — removing SessionCreate"
+    cp "$plist" "$plist.bak.$(date +%Y%m%d%H%M%S)"
+    plutil -remove SessionCreate "$plist"
+    reload "$label" "$plist"
+    changed=1
+done
+
+if [ "$changed" -eq 0 ]; then
+    echo
+    echo "Nothing needed changing."
+fi


### PR DESCRIPTION
The two follow-ups from #108. Both are about a failure that points somewhere other than its cause.

### 1. The runner fix lived only on one Mac

Removing `SessionCreate` from the LaunchAgent is what lets the runner reach the login keychain — and **`svc.sh install` writes that key back on every reinstall.** So the repair was one reinstall away from being silently undone, with a symptom (a Docker credential error four minutes into a build, blaming a keychain that isn't locked) nowhere near the cause.

- `scripts/fix-macos-runner-session.sh` makes it reproducible and idempotent.
- A preflight step in the job now fails in about a second with a pointer to it, instead of four minutes later inside the build.

**Two things the script got wrong on its first run**, both fixed, both named in the comments because they are why it is shaped this way:

- It globbed every `actions.runner.*.plist` on the machine and reconfigured **another project's runner**. A script in this repo has no business doing that. It now defaults to `actions.runner.seethroughlab.*` and takes labels explicitly to go wider.
- Its reload **raced**. `launchctl bootout` returns before the job is gone, so the immediately-following `bootstrap` failed and left that runner unloaded. It now waits for the unload, verifies the agent comes back, and fails loudly with the recovery command if it doesn't.

Both runners on the host were verified running afterwards.

### 2. Vitest's 5s default is too tight for these machines

CI is a NAS that also streams music and builds images, plus a Mac that is somebody's desktop. On 2026-08-06 a run took **4m21s where it normally takes 31s** and two tests hit the ceiling.

Both were **synchronous** — a `render` followed by `getByRole`, no awaiting anywhere — so nothing was hanging; the render was starved of CPU. There is no smarter fix inside the tests.

`testTimeout`/`hookTimeout` go to 15s: ~3x headroom over the observed worst case, still prompt on a genuinely hung test.

Raised rather than pinning the job to one runner, deliberately: **either machine can be busy**, so placement moves the flake rather than removing it. Worth knowing regardless — bare `runs-on: self-hosted` lands on *either* machine, and `Frontend Test` regularly runs on the Mac.

### Verification

`pnpm test` in `packages/frontend`: 66 files, 981 tests, all passing. The script runs clean and idempotent against the already-fixed host. The preflight's real test is this PR's own `macOS Compose Integration` run.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_014P9p2fvFnyiywBxGkv4gfW
