### PR TITLE
ADR-0033 is revised against what the analysis path actually does

### DIFF
--- a/docs/decisions/ADR-0033-the-embed-bridge-gains-a-return-channel.md
+++ b/docs/decisions/ADR-0033-the-embed-bridge-gains-a-return-channel.md
@@ -81,6 +81,34 @@ first callback at or past 16.67 ms is the third, so frames emit every ~17.4 ms �
 48 kHz device gives a different number again. `NativeAudioAnalysisMetrics.cadenceHz` already carries
 the measured rate in every frame, which is the right thing for the page to trust.
 
+**The purpose is a plugin ecosystem, and the plugin surface is already built and empty.** Recorded
+2026-08-07, because it is the rationale for this ADR and it was missing: the visualizer is the one
+place in Familiar where someone outside this repository can add something, and the scaffolding for
+that shipped long ago. `docs/VISUALIZER_API.md` is **575 lines** with Registration, Guidelines,
+Performance Tips and Contributing sections; `visualizers/_template/` holds an `ExampleVisualizer.tsx`
+and its own README; `VisualizerMeta` carries an `author` field commented *"for community
+visualizers"*. And `visualizers/community/` has contained nothing but `.gitkeep` since it was created
+on 2026-04-20.
+
+**A correction, per rule 4.** This ADR's Alternatives section claimed a native rebuild would strand
+*"the three plugin repositories that target the web API"*. There are none — not in this
+organisation, not referenced anywhere in the docs. `community/` is empty and the four visualizers in
+the picker are all first-party. The sentence is fixed below; the ambition it described is real and
+unrealised, which is a different and more useful thing to record.
+
+**Which reframes what embedding buys.** A visualizer author writes Three.js against
+`getAudioData()`. Today that runs in a browser tab — and the browser tab is not where this product
+is used any more: ADR-0001 moved listening to the native clients and ADR-0013 left the web app as a
+management surface. So the reward for writing one is that it runs in the place nobody listens.
+Embedding is what makes a third-party visualizer appear on the Mac and the phone **without its
+author writing a line of Swift**, which is the only version of this that a person outside the repo
+would spend an evening on. Points 4 and 5 are what deliver that: the contract they preserve is not
+an internal convenience, it is the thing being offered to other people.
+
+The two occurrences of the phrase *"from Web Audio API"* — `VISUALIZER_API.md:156` and
+`types.ts:27` — are the only promise in that contract a push source falsifies. Neither states a bin
+count and neither names `AnalyserNode`, so the fix is two sentences, not a versioned API change.
+
 Exposing an FFT here is mostly a publishing problem. Two signal-processing problems come with it,
 below.
 
@@ -269,7 +297,8 @@ hold; not yet diagnosed"* — and CI never reported it because the iOS job ends
 already in the right process. Rejected on maintenance, for the reason ADR-0016 rejected a native
 Discover: 3,985 lines across 22 files with 14 commits in six months is the most active surface in
 the product, and a second implementation would have to change with it every time. It would also
-strand the four existing visualizers and the three plugin repositories that target the web API.
+strand the four existing visualizers and the plugin API they are written against — see the
+Context note on what that API is worth, and on the claim this sentence used to make.
 
 **Have the page pull each frame with `WKScriptMessageHandlerWithReply`.** Genuinely attractive: the
 page's `requestAnimationFrame` becomes the clock, so backpressure is automatic and a hidden page
@@ -298,16 +327,28 @@ would need point 7 and not points 3–6, which is most of the work avoided. Reje
 that need no FFT are the two least worth embedding a web view for, and the channel gets built the
 first time anyone wants `reactive-terrain` — which at 1,311 lines is the default and the largest.
 
-**Leave the visualizer web-only, as ADR-0001 point 5 said.** Still defensible: it is the one
-feature in the product with no functional purpose, and the web app is a browser tab away. Rejected
-because the phone and the Mac are now where the listening happens, the DSP is already running and
-being discarded on every track, and "possibly permanently" was written as a scope boundary for v1
-rather than as a finding.
+**Leave the visualizer web-only, as ADR-0001 point 5 said.** The case for it, which this ADR
+previously made in its own voice: the visualizer plays nothing, finds nothing and manages nothing,
+and the web app is a browser tab away. **That framing is wrong and is corrected here rather than
+left standing** — it measures the visualizer as a playback feature, and it is not one. It is the
+product's only extension point, the one thing a stranger can contribute without touching the
+backend, the LLM or the audio engine; and it is the part that makes the app enjoyable rather than
+merely useful, which is not nothing in a music player. Rejected because leaving it web-only leaves
+that extension point pointed at the surface ADR-0013 reduced to management, so the plugin API stays
+what it is today — 575 lines of documentation, a template, and an empty `community/` directory.
+Also because the phone and the Mac are now where the listening happens, the DSP is already running
+and being discarded on every track, and "possibly permanently" was written as a scope boundary for
+v1 rather than as a finding.
 
 ## Consequences
 
 - **Positive:** The four existing visualizers work on both Apple clients with no changes to any of
   them, because points 4 and 5 keep `getAudioData()` and its shape intact.
+- **Positive, and the reason to do this at all:** the plugin API stops pointing at a surface
+  nobody listens on. A Three.js visualizer written against `getAudioData()` would run on the Mac and
+  the phone with no Swift and no change by its author, which is the first time contributing one has
+  been worth an evening. Whether anyone takes it up is not something this ADR can promise — but
+  today the offer is one the product cannot keep, and after this it is one it can.
 - **Positive:** An FFT that currently runs ~57 times a second and is discarded starts being used.
 - **Positive:** The band maths and the onset detector stop existing in two places that disagree.
   Point 5 makes `analysisMetrics.ts` the single implementation for every client.

