### PR TITLE
Drive silero-vad v5, and stop a dead VAD looking like a measurement

### DIFF
--- a/backend/app/services/analysis.py
+++ b/backend/app/services/analysis.py
@@ -9,6 +9,9 @@ from pathlib import Path
 import acoustid
 import numpy as np
 
+# Cheap at import time: vocal_detection imports onnxruntime lazily, inside its functions.
+from app.services.vocal_detection import VADError
+
 # Check torch availability without importing it (~0 memory cost)
 # The actual torch import happens lazily inside functions that need it
 _torch_available = importlib.util.find_spec("torch") is not None
@@ -569,8 +572,14 @@ def derive_features(
     try:
         from app.services.vocal_detection import detect_speech
         vad_result = detect_speech(y, sr)
+    except VADError as e:
+        # The model is present and did not work. This was logged at debug and therefore
+        # invisible, while the spectral fallback below wrote a saturated value that looked
+        # like a measurement. Warn: every track taking this path has wrong
+        # instrumentalness and speechiness.
+        logger.warning(f"VAD unusable, falling back to spectral heuristic: {e}")
     except Exception as e:
-        logger.debug(f"VAD detection failed, using spectral fallback: {e}")
+        logger.debug(f"VAD detection unavailable, using spectral fallback: {e}")
 
     if vad_result is not None:
         mean_speech_prob, _speech_frac = vad_result

--- a/backend/app/services/vocal_detection.py
+++ b/backend/app/services/vocal_detection.py
@@ -18,6 +18,19 @@ if TYPE_CHECKING:
 
 logger = logging.getLogger(__name__)
 
+
+class VADError(RuntimeError):
+    """Raised when the VAD model is present but cannot be used.
+
+    Deliberately distinct from "model unavailable", which `detect_speech` reports by
+    returning None so the caller can use its spectral fallback. This means *the model is
+    here and it did not work*, which is never a legitimate measurement.
+    """
+
+
+def _model_input_names(session: onnxruntime.InferenceSession) -> set[str]:
+    return {i.name for i in session.get_inputs()}
+
 # Default model location
 _MODEL_DIR = Path(__file__).resolve().parent.parent.parent / "data" / "models"
 _MODEL_PATH = _MODEL_DIR / "silero_vad.onnx"
@@ -66,6 +79,10 @@ def _download_model(dest: Path) -> None:
     """Download silero-vad ONNX model from GitHub releases."""
     import urllib.request
 
+    # NOTE: this tracks `master`, which is how a v4-era integration silently acquired a v5
+    # model. The signature check in `detect_speech` is what makes that loud rather than
+    # silent now; pinning to a release tag would stop it happening at all, and is the better
+    # fix whenever someone can verify a stable URL.
     url = (
         "https://github.com/snakers4/silero-vad/raw/master/src/silero_vad/data/silero_vad.onnx"
     )
@@ -97,10 +114,13 @@ def detect_speech(
     if session is None:
         return None
 
-    import librosa
-
-    # Resample to 16kHz if needed
+    # Resample to 16kHz if needed. librosa is imported here rather than at the top of the
+    # function because it is only needed for resampling — it lives in the optional `analysis`
+    # extra, and requiring it unconditionally made this module untestable wherever that extra
+    # is not installed, which includes CI.
     if sr != _TARGET_SR:
+        import librosa
+
         y = librosa.resample(y, orig_sr=sr, target_sr=_TARGET_SR)
 
     # Limit duration to cap processing time
@@ -118,12 +138,22 @@ def detect_speech(
     if num_windows == 0:
         return (0.0, 0.0)
 
-    # silero-vad state: h and c tensors (2, 1, 64)
+    names = _model_input_names(session)
+    is_v5 = "state" in names
+    if not is_v5 and "h" not in names:
+        raise VADError(
+            f"Unrecognised silero-vad signature: inputs are {sorted(names)}. "
+            "Expected 'state' (v5) or 'h'/'c' (v4)."
+        )
+
+    # v5 carries one combined (2, 1, 128) state tensor; v4 carried separate (2, 1, 64) h and c.
+    state = np.zeros((2, 1, 128), dtype=np.float32)
     h = np.zeros((2, 1, 64), dtype=np.float32)
     c = np.zeros((2, 1, 64), dtype=np.float32)
     sr_tensor = np.array([_TARGET_SR], dtype=np.int64)
 
     speech_probs = []
+    first_error: Exception | None = None
 
     for i in range(num_windows):
         chunk = y[i * _WINDOW_SIZE : (i + 1) * _WINDOW_SIZE]
@@ -133,21 +163,41 @@ def detect_speech(
         input_data = chunk.reshape(1, -1)
 
         try:
-            ort_inputs = {
-                "input": input_data,
-                "h": h,
-                "c": c,
-                "sr": sr_tensor,
-            }
-            output, h, c = session.run(None, ort_inputs)
-            prob = float(output[0][0])
-            speech_probs.append(prob)
-        except Exception:
-            # Skip bad windows
+            if is_v5:
+                output, state = session.run(
+                    None, {"input": input_data, "state": state, "sr": sr_tensor}
+                )
+            else:
+                output, h, c = session.run(
+                    None, {"input": input_data, "h": h, "c": c, "sr": sr_tensor}
+                )
+            speech_probs.append(float(output[0][0]))
+        except Exception as exc:  # noqa: BLE001 - one bad window is tolerable; all of them is not
+            # Keep going: a single malformed window should not lose the track. The
+            # all-windows-failed case is raised after the loop, where it cannot be mistaken
+            # for a confident "no speech".
+            if first_error is None:
+                first_error = exc
             continue
 
+    if first_error is not None:
+        logger.warning(
+            "silero-vad: %d of %d windows failed (first: %r)",
+            num_windows - len(speech_probs),
+            num_windows,
+            first_error,
+        )
+
     if not speech_probs:
-        return (0.0, 0.0)
+        # Every window failed. Returning (0.0, 0.0) here is what silently produced
+        # instrumentalness=1.0 and speechiness=0.0 for 25,661 of 25,697 analysed tracks:
+        # a model-signature change made every session.run() raise, and the per-window
+        # `continue` swallowed all of them. A total failure must not look like an answer.
+        raise VADError(
+            f"silero-vad produced no probabilities across {num_windows} windows. "
+            f"Model inputs are {sorted(_model_input_names(session))}; "
+            f"this build supports v5 ('state') and v4 ('h'/'c')."
+        )
 
     mean_prob = float(np.mean(speech_probs))
     speech_fraction = float(np.mean([1.0 if p > 0.5 else 0.0 for p in speech_probs]))

--- a/backend/tests/test_vocal_detection.py
+++ b/backend/tests/test_vocal_detection.py
@@ -1,0 +1,146 @@
+"""Tests for silero-vad speech detection.
+
+These exist because of a specific, silent failure. The ONNX model download URL tracks
+`master`, silero-vad moved from v4 to v5, and the v5 model takes a single `state` input
+where v4 took `h` and `c`. Every `session.run` raised, a per-window `except: continue`
+swallowed all of them, and `detect_speech` returned `(0.0, 0.0)` — which the caller turned
+into `instrumentalness=1.0, speechiness=0.0`.
+
+That is a plausible-looking measurement, so nothing looked broken: **25,661 of 25,697
+analysed tracks were recorded as fully instrumental with no speech.**
+
+The tests below fake the ONNX session rather than loading a real model, so they run
+anywhere and assert the two things that actually failed: that both signatures are driven
+correctly, and that a total failure is raised rather than returned.
+"""
+
+from __future__ import annotations
+
+import numpy as np
+import pytest
+
+from app.services import vocal_detection
+from app.services.vocal_detection import VADError, detect_speech
+
+SR = 16000
+AUDIO = np.zeros(SR * 2, dtype=np.float32)  # 2s -> 62 windows of 512
+
+
+class _FakeInput:
+    def __init__(self, name: str) -> None:
+        self.name = name
+
+
+class _FakeSession:
+    """Stands in for onnxruntime.InferenceSession.
+
+    `input_names` decides which signature it advertises; `accepts` decides which it will
+    actually run. Setting them differently is exactly the production bug.
+    """
+
+    def __init__(self, input_names: list[str], accepts: set[str] | None = None, prob: float = 0.8):
+        self._inputs = [_FakeInput(n) for n in input_names]
+        self._accepts = accepts if accepts is not None else set(input_names)
+        self._prob = prob
+        self.calls = 0
+
+    def get_inputs(self) -> list[_FakeInput]:
+        return self._inputs
+
+    def run(self, _outputs, feed: dict) -> tuple:
+        if set(feed) != self._accepts:
+            raise RuntimeError(f"unexpected inputs {sorted(feed)}; wants {sorted(self._accepts)}")
+        self.calls += 1
+        out = np.array([[self._prob]], dtype=np.float32)
+        if "state" in self._accepts:
+            return out, feed["state"]
+        return out, feed["h"], feed["c"]
+
+
+@pytest.fixture(autouse=True)
+def _no_real_model(monkeypatch):
+    """Never touch the network or a real model file."""
+    monkeypatch.setattr(vocal_detection, "_load_vad_model", lambda: None)
+
+
+def _use(monkeypatch, session):
+    monkeypatch.setattr(vocal_detection, "_load_vad_model", lambda: session)
+
+
+def test_v5_signature_is_driven_with_state(monkeypatch):
+    """The regression. A v5 model must be fed `state`, not `h`/`c`."""
+    session = _FakeSession(["input", "state", "sr"], prob=0.8)
+    _use(monkeypatch, session)
+
+    mean_prob, speech_fraction = detect_speech(AUDIO, SR)
+
+    assert session.calls > 0, "no window was ever run against the model"
+    assert mean_prob == pytest.approx(0.8)
+    assert speech_fraction == pytest.approx(1.0)
+
+
+def test_v4_signature_still_works(monkeypatch):
+    """Installs that already hold a v4 model must keep working."""
+    session = _FakeSession(["input", "h", "c", "sr"], prob=0.9)
+    _use(monkeypatch, session)
+
+    mean_prob, _ = detect_speech(AUDIO, SR)
+
+    assert session.calls > 0
+    assert mean_prob == pytest.approx(0.9)
+
+
+def test_total_failure_raises_instead_of_reporting_silence(monkeypatch):
+    """The heart of it.
+
+    A model that advertises v5 but rejects every call must not yield `(0.0, 0.0)` —
+    that value is indistinguishable from a confident 'this track is pure instrumental'.
+    """
+    session = _FakeSession(["input", "state", "sr"], accepts={"input", "h", "c", "sr"})
+    _use(monkeypatch, session)
+
+    with pytest.raises(VADError):
+        detect_speech(AUDIO, SR)
+
+
+def test_unknown_signature_raises(monkeypatch):
+    """A future v6 that renames the state input again should fail loudly on arrival."""
+    session = _FakeSession(["input", "memory", "sr"])
+    _use(monkeypatch, session)
+
+    with pytest.raises(VADError):
+        detect_speech(AUDIO, SR)
+
+
+def test_missing_model_returns_none_not_error(monkeypatch):
+    """'No model' is a legitimate state and keeps the spectral fallback available.
+
+    This is the distinction VADError exists to draw: absent is not the same as broken.
+    """
+    _use(monkeypatch, None)
+    assert detect_speech(AUDIO, SR) is None
+
+
+def test_one_bad_window_does_not_lose_the_track(monkeypatch):
+    """A single malformed window is tolerable; the result should still be computed."""
+    session = _FakeSession(["input", "state", "sr"], prob=0.6)
+    real_run = session.run
+    state = {"n": 0}
+
+    def flaky(outputs, feed):
+        state["n"] += 1
+        if state["n"] == 3:
+            raise RuntimeError("bad window")
+        return real_run(outputs, feed)
+
+    session.run = flaky  # type: ignore[method-assign]
+    _use(monkeypatch, session)
+
+    mean_prob, _ = detect_speech(AUDIO, SR)
+    assert mean_prob == pytest.approx(0.6)
+
+
+def test_audio_shorter_than_one_window_returns_zero(monkeypatch):
+    """Pre-existing behaviour, pinned so the VADError change does not alter it."""
+    _use(monkeypatch, _FakeSession(["input", "state", "sr"]))
+    assert detect_speech(np.zeros(100, dtype=np.float32), SR) == (0.0, 0.0)


### PR DESCRIPTION
**25,661 of 25,697 analysed tracks** carry `instrumentalness` exactly **1.0** and `speechiness` exactly **0.0** — the same count for both, because both come from one call that was returning `(0.0, 0.0)` for every track.

## Cause

The model download URL tracks `master`. silero-vad moved **v4 → v5**, and the v5 ONNX takes a single `state` input where v4 took `h` and `c`:

```
EXPECTED INPUTS: ['input', 'state', 'sr']
CODE SUPPLIES  : ['input', 'h', 'c', 'sr']
detect_speech -> (0.0, 0.0)
```

Every `session.run` raised, the per-window `except Exception: continue` swallowed all of them, `speech_probs` came out empty, and the function returned `(0.0, 0.0)`. The caller turned that into "fully instrumental, no speech" and logged the cause at **debug** level. Nothing looked broken — the wrong values are perfectly plausible ones.

## What this changes

- **Both signatures are driven**, so installs holding either model work.
- **A single bad window is still tolerated; all windows failing now raises `VADError`.** That is deliberately distinct from *model unavailable*, which still returns `None` so the spectral fallback stays available. Absent is not the same as broken.
- **`analysis.py` logs `VADError` at warning.** Every track on that path has wrong values, which is not a debug-level fact.
- **Tests fake the ONNX session** rather than loading a model, so they run without the optional `analysis` extra. That required moving the `librosa` import into the resample branch — the only place it was needed. As written, this module could not be tested anywhere librosa is absent, **including CI**.
- **Verified to fail against the bug.** Forcing the v4 path makes `test_v5_signature_is_driven_with_state` fail. A guard that has not been seen to fail is not a guard.

## Read this before scheduling a re-analysis

**This does not restore the feature.** Against the real model on the NAS:

| track | genre | speech prob |
|---|---|---|
| Pulp — Common People | Britpop | 0.0014 |
| The Clash — Clampdown | Punk Rock | 0.0014 |
| Michael McDonald — On My Own | Rock | 0.0012 |
| Cocteau Twins — I Wear Your Ring | Rock | 0.0012 |
| Beach House — Space Song | Indie Rock | 0.0012 |
| Tiki Obmar — A Bench Per Couple | IDM (instrumental) | 0.0006 |

Silero-vad detects **speech**, not **singing**. Sung vocals over music do not register, so it reports near-zero for essentially all music. Correctly wired, `instrumentalness` goes from *1.0 for everyone* to *0.997 for everyone*.

**So an `ANALYSIS_VERSION` bump would spend a full re-analysis of ~26K tracks and buy nothing for these two features.** What this PR buys is that the failure is now loud, the wiring is right, and nobody re-diagnoses it. Choosing a vocal detector suited to music is separate work.

There is a faint hint of signal — instrumental 0.0006 against vocal 0.0012–0.0017, roughly 2–3× — which percentile ranking might exploit. One instrumental sample is not evidence, so it is a hypothesis, not a plan.

## Blast radius of the bad data

`instrumentalness` and `speechiness` are consumed by smart-playlist rule fields (`smart_playlists.py:349-350`), the ambient/radio ranking engine (`ambient.py:39-40`), the `fx`/`fy` generic filter axes and the aggregation endpoints behind the Music Map, generated album artwork (`generative_art.py:236` — alpha is pinned at 60 for every track), and the LLM's `filter_tracks`.

Found while investigating why `filter_tracks` produced bad playlists for #114.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
