### PR TITLE
Accept ADR-0046, and propose ADR-0047 — audio feature scales

### DIFF
--- a/docs/decisions/ADR-0045-audio-features-are-filtered-by-percentile.md
+++ b/docs/decisions/ADR-0045-audio-features-are-filtered-by-percentile.md
@@ -1,0 +1,175 @@
+# ADR-0045: Audio Features Are Filtered by Percentile, Not by Absolute Value
+
+Status: proposed
+
+Date: 2026-08-08
+
+## Context
+
+**Familiar's 0–1 audio features are real measurements on scales that do not mean what their names
+imply.** Measured across the 25,697 analysed tracks in the live library:
+
+| feature | p10 | p50 | p90 | distinct values |
+|---|---|---|---|---|
+| `energy` | 0.700 | 0.826 | 0.898 | 25,590 |
+| `valence` | 0.665 | 0.848 | 0.985 | 23,640 |
+| `danceability` | 0.096 | 0.149 | 0.206 | 25,583 |
+| `acousticness` | 0.391 | 0.491 | 0.578 | 25,614 |
+
+The signal is there — roughly 25,600 distinct values each — but it is compressed into a narrow band
+that sits nowhere near the middle of 0–1. **This is arithmetic, not accident.**
+`services/analysis.py:550` computes `energy = clip((rms_db + 60) / 54, 0, 1)`, so a typical master
+at −15 dBFS yields 0.83, which is the observed median. `danceability` is `mean(shared["pulse"])` —
+the raw mean of librosa's predominant-local-pulse curve, a quantity that naturally lands near 0.15
+and was never on a perceptual scale.
+
+**The consequence is that an absolute threshold carries almost no information**, and it fails in
+both directions. Verified by counting:
+
+| filter | matches | share of library |
+|---|---|---|
+| `energy≥0.6 and valence≥0.6` | 23,761 | **92.5%** |
+| `energy≥0.85 and valence≥0.85` | 5,956 | 23.2% |
+| `energy≥0.85` | 9,520 | 37.0% |
+| `danceability≥0.4` | **5** | **0.02%** |
+
+**This is not hypothetical.** The MCP spike in `familiar` #114 asked a model for "something upbeat
+and happy" with no calibration guidance; it filtered `energy≥0.6, valence≥0.6` and got 92.5% of the
+library — and nothing in the result would have told the listener that. Asked for "really danceable",
+a *correctly calibrated* model chose 0.4 and got five tracks, because there is no threshold that
+works.
+
+**A workaround already exists and is not enough.**
+[ADR-0042](ADR-0042-the-llm-surface-is-an-mcp-server.md) point 3 requires tool descriptions to tell
+a model to call `get_feature_distribution` before choosing a bound, and the spike showed it works:
+blind thresholding went from 3 occurrences to 0. But it only helps the one consumer that has a model
+in the loop reading descriptions. **It does nothing for the other consumers**, which have no
+opportunity to calibrate at all: the `fx`/`fy` generic filter axes on `GET /tracks`, smart-playlist
+rule fields, the ambient/radio ranking engine, and the Music Map's aggregation endpoints.
+
+**Four facts established by measurement before writing this, because each one shapes the decision:**
+
+- **Percentile boundaries are cheap.** All six percentiles (`p10, p25, p50, p75, p90, p95`) for six
+  features, in **one query over 25,697 rows: 252 ms**. This is a derived quantity, not a stored one.
+- **Translating a percentile to a raw threshold keeps the existing indexes.** `energy >= 0.898`
+  returns 2,558 rows in **3 ms**, and `ix_track_analysis_energy`, `_valence`, `_bpm`, `_swing_ratio`
+  and `_brightness` already exist. A per-track percentile column would need new columns and new
+  indexes to reach the same place.
+- **Per-track `percent_rank()` is 53 ms for one feature** — affordable, but it has to be recomputed
+  whenever the library changes, and it stores a value that goes stale silently.
+- **Feature filtering is implemented four times.** `routes/tracks/listing.py:108`, `:348`, `:506`
+  and `services/llm/handlers/search.py:393` each write `TrackAnalysis.energy >= energy_min`
+  independently. Adding percentiles naively would make it five.
+
+**A premise that was tested and failed, recorded so it is not retried.** Percentiles do *not* rescue
+every feature. `instrumentalness` is exactly 1.0 for 25,661 of 25,697 tracks and `speechiness`
+exactly 0.0 for the same set, because silero-VAD was being driven with a v4 signature against a v5
+model (`familiar` #116). Fixing the call does not help: silero detects **speech, not singing**, so
+obviously vocal tracks score 0.0012–0.0017 against instrumental at 0.0006. **The percentile of a
+near-constant is noise**, and presenting it as a rank would dress up a dead feature as a live one.
+Point 7 below is a direct consequence.
+
+## Decision
+
+1. **Percentile *boundaries* are computed and cached; per-track percentile ranks are not stored.**
+   A small cached table — features × a fixed set of percentiles — is refreshed on a schedule and
+   after analysis runs. At 252 ms for six features this is affordable to recompute often, and it
+   holds tens of rows rather than 26,000.
+
+2. **A percentile request is translated into a raw threshold before it reaches the query.**
+   `energy_min_pct=90` becomes `TrackAnalysis.energy >= 0.898`. This is what keeps the existing
+   indexes doing the work — 3 ms, measured — and it means percentile support adds no new query
+   shape, no new index, and no new column.
+
+3. **Audio-feature filtering gets one implementation, and the four existing copies collapse into
+   it.** This is a prerequisite rather than a tidy-up: percentiles added on top of four independent
+   copies would produce four subtly different translations, and this codebase has already been bitten
+   by one rule copied into divergent subsets.
+
+4. **Percentile parameters sit alongside absolute ones rather than replacing them.** Absolute bounds
+   remain correct for the cases that genuinely mean an absolute quantity — `bpm`, and any caller
+   reproducing a stored filter. Removing them would also break every existing smart playlist. The
+   percentile form is the one documented as the default for perceptual language.
+
+5. **`get_feature_distribution` returns the boundaries**, so the tool that already exists to answer
+   "what does high mean here" answers it in the units the filter now speaks. ADR-0042 point 3's
+   guidance stays, and becomes cheaper to follow rather than redundant.
+
+6. **No `ANALYSIS_VERSION` bump and no re-analysis.** Everything here is derived from data already
+   in `track_analysis`. This is the decisive practical advantage over rescaling at extraction time,
+   and it means the fix reaches the whole library the day it ships.
+
+7. **A feature whose distribution is degenerate is withdrawn, not ranked.** If the interquartile
+   range is empty — `instrumentalness` and `speechiness` today — the feature is excluded from
+   percentile filtering and from the surfaces that offer it, rather than being served as a rank
+   computed over a constant. **Degeneracy is detectable from the same boundary computation** that
+   point 1 already runs, so this is a property the system can check rather than a list someone
+   maintains.
+
+8. **The boundaries are per-installation, and that is the point.** They describe *this* library, so
+   "high energy" means something different on a folk collection and an EDM collection without anyone
+   configuring anything. Nothing is shared between installations and nothing is seeded.
+
+## Alternatives Considered
+
+**Store a per-track `percent_rank()` column for each feature.** The obvious shape, and it makes
+sorting by rank trivial. Measured at 53 ms per feature, so computing it is not the objection.
+Rejected because it stores a derived value that every insert invalidates: adding one album silently
+makes 26,000 stored ranks slightly wrong, and nothing would detect that. It also needs a new column
+and a new index per feature to match the 3 ms the existing indexes already deliver, in exchange for
+a number that can be derived on demand.
+
+**Rescale the features at extraction time so the stored 0–1 values are perceptually meaningful.**
+The most honest fix in principle — `energy` would then actually mean energy, and every consumer
+benefits with no API change at all. Rejected on two grounds. It requires re-analysing ~26K tracks on
+a machine that is also the music server and the CI runner, and more importantly it bakes one
+library's distribution into the definition: the constants would be fitted to this collection, and
+would be wrong for anyone else's, which is the same failure one layer down.
+
+**Leave it, and rely on ADR-0042 point 3's calibration guidance.** It works — the spike measured
+blind thresholding falling from 3 to 0 — and it costs nothing to keep. Rejected as a complete answer
+because it only reaches the consumer with a language model in it. The `fx`/`fy` axes, smart-playlist
+rules and the ranking engine have no way to calibrate, and a listener building a smart playlist by
+hand gets no guidance at all.
+
+**Use z-scores rather than percentiles.** Cheaper to maintain — mean and standard deviation are two
+numbers per feature — and it handles unbounded features like `harmonic_complexity` naturally.
+Rejected because these distributions are visibly skewed and clipped: `valence` has p90 at 0.985
+against a hard ceiling of 1.0, so a z-score above the mean is compressed against the boundary and
+does not correspond to rank. Percentiles are distribution-free, which is exactly the property needed
+when the underlying shape is this irregular.
+
+**Expose percentiles only to the LLM tools.** Much smaller, and it targets the consumer where the
+failure was actually observed. Rejected because the failure was observed there only because that is
+where someone looked. The same wrong thresholds are reachable from the filter UI and from smart
+playlists, and a decision that fixes one caller leaves the shared defect in place.
+
+## Consequences
+
+- **Positive.** "High energy" becomes expressible. A request for the top decile returns the top
+  decile on any library, rather than 37% of this one.
+- **Positive.** It ships without re-analysis, so it reaches all 25,697 analysed tracks immediately.
+- **Positive.** Point 3 leaves one place where audio-feature filtering happens, which is where the
+  next feature predicate should be added.
+- **Positive.** Point 7 turns a class of silent data failure into a detectable condition. The
+  `instrumentalness` case took a spike, a distribution query and a model-signature investigation to
+  find; the same check would have surfaced it from the boundaries alone.
+- **Tradeoff.** Two ways to express the same filter, and callers must understand which they want.
+  Point 4 accepts this deliberately — the alternative breaks every stored smart playlist — but
+  "why did `energy_min=0.9` and `energy_min_pct=90` give different answers" is a question someone
+  will ask.
+- **Tradeoff.** Cached boundaries are stale between refreshes. Harmless at 26K tracks, where one
+  album moves nothing; the failure mode to watch is a *small* new library, where each import shifts
+  the distribution materially and a stale cache is proportionally wrong.
+- **Tradeoff.** Point 3 touches four call sites across two subsystems, one of which is the LLM tool
+  path that `ADR-0042` is concurrently proposing to re-host. Whichever lands second inherits the
+  merge.
+- **Follow-up.** `bpm` is quantised to **33 distinct values** across the whole library — librosa's
+  geometric tempo lattice, `…117.45, 123.05, 129.20…`. Percentiles are the wrong tool for it and it
+  is excluded here, but a BPM filter that cannot distinguish 122 from 124 is worth its own look.
+- **Follow-up.** If this lands, `ADR-0042` point 3's calibration guidance becomes a convenience
+  rather than a load-bearing requirement, and that ADR's tradeoff about description quality softens.
+  It does not become wrong, and it should not be edited until this is accepted.
+- **Follow-up.** `instrumentalness` and `speechiness` stay withdrawn under point 7 until a vocal
+  detector suited to music exists (`familiar` #116). Point 7 is what stops them quietly returning
+  as ranks in the meantime.

--- a/docs/decisions/ADR-0046-audio-features-are-filtered-by-percentile.md
+++ b/docs/decisions/ADR-0046-audio-features-are-filtered-by-percentile.md
@@ -1,4 +1,4 @@
-# ADR-0045: Audio Features Are Filtered by Percentile, Not by Absolute Value
+# ADR-0046: Audio Features Are Filtered by Percentile, Not by Absolute Value
 
 Status: proposed
 
@@ -40,7 +40,7 @@ a *correctly calibrated* model chose 0.4 and got five tracks, because there is n
 works.
 
 **A workaround already exists and is not enough.**
-[ADR-0042](ADR-0042-the-llm-surface-is-an-mcp-server.md) point 3 requires tool descriptions to tell
+[ADR-0043](ADR-0043-the-llm-surface-is-an-mcp-server.md) point 3 requires tool descriptions to tell
 a model to call `get_feature_distribution` before choosing a bound, and the spike showed it works:
 blind thresholding went from 3 occurrences to 0. But it only helps the one consumer that has a model
 in the loop reading descriptions. **It does nothing for the other consumers**, which have no
@@ -92,7 +92,7 @@ Point 7 below is a direct consequence.
    percentile form is the one documented as the default for perceptual language.
 
 5. **`get_feature_distribution` returns the boundaries**, so the tool that already exists to answer
-   "what does high mean here" answers it in the units the filter now speaks. ADR-0042 point 3's
+   "what does high mean here" answers it in the units the filter now speaks. ADR-0043 point 3's
    guidance stays, and becomes cheaper to follow rather than redundant.
 
 6. **No `ANALYSIS_VERSION` bump and no re-analysis.** Everything here is derived from data already
@@ -126,7 +126,7 @@ a machine that is also the music server and the CI runner, and more importantly 
 library's distribution into the definition: the constants would be fitted to this collection, and
 would be wrong for anyone else's, which is the same failure one layer down.
 
-**Leave it, and rely on ADR-0042 point 3's calibration guidance.** It works — the spike measured
+**Leave it, and rely on ADR-0043 point 3's calibration guidance.** It works — the spike measured
 blind thresholding falling from 3 to 0 — and it costs nothing to keep. Rejected as a complete answer
 because it only reaches the consumer with a language model in it. The `fx`/`fy` axes, smart-playlist
 rules and the ranking engine have no way to calibrate, and a listener building a smart playlist by
@@ -162,12 +162,12 @@ playlists, and a decision that fixes one caller leaves the shared defect in plac
   album moves nothing; the failure mode to watch is a *small* new library, where each import shifts
   the distribution materially and a stale cache is proportionally wrong.
 - **Tradeoff.** Point 3 touches four call sites across two subsystems, one of which is the LLM tool
-  path that `ADR-0042` is concurrently proposing to re-host. Whichever lands second inherits the
+  path that `ADR-0043` is concurrently proposing to re-host. Whichever lands second inherits the
   merge.
 - **Follow-up.** `bpm` is quantised to **33 distinct values** across the whole library — librosa's
   geometric tempo lattice, `…117.45, 123.05, 129.20…`. Percentiles are the wrong tool for it and it
   is excluded here, but a BPM filter that cannot distinguish 122 from 124 is worth its own look.
-- **Follow-up.** If this lands, `ADR-0042` point 3's calibration guidance becomes a convenience
+- **Follow-up.** If this lands, `ADR-0043` point 3's calibration guidance becomes a convenience
   rather than a load-bearing requirement, and that ADR's tradeoff about description quality softens.
   It does not become wrong, and it should not be edited until this is accepted.
 - **Follow-up.** `instrumentalness` and `speechiness` stay withdrawn under point 7 until a vocal

--- a/docs/decisions/ADR-0046-audio-features-are-filtered-by-percentile.md
+++ b/docs/decisions/ADR-0046-audio-features-are-filtered-by-percentile.md
@@ -1,8 +1,24 @@
 # ADR-0046: Audio Features Are Filtered by Percentile, Not by Absolute Value
 
-Status: proposed
+Status: accepted
 
 Date: 2026-08-08
+
+Implementation:
+- Accepted 2026-08-08.
+- **The rejected "rescale at extraction" alternative was reopened on acceptance and then narrowed,
+  not revived.** It was offered a full re-analysis of the library — and the investigation that
+  followed found that almost nothing needs one. Every miscalibrated scalar here is a *monotonic
+  function of a value already stored*, so correcting it is arithmetic rather than re-extraction.
+  That is [ADR-0047](ADR-0047-feature-scales-are-corrected-in-place.md), which sits alongside this
+  one: **0046 fixes how you ask, 0047 fixes what the numbers mean.** They are complementary, and
+  neither makes the other unnecessary — even perfectly scaled features have a library-specific
+  distribution, which is the case for percentiles regardless.
+- **The `bpm` follow-up got sharper and stayed out.** The lattice is exactly
+  `BPM(k) = 60·sr/hop = 2583.984 / k` at `sr=22050, hop_length=512` (`analysis.py:343-345`) — k=21
+  gives 123.05 and k=22 gives 117.45, matching the observed values. It is the **only** feature whose
+  correction genuinely requires re-extraction, because a lattice destroys information no transform
+  recovers. That makes it a cost decision rather than a scaling one, and it belongs in its own ADR.
 
 ## Context
 

--- a/docs/decisions/ADR-0047-feature-scales-are-corrected-in-place.md
+++ b/docs/decisions/ADR-0047-feature-scales-are-corrected-in-place.md
@@ -1,0 +1,155 @@
+# ADR-0047: Feature Scales Are Corrected in Place, Not Re-Extracted
+
+Status: proposed
+
+Date: 2026-08-08
+
+Extends [ADR-0046](ADR-0046-audio-features-are-filtered-by-percentile.md)
+
+## Context
+
+[ADR-0046](ADR-0046-audio-features-are-filtered-by-percentile.md) fixes how a caller *asks* for a
+feature: percentile boundaries instead of absolute thresholds, so "high energy" means the top decile
+of this library rather than a number that happens to sit near the median. It deliberately left the
+stored values alone, and rejected rescaling at extraction time partly on the cost of re-analysing
+~26,000 tracks.
+
+**That rejection was reopened by an offer to pay the cost — and the investigation that followed
+found the cost mostly does not need paying.** Both halves of that finding are worth recording.
+
+### Re-analysis is far more expensive than the ADR assumed
+
+- **`ANALYSIS_VERSION` no longer exists.** It is `FEATURES_VERSION = 8` (`backend/app/config.py:114`),
+  split per phase alongside `EMBEDDING_VERSION` and `MELODIC_VERSION`. A vestigial
+  `Settings.analysis_version` survives at `config.py:46` with no readers, and `CLAUDE.md`,
+  `AGENTS.md` and `VERSIONING.md` still instruct bumping the old constant and show `= 3`. Anyone
+  following the documented procedure today would edit a dead value and watch nothing happen.
+- **Analysis runs on one worker.** `max_analysis_workers = 1` (`config.py:88`) feeding a
+  `ProcessPoolExecutor(max_workers=1, max_tasks_per_child=1)` (`services/background/executors.py:70-78`)
+  — a fresh interpreter spawn per track. Nothing anywhere sets `MAX_ANALYSIS_WORKERS`.
+- **A features pass aborts after 8 hours** (`services/tasks/library_sync.py:355`), so a full
+  re-analysis is 5–10 consecutive sync runs, not one job.
+- **It re-runs work unrelated to any scalar**: AcoustID fingerprinting in a subprocess, a MusicBrainz
+  lookup rate-limited to 1 req/s, and community-cache network calls. The rate-limited I/O, not the
+  DSP, likely dominates.
+- The last bump was **2026-02-24, ~17 months ago**. Nothing has exercised this path at 26K scale on
+  the current code.
+
+### But every scale problem except one is a transform over a stored number
+
+Each miscalibrated feature is a **monotonic function of a scalar already in `track_analysis`**:
+
+| feature | what is stored | why the scale misleads |
+|---|---|---|
+| `energy` | `clip((rms_db + 60) / 54, 0, 1)` (`analysis.py:548-550`) | a fixed −60…−6 dBFS window; modern masters at −15 dBFS all land ≈0.83 |
+| `danceability` | `mean(librosa.beat.plp(...))` (`analysis.py:557-558`) | PLP is peak-normalised per track, so its **mean** is inherently ≈0.15 — never a calibrated 0–1 |
+| `swing_ratio` | onset position, gated `0.3 < x < 0.8`, default 0.5 (`analyzers.py:901-919`) | **the observed 0.300–0.800 range is the gate itself**, not the music |
+| `syncopation` | `mean(dist to 16th grid) × 4` (`analyzers.py:921-939`) | maximum possible min-distance is 0.125, so it **cannot exceed ~0.5 by construction** |
+| `harmonic_complexity` | chord changes per bar, unscaled (`analyzers.py:297-298`) | unbounded; observed max 14.0 while its neighbours claim 0–1 |
+| `brightness` | `min(centroid / 8000, 1.0)` (`analyzers.py:1121-1123`) | while `analysis.py:632` uses `centroid/(sr/2)*2` for valence's own brightness term — **two brightness scales in one codebase** |
+
+None of these requires touching audio. There is precedent for the correction living in code rather
+than in the data: **`valence` already applies a post-hoc rescaler**, `sign(c)·|c|^0.6 · 1.8` at
+`analysis.py:661`, for exactly this reason.
+
+### The one genuine exception
+
+**`bpm` cannot be fixed this way.** `librosa.feature.tempo` at `sr=22050` with the default
+`hop_length=512` (`analysis.py:343-345`) admits only `BPM(k) = 60·sr/hop/k = 2583.984 / k` — k=21
+gives 123.05, k=22 gives 117.45, matching the 33 distinct values observed across 25,697 tracks. A
+lattice **destroys information**, and no transform over the stored value recovers what was never
+measured. Fixing it means re-extraction, which makes it a cost decision rather than a scaling one.
+
+## Decision
+
+1. **Feature scales are corrected by transform, not by re-extraction.** Every feature named above is
+   a monotonic function of a stored scalar, so the correction is arithmetic. **No
+   `FEATURES_VERSION` bump, and no re-analysis**, which means the fix reaches all 25,697 analysed
+   tracks the day it ships rather than over the following fortnight.
+
+2. **The raw column stays raw; the correction is applied on read.** Stored values remain exactly
+   what the extractor measured, and the corrected scale is derived when serving. This keeps the
+   change reversible, keeps the correction reviewable as code rather than as a one-way migration,
+   and means a better correction later is a code change rather than another data migration.
+
+3. **A feature declares its real range, and that declaration is the single source of truth.**
+   `syncopation` is 0–0.5 by construction, `swing_ratio` is 0.3–0.8 by its gate,
+   `harmonic_complexity` is unbounded. Today these are implicit in the extraction code and
+   contradicted by the API, which presents them beside genuinely 0–1 values with nothing marking the
+   difference. The same declaration is what [ADR-0046](ADR-0046-audio-features-are-filtered-by-percentile.md)
+   point 7 already needs to detect a degenerate feature, so it is one mechanism, not two.
+
+4. **The two brightness formulas are reconciled to one.** `analyzers.py:1121` divides the spectral
+   centroid by a fixed 8 kHz; `analysis.py:632` divides by `sr/2` and doubles it. They disagree for
+   every track, and one of them feeds a stored column while the other feeds `valence`. Which
+   survives is an implementation choice; **having two is not**.
+
+5. **`bpm` is excluded, named, and deferred to its own decision.** It is the sole feature whose
+   correction requires re-extraction, and therefore the sole one whose price is a multi-day
+   re-analysis. Bundling it here would attach that cost to a change that otherwise has none.
+
+6. **This does not replace [ADR-0046](ADR-0046-audio-features-are-filtered-by-percentile.md), and
+   cannot.** Percentiles answer *"what counts as high energy in this collection"*, which remains
+   library-specific no matter how well the scale is calibrated — a folk library and an EDM library
+   have different top deciles of a perfectly scaled feature. **0046 fixes how you ask; this fixes
+   what the number means.** Both are needed, and the second is not a workaround for the first.
+
+7. **The stale versioning documentation is corrected as part of this.** `CLAUDE.md`, `AGENTS.md` and
+   `VERSIONING.md` describe a constant that no longer exists. This ADR is the first work in a year
+   to depend on knowing how re-analysis is triggered, and it found the documented procedure to be
+   wrong — leaving it wrong would guarantee the next person repeats the investigation.
+
+## Alternatives Considered
+
+**Rescale at extraction and re-analyse the library.** The version this ADR was asked to consider,
+and the most honest in principle: the stored numbers would then mean what their names say, with no
+read-time layer at all. Rejected because the investigation showed the cost is real and the benefit
+is not — one worker with a per-track interpreter spawn, an 8-hour phase cap forcing 5–10 runs, and a
+pass that re-does AcoustID and MusicBrainz I/O to change arithmetic. **Paying days of compute for a
+result obtainable by a pure function of a number already stored is the wrong trade**, and it would
+have been made on an assumption rather than a measurement.
+
+**Rewrite the stored values with a migration.** No read-time layer, no ongoing cost, and a one-time
+`UPDATE` is minutes rather than days. Genuinely tempting. Rejected because it discards the raw
+measurement: every future refinement of the correction would then compose on top of the previous
+one, and there would be no way to check a corrected value against what the extractor actually
+produced. Point 2 keeps the audit trail for the price of an arithmetic operation per read.
+
+**Do nothing beyond ADR-0046.** Percentiles already make queries behave correctly, which was the
+observed failure. Rejected because percentiles fix *filtering* and leave everything that
+**displays** a feature still lying — the Music Map axes, any UI showing "energy 0.83", and every
+comparison between two features on incompatible scales. It also leaves point 4's contradiction in
+place, which is a latent bug independent of presentation.
+
+**Fix each feature ad hoc, where it is consumed.** Smallest possible diff per site, no new concept.
+Rejected because it is exactly how the codebase arrived at two brightness formulas, and because
+ADR-0046 point 3 is simultaneously consolidating four duplicate implementations of feature
+filtering. Adding per-site corrections while removing per-site filters would be pulling in two
+directions at once.
+
+## Consequences
+
+- **Positive.** Every feature the API serves can be given an honest scale without re-analysing
+  anything, so the correction reaches the whole library immediately.
+- **Positive.** Point 3's range declaration is a single mechanism serving two decisions — this one
+  and ADR-0046 point 7's degeneracy check — rather than two overlapping ones.
+- **Positive.** Point 4 removes a genuine contradiction: two functions in one codebase computing
+  "brightness" differently, one feeding a column and one feeding `valence`.
+- **Positive.** Keeping raw values means a wrong correction is a code fix, not a data-recovery job.
+- **Tradeoff.** A stored value and a served value now differ, so anyone reading the database
+  directly sees numbers that do not match the API. Point 2 accepts this deliberately, but it needs
+  saying out loud: the column is the measurement, not the answer.
+- **Tradeoff.** Read-time arithmetic on every feature served, forever, in exchange for never paying
+  a migration. Negligible per row; it is a permanent cost against a one-time one, and that is the
+  shape of the trade.
+- **Tradeoff.** `bpm` stays wrong. Its 33 values remain the worst scale problem in the library, and
+  point 5 defers rather than solves it.
+- **Follow-up.** The `bpm` decision. Cheap options exist and should be weighed before assuming a
+  full re-analysis: passing `hop_length=256` or `128` to both `onset_strength` and `feature.tempo`,
+  parabolic interpolation of the tempogram peak, or **free** — `60 / median(diff(beat_times))` from
+  the PLP beats already computed at `analysis.py:348-351`.
+- **Follow-up.** Whether the corrected scale should also be written back to a second column, if
+  read-time arithmetic ever shows up in a profile. Nothing suggests it will.
+- **Follow-up.** `instrumentalness` and `speechiness` are excluded from all of this: they are not
+  miscalibrated but dead, pending a vocal detector suited to music (`familiar` #116). A scale
+  correction cannot rescue a constant.


### PR DESCRIPTION
One ADR, `proposed`. It stands alone — it does not depend on #114 — but it changes how load-bearing that PR's point 3 is.

> **Note:** the link to ADR-0042 will show as broken until #114 merges. That file only exists on the ADR-0042 branch.

## The problem, measured

The 0–1 audio features are real measurements on scales that don't mean what their names imply. Across 25,697 analysed tracks:

| feature | p10 | p50 | p90 | distinct values |
|---|---|---|---|---|
| `energy` | 0.700 | 0.826 | 0.898 | 25,590 |
| `valence` | 0.665 | 0.848 | 0.985 | 23,640 |
| `danceability` | 0.096 | 0.149 | 0.206 | 25,583 |
| `acousticness` | 0.391 | 0.491 | 0.578 | 25,614 |

The signal is there — ~25,600 distinct values each. It's just compressed into a narrow band nowhere near the middle of 0–1.

**That's arithmetic, not accident.** `energy = clip((rms_db + 60) / 54, 0, 1)`, so a typical master at −15 dBFS gives 0.83 — the observed median. `danceability` is the raw mean of librosa's PLP curve, which naturally lands near 0.15 and was never on a perceptual scale.

**So absolute thresholds fail in both directions:**

| filter | matches | share |
|---|---|---|
| `energy≥0.6 and valence≥0.6` | 23,761 | **92.5%** |
| `danceability≥0.4` | **5** | **0.02%** |

The spike in #114 hit exactly this: asked for "something upbeat and happy" it returned 92.5% of the library, and nothing in the response would have said so.

## Why the existing workaround isn't enough

ADR-0042 point 3's calibration guidance **works** — the spike measured blind thresholding falling from 3 to 0. But it only reaches the consumer with a model in the loop reading tool descriptions. The `fx`/`fy` axes on `GET /tracks`, smart-playlist rule fields, the ambient/radio ranking engine and the Music Map aggregations have no way to calibrate at all.

## Measured before deciding

- **Percentile boundaries are cheap** — six percentiles × six features, one query over 25,697 rows: **252 ms**.
- **Translating percentile → raw threshold keeps existing indexes** — `energy >= 0.898` returns 2,558 rows in **3 ms**, and `ix_track_analysis_energy`/`_valence`/`_bpm` already exist.
- **Per-track `percent_rank()` is 53 ms/feature** — affordable, but it stores a value every insert silently invalidates.
- **Feature filtering is implemented four times** — `listing.py:108`, `:348`, `:506`, `search.py:393`. Adding percentiles naively makes it five.

## The shape of the decision

Store **boundaries**, not per-track ranks. Translate to a raw threshold so indexes still do the work. **Consolidate the four copies first** — that's a prerequisite, not a tidy-up. Keep absolute bounds alongside so stored smart playlists survive. **No `ANALYSIS_VERSION` bump and no re-analysis** — it's all derived from data already in `track_analysis`, so it reaches the whole library the day it ships.

## Point 7 comes from a premise that failed

Percentiles do **not** rescue every feature. `instrumentalness` is exactly 1.0 for 25,661 of 25,697 tracks (see #116), and **the percentile of a near-constant is noise** — ranking it would dress a dead feature up as a live one. So a degenerate feature is *withdrawn*, not ranked. Degeneracy is detectable from the same boundary computation, making it a property the system checks rather than a list someone maintains.

## What to push back on

- **Two ways to express one filter** is a real cost. Point 4 accepts it because removing absolute bounds breaks every stored smart playlist — but "why did `energy_min=0.9` and `energy_min_pct=90` differ?" will get asked.
- **Stale boundaries.** Harmless at 26K tracks; the failure mode to watch is a *small* new library where each import shifts the distribution materially.
- **Point 3 collides with #114.** It touches the LLM tool path that ADR-0042 proposes to re-host. Whichever lands second inherits the merge.
- **The rescale-at-extraction alternative** is arguably more honest and I rejected it partly on cost. Worth disagreeing with if you think baking constants is acceptable.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