--- a/docs/decisions/ADR-0033-the-embed-bridge-gains-a-return-channel.md
+++ b/docs/decisions/ADR-0033-the-embed-bridge-gains-a-return-channel.md
@@ -10,6 +10,27 @@ Extends [ADR-0016](ADR-0016-embedded-web-surfaces-on-the-mac.md),
 Amends [ADR-0001](ADR-0001-native-apple-clients-supersede-capacitor.md) point 5 and
 [ADR-0013](ADR-0013-the-mac-is-a-management-surface-too.md) point 4.
 
+Implementation:
+- **Nothing of the channel itself is built.** This ADR remains `proposed`: whether the visualizer is
+  worth an embedded surface is undecided, and points 1–5 and 7–11 describe work not started.
+- **Points 6 and 12 shipped early, on 2026-08-08, in `familiar-apple` #84**, driven by a different
+  and much smaller feature: a 24-bar spectrum meter above the Mac's scrubber, drawn natively from
+  these frames. It needed the same two fixes for the same reasons, so they landed there rather than
+  waiting on a decision about the web visualizer.
+- That is why the numbers in `## Context` changed. A consumer is the only thing that makes an
+  analysis path measurable, and this ADR had been reasoning from arithmetic — **the 57.4 Hz cadence
+  it previously stated as verified was wrong by a factor of six.** Points 6 and 12 were both
+  right in direction and wrong in detail until something drew the frames.
+- The meter needs no ADR of its own, on the precedent
+  [ADR-0013](ADR-0013-the-mac-is-a-management-surface-too.md) set when it separated the Music Map
+  from ADR-0001 point 5: *"'4,017 lines of three.js' is the visualizer, a different feature."* The
+  3,985-line Three.js surface stays out of scope and remains this ADR's subject.
+- **Four changes now sit inside the fence ADR-0015 point 2 put around
+  `NativeAudioEngine`'s processing** — smoothing, `fftSize`, accumulation order, and the `cadenceHz`
+  the last of those broke. Each is recorded where it was made and none can alter what anyone hears,
+  the processor being a read-only tap. Accepting this ADR is what makes them a decision rather than
+  a run of exceptions; that acceptance has not happened.
+
 ## Context
 
 [ADR-0001](ADR-0001-native-apple-clients-supersede-capacitor.md) point 5 put the visualizer
@@ -63,23 +84,46 @@ nonisolated func audioEngineDidUpdateAnalysis(
 ) {}
 ```
 
-An empty body. The tap is installed on every `play()`, the FFT runs at 60 Hz, the frame hops to the
-main actor, and it is thrown away — because of the ADR point this one amends.
+An empty body. The tap was installed on every `play()`, the FFT ran, the frame hopped to the main
+actor, and it was thrown away — because of the ADR point this one amends. **That body is no longer
+empty**: the Mac's transport gained a spectrum meter on 2026-08-08 (`familiar-apple` #84), which is
+what turned several of the numbers below from estimates into measurements. See `Implementation`.
 
 **The main-thread cost of this channel is therefore already being paid, into nothing.** Verified
 2026-08-07, after [ADR-0041](ADR-0041-the-playhead-is-published-separately.md) made this the
 question worth asking: `NativeAudioEngine.swift:2199` performs a `DispatchQueue.main.async` for
-every emitted frame — roughly **57 times a second throughout playback** — carrying two `[UInt8]`
-arrays and a thirteen-field struct to that empty function. This ADR does not add a 60 Hz main-thread
-burden. It gives one that already exists a purpose, which is a materially better position than "a
-visualizer would cost 60 hops a second" and is worth stating plainly, because ADR-0041's measurement
-otherwise reads as an argument against this ADR.
+every emitted frame — **ten times a second throughout playback** — carrying two `[UInt8]` arrays and
+a thirteen-field struct to that empty function. This ADR does not add a 60 Hz main-thread burden. It
+gives one that already exists a purpose, which is a materially better position than "a visualizer
+would cost 60 hops a second" and is worth stating plainly, because ADR-0041's measurement otherwise
+reads as an argument against this ADR.
 
-**~57 Hz, not 60, and it is the hardware's number rather than ours.** `analysisMinInterval` is
-`1.0/60.0`, but the guard is evaluated on tap callbacks, which arrive at 44100/256 ≈ 172 Hz. The
-first callback at or past 16.67 ms is the third, so frames emit every ~17.4 ms ≈ 57.4 Hz — and a
-48 kHz device gives a different number again. `NativeAudioAnalysisMetrics.cadenceHz` already carries
-the measured rate in every frame, which is the right thing for the page to trust.
+**10 Hz, and it is the platform's number rather than ours.**
+
+**Corrected 2026-08-08, and this replaces a figure this ADR previously asserted as verified.** An
+earlier revision of this section said "~57.4 Hz", derived by assuming tap callbacks arrive at
+44100/256 ≈ 172 Hz and counting how many the `1.0/60.0` throttle would let through. That arithmetic
+was sound and its premise was invented — nothing had ever measured the callback rate, because until
+#84 nothing consumed the frames.
+
+Measured two ways once something did. A probe on the delegate, on the running Mac app during real
+playback:
+
+    frames/s(observed)=10.0  cadenceHz mean=10.0 min=9.4 max=10.8  bins=512
+
+and then a standalone `AVAudioEngine` playing silence, to find out why:
+
+    requested  256 / 512 / 1024 / 2048 / 4096  ->  actual 4410  (10.0 Hz)
+    mainMixerNode 4410 (10.0 Hz),  playerNode 4410 (10.0 Hz)
+
+4410 frames is **exactly 0.1 seconds**. macOS clamps `installTap` to a 100 ms buffer for every
+requested `bufferSize` and on every tappable node, so `analysisMinInterval` never binds and the
+emission rate is the callback rate. **10 Hz is a platform floor**, not a tuning choice, and it is
+the rate any consumer of this channel gets.
+
+`NativeAudioAnalysisMetrics.cadenceHz` carries the measured rate in every frame and is the right
+thing for the page to trust — which is the lesson here restated: the number was available all along
+and the ADR preferred a derivation.
 
 **The purpose is a plugin ecosystem, and the plugin surface is already built and empty.** Recorded
 2026-08-07, because it is the rationale for this ADR and it was missing: the visualizer is the one
@@ -150,13 +194,18 @@ guard now - lastFrameAt >= minInterval else { return nil }
 sampleBuffer.append(contentsOf: UnsafeBufferPointer(start: channelData, count: frameCount))
 ```
 
