### PR TITLE
Correct the audio-feature instructions — wrong on both counts

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -85,9 +85,18 @@ Each platform entry point (`packages/web/src/main.tsx`, `packages/ios/src/main.t
 ## Common Tasks
 
 ### Add a new audio feature
-1. Add extraction logic to `analysis.py` in `extract_features()`
-2. No schema change needed (features stored as JSONB)
-3. Bump `ANALYSIS_VERSION` in `config.py` to re-analyze existing tracks
+1. Add extraction logic in `analysis.py` — `derive_features()` for librosa scalars (`extract_features()`
+   is a thin wrapper), or `services/track_analysis/analyzers.py` for the section analyzers, mapped
+   through `extract_feature_scalars()` in `track_analysis/pipeline.py`
+2. **Add a typed column** to `TrackAnalysis` in `backend/app/db/models/tracks.py`, list it in
+   `ANALYSIS_FEATURE_COLUMNS`, and write an Alembic migration. Features were promoted out of JSONB
+   into typed columns — a new feature that skips this is computed and then silently dropped
+3. Bump `FEATURES_VERSION` in `config.py` and add a line to the history comment beside it. There is
+   **no `ANALYSIS_VERSION`**; the constants are per phase, so bumping features leaves embeddings and
+   melodic data alone
+4. Re-analysis only happens during a **library sync** — nothing is scheduled. Budget for it: one
+   worker, a fresh interpreter per track, and an 8-hour cap on the features phase, so a large
+   library takes several consecutive syncs. See `VERSIONING.md`
 
 ### Add a new LLM tool
 1. Define tool schema in `MUSIC_TOOLS` list in `services/llm/tools.py`

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -229,9 +229,18 @@ Each platform entry point (`packages/web/src/main.tsx`, `packages/ios/src/main.t
 ## Common Tasks
 
 ### Add a new audio feature
-1. Add extraction logic to `analysis.py` in `extract_features()`
-2. No schema change needed (features stored as JSONB)
-3. Bump `ANALYSIS_VERSION` in `config.py` to re-analyze existing tracks
+1. Add extraction logic in `analysis.py` — `derive_features()` for librosa scalars (`extract_features()`
+   is a thin wrapper), or `services/track_analysis/analyzers.py` for the section analyzers, mapped
+   through `extract_feature_scalars()` in `track_analysis/pipeline.py`
+2. **Add a typed column** to `TrackAnalysis` in `backend/app/db/models/tracks.py`, list it in
+   `ANALYSIS_FEATURE_COLUMNS`, and write an Alembic migration. Features were promoted out of JSONB
+   into typed columns — a new feature that skips this is computed and then silently dropped
+3. Bump `FEATURES_VERSION` in `config.py` and add a line to the history comment beside it. There is
+   **no `ANALYSIS_VERSION`**; the constants are per phase, so bumping features leaves embeddings and
+   melodic data alone
+4. Re-analysis only happens during a **library sync** — nothing is scheduled. Budget for it: one
+   worker, a fresh interpreter per track, and an 8-hour cap on the features phase, so a large
+   library takes several consecutive syncs. See `VERSIONING.md`
 
 ### Add a new LLM tool
 1. Define tool schema in `MUSIC_TOOLS` list in `services/llm/tools.py`

--- a/VERSIONING.md
+++ b/VERSIONING.md
@@ -219,18 +219,39 @@ The version is exposed via:
 - Settings UI (bottom of System Status panel)
 - FastAPI OpenAPI docs
 
-## Analysis Version
+## Analysis Versions
 
-Separate from the app version, `ANALYSIS_VERSION` tracks the audio analysis pipeline:
+Separate from the app version, the analysis pipeline is versioned **per phase**. There is no single
+`ANALYSIS_VERSION` — it was split so that changing one phase does not re-run the others:
 
 ```python
 # backend/app/config.py
-ANALYSIS_VERSION = 3
+FEATURES_VERSION = 8    # librosa scalars, key, loudness, VAD
+EMBEDDING_VERSION = 6   # CLAP 512-dim embeddings
+MELODIC_VERSION = 6     # basic-pitch MIDI transcription
+GENERATIVE_ART_VERSION = 4
+MOOD_TAGS_VERSION = 1
 ```
 
-**When to bump:** When analysis output changes (new features extracted, algorithm changes).
+**Bump only the phase that changed.** Each constant has a history comment beside it in `config.py`
+recording what every prior version altered; add a line there when bumping.
 
-Bumping this version causes all tracks to be re-analyzed on next library scan.
+`Settings.analysis_version` also exists in `config.py` and is **dead** — nothing reads it. The
+backward-compatible `Track.analysis_version` property returns `analyses[0].features_version`.
+
+**What a bump actually does.** Nothing, on its own. Re-analysis is driven by
+`queue_tracks_for_features()` (`app/services/tasks/analysis_queue.py`), which selects tracks whose
+`features_version` is behind — and that only runs during a **library sync**. There is no scheduler
+for it.
+
+**Budget before bumping `FEATURES_VERSION`.** Analysis runs on a single worker
+(`max_analysis_workers = 1`) with `max_tasks_per_child=1`, so every track pays a fresh interpreter
+spawn, and the features phase aborts after 8 hours — a large library needs several consecutive syncs
+to finish. The pass also re-runs AcoustID fingerprinting and a MusicBrainz lookup rate-limited to
+1 req/s, so for a library in the tens of thousands the network I/O, not the DSP, tends to dominate.
+
+**A features bump does not recompute embeddings or melodic data** — those gate on their own
+constants, so they are skipped while `EMBEDDING_VERSION` and `MELODIC_VERSION` are unchanged.
 
 ## When to Release
 


### PR DESCRIPTION
"Add a new audio feature" appears identically in `CLAUDE.md` and `AGENTS.md`, and **both of its substantive steps are false**. Following them produces a feature that never persists, then bumps a constant nothing reads.

```
1. Add extraction logic to `analysis.py` in `extract_features()`
2. No schema change needed (features stored as JSONB)     <- false
3. Bump `ANALYSIS_VERSION` in `config.py`                 <- does not exist
```

## Step 2 is the damaging one

Features were **promoted out of JSONB into typed columns** on `TrackAnalysis` — the comment at `models/tracks.py:188` says exactly that. So a new feature also needs a column, an entry in `ANALYSIS_FEATURE_COLUMNS`, and a migration.

Skip those and it is computed and **silently dropped**, which presents as a broken extractor rather than a missing migration.

## Step 3 names a constant that no longer exists

It was split per phase so that changing one does not re-run the others:

| constant | value |
|---|---|
| `FEATURES_VERSION` | 8 |
| `EMBEDDING_VERSION` | 6 |
| `MELODIC_VERSION` | 6 |
| `GENERATIVE_ART_VERSION` | 4 |
| `MOOD_TAGS_VERSION` | 1 |

A vestigial `Settings.analysis_version` survives at `config.py:46` with **no readers** — precisely the wrong thing to stumble on while following stale instructions.

`VERSIONING.md` showed `ANALYSIS_VERSION = 3` against a real value of 8, and claimed a bump "causes all tracks to be re-analyzed on next library scan." It now describes the per-phase set and what a bump actually does — **nothing on its own**. Re-analysis is driven by `queue_tracks_for_features()` and only runs during a library sync; nothing schedules it.

## All three now state the cost, because it was recorded nowhere

- One worker (`max_analysis_workers = 1`), `max_tasks_per_child=1` — a **fresh interpreter spawn per track**
- The features phase **aborts after 8 hours**, so a large library needs several consecutive syncs
- The pass re-runs AcoustID fingerprinting and a MusicBrainz lookup at 1 req/s, so for tens of thousands of tracks the **network I/O dominates the DSP**

That cost is why ADR-0047 (#117) corrects feature scales by transform rather than re-extraction. It deserved to be written down where someone contemplating a bump will see it.

The three surviving mentions of `ANALYSIS_VERSION` are deliberate — they say it does not exist, so searching the old name lands somewhere useful.

Found while establishing what ADR-0047 would cost.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