-So a throttled callback discards its buffer entirely — **roughly two of every three buffers of audio
-are never seen.** Each frame is a 256-sample window with ~740 samples unobserved before it, not a
-window onto a continuous stream. That is harmless for a level meter and is *not* harmless for
-spectral flux, which is defined as the frame-to-frame difference of consecutive spectra: the page's
-detector would be differencing snapshots taken across gaps. This is independent of the smoothing
-problem, undermines point 5 in the same way, and is invisible from the ADR's vantage point because
-the frames currently go nowhere.
+So a throttled callback discarded its buffer entirely. **Corrected 2026-08-08:** this ADR first
+described that as "roughly two of every three buffers", which followed from the invented 172 Hz.
+With callbacks at 10 Hz the throttle never fires at all — and the real loss was worse and in a
+different place. Each 4410-frame buffer was appended whole and then a *single* 1024-sample window
+taken from it, so **under a quarter of the audio was analysed**: the last 23 ms of every 100 ms. A
+transient landing anywhere else was never seen.
+
+That is survivable for a level meter and is *not* survivable for spectral flux, which is defined as
+the frame-to-frame difference of consecutive spectra: the page's detector would be differencing
+snapshots taken across gaps. It is independent of the smoothing problem and undermines point 5 in
+the same way. It was invisible from this ADR's original vantage point precisely because the frames
+went nowhere — which is the argument for landing a consumer early, and is what happened.
 
 **And two native tests have never passed.** `NativeAudioAnalysisProcessorTests.swift:54` and `:75`
 are unconditional skips — *"Band edges disagree with the fixture"* and *"Variance ordering does not
@@ -183,7 +232,12 @@ hold; not yet diagnosed"* — and CI never reported it because the iOS job ends
    frame.** The native side calls `evaluateJavaScript` with the latest frame, fire-and-forget, and
    **never has more than one call in flight** — if a frame is ready while one is outstanding, the
    newer frame replaces it and the older is dropped. A visualizer rendering at 30 fps must not
-   accumulate a queue of 60 Hz frames it will never draw.
+   accumulate a queue of frames it will never draw.
+
+   **Cheaper than it reads, now the rate is known.** At the measured 10 Hz a 30 fps page is *three*
+   redraws per frame, not the other way round, so coalescing will almost never have anything to
+   drop. It stays in the design because a stalled main thread is the case it exists for, not the
+   steady state.
 
    **Nothing to build this on exists today.** There is no buffering anywhere in the analysis path:
    each frame is an independent `DispatchQueue.main.async`, so a busy main queue delays every frame
@@ -209,6 +263,9 @@ hold; not yet diagnosed"* — and CI never reported it because the iOS job ends
 
 6. **The native `fftSize` rises from 256 to 1024 and its smoothing falls from 0.8 to 0.5**, both
    matching `WebAudioEngine`, so the page's detector receives the spectrum it was tuned for.
+   **Both shipped on 2026-08-08 ahead of this ADR** — see `Implementation`; the native meter needed
+   them for the same reasons, and 256 turned out to be worse than "lower resolution": its first bin
+   begins at 172 Hz, above the kick drum, so there was no bass in the data at all.
    Anything less makes point 5 a downgrade dressed as reuse — and the smoothing is the half this
    ADR originally missed. `WebAudioEngine.ts`'s comment gives both numbers for both reasons, and
    0.8 is named there as the value that "starved spectral-flux onset detection". Shipping 1024 bins
@@ -266,12 +323,19 @@ hold; not yet diagnosed"* — and CI never reported it because the iOS job ends
     shared file so both surfaces use it makes those tests fail on the *path* rather than on the
     substance they exist to protect.
 
-12. **The processor accumulates continuously instead of discarding throttled buffers.** Added
-    2026-08-07. The throttle currently returns *before* appending, so ~2 of every 3 buffers are
-    dropped and each frame is a window with ~740 unobserved samples in front of it. Point 5 hands
-    onset detection to the page, and spectral flux is the difference between *consecutive* spectra —
-    so the fix is to keep appending on every callback and throttle only the *emission*, leaving the
-    ring of samples continuous.
+12. **The processor analyses every window of every buffer instead of one window per callback.**
+    Added 2026-08-07, corrected and shipped 2026-08-08.
+
+    As first written this point said the throttle returned before appending and dropped ~2 of every
+    3 buffers. The append order was indeed wrong and is fixed; but with callbacks at 10 Hz the
+    throttle never fires, and the real loss was that a single 1024-sample window was taken from each
+    4410-frame buffer — **under a quarter of the audio**, the last 23 ms of every 100 ms. Point 5
+    hands onset detection to the page, and spectral flux is the difference between *consecutive*
+    spectra, so a detector fed this is differencing across gaps three times wider than the windows.
+
+    The processor now appends on every callback, throttles only the emission, and folds **every**
+    complete window in the buffer, keeping the loudest value per bin so a transient anywhere is
+    carried. Given the 100 ms floor this is the only place the temporal detail can come from.
 
     **This changes code inside `NativeAudioEngine`'s processing**, which
     [ADR-0015](ADR-0015-audio-effects-are-exposed-not-rebuilt.md) point 2 fenced off — *"If exposing
@@ -303,7 +367,7 @@ Context note on what that API is worth, and on the claim this sentence used to m
 **Have the page pull each frame with `WKScriptMessageHandlerWithReply`.** Genuinely attractive: the
 page's `requestAnimationFrame` becomes the clock, so backpressure is automatic and a hidden page
 asks for nothing. Rejected because it inverts a schedule that already exists — the engine throttles
-the tap to 60 Hz and knows when a frame is ready — and it adds an asynchronous round trip per
+the tap and knows when a frame is ready — and it adds an asynchronous round trip per
 rendered frame to fetch data that is already sitting in a buffer. `getAudioData()` is synchronous
 inside `useFrame`; making it await would change the contract every visualizer is written against,
 which is point 4's whole value.
@@ -317,9 +381,9 @@ anyone drawing a treble bar means. Deriving on the page keeps one tuned implemen
 
 **Add a third message to the existing `familiar` handler instead of a second channel.** No new
 plumbing, one contract to keep in step. Rejected because it conflates two things ADR-0020 was
-careful to separate: a listener-initiated intent, of which there may be two, and a 60 Hz render
-feed. It would also make ADR-0020 point 2's cap meaningless — "two messages" would come to include
-one that fires sixty times a second — and the bar in point 3 would then have to be argued about
+careful to separate: a listener-initiated intent, of which there may be two, and a continuous
+render feed. It would also make ADR-0020 point 2's cap meaningless — "two messages" would come to include
+one that fires continuously for as long as a track plays — and the bar in point 3 would then have to be argued about
 every future push as well as every future intent.
 
 **Ship only the `lyrics` and `music-video` visualizers, which need metadata but no spectrum.** It
@@ -349,7 +413,8 @@ v1 rather than as a finding.
   the phone with no Swift and no change by its author, which is the first time contributing one has
   been worth an evening. Whether anyone takes it up is not something this ADR can promise — but
   today the offer is one the product cannot keep, and after this it is one it can.
-- **Positive:** An FFT that currently runs ~57 times a second and is discarded starts being used.
+- **Positive:** An FFT that ran ten times a second and was discarded is already being used, by the
+  native meter #84 added; this puts the same frames to a second purpose rather than starting one.
 - **Positive:** The band maths and the onset detector stop existing in two places that disagree.
   Point 5 makes `analysisMetrics.ts` the single implementation for every client.
 - **Positive:** Raising `fftSize` to 1024 *and* dropping smoothing to 0.5 fixes a mismatch that
@@ -368,11 +433,11 @@ v1 rather than as a finding.
   a signal to stop and reconsider. The reconsideration is recorded there rather than skipped, and it
   is the one place this ADR spends its "no engine changes" credit — worth knowing before anything
   else in it is treated as licence to spend more.
-- **Tradeoff, and smaller than it first read:** ~57 `evaluateJavaScript` calls a second is real
-  main-thread work whenever the visualizer is on screen, on top of the render loop inside the web
-  view. What it is *not* is a new 60 Hz hop: measured 2026-08-07, the app already performs a
-  main-queue dispatch per frame at that rate into an empty delegate, so the added cost is the
-  `evaluateJavaScript` call and the serialisation, not the hop. ADR-0041's finding — a **4 Hz**
+- **Tradeoff, and much smaller than it first read:** **ten** `evaluateJavaScript` calls a second is
+  real main-thread work whenever the visualizer is on screen, on top of the render loop inside the
+  web view. Not sixty, and not the ~57 an earlier revision of this ADR assumed — see the Context
+  note on the 100 ms tap floor. Nor is it a new hop: the app already performs a main-queue dispatch
+  per frame at that rate, so the added cost is the `evaluateJavaScript` call and the serialisation. ADR-0041's finding — a **4 Hz**
   publisher saturating the main thread — reads as an argument against this ADR and on inspection is
   not one: that cost was unbounded SwiftUI invalidation, where this is a bounded call with a fixed
   payload. The yardstick worth holding it against is `MusicMapView`'s 0.83 ms/frame of dictionary
@@ -382,8 +447,9 @@ v1 rather than as a finding.
   `currentTime` and `duration` — all from a player store the embedded document will not have. Point
   7 carries identity and point 8 sends the page to fetch its own lyrics, so the gap is the *clock*:
   `currentTime` advances continuously and the lyrics visualizer is built on it. Whether that rides
-  the analysis channel, which already arrives ~57 times a second, or is derived page-side from a
-  start time is unresolved here and is the first thing implementation will hit.
+  the analysis channel or is derived page-side from a start time is unresolved here and is the first
+  thing implementation will hit. The measured 10 Hz makes the second more likely: a clock that
+  updates ten times a second is visibly steppy, and lyrics timing is exactly where that shows.
 - **Follow-up:** The two skipped tests in `NativeAudioAnalysisProcessorTests` are now routed around
   rather than fixed. They still assert something about a processor this ADR depends on, and
   `testBrightFixtureDominatesTreble` in particular encodes a disagreement about where treble begins

--- a/docs/decisions/ADR-0033-the-embed-bridge-gains-a-return-channel.md
+++ b/docs/decisions/ADR-0033-the-embed-bridge-gains-a-return-channel.md
@@ -49,10 +49,10 @@ scheduling `AVAudioFile` buffers. There is no Web Audio graph in the web view to
 to make one. Either data flows app → page, or there is no embedded visualizer.
 
 **The DSP is already built, already running, and already discarded.** `NativeAudioEngine`
-installs a tap on `mainMixerNode` in `enableAnalysis()` (`NativeAudioEngine.swift:2125`), runs a
+installs a tap on `mainMixerNode` in `enableAnalysis()` (`NativeAudioEngine.swift:2165`), runs a
 Hann-windowed FFT off the main actor in `NativeAudioAnalysisProcessor`, throttles to
 `analysisMinInterval = 1.0/60.0`, and hands a `NativeAudioAnalysisFrame` to its delegate. The
-delegate is `FamiliarPlayer.swift:1388`:
+delegate is `FamiliarPlayer.swift:1466`:
 
 ```swift
 /// Analysis drives the visualizer, which ADR-0001 point 5 puts out of v1 scope.
@@ -64,8 +64,25 @@ nonisolated func audioEngineDidUpdateAnalysis(
 ```
 
 An empty body. The tap is installed on every `play()`, the FFT runs at 60 Hz, the frame hops to the
-main actor, and it is thrown away — because of the ADR point this one amends. Exposing an FFT here
-is a publishing problem, not a signal-processing problem.
+main actor, and it is thrown away — because of the ADR point this one amends.
+
+**The main-thread cost of this channel is therefore already being paid, into nothing.** Verified
+2026-08-07, after [ADR-0041](ADR-0041-the-playhead-is-published-separately.md) made this the
+question worth asking: `NativeAudioEngine.swift:2199` performs a `DispatchQueue.main.async` for
+every emitted frame — roughly **57 times a second throughout playback** — carrying two `[UInt8]`
+arrays and a thirteen-field struct to that empty function. This ADR does not add a 60 Hz main-thread
+burden. It gives one that already exists a purpose, which is a materially better position than "a
+visualizer would cost 60 hops a second" and is worth stating plainly, because ADR-0041's measurement
+otherwise reads as an argument against this ADR.
+
+**~57 Hz, not 60, and it is the hardware's number rather than ours.** `analysisMinInterval` is
+`1.0/60.0`, but the guard is evaluated on tap callbacks, which arrive at 44100/256 ≈ 172 Hz. The
+first callback at or past 16.67 ms is the third, so frames emit every ~17.4 ms ≈ 57.4 Hz — and a
+48 kHz device gives a different number again. `NativeAudioAnalysisMetrics.cadenceHz` already carries
+the measured rate in every frame, which is the right thing for the page to trust.
+
+Exposing an FFT here is mostly a publishing problem. Two signal-processing problems come with it,
+below.
 
 **Both ends of the channel were built once before, for Capacitor, and ADR-0001 deleted the middle.**
 `NativeAudioAnalysisMetrics` still carries an `asDictionary()` — a survival from
@@ -81,12 +98,37 @@ one shared `requestAnimationFrame` loop that mutates a persistent object; visual
 this ADR builds has to land in a buffer the page reads on its own schedule, or every visualizer in
 `docs/VISUALIZER_API.md` has to change.
 
-**One resolution mismatch has to be settled here rather than found later.** The native processor
-uses `fftSize = 256`, giving 128 bins. `WebAudioEngine` uses `fftSize = 1024` — 512 bins — and its
-comment says why: *"finer bass/kick separation; lower smoothing so transients survive for the
-onset/beat detector (0.8 over-averaged the spectrum and starved spectral-flux onset detection)."*
-Feeding 128 bins into a detector tuned on 512 starves it in exactly the way that comment warns
-about.
+**Two mismatches have to be settled here rather than found later, and only one of them is
+resolution.** Both were found on 2026-08-07 by reading the processor rather than the ADR.
+
+*Resolution.* The native processor uses `fftSize = 256`, giving 128 bins. `WebAudioEngine` uses
+`fftSize = 1024` — 512 bins. Feeding 128 bins into a detector tuned on 512 starves it.
+
+*Smoothing, which is the half that was missed.* The same `WebAudioEngine.ts:92-96` comment gives two
+reasons, not one: *"1024-pt FFT (512 bins) for finer bass/kick separation; **lower smoothing so
+transients survive for the onset/beat detector (0.8 over-averaged the spectrum and starved
+spectral-flux onset detection)**"* — and it sets `smoothingTimeConstant = 0.5` accordingly. The
+native processor applies `frequencyFloats[i] = 0.8 * previous[i] + 0.2 * frequencyFloats[i]`
+(`NativeAudioEngine.swift:349`): **exactly the value the web deliberately tuned away from.** Point 5
+moves onset derivation to the page to keep one tuned implementation, and would then hand that
+implementation a spectrum pre-smoothed at the setting it was tuned *against*. Matching
+`WebAudioEngine` means matching both numbers or the fix is half a fix.
+
+**And the frames are not a continuous spectrogram.** `NativeAudioAnalysisProcessor.accumulate`
+evaluates its throttle **before** appending:
+
+```swift
+guard now - lastFrameAt >= minInterval else { return nil }
+sampleBuffer.append(contentsOf: UnsafeBufferPointer(start: channelData, count: frameCount))
+```
+
+So a throttled callback discards its buffer entirely — **roughly two of every three buffers of audio
+are never seen.** Each frame is a 256-sample window with ~740 samples unobserved before it, not a
+window onto a continuous stream. That is harmless for a level meter and is *not* harmless for
+spectral flux, which is defined as the frame-to-frame difference of consecutive spectra: the page's
+detector would be differencing snapshots taken across gaps. This is independent of the smoothing
+problem, undermines point 5 in the same way, and is invisible from the ADR's vantage point because
+the frames currently go nowhere.
 
 **And two native tests have never passed.** `NativeAudioAnalysisProcessorTests.swift:54` and `:75`
 are unconditional skips — *"Band edges disagree with the fixture"* and *"Variance ordering does not
@@ -115,6 +157,16 @@ hold; not yet diagnosed"* — and CI never reported it because the iOS job ends
    newer frame replaces it and the older is dropped. A visualizer rendering at 30 fps must not
    accumulate a queue of 60 Hz frames it will never draw.
 
+   **Nothing to build this on exists today.** There is no buffering anywhere in the analysis path:
+   each frame is an independent `DispatchQueue.main.async`, so a busy main queue delays every frame
+   in order rather than dropping any. The coalescing described here is new machinery, not a
+   configuration of something present.
+
+   **And it trades directly against point 5.** Every dropped frame widens the gap the page's
+   spectral flux is differenced across, on top of the gaps point 12 already has to close. Coalescing
+   is right for the render loop and is a cost to the detector; the two must be designed together
+   rather than each in isolation.
+
 4. **The page-side landing point is `nativeAnalysisBuffers.ts`, unchanged.** The frame is written
    with `setNativeAnalysisBuffers`, `useAudioAnalyser` reads it, and `getAudioData()` keeps its
    current signature. Every visualizer in `docs/VISUALIZER_API.md` works without modification,
@@ -127,9 +179,13 @@ hold; not yet diagnosed"* — and CI never reported it because the iOS job ends
    rather than depending on them, and it leaves **one** implementation of the band maths instead of
    two that are known to disagree.
 
-6. **The native `fftSize` rises from 256 to 1024**, matching `WebAudioEngine`, so the page's
-   detector receives the resolution it was tuned for. Anything less makes point 5 a downgrade
-   dressed as reuse.
+6. **The native `fftSize` rises from 256 to 1024 and its smoothing falls from 0.8 to 0.5**, both
+   matching `WebAudioEngine`, so the page's detector receives the spectrum it was tuned for.
+   Anything less makes point 5 a downgrade dressed as reuse — and the smoothing is the half this
+   ADR originally missed. `WebAudioEngine.ts`'s comment gives both numbers for both reasons, and
+   0.8 is named there as the value that "starved spectral-flux onset detection". Shipping 1024 bins
+   still smoothed at 0.8 would fix the resolution complaint and leave the detector starved by the
+   thing the comment is actually about.
 
 7. **Now-playing identity travels on the same channel**: track id, title, artist, album, artwork
    URL, duration, position, and an explicit `playing` flag. This is the part that plainly reverses
@@ -141,21 +197,69 @@ hold; not yet diagnosed"* — and CI never reported it because the iOS job ends
    The page has the server URL and the profile ([ADR-0016](ADR-0016-embedded-web-surfaces-on-the-mac.md)
    point 6) and can fetch it itself. A channel that carries everything is a channel with no shape.
 
-9. **The null engine is unchanged and still reports `visualizer: false`.** The page reads the
-   buffer; it never asks the engine for an analyser. ADR-0017's guarantee holds exactly as written
-   — a missed play path is inert rather than a second `AudioContext` — and this ADR adds nothing
-   that could construct one.
+9. **The visualizer document declares `visualizer: true` while still constructing no
+   `AudioContext`**, and the distinction is what makes this work. The page reads the buffer; it
+   never asks the engine for an analyser. ADR-0017's guarantee holds exactly as written — a missed
+   play path is inert rather than a second `AudioContext` — and this ADR adds nothing that could
+   construct one.
+
+   **Corrected 2026-08-07.** This point previously said the null engine was unchanged at
+   `visualizer: false`. That does not work: `isVisualizerAvailable()` reads the *registered
+   capability descriptor*, and `FullPlayer.tsx:260` gates on it — `!isVisualizerAvailable()` renders
+   album art instead. A surface declaring `false` would never draw a visualizer at all. What keeps
+   the guarantee is not the flag but the omission: `NullAudioEngine` omits all fifteen optional
+   `AudioEngine` members including `getAnalyser`, and `getAudioAnalyser()` calls
+   `existingEngine()?.getAnalyser?.()` — which never constructs. So the visualizer surface registers
+   an engine that says it can show a visualizer and still cannot make or analyse a sound.
+   `assertCapabilitiesMatch` requires the class-level capabilities and the registration to agree, so
+   this is one coherent change rather than a flag flipped in one place.
 
 10. **`disableAnalysis()` runs on `pause()`, so a paused visualizer receives no frames.** The last
     frame is held and `playing: false` is pushed once. Deciding this now is cheaper than
     diagnosing it later as a visualizer that looks frozen rather than paused.
 
-11. **The surface needs its own marker.** `EmbedIntent.surfaceMarker` is the single value
-    `"embed"`, probed out of `<meta name="familiar-surface">`. A second embedded document must
-    identify itself distinctly, or the probe that exists to catch a pre-`/embed` server answering
-    from its SPA fallback cannot tell the two surfaces apart.
+11. **The surface needs its own marker, and the marker is the small part.**
+    `EmbedIntent.surfaceMarker` is the single value `"embed"`, probed out of
+    `<meta name="familiar-surface">` and compared by `==` in one place. A second embedded document
+    must identify itself distinctly, or the probe that exists to catch a pre-`/embed` server
+    answering from its SPA fallback cannot tell the two surfaces apart.
 
-12. **The frame shape is parsed and formatted in `FamiliarKit`, under test.** `swift test` cannot
+    **What a second surface actually touches**, inventoried 2026-08-07, because "its own marker"
+    reads much cheaper than it is: `isEmbeddedSurface` and its five-assertion test; the `"embed"`
+    path segment, which is an inline literal in `EmbeddedDiscoverView.swift` with no route constant;
+    the copy in both failure states, which names Discover; a third entry in
+    `packages/web/vite.config.ts` plus an `.html` and a `.tsx`; and the sentence in
+    `packages/web/src/embed.tsx` asserting it is *"the only thing that boots the embedded page"*,
+    which a second entry point falsifies and which must be rewritten rather than quietly broken.
+
+    **The sharp one is the tests.** `EmbedNavigationPolicyTests` asserts against the **source text
+    of `App/Shared/EmbeddedDiscoverView.swift`, located by file path** — because `swift test` cannot
+    see the app target. A second view is not covered by them, and extracting the coordinator into a
+    shared file so both surfaces use it makes those tests fail on the *path* rather than on the
+    substance they exist to protect.
+
+12. **The processor accumulates continuously instead of discarding throttled buffers.** Added
+    2026-08-07. The throttle currently returns *before* appending, so ~2 of every 3 buffers are
+    dropped and each frame is a window with ~740 unobserved samples in front of it. Point 5 hands
+    onset detection to the page, and spectral flux is the difference between *consecutive* spectra —
+    so the fix is to keep appending on every callback and throttle only the *emission*, leaving the
+    ring of samples continuous.
+
+    **This changes code inside `NativeAudioEngine`'s processing**, which
+    [ADR-0015](ADR-0015-audio-effects-are-exposed-not-rebuilt.md) point 2 fenced off — *"If exposing
+    an effect appears to require engine changes, that is a signal to stop and reconsider, not to
+    proceed."* So it is named here rather than discovered during implementation, and the
+    reconsideration is this: the alternative is deriving onsets natively instead, which means a
+    second tuned detector in a second language — the duplication point 5 exists to avoid and the one
+    [ADR-0005](ADR-0005-one-ranking-engine-serves-ambient-and-radio.md) refused for ranking.
+    Appending unconditionally is a few lines inside `NativeAudioAnalysisProcessor`, which is already
+    `@unchecked Sendable` and already confined to the tap callback under
+    [ADR-0024](ADR-0024-the-audio-engine-is-main-actor-except-where-it-cannot-be.md)'s exception, so
+    it crosses no isolation boundary that is not already crossed. It adds no allocation the throttle
+    was saving either — the discarded buffers were already copied into the tap's parameter before
+    the guard ran.
+
+13. **The frame shape is parsed and formatted in `FamiliarKit`, under test.** `swift test` cannot
     see `App/`, and a wire format is exactly the kind of decision that belongs in the package —
     the same reasoning that put `EmbedIntent.parse` there rather than in the message handler.
 
@@ -204,11 +308,12 @@ rather than as a finding.
 
 - **Positive:** The four existing visualizers work on both Apple clients with no changes to any of
   them, because points 4 and 5 keep `getAudioData()` and its shape intact.
-- **Positive:** An FFT that currently runs 60 times a second and is discarded starts being used.
+- **Positive:** An FFT that currently runs ~57 times a second and is discarded starts being used.
 - **Positive:** The band maths and the onset detector stop existing in two places that disagree.
   Point 5 makes `analysisMetrics.ts` the single implementation for every client.
-- **Positive:** Raising `fftSize` to 1024 fixes a resolution mismatch that would otherwise have
-  been discovered as "the beat detection is worse on the Mac".
+- **Positive:** Raising `fftSize` to 1024 *and* dropping smoothing to 0.5 fixes a mismatch that
+  would otherwise have been discovered as "the beat detection is worse on the Mac" — and the
+  smoothing half would have survived the resolution fix, so it would have been discovered twice.
 - **Tradeoff:** **ADR-0016 point 5 is no longer true as written.** The bridge is one-way for
   Discover and two-way for the visualizer, and a rule stated in absolute terms now has an
   exception. Anyone reading ADR-0016 alone will get the wrong answer, which is why point 2
@@ -218,8 +323,26 @@ rather than as a finding.
   already named the first of these as a cost; this doubles it.
 - **Tradeoff:** The seam ADR-0016 called embedding's main risk now has a third contract across it,
   and like the other two nothing checks the TypeScript half against the Swift half at compile time.
-- **Tradeoff:** 60 `evaluateJavaScript` calls a second is real main-thread work on the native side
-  whenever the visualizer is on screen, on top of the render loop inside the web view.
+- **Tradeoff:** point 12 changes `NativeAudioEngine`'s processing, which ADR-0015 point 2 said was
+  a signal to stop and reconsider. The reconsideration is recorded there rather than skipped, and it
+  is the one place this ADR spends its "no engine changes" credit — worth knowing before anything
+  else in it is treated as licence to spend more.
+- **Tradeoff, and smaller than it first read:** ~57 `evaluateJavaScript` calls a second is real
+  main-thread work whenever the visualizer is on screen, on top of the render loop inside the web
+  view. What it is *not* is a new 60 Hz hop: measured 2026-08-07, the app already performs a
+  main-queue dispatch per frame at that rate into an empty delegate, so the added cost is the
+  `evaluateJavaScript` call and the serialisation, not the hop. ADR-0041's finding — a **4 Hz**
+  publisher saturating the main thread — reads as an argument against this ADR and on inspection is
+  not one: that cost was unbounded SwiftUI invalidation, where this is a bounded call with a fixed
+  payload. The yardstick worth holding it against is `MusicMapView`'s 0.83 ms/frame of dictionary
+  building, which was measured and then removed as too expensive for a frame budget.
+- **Tradeoff, found 2026-08-07:** the visualizer document needs more than a spectrum.
+  `FullPlayer.tsx:276-283` hands `AudioVisualizer` a track, an artwork URL, lyrics, `isPlaying`,
+  `currentTime` and `duration` — all from a player store the embedded document will not have. Point
+  7 carries identity and point 8 sends the page to fetch its own lyrics, so the gap is the *clock*:
+  `currentTime` advances continuously and the lyrics visualizer is built on it. Whether that rides
+  the analysis channel, which already arrives ~57 times a second, or is derived page-side from a
+  start time is unresolved here and is the first thing implementation will hit.
 - **Follow-up:** The two skipped tests in `NativeAudioAnalysisProcessorTests` are now routed around
   rather than fixed. They still assert something about a processor this ADR depends on, and
   `testBrightFixtureDominatesTreble` in particular encodes a disagreement about where treble begins


### PR DESCRIPTION
ADR-0033 proposes feeding the web visualizer from the native FFT over a ~60 Hz channel. It was written before ADR-0041 measured what high-frequency main-thread work costs this app — 86% of main-thread samples inside `flushObservers`, from a **4 Hz** publisher — which made its channel worth checking before any code exists.

**The investigation moved it in both directions.** The performance worry was largely unfounded; two correctness problems it does not mention are more serious. It stays `proposed`, so this revises it in place rather than superseding it.

## Its own case was understated

The main-thread hop **already exists and already runs**. `NativeAudioEngine.swift:2199` dispatches to the main queue ~57×/sec throughout playback, carrying two `[UInt8]` arrays and a 13-field struct into `FamiliarPlayer.audioEngineDidUpdateAnalysis` — an empty function. The channel does not add a 60 Hz burden; it gives one already being paid a purpose. That is the strongest argument for the ADR and it was not in it.

## Two signal-processing problems, now in the Decision

**Point 6 fixed the resolution and left the smoothing.** It raised native `fftSize` 256 → 1024 to match `WebAudioEngine`. But `WebAudioEngine.ts:92-96` also sets `smoothingTimeConstant = 0.5`, with the comment: *"0.8 over-averaged the spectrum and starved spectral-flux onset detection."* The native processor applies `0.8 * previous + 0.2 * current` — exactly the value the web tuned away from. Point 5 moves onset derivation to the page to keep one tuned implementation, then hands it a spectrum pre-smoothed at the setting it was tuned *against*. Point 6 now matches both numbers.

**New point 12 — the frames are not a continuous spectrogram.** `accumulate` evaluates its throttle *before* appending, so ~2 of every 3 audio buffers are discarded and each frame is a 256-sample window with ~740 samples never observed. Harmless for a level meter; not harmless for spectral flux, which is the difference between *consecutive* spectra. This touches `NativeAudioEngine`'s processing, which **ADR-0015 point 2 fenced off** — so it is named here with the reconsideration that point asks for, rather than discovered during implementation.

Both were invisible from the ADR's vantage point because the frames currently go nowhere.

## Smaller corrections

- **Point 9 conflicted with the visualizer gate.** It said the null engine stays at `visualizer: false` — but `isVisualizerAvailable()` reads that registered descriptor and `FullPlayer.tsx:260` gates on it, so such a surface renders album art and never a visualizer. What preserves ADR-0017's guarantee is that `NullAudioEngine` **omits `getAnalyser`**, not the flag.
- **Point 3's coalescing has nothing to configure** — no buffering exists anywhere in the path — and dropping frames trades directly against point 5's detector.
- **Point 11's "own marker" is an inventory**, the sharp part being that `EmbedNavigationPolicyTests` asserts against the source text of `EmbeddedDiscoverView.swift` **by file path**, so a second surface is uncovered and sharing the coordinator fails those tests on the path rather than the substance.
- **A stated invariant is falsified**: `embed.tsx` says it is *"the only thing that boots the embedded page"*. Rewrite it rather than quietly break it.
- **The realised rate is ~57.4 Hz, not 60**, and it is sample-rate dependent; `cadenceHz` already ships the measured value.
- **Per ADR rule 4, two citations were stale**: `enableAnalysis()` is `:2165` not `:2125`; the delegate is `:1466` not `:1388`.

## What this does not do

It does not build the channel and does not decide to. Whether the visualizer is worth this — it is the one feature in the product with no functional purpose, and the work now includes touching the render path — is the next decision, and a separate one.

## Verification

Documentation only; **nothing in either repo changes.** Every cited path and line number was re-checked against both repos at write time, and the two load-bearing findings were re-grepped immediately before commit: the smoothing constants are still 0.8 native / 0.5 web, and `accumulate`'s early return still precedes the append.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_014P9p2fvFnyiywBxGkv4gfW