### PR TITLE
Serve Familiar's tools over MCP (ADR-0043)

### DIFF
--- a/backend/app/config.py
+++ b/backend/app/config.py
@@ -45,6 +45,12 @@ class Settings(BaseSettings):
     # Analysis
     analysis_version: int = 1
 
+    # MCP (ADR-0043). Comma-separated hosts this server is reached by, e.g.
+    # "localhost:4400,myserver:4400". Set it and DNS-rebinding protection is enabled for /mcp;
+    # leave it empty and the protection is off, with a warning at startup. The SDK ships no default
+    # allowlist, so enabling it without naming your host rejects every request with a 421.
+    mcp_allowed_hosts: str = ""
+
     # API Keys (Phase 3+)
     anthropic_api_key: str | None = None
     frontend_url: str | None = None  # Base URL for OAuth callbacks (e.g., http://myserver:4400)

--- a/backend/app/main.py
+++ b/backend/app/main.py
@@ -295,7 +295,11 @@ async def lifespan(app: FastAPI) -> AsyncGenerator[None, None]:
     await bg.startup()
     logger.info("Background task manager started")
 
-    yield
+    # The MCP session manager must be running or every /mcp request fails at *request* time with
+    # "Task group is not initialized", not at startup — so it looks like a runtime bug rather than
+    # missing wiring (ADR-0043 point 1).
+    async with _mcp_session_manager_running(app):
+        yield
 
     # Shutdown
     logger.info("Shutting down Familiar API")
@@ -330,6 +334,24 @@ app = FastAPI(
     lifespan=lifespan,
     generate_unique_id_function=custom_generate_unique_id,
 )
+
+# MCP (ADR-0043). Mounted here rather than beside the API routers because the SPA catch-all is
+# registered last and would swallow it — and asymmetrically: streamable HTTP uses POST for requests
+# and GET for the server-initiated stream, so a late mount leaves POST working while GET quietly
+# returns index.html. `mcp` is in NON_SPA_PREFIXES for the same reason.
+from app.mcp.server import MCPDispatch  # noqa: E402
+from app.mcp.server import build_asgi_app as _build_mcp_app  # noqa: E402
+
+_mcp_asgi_app = _build_mcp_app()
+app.add_middleware(MCPDispatch, mcp_app=_mcp_asgi_app)
+
+
+@asynccontextmanager
+async def _mcp_session_manager_running(_app: FastAPI) -> AsyncGenerator[None, None]:
+    """Run the MCP session manager for the lifetime of the app."""
+    async with _mcp_asgi_app.router.lifespan_context(_mcp_asgi_app):
+        yield
+
 
 # Rate limiting
 app.state.limiter = limiter
@@ -508,7 +530,7 @@ STATIC_DIR = Path(__file__).parent.parent / "static"
 
 # Prefixes the single-page app must never swallow. A miss inside these belongs to the API, and the
 # answer to it is a 404 rather than an HTML document.
-NON_SPA_PREFIXES = ("api/", "docs", "redoc", "openapi.json", "health")
+NON_SPA_PREFIXES = ("api/", "docs", "redoc", "openapi.json", "health", "mcp")
 
 
 async def serve_embed() -> FileResponse:

--- a/backend/app/mcp/__init__.py
+++ b/backend/app/mcp/__init__.py
@@ -1,0 +1,5 @@
+"""Familiar's MCP surface (ADR-0043)."""
+
+from app.mcp.server import EXCLUDED, ProfileNotBound, build_server, exposed_tools
+
+__all__ = ["EXCLUDED", "ProfileNotBound", "build_server", "exposed_tools"]

--- a/backend/app/mcp/guidance.py
+++ b/backend/app/mcp/guidance.py
@@ -1,0 +1,79 @@
+"""The portable half of the chat system prompt (ADR-0043 point 3).
+
+`SYSTEM_PROMPT` in `services/llm/tools.py` is ~11,000 characters, and most of it is **chat-loop
+control** — "SEARCH ONCE, THEN QUEUE", "STOP CONDITIONS", "you've made 2 searches → STOP". That
+exists to stop a chat agent looping. An MCP host runs its own loop and the listener can iterate, so
+porting it would be actively misleading.
+
+What is portable is the operating knowledge a model cannot derive from a schema: which tool to reach
+for, what order two tools go in, and which numbers are meaningless without calibration.
+
+**This is not decoration.** Measured against both arms of `scripts/spike_mcp_arms.py`, the guided
+arm calibrated before thresholding in 4 of 8 prompts against the bare arm's 1, and never thresholded
+blind where the bare arm did so three times. The one that matters: asked for "something upbeat and
+happy", an uncalibrated model filtered `energy>=0.6, valence>=0.6` — which matches 92.5% of the
+library.
+
+Two of the three worries in ADR-0043 point 3 turned out to be unfounded: both arms already ordered
+`identify_track` before `find_similar_tracks`, and both already reached for `semantic_search` on
+abstract moods, because those tool descriptions carry their own sequencing. **The whole measured
+effect was calibration.** The other entries are kept because they cost nothing and the measurement
+was n=1 per cell.
+"""
+
+from __future__ import annotations
+
+INSTRUCTIONS = (
+    "Familiar is a personal music library, locally analysed. Every track carries audio features "
+    "extracted from the audio itself — energy, valence, danceability, acousticness, BPM, key — plus "
+    "CLAP audio embeddings supporting natural-language search over how music actually sounds.\n\n"
+    "Two things make answers good here, and neither is obvious from the schemas:\n\n"
+    "1. **Numeric feature thresholds are meaningless until calibrated against this collection.** "
+    "The stored values are raw measurements on compressed scales, not perceptual 0-1 ratings. Call "
+    "get_feature_distribution before filtering on a feature and choose bounds from the actual "
+    "spread. A guessed threshold silently returns almost everything or almost nothing.\n"
+    "2. **Sonic similarity lives in the embeddings, not the metadata.** For anything abstract or "
+    "figurative, reach for semantic_search rather than trying to express the idea as feature ranges."
+)
+
+# Appended to the tool's own MUSIC_TOOLS description. Keep each one about *this* tool: MCP gives no
+# other channel, and a host may show only the tool it is about to call.
+GUIDANCE: dict[str, str] = {
+    "filter_tracks": (
+        "\n\nCALIBRATE BEFORE YOU THRESHOLD. Do not guess numeric bounds. Call "
+        "get_feature_distribution for a feature first and pick bounds from this library's actual "
+        "spread — 'high energy' in a folk collection is a different number from an EDM collection, "
+        "and a guessed threshold silently returns nothing or everything.\n"
+        "Prefer this over search_library whenever you want more than a couple of tracks by one "
+        "artist: search_library applies a diversity filter that caps results at 2 per artist."
+    ),
+    "get_feature_distribution": (
+        "\n\nCall this BEFORE choosing any numeric bound for filter_tracks. It is cheap, and it is "
+        "the difference between a filter tuned to this collection and one tuned to a guess."
+    ),
+    "search_library": (
+        "\n\nNote: results are capped at 2 tracks per artist by a diversity filter. If you want a "
+        "set of tracks by one artist, use filter_tracks(artist=...) instead."
+    ),
+    "semantic_search": (
+        "\n\nPREFER THIS over filter_tracks for abstract or figurative descriptions — 'dreamy', "
+        "'ethereal', 'gloomy with Eastern influences', 'sounds like a rainy commute'. Audio-feature "
+        "filters cannot express those. Use filter_tracks for concrete metadata and for simple mood "
+        "words that map directly onto energy/valence."
+    ),
+    "identify_track": (
+        "\n\nCall this FIRST whenever the user names a specific song — 'something like [title] by "
+        "[artist]'. find_similar_tracks needs the track_id this returns and cannot accept a title. "
+        "If the track is NOT in the library, do not stop: use get_similar_artists_in_library to "
+        "find related artists the listener does have."
+    ),
+    "find_similar_tracks": (
+        "\n\nRequires a track_id from identify_track or a previous search result. It will not "
+        "accept a title or artist name."
+    ),
+    "create_playlist_from_items": (
+        "\n\nThis writes a real playlist the listener will see. Pass generation_prompt describing "
+        "what was asked for, in their words where you have them — it is stored with the playlist "
+        "and is what explains later why the playlist exists."
+    ),
+}

--- a/backend/app/mcp/server.py
+++ b/backend/app/mcp/server.py
@@ -1,0 +1,253 @@
+"""Familiar's MCP server (ADR-0043).
+
+The LLM surface. Familiar exposes its analysis tools over MCP rather than shipping a chat client,
+so the host the listener already uses — Claude Desktop, Claude Code — drives them.
+
+**This is an adapter, not a reimplementation.** `ToolExecutor.execute(name, arguments)` already
+takes a tool name and a dict, which is exactly what MCP's `tools/call` provides, so the tool schemas
+come straight from `MUSIC_TOOLS` and the handlers from `services/llm/handlers/` unchanged. Nothing
+here can drift from the chat path, because there is nothing here to drift.
+
+Two entry points over one tool set (ADR-0043 point 1): this module is mounted in-process by
+`app.main`, and `scripts/mcp_stdio.py` serves the same tools over stdio for local development.
+"""
+
+from __future__ import annotations
+
+import json
+import logging
+import os
+from copy import deepcopy
+from typing import Any
+from uuid import UUID
+
+import mcp.types as types
+from mcp.server.lowlevel import Server
+from mcp.server.lowlevel.server import ServerRequestContext
+from mcp.server.transport_security import TransportSecuritySettings
+from sqlalchemy import select
+
+from app.config import settings as app_config
+from app.db.models import Profile
+from app.db.session import async_session_maker
+from app.mcp.guidance import GUIDANCE, INSTRUCTIONS
+from app.services.llm.tools import MUSIC_TOOLS
+
+logger = logging.getLogger(__name__)
+
+SERVER_NAME = "familiar"
+PROFILE_HEADER = "x-profile-id"
+PROFILE_ENV = "FAMILIAR_MCP_PROFILE_ID"
+
+#: Requires a Familiar client to mean anything — ADR-0043 point 2 defers these to ADR-0044.
+#: `get_visible_tracks` answers only because a chat client uploaded its viewport; `queue_tracks`
+#: and `control_playback` write to in-memory fields that never reach the server's state.
+_CLIENT_BOUND = {"get_visible_tracks", "queue_tracks", "control_playback"}
+
+#: Dropped outright. A server-side URL fetcher on an API with no inbound authentication is an SSRF
+#: primitive, and the host's own web access does the job better (ADR-0043 point 2).
+_WITHHELD = {"fetch_webpage"}
+
+EXCLUDED = _CLIENT_BOUND | _WITHHELD
+
+
+class ProfileNotBound(Exception):
+    """No profile is bound to this connection.
+
+    ADR-0043 point 9: the profile is configured per connection rather than passed per call, because
+    nine handler paths depend on it and a tool that took it as a parameter would let a model guess
+    at another listener's favourites.
+    """
+
+
+def exposed_tools() -> list[types.Tool]:
+    """The tool surface, taken from MUSIC_TOOLS so it cannot drift."""
+    tools: list[types.Tool] = []
+    for spec in MUSIC_TOOLS:
+        name = spec["name"]
+        if name in EXCLUDED:
+            continue
+        schema = deepcopy(spec["input_schema"])
+        if name == "create_playlist_from_items":
+            # ADR-0043 point 9. The handler stores `user_message` as Playlist.generation_prompt,
+            # and an MCP host never passes the listener's raw turn — so it becomes an argument or
+            # every MCP-created playlist has an empty one.
+            schema.setdefault("properties", {})["generation_prompt"] = {
+                "type": "string",
+                "description": (
+                    "What the listener asked for, in their words where you have them. Stored with "
+                    "the playlist as the record of why it exists."
+                ),
+            }
+        tools.append(
+            types.Tool(
+                name=name,
+                description=str(spec["description"]) + GUIDANCE.get(name, ""),
+                input_schema=schema,
+            )
+        )
+    return tools
+
+
+def _header_profile(ctx: ServerRequestContext[Any]) -> str | None:
+    request = getattr(ctx, "request", None)
+    headers = getattr(request, "headers", None)
+    if headers is None:
+        return None
+    try:
+        return headers.get(PROFILE_HEADER)
+    except Exception:  # noqa: BLE001 - a header bag that does not behave is simply absent
+        return None
+
+
+async def resolve_profile(ctx: ServerRequestContext[Any]) -> UUID:
+    """The profile this connection acts as.
+
+    Header first so one server can serve several listeners; the environment variable is how the
+    stdio entry point binds a single one. Raises rather than defaulting: acting as *some* profile
+    because none was named is how a model ends up reading the wrong person's favourites.
+    """
+    raw = _header_profile(ctx) or os.environ.get(PROFILE_ENV)
+    if not raw:
+        raise ProfileNotBound(
+            f"No profile is bound to this connection. Send the {PROFILE_HEADER} header, or set "
+            f"{PROFILE_ENV} for stdio. Familiar's tools are per-listener — favourites, play history "
+            f"and playlists all depend on it — so there is no safe default."
+        )
+    try:
+        profile_id = UUID(raw)
+    except ValueError as exc:
+        raise ProfileNotBound(f"Profile id {raw!r} is not a UUID.") from exc
+
+    async with async_session_maker() as session:
+        exists = await session.scalar(select(Profile.id).where(Profile.id == profile_id))
+    if exists is None:
+        raise ProfileNotBound(
+            f"Profile {profile_id} does not exist on this server. GET /api/v1/profiles lists them."
+        )
+    return profile_id
+
+
+async def on_list_tools(
+    ctx: ServerRequestContext[Any], _params: types.PaginatedRequestParams | None
+) -> types.ListToolsResult:
+    # Resolving here as well as in call_tool is deliberate. Listing tools is the first thing every
+    # host does, so an unbound connection fails immediately and says why — rather than presenting a
+    # working-looking surface that fails on the first call (ADR-0043 point 9, and the "Listening
+    # Ideas" defect one step later that ADR-0022 point 3 refused).
+    await resolve_profile(ctx)
+    return types.ListToolsResult(tools=exposed_tools())
+
+
+async def on_call_tool(
+    ctx: ServerRequestContext[Any], params: types.CallToolRequestParams
+) -> types.CallToolResult:
+    name = params.name
+    if name in EXCLUDED or not any(t.name == name for t in exposed_tools()):
+        return _error(f"Unknown tool {name!r}.")
+
+    arguments: dict[str, Any] = dict(params.arguments or {})
+    # Not an argument the handler takes; it is how `user_message` is supplied outside a chat.
+    generation_prompt = str(arguments.pop("generation_prompt", "") or "")
+
+    try:
+        profile_id = await resolve_profile(ctx)
+    except ProfileNotBound as exc:
+        return _error(str(exc))
+
+    # A session per call, never held across calls. A yield-scoped session outliving its handler is
+    # how 834 downloads once became 83-byte error bodies here.
+    from app.services.llm.executor import ToolExecutor
+
+    async with async_session_maker() as session:
+        executor = ToolExecutor(session, profile_id=profile_id, user_message=generation_prompt)
+        result = await executor.execute(name, arguments)
+
+    is_error = isinstance(result, dict) and "error" in result
+    if is_error:
+        logger.info("mcp tool %s returned an error: %s", name, result.get("error"))
+    return types.CallToolResult(
+        content=[types.TextContent(type="text", text=json.dumps(result, default=str))],
+        is_error=is_error,
+    )
+
+
+def _error(message: str) -> types.CallToolResult:
+    return types.CallToolResult(
+        content=[types.TextContent(type="text", text=message)], is_error=True
+    )
+
+
+def build_server() -> Server[Any]:
+    return Server(
+        name=SERVER_NAME,
+        instructions=INSTRUCTIONS,
+        on_list_tools=on_list_tools,
+        on_call_tool=on_call_tool,
+    )
+
+
+def _transport_security() -> TransportSecuritySettings:
+    """DNS-rebinding protection for the streamable-HTTP transport.
+
+    The SDK enables this and ships **no default allowlist**, so every `Host` — including
+    `localhost` — is rejected with `421 Misdirected Request` until named. A 421 reads as a proxy
+    fault, which is a bad way to learn about a setting.
+
+    Configure `mcp_allowed_hosts` and the protection is on. Leave it empty and it is off, with a
+    warning, because Familiar's actual inbound control is Tailscale today and a token under
+    ADR-0045 tomorrow — and a server that 421s every request out of the box teaches people to
+    disable security they never understood.
+    """
+    hosts = [h.strip() for h in (app_config.mcp_allowed_hosts or "").split(",") if h.strip()]
+    if hosts:
+        return TransportSecuritySettings(
+            enable_dns_rebinding_protection=True,
+            allowed_hosts=hosts,
+            allowed_origins=hosts,
+        )
+    logger.warning(
+        "MCP DNS-rebinding protection is OFF (mcp_allowed_hosts is unset). Set it to the hosts "
+        "this server is reached by — e.g. 'localhost:4400,myserver:4400' — to enable it."
+    )
+    return TransportSecuritySettings(
+        enable_dns_rebinding_protection=False, allowed_hosts=["*"], allowed_origins=["*"]
+    )
+
+
+def build_asgi_app() -> Any:
+    """The streamable-HTTP app, served at the mount point itself rather than a nested `/mcp`."""
+    return build_server().streamable_http_app(
+        streamable_http_path="/",
+        transport_security=_transport_security(),
+    )
+
+
+class MCPDispatch:
+    """Serves the MCP app at exactly `/mcp`, dispatching before the router sees the request.
+
+    `app.mount("/mcp", ...)` does not work here, and the way it fails is worth recording.
+    Starlette's `Mount` compiles to a pattern that requires a trailing segment, so a request to
+    `/mcp` never matches the mount; the router then falls through to `redirect_slashes` and answers
+    **307 → /mcp/**. MCP clients POST their handshake, a redirected POST is not something every
+    client replays correctly, and the symptom — a handshake that simply never completes — points
+    nowhere near a trailing slash.
+
+    Dispatching as middleware runs before routing, so both `/mcp` and `/mcp/` are served directly
+    with no redirect, and the SPA catch-all never sees either.
+    """
+
+    def __init__(self, app: Any, mcp_app: Any = None, path: str = "/mcp") -> None:
+        self.app = app
+        self.mcp_app = mcp_app
+        self.path = path
+
+    async def __call__(self, scope: dict[str, Any], receive: Any, send: Any) -> None:
+        if (
+            self.mcp_app is not None
+            and scope.get("type") == "http"
+            and scope.get("path", "").rstrip("/") == self.path
+        ):
+            await self.mcp_app({**scope, "path": "/", "raw_path": b"/"}, receive, send)
+            return
+        await self.app(scope, receive, send)

--- a/backend/app/mcp/server.py
+++ b/backend/app/mcp/server.py
@@ -89,43 +89,81 @@ def exposed_tools() -> list[types.Tool]:
     return tools
 
 
-def _header_profile(ctx: ServerRequestContext[Any]) -> str | None:
+def _request_profile(ctx: ServerRequestContext[Any]) -> str | None:
+    """The profile named by the request, by header or by query string.
+
+    The query string exists because **hosts cannot all set headers.** Claude Desktop's custom
+    connector takes a URL and nothing else, so a header-only server cannot be added to it at all.
+    A profile id is not a secret — `GET /api/v1/profiles` lists them unauthenticated — so carrying
+    it in the URL gives nothing away that the API does not already.
+    """
     request = getattr(ctx, "request", None)
-    headers = getattr(request, "headers", None)
-    if headers is None:
+    if request is None:
         return None
     try:
-        return headers.get(PROFILE_HEADER)
-    except Exception:  # noqa: BLE001 - a header bag that does not behave is simply absent
+        headers = getattr(request, "headers", None)
+        if headers is not None:
+            named = headers.get(PROFILE_HEADER)
+            if named:
+                return str(named)
+        params = getattr(request, "query_params", None)
+        if params is not None:
+            named = params.get("profile")
+            if named:
+                return str(named)
+    except Exception:  # noqa: BLE001 - a request object that does not behave is simply silent
         return None
+    return None
+
+
+async def _sole_profile() -> UUID | None:
+    """The only profile, when there is exactly one.
+
+    ADR-0043 point 9 refuses a *default* profile because a model must not guess at another
+    listener's favourites. With exactly one profile there is nothing to guess: the single
+    possibility is the correct one, and requiring configuration to state the obvious is how a
+    working server looks broken. Add a second profile and this returns None immediately, so
+    connections must name one from that moment on.
+    """
+    async with async_session_maker() as session:
+        ids = (await session.scalars(select(Profile.id).limit(2))).all()
+    return ids[0] if len(ids) == 1 else None
 
 
 async def resolve_profile(ctx: ServerRequestContext[Any]) -> UUID:
     """The profile this connection acts as.
 
-    Header first so one server can serve several listeners; the environment variable is how the
-    stdio entry point binds a single one. Raises rather than defaulting: acting as *some* profile
-    because none was named is how a model ends up reading the wrong person's favourites.
+    Request first, so one server can serve several listeners; then the environment variable, which
+    is how the stdio entry point binds one; then the sole profile, if there is only one.
     """
-    raw = _header_profile(ctx) or os.environ.get(PROFILE_ENV)
+    raw = _request_profile(ctx) or os.environ.get(PROFILE_ENV)
     if not raw:
+        only = await _sole_profile()
+        if only is not None:
+            return only
         raise ProfileNotBound(
-            f"No profile is bound to this connection. Send the {PROFILE_HEADER} header, or set "
-            f"{PROFILE_ENV} for stdio. Familiar's tools are per-listener — favourites, play history "
-            f"and playlists all depend on it — so there is no safe default."
+            f"No profile is bound to this connection, and this server has more than one. Send the "
+            f"{PROFILE_HEADER} header, add ?profile=<uuid> to the URL, or set {PROFILE_ENV} for "
+            f"stdio. Familiar's tools are per-listener — favourites, play history and playlists all "
+            f"depend on it — so with several profiles there is no safe default. "
+            f"GET /api/v1/profiles lists them."
         )
     try:
         profile_id = UUID(raw)
     except ValueError as exc:
         raise ProfileNotBound(f"Profile id {raw!r} is not a UUID.") from exc
 
-    async with async_session_maker() as session:
-        exists = await session.scalar(select(Profile.id).where(Profile.id == profile_id))
-    if exists is None:
+    if await _verify_profile(profile_id) is None:
         raise ProfileNotBound(
             f"Profile {profile_id} does not exist on this server. GET /api/v1/profiles lists them."
         )
     return profile_id
+
+
+async def _verify_profile(profile_id: UUID) -> UUID | None:
+    """The profile id if it exists, else None. A named profile is checked, never assumed."""
+    async with async_session_maker() as session:
+        return await session.scalar(select(Profile.id).where(Profile.id == profile_id))
 
 
 async def on_list_tools(

--- a/backend/app/mcp/server.py
+++ b/backend/app/mcp/server.py
@@ -201,7 +201,22 @@ async def on_call_tool(
         executor = ToolExecutor(session, profile_id=profile_id, user_message=generation_prompt)
         result = await executor.execute(name, arguments)
 
+    # Every call is logged with its arguments, because the arguments are the interesting part.
+    # ADR-0043 point 3 rests on a host calling get_feature_distribution *before* it thresholds,
+    # and there is otherwise no way to see whether it did: the tool sequence lives in the host's
+    # conversation, not here. `docker logs familiar-api | grep mcp_tool_call` is the record.
     is_error = isinstance(result, dict) and "error" in result
+    matched = result.get("count") if isinstance(result, dict) else None
+    logger.info(
+        "mcp_tool_call",
+        extra={
+            "tool": name,
+            "arguments": json.dumps(arguments, default=str)[:400],
+            "profile_id": str(profile_id),
+            "matched": matched,
+            "is_error": is_error,
+        },
+    )
     if is_error:
         logger.info("mcp tool %s returned an error: %s", name, result.get("error"))
     return types.CallToolResult(

--- a/backend/pyproject.toml
+++ b/backend/pyproject.toml
@@ -30,6 +30,8 @@ dependencies = [
     "greenlet>=3.0.0",
     # Rate limiting
     "slowapi>=0.1.9",
+    # MCP server (ADR-0043) — Familiar's LLM surface
+    "mcp>=2.0.0",
     # Password hashing (for Subsonic API auth)
     "bcrypt>=4.0.0",
     # Utilities

--- a/backend/scripts/mcp_bridge.py
+++ b/backend/scripts/mcp_bridge.py
@@ -1,0 +1,71 @@
+"""Bridge a remote Familiar `/mcp` to stdio, for hosts that only speak stdio.
+
+Claude Desktop's `claude_desktop_config.json` accepts **stdio servers only** — `command`, `args`,
+`env`. There is no `type: http` form; a remote URL has to be added through Settings → Connectors
+instead, and that path may refuse a plain `http://` host on a local network. This bridge covers the
+gap: a stdio server that forwards to the HTTP one.
+
+It is deliberately in this repository rather than an `npx` of somebody else's proxy. Familiar is
+self-hosted software, the `mcp` SDK is already a backend dependency, and downloading a third-party
+bridge onto the listener's machine to reach their own music server is the wrong shape.
+
+Tools are the whole surface Familiar exposes, so forwarding `tools/list` and `tools/call` forwards
+everything. Add prompts or resources to the server and they need forwarding here too.
+
+    FAMILIAR_MCP_URL=http://openmediavault:4400/mcp \\
+    uv run --project backend python backend/scripts/mcp_bridge.py
+
+`FAMILIAR_MCP_PROFILE_ID` is optional — send it only if the server has more than one profile.
+"""
+
+from __future__ import annotations
+
+import asyncio
+import os
+import sys
+from typing import Any
+
+import httpx2
+import mcp.types as types
+from mcp import ClientSession
+from mcp.client.streamable_http import streamable_http_client
+from mcp.server.lowlevel import Server
+from mcp.server.stdio import stdio_server
+
+URL = os.environ.get("FAMILIAR_MCP_URL", "http://localhost:4400/mcp")
+PROFILE = os.environ.get("FAMILIAR_MCP_PROFILE_ID", "")
+
+
+async def main() -> None:
+    headers = {"X-Profile-ID": PROFILE} if PROFILE else {}
+    http_client = httpx2.AsyncClient(headers=headers, timeout=180.0)
+
+    async with streamable_http_client(URL, http_client=http_client) as (read, write):
+        async with ClientSession(read, write) as upstream:
+            init = await upstream.initialize()
+            print(f"[familiar-mcp] bridging {URL} ({init.server_info.name})", file=sys.stderr)
+
+            async def on_list_tools(
+                _ctx: Any, _params: types.PaginatedRequestParams | None
+            ) -> types.ListToolsResult:
+                return types.ListToolsResult(tools=(await upstream.list_tools()).tools)
+
+            async def on_call_tool(
+                _ctx: Any, params: types.CallToolRequestParams
+            ) -> types.CallToolResult:
+                return await upstream.call_tool(params.name, params.arguments or {})
+
+            # The upstream's instructions are forwarded too. ADR-0043 point 3 leans on them, and a
+            # bridge that dropped them would quietly remove half the guidance the host ever sees.
+            server = Server(
+                name=init.server_info.name,
+                instructions=init.instructions,
+                on_list_tools=on_list_tools,
+                on_call_tool=on_call_tool,
+            )
+            async with stdio_server() as (stdin, stdout):
+                await server.run(stdin, stdout, server.create_initialization_options())
+
+
+if __name__ == "__main__":
+    asyncio.run(main())

--- a/backend/scripts/mcp_stdio.py
+++ b/backend/scripts/mcp_stdio.py
@@ -29,17 +29,17 @@ from pathlib import Path
 
 sys.path.insert(0, str(Path(__file__).resolve().parent.parent))
 
+from mcp.server.stdio import stdio_server  # noqa: E402
+
 from app.mcp.server import PROFILE_ENV, build_server  # noqa: E402
 
 
 async def main() -> None:
-    if not os.environ.get(PROFILE_ENV):
-        raise SystemExit(
-            f"{PROFILE_ENV} is not set. Familiar's tools are per-listener, so there is no safe "
-            f"default profile. GET /api/v1/profiles lists the ids on your server."
-        )
-    print(f"[familiar-mcp] stdio, profile={os.environ[PROFILE_ENV]}", file=sys.stderr)
-    await build_server().run("stdio")
+    bound = os.environ.get(PROFILE_ENV)
+    print(f"[familiar-mcp] stdio, profile={bound or 'sole profile'}", file=sys.stderr)
+    server = build_server()
+    async with stdio_server() as (stdin, stdout):
+        await server.run(stdin, stdout, server.create_initialization_options())
 
 
 if __name__ == "__main__":

--- a/backend/scripts/mcp_stdio.py
+++ b/backend/scripts/mcp_stdio.py
@@ -1,0 +1,46 @@
+"""Serve Familiar's MCP tools over stdio (ADR-0043 point 1's second entry point).
+
+Same tool set, same handlers, same `ToolExecutor` as the `/mcp` mount — only the transport
+differs. This exists because tuning tool descriptions is the work ADR-0043 point 3 says decides
+whether the surface is any good, and doing that against the mount means a `make deploy-dev` per
+edit. Here it is a file save.
+
+Bind a profile, because there is no header on stdio:
+
+    FAMILIAR_MCP_PROFILE_ID=<uuid> \\
+    DATABASE_URL=postgresql+asyncpg://... \\
+    uv run --directory backend python scripts/mcp_stdio.py
+
+Register it with Claude Code from the repository root:
+
+    claude mcp add familiar -- uv run --directory backend python scripts/mcp_stdio.py
+
+Note that this runs where you run it. The tools reach the database directly, and `semantic_search`
+needs torch — both of which are true inside the server's own environment and often not on a laptop.
+For the full surface, use the `/mcp` mount instead.
+"""
+
+from __future__ import annotations
+
+import asyncio
+import os
+import sys
+from pathlib import Path
+
+sys.path.insert(0, str(Path(__file__).resolve().parent.parent))
+
+from app.mcp.server import PROFILE_ENV, build_server  # noqa: E402
+
+
+async def main() -> None:
+    if not os.environ.get(PROFILE_ENV):
+        raise SystemExit(
+            f"{PROFILE_ENV} is not set. Familiar's tools are per-listener, so there is no safe "
+            f"default profile. GET /api/v1/profiles lists the ids on your server."
+        )
+    print(f"[familiar-mcp] stdio, profile={os.environ[PROFILE_ENV]}", file=sys.stderr)
+    await build_server().run("stdio")
+
+
+if __name__ == "__main__":
+    asyncio.run(main())

--- a/backend/tests/test_mcp_server.py
+++ b/backend/tests/test_mcp_server.py
@@ -14,9 +14,9 @@ quietly if broken:
 
 from __future__ import annotations
 
-import os
 from types import SimpleNamespace
 from typing import Any
+from uuid import UUID
 
 import pytest
 
@@ -187,37 +187,75 @@ class TestMountedEndpoint:
         assert installed[0].kwargs.get("mcp_app") is not None
 
 
+ONE = UUID("11111111-1111-1111-1111-111111111111")
+TWO = UUID("22222222-2222-2222-2222-222222222222")
+
+
 class TestProfileBinding:
-    @pytest.mark.asyncio
-    async def test_unbound_connection_is_refused(self, monkeypatch):
+    """Resolution order: request (header, then query), environment, then a sole profile."""
+
+    @pytest.fixture(autouse=True)
+    def _no_database(self, monkeypatch):
+        """Keep these off the database; each test says what the server should look like."""
         monkeypatch.delenv(PROFILE_ENV, raising=False)
+
+        async def sole_none():
+            return None
+
+        async def exists(profile_id):
+            return profile_id
+
+        monkeypatch.setattr("app.mcp.server._sole_profile", sole_none)
+        monkeypatch.setattr("app.mcp.server._verify_profile", exists)
+
+    @pytest.mark.asyncio
+    async def test_unbound_with_several_profiles_is_refused(self):
         with pytest.raises(ProfileNotBound) as exc:
             await resolve_profile(_ctx())
         assert "no safe default" in str(exc.value)
 
     @pytest.mark.asyncio
-    async def test_malformed_profile_is_refused(self, monkeypatch):
-        monkeypatch.delenv(PROFILE_ENV, raising=False)
+    async def test_malformed_profile_is_refused(self):
         with pytest.raises(ProfileNotBound) as exc:
             await resolve_profile(_ctx({"x-profile-id": "not-a-uuid"}))
         assert "not a UUID" in str(exc.value)
 
     @pytest.mark.asyncio
-    async def test_header_is_preferred_over_environment(self, monkeypatch):
-        """One server, several listeners: the header wins so stdio's binding cannot leak in."""
-        monkeypatch.setenv(PROFILE_ENV, "11111111-1111-1111-1111-111111111111")
-        seen: list[str] = []
+    async def test_header_binds_the_connection(self):
+        assert await resolve_profile(_ctx({"x-profile-id": str(TWO)})) == TWO
 
-        async def fake_lookup(ctx):
-            raw = ctx.request.headers.get("x-profile-id") or os.environ.get(PROFILE_ENV)
-            seen.append(raw)
-            raise ProfileNotBound("stop before the database")
+    @pytest.mark.asyncio
+    async def test_query_string_binds_the_connection(self):
+        """Claude Desktop's custom connector takes a URL and cannot set headers."""
+        ctx = SimpleNamespace(request=SimpleNamespace(headers={}, query_params={"profile": str(TWO)}))
+        assert await resolve_profile(ctx) == TWO
 
-        monkeypatch.setattr("app.mcp.server.resolve_profile", fake_lookup)
-        from app.mcp import server as mcp_server
-
-        with pytest.raises(ProfileNotBound):
-            await mcp_server.resolve_profile(
-                _ctx({"x-profile-id": "22222222-2222-2222-2222-222222222222"})
+    @pytest.mark.asyncio
+    async def test_header_beats_query_string(self):
+        ctx = SimpleNamespace(
+            request=SimpleNamespace(
+                headers={"x-profile-id": str(ONE)}, query_params={"profile": str(TWO)}
             )
-        assert seen == ["22222222-2222-2222-2222-222222222222"]
+        )
+        assert await resolve_profile(ctx) == ONE
+
+    @pytest.mark.asyncio
+    async def test_request_beats_environment(self, monkeypatch):
+        """stdio's binding must not leak into an HTTP connection that named its own."""
+        monkeypatch.setenv(PROFILE_ENV, str(ONE))
+        assert await resolve_profile(_ctx({"x-profile-id": str(TWO)})) == TWO
+
+    @pytest.mark.asyncio
+    async def test_environment_is_used_when_the_request_names_none(self, monkeypatch):
+        monkeypatch.setenv(PROFILE_ENV, str(ONE))
+        assert await resolve_profile(_ctx()) == ONE
+
+    @pytest.mark.asyncio
+    async def test_sole_profile_needs_no_configuration(self, monkeypatch):
+        """With exactly one profile there is nothing to guess, so nothing to configure."""
+
+        async def sole_one():
+            return ONE
+
+        monkeypatch.setattr("app.mcp.server._sole_profile", sole_one)
+        assert await resolve_profile(_ctx()) == ONE

--- a/backend/tests/test_mcp_server.py
+++ b/backend/tests/test_mcp_server.py
@@ -1,0 +1,223 @@
+"""Tests for the MCP surface (ADR-0043).
+
+These pin the four things that are decisions rather than implementation, and that would fail
+quietly if broken:
+
+1. **Which tools are exposed.** ADR-0043 point 2 excludes three client-bound tools and withholds
+   `fetch_webpage`. A regression here leaks a tool that cannot work, or an SSRF primitive.
+2. **`/mcp` is not swallowed by the SPA catch-all.** The failure is asymmetric — POST keeps working
+   while GET returns `index.html` with HTTP 200 — so half the transport dies looking healthy.
+3. **An unbound connection fails, naming the reason** (point 9), rather than acting as some
+   default profile.
+4. **`generation_prompt` is an argument**, because an MCP host never passes the listener's turn.
+"""
+
+from __future__ import annotations
+
+import os
+from types import SimpleNamespace
+from typing import Any
+
+import pytest
+
+from app.api.exceptions import NotFoundError
+from app.main import NON_SPA_PREFIXES, spa_fallback
+from app.mcp.server import (
+    EXCLUDED,
+    PROFILE_ENV,
+    ProfileNotBound,
+    exposed_tools,
+    resolve_profile,
+)
+from app.services.llm.tools import MUSIC_TOOLS
+
+
+def _ctx(headers: dict[str, str] | None = None) -> SimpleNamespace:
+    """A stand-in for ServerRequestContext — only `.request.headers` is read."""
+    if headers is None:
+        return SimpleNamespace(request=None)
+    return SimpleNamespace(request=SimpleNamespace(headers=headers))
+
+
+class TestToolSurface:
+    def test_excludes_client_bound_and_withheld_tools(self):
+        names = {t.name for t in exposed_tools()}
+        assert not (names & EXCLUDED), f"excluded tools leaked: {names & EXCLUDED}"
+        for withheld in ("get_visible_tracks", "queue_tracks", "control_playback", "fetch_webpage"):
+            assert withheld not in names
+
+    def test_exposes_everything_else(self):
+        """The surface is MUSIC_TOOLS minus the exclusions — not a hand-maintained list."""
+        names = {t.name for t in exposed_tools()}
+        expected = {t["name"] for t in MUSIC_TOOLS} - EXCLUDED
+        assert names == expected
+
+    def test_schemas_come_from_music_tools_unchanged(self):
+        """ADR-0043 point 2: re-hosted, not reimplemented. Drift here is the thing to prevent."""
+        by_name = {t["name"]: t for t in MUSIC_TOOLS}
+        for tool in exposed_tools():
+            if tool.name == "create_playlist_from_items":
+                continue  # gains one property; covered separately
+            assert tool.input_schema == by_name[tool.name]["input_schema"]
+
+    def test_create_playlist_gains_generation_prompt(self):
+        tool = next(t for t in exposed_tools() if t.name == "create_playlist_from_items")
+        assert "generation_prompt" in tool.input_schema["properties"]
+
+    def test_adding_the_argument_does_not_mutate_music_tools(self):
+        """The schema is deep-copied; the chat path must not see the MCP-only property."""
+        exposed_tools()
+        spec = next(t for t in MUSIC_TOOLS if t["name"] == "create_playlist_from_items")
+        assert "generation_prompt" not in spec["input_schema"].get("properties", {})
+
+    def test_calibration_guidance_reaches_the_filter_tool(self):
+        """ADR-0043 point 3. Measured: without it a model filters energy>=0.6 and gets 92.5%."""
+        tool = next(t for t in exposed_tools() if t.name == "filter_tracks")
+        assert "get_feature_distribution" in tool.description
+
+
+class TestSpaCatchAll:
+    """The trap. `/embed` hit it once and the `/api/` 200-instead-of-404 bug hit it again."""
+
+    def test_mcp_is_a_non_spa_prefix(self):
+        assert "mcp" in NON_SPA_PREFIXES
+
+    @pytest.mark.asyncio
+    async def test_spa_fallback_refuses_mcp_paths(self):
+        """Must raise, not return index.html.
+
+        Streamable HTTP uses GET for the server-initiated stream, and the catch-all is GET-only —
+        so without this, POST works while GET silently serves HTML and the session half dies.
+        """
+        for path in ("mcp", "mcp/"):
+            with pytest.raises(NotFoundError):
+                await spa_fallback(path)
+
+    @pytest.mark.asyncio
+    async def test_spa_fallback_still_serves_app_routes(self):
+        """Guard the guard.
+
+        A real SPA route must still get `index.html`, or the test above would pass just as well
+        against a `spa_fallback` that refused everything — which is not a guard, it is a coincidence.
+        """
+        response = await spa_fallback("library/artists")
+        assert response.__class__.__name__ == "FileResponse"
+
+
+class TestMountedEndpoint:
+    """The handshake, over the real transport, against the real app.
+
+    `app.mount("/mcp", ...)` looks right and answers **307**: Starlette's Mount pattern requires a
+    trailing segment, so `/mcp` never matches and the router falls through to `redirect_slashes`.
+    MCP clients POST their handshake, and a redirected POST is not reliably replayed — the symptom
+    is a handshake that never completes, pointing nowhere near a trailing slash.
+    """
+
+    INIT = {
+        "jsonrpc": "2.0",
+        "id": 1,
+        "method": "initialize",
+        "params": {
+            "protocolVersion": "2025-06-18",
+            "capabilities": {},
+            "clientInfo": {"name": "test", "version": "1"},
+        },
+    }
+    HEADERS = {
+        "Accept": "application/json, text/event-stream",
+        "Content-Type": "application/json",
+    }
+
+    async def _initialize(self, path: str) -> Any:
+        """A fresh MCP app per call.
+
+        `StreamableHTTPSessionManager.run()` raises if entered twice on one instance, so tests
+        cannot share the module-level app the way the running server does.
+        """
+        import httpx
+        from fastapi import FastAPI
+
+        from app.mcp.server import MCPDispatch, build_asgi_app
+
+        mcp_app = build_asgi_app()
+        host = FastAPI()
+        host.add_middleware(MCPDispatch, mcp_app=mcp_app)
+
+        @host.get("/api/v1/sentinel")
+        async def _sentinel() -> dict[str, bool]:
+            return {"ok": True}
+
+        async with mcp_app.router.lifespan_context(mcp_app):
+            transport = httpx.ASGITransport(app=host)
+            async with httpx.AsyncClient(
+                transport=transport, base_url="http://localhost:4400"
+            ) as client:
+                if path == "__sentinel__":
+                    return await client.get("/api/v1/sentinel")
+                return await client.post(path, json=self.INIT, headers=self.HEADERS)
+
+    @pytest.mark.asyncio
+    @pytest.mark.parametrize("path", ["/mcp", "/mcp/"])
+    async def test_initialize_succeeds_without_a_redirect(self, path):
+        response = await self._initialize(path)
+        assert response.status_code == 200, f"{path} answered {response.status_code}"
+        assert "text/event-stream" in response.headers.get("content-type", "")
+        assert '"serverInfo"' in response.text
+
+    @pytest.mark.asyncio
+    async def test_server_advertises_instructions(self):
+        """ADR-0043 point 3: instructions are one of the two channels that reach every host."""
+        response = await self._initialize("/mcp")
+        assert "get_feature_distribution" in response.text
+
+    @pytest.mark.asyncio
+    async def test_dispatch_leaves_other_routes_alone(self):
+        """Guard the guard: the dispatch must intercept /mcp and nothing else."""
+        response = await self._initialize("__sentinel__")
+        assert response.status_code == 200
+        assert response.json() == {"ok": True}
+
+    def test_the_real_app_wires_the_dispatch(self):
+        """The tests above prove MCPDispatch works; this proves main.py actually installed it."""
+        from app.main import app
+        from app.mcp.server import MCPDispatch
+
+        installed = [m for m in app.user_middleware if m.cls is MCPDispatch]
+        assert installed, "MCPDispatch is not installed on the application"
+        assert installed[0].kwargs.get("mcp_app") is not None
+
+
+class TestProfileBinding:
+    @pytest.mark.asyncio
+    async def test_unbound_connection_is_refused(self, monkeypatch):
+        monkeypatch.delenv(PROFILE_ENV, raising=False)
+        with pytest.raises(ProfileNotBound) as exc:
+            await resolve_profile(_ctx())
+        assert "no safe default" in str(exc.value)
+
+    @pytest.mark.asyncio
+    async def test_malformed_profile_is_refused(self, monkeypatch):
+        monkeypatch.delenv(PROFILE_ENV, raising=False)
+        with pytest.raises(ProfileNotBound) as exc:
+            await resolve_profile(_ctx({"x-profile-id": "not-a-uuid"}))
+        assert "not a UUID" in str(exc.value)
+
+    @pytest.mark.asyncio
+    async def test_header_is_preferred_over_environment(self, monkeypatch):
+        """One server, several listeners: the header wins so stdio's binding cannot leak in."""
+        monkeypatch.setenv(PROFILE_ENV, "11111111-1111-1111-1111-111111111111")
+        seen: list[str] = []
+
+        async def fake_lookup(ctx):
+            raw = ctx.request.headers.get("x-profile-id") or os.environ.get(PROFILE_ENV)
+            seen.append(raw)
+            raise ProfileNotBound("stop before the database")
+
+        monkeypatch.setattr("app.mcp.server.resolve_profile", fake_lookup)
+        from app.mcp import server as mcp_server
+
+        with pytest.raises(ProfileNotBound):
+            await mcp_server.resolve_profile(
+                _ctx({"x-profile-id": "22222222-2222-2222-2222-222222222222"})
+            )
+        assert seen == ["22222222-2222-2222-2222-222222222222"]

--- a/backend/uv.lock
+++ b/backend/uv.lock
@@ -2,7 +2,8 @@ version = 1
 revision = 2
 requires-python = ">=3.11"
 resolution-markers = [
-    "python_full_version >= '3.13'",
+    "python_full_version >= '3.14'",
+    "python_full_version == '3.13.*'",
     "python_full_version == '3.12.*'",
     "python_full_version < '3.12'",
 ]
@@ -1141,6 +1142,7 @@ dependencies = [
     { name = "greenlet" },
     { name = "httpx" },
     { name = "langdetect" },
+    { name = "mcp" },
     { name = "musicbrainzngs" },
     { name = "mutagen" },
     { name = "openai" },
@@ -1209,6 +1211,7 @@ requires-dist = [
     { name = "langdetect", specifier = ">=1.0.9" },
     { name = "librosa", marker = "extra == 'analysis'", specifier = ">=0.10.0" },
     { name = "matplotlib", marker = "extra == 'analysis'", specifier = ">=3.5.0" },
+    { name = "mcp", specifier = ">=2.0.0" },
     { name = "musicbrainzngs", specifier = ">=0.7.1" },
     { name = "mutagen", specifier = ">=1.47.0" },
     { name = "mypy", marker = "extra == 'dev'", specifier = ">=1.8.0" },
@@ -1720,6 +1723,19 @@ wheels = [
 ]
 
 [[package]]
+name = "httpcore2"
+version = "2.9.1"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "h11" },
+    { name = "truststore" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/39/a8/20ed1ed79cbc2ecdf5301c0968ab7c85547212e2a7bd126ddd2d986e206e/httpcore2-2.9.1.tar.gz", hash = "sha256:4d8acbf8b306f48c9d6046591fd5ba4037d1b1b1000d140fc2c3eab1e9a0c0e2", size = 67089, upload-time = "2026-07-24T09:21:03.867Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/9f/fb/46c52b781975c335a2bcf1072c7bbc007cbdc8d674217f5ee1daba2c848b/httpcore2-2.9.1-py3-none-any.whl", hash = "sha256:6182472379e855fe4221246a2bb7ecede403bc61c6798062ae1787d051ccde26", size = 82809, upload-time = "2026-07-24T09:21:01.178Z" },
+]
+
+[[package]]
 name = "httptools"
 version = "0.7.1"
 source = { registry = "https://pypi.org/simple" }
@@ -1771,6 +1787,22 @@ wheels = [
 ]
 
 [[package]]
+name = "httpx2"
+version = "2.9.1"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "anyio" },
+    { name = "httpcore2" },
+    { name = "idna" },
+    { name = "truststore" },
+    { name = "typing-extensions", marker = "python_full_version < '3.13'" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/21/14/38128fbafd7e0ed41d874df6c9a653d47c2d111cfe59e2b4ac95161b4abd/httpx2-2.9.1.tar.gz", hash = "sha256:1932a768737e3666291582833da748cc4e563c337cf96706fccc04fa6e58764a", size = 95458, upload-time = "2026-07-24T09:21:04.972Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/13/b8/cfd91c4ab9134d386d48f0b6ac662ff3d4be6efdee59ee1c67ebc3c0487c/httpx2-2.9.1-py3-none-any.whl", hash = "sha256:1820fe14a9ab1107bfeff39259987429450b070ec0ff38cc87eb0d8c97fdc71a", size = 91191, upload-time = "2026-07-24T09:21:02.6Z" },
+]
+
+[[package]]
 name = "huggingface-hub"
 version = "0.36.0"
 source = { registry = "https://pypi.org/simple" }
@@ -1791,11 +1823,11 @@ wheels = [
 
 [[package]]
 name = "idna"
-version = "3.11"
+version = "3.18"
 source = { registry = "https://pypi.org/simple" }
-sdist = { url = "https://files.pythonhosted.org/packages/6f/6d/0703ccc57f3a7233505399edb88de3cbd678da106337b9fcde432b65ed60/idna-3.11.tar.gz", hash = "sha256:795dafcc9c04ed0c1fb032c2aa73654d8e8c5023a7df64a53f39190ada629902", size = 194582, upload-time = "2025-10-12T14:55:20.501Z" }
+sdist = { url = "https://files.pythonhosted.org/packages/cd/63/9496c57188a2ee585e0f1db071d75089a11e98aa86eb99d9d7618fc1edce/idna-3.18.tar.gz", hash = "sha256:ffb385a7e039654cef1ab9ef32c6fafe283c0c0467bba1d9029738ce4a14a848", size = 196711, upload-time = "2026-06-02T14:34:07.794Z" }
 wheels = [
-    { url = "https://files.pythonhosted.org/packages/0e/61/66938bbb5fc52dbdf84594873d5b51fb1f7c7794e9c0f5bd885f30bc507b/idna-3.11-py3-none-any.whl", hash = "sha256:771a87f49d9defaf64091e6e6fe9c18d4833f140bd19464795bc32d966ca37ea", size = 71008, upload-time = "2025-10-12T14:55:18.883Z" },
+    { url = "https://files.pythonhosted.org/packages/1e/5e/d4e9f1a599fb8e573b7b87160658329fbf28d19eac2718f51fc3def3aa5a/idna-3.18-py3-none-any.whl", hash = "sha256:7f952cbe720b688055e3f87de14f5c3e5fdaa8bc3928985c4077ca689de849a2", size = 65455, upload-time = "2026-06-02T14:34:06.319Z" },
 ]
 
 [[package]]
@@ -1926,6 +1958,33 @@ source = { registry = "https://pypi.org/simple" }
 sdist = { url = "https://files.pythonhosted.org/packages/41/f2/d34e8b3a08a9cc79a50b2208a93dce981fe615b64d5a4d4abee421d898df/joblib-1.5.3.tar.gz", hash = "sha256:8561a3269e6801106863fd0d6d84bb737be9e7631e33aaed3fb9ce5953688da3", size = 331603, upload-time = "2025-12-15T08:41:46.427Z" }
 wheels = [
     { url = "https://files.pythonhosted.org/packages/7b/91/984aca2ec129e2757d1e4e3c81c3fcda9d0f85b74670a094cc443d9ee949/joblib-1.5.3-py3-none-any.whl", hash = "sha256:5fc3c5039fc5ca8c0276333a188bbd59d6b7ab37fe6632daa76bc7f9ec18e713", size = 309071, upload-time = "2025-12-15T08:41:44.973Z" },
+]
+
+[[package]]
+name = "jsonschema"
+version = "4.26.0"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "attrs" },
+    { name = "jsonschema-specifications" },
+    { name = "referencing" },
+    { name = "rpds-py" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/b3/fc/e067678238fa451312d4c62bf6e6cf5ec56375422aee02f9cb5f909b3047/jsonschema-4.26.0.tar.gz", hash = "sha256:0c26707e2efad8aa1bfc5b7ce170f3fccc2e4918ff85989ba9ffa9facb2be326", size = 366583, upload-time = "2026-01-07T13:41:07.246Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/69/90/f63fb5873511e014207a475e2bb4e8b2e570d655b00ac19a9a0ca0a385ee/jsonschema-4.26.0-py3-none-any.whl", hash = "sha256:d489f15263b8d200f8387e64b4c3a75f06629559fb73deb8fdfb525f2dab50ce", size = 90630, upload-time = "2026-01-07T13:41:05.306Z" },
+]
+
+[[package]]
+name = "jsonschema-specifications"
+version = "2025.9.1"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "referencing" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/19/74/a633ee74eb36c44aa6d1095e7cc5569bebf04342ee146178e2d36600708b/jsonschema_specifications-2025.9.1.tar.gz", hash = "sha256:b540987f239e745613c7a9176f3edb72b832a4ac465cf02712288397832b5e8d", size = 32855, upload-time = "2025-09-08T01:34:59.186Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/41/45/1a4ed80516f02155c51f51e8cedb3c1902296743db0bbc66608a0db2814f/jsonschema_specifications-2025.9.1-py3-none-any.whl", hash = "sha256:98802fee3a11ee76ecaca44429fda8a41bff98b00a0f2838151b113f210cc6fe", size = 18437, upload-time = "2025-09-08T01:34:57.871Z" },
 ]
 
 [[package]]
@@ -2483,6 +2542,44 @@ wheels = [
 ]
 
 [[package]]
+name = "mcp"
+version = "2.0.0"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "anyio" },
+    { name = "httpx2" },
+    { name = "jsonschema" },
+    { name = "mcp-types" },
+    { name = "opentelemetry-api" },
+    { name = "pydantic" },
+    { name = "pyjwt", extra = ["crypto"] },
+    { name = "python-multipart" },
+    { name = "pywin32", marker = "sys_platform == 'win32'" },
+    { name = "sse-starlette" },
+    { name = "starlette" },
+    { name = "typing-extensions" },
+    { name = "typing-inspection" },
+    { name = "uvicorn", marker = "sys_platform != 'emscripten'" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/74/33/32d4dff2c95bb5d897c3ef4c83649a08996b17b58f0a326d2495d4c81179/mcp-2.0.0.tar.gz", hash = "sha256:0f440e735c13ece8bb19bc62cf0b86f4313448432fbb77d35e14034f4e050728", size = 1662284, upload-time = "2026-07-28T13:45:32.346Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/67/72/7d7897418912c1d12e87556630dfb7bf0eac71160e9bef8b447960804ee3/mcp-2.0.0-py3-none-any.whl", hash = "sha256:1cb4c75d2d2c7b8c1d756355e5d82a39f2822cc7f13e22a2051d7ca3592349d6", size = 349980, upload-time = "2026-07-28T13:45:28.853Z" },
+]
+
+[[package]]
+name = "mcp-types"
+version = "2.0.0"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "pydantic" },
+    { name = "typing-extensions" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/bb/56/9b8e1c152f61f6c6b07c4b5896c88c7d0ae90bac6ee6306f852fcc5c1eb0/mcp_types-2.0.0.tar.gz", hash = "sha256:d7d939b9285c9961ae8866ba75ef85da34d12bafe276efbf4eb6a131786d8379", size = 66632, upload-time = "2026-07-28T13:45:33.804Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/f5/4c/c78d78c3d52b0ac594ad7cc8ef5972adfe070e3597a8a4c6ce0cd39196ea/mcp_types-2.0.0-py3-none-any.whl", hash = "sha256:6b2de797ca2797f568b79529e1b25948e34de511bcc0bd82fef1039a6d1b8eb0", size = 69649, upload-time = "2026-07-28T13:45:30.713Z" },
+]
+
+[[package]]
 name = "mediafile"
 version = "0.17.0"
 source = { registry = "https://pypi.org/simple" }
@@ -2928,6 +3025,18 @@ dependencies = [
 sdist = { url = "https://files.pythonhosted.org/packages/ed/59/bdcc6b759b8c42dd73afaf5bf8f902c04b37987a5514dbc1c64dba390fef/openai-2.32.0.tar.gz", hash = "sha256:c54b27a9e4cb8d51f0dd94972ffd1a04437efeb259a9e60d8922b8bd26fe55e0", size = 693286, upload-time = "2026-04-15T22:28:19.434Z" }
 wheels = [
     { url = "https://files.pythonhosted.org/packages/1e/c1/d6e64ccd0536bf616556f0cad2b6d94a8125f508d25cfd814b1d2db4e2f1/openai-2.32.0-py3-none-any.whl", hash = "sha256:4dcc9badeb4bf54ad0d187453742f290226d30150890b7890711bda4f32f192f", size = 1162570, upload-time = "2026-04-15T22:28:17.714Z" },
+]
+
+[[package]]
+name = "opentelemetry-api"
+version = "1.44.0"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "typing-extensions" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/ee/8b/aa9e2d8b8dfa7c946f7dec5d1f8f6ba8eca062f43509a06bdb5ce93d26c0/opentelemetry_api-1.44.0.tar.gz", hash = "sha256:67647e5e9566edcf421166fdf022b3537f818635daa852b289e34604dc6fb33a", size = 72406, upload-time = "2026-07-16T15:25:32.678Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/ca/6f/a04e900f465ff3221ccc395522503e2d10e79fa21f2723c8e177aae1e0d1/opentelemetry_api-1.44.0-py3-none-any.whl", hash = "sha256:94b98c893a91b88657eaac1e3ba89618cdb85be6918196705354f34728b2cdef", size = 60018, upload-time = "2026-07-16T15:25:11.657Z" },
 ]
 
 [[package]]
@@ -3531,6 +3640,20 @@ wheels = [
 ]
 
 [[package]]
+name = "pyjwt"
+version = "2.13.0"
+source = { registry = "https://pypi.org/simple" }
+sdist = { url = "https://files.pythonhosted.org/packages/3b/81/58d0ac84e1ef3a3843791d6954d94c0b33d526c75eeb1efbce9d0a4c4077/pyjwt-2.13.0.tar.gz", hash = "sha256:41571c89ca91598c79e8ef18a2d07367d4810fbbd6f637794879baf1b7703423", size = 107515, upload-time = "2026-05-21T19:54:36.618Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/a3/5e/ecf12fdb62546d64385c158514e9b2b671f7832108ef2ecd2020ce0af2d1/pyjwt-2.13.0-py3-none-any.whl", hash = "sha256:66adcc2aff09b3f1bbd95fc1e1577df8ac8723c978552fd43304c8a290ac5728", size = 31274, upload-time = "2026-05-21T19:54:35.362Z" },
+]
+
+[package.optional-dependencies]
+crypto = [
+    { name = "cryptography" },
+]
+
+[[package]]
 name = "pyloudnorm"
 version = "0.2.0"
 source = { registry = "https://pypi.org/simple" }
@@ -3673,6 +3796,28 @@ source = { registry = "https://pypi.org/simple" }
 sdist = { url = "https://files.pythonhosted.org/packages/f8/bf/abbd3cdfb8fbc7fb3d4d38d320f2441b1e7cbe29be4f23797b4a2b5d8aac/pytz-2025.2.tar.gz", hash = "sha256:360b9e3dbb49a209c21ad61809c7fb453643e048b38924c765813546746e81c3", size = 320884, upload-time = "2025-03-25T02:25:00.538Z" }
 wheels = [
     { url = "https://files.pythonhosted.org/packages/81/c4/34e93fe5f5429d7570ec1fa436f1986fb1f00c3e0f43a589fe2bbcd22c3f/pytz-2025.2-py2.py3-none-any.whl", hash = "sha256:5ddf76296dd8c44c26eb8f4b6f35488f3ccbf6fbbd7adee0b7262d43f0ec2f00", size = 509225, upload-time = "2025-03-25T02:24:58.468Z" },
+]
+
+[[package]]
+name = "pywin32"
+version = "312"
+source = { registry = "https://pypi.org/simple" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/1f/f5/10a6e845a00fc5e7afd0a988b744f403d4d57162a28d160a093c4d9322f0/pywin32-312-cp311-cp311-win32.whl", hash = "sha256:17948aeadbdb091f0ced6ef0841620794e68327b94ee415571c1203594b7215c", size = 6362659, upload-time = "2026-06-04T07:49:21.349Z" },
+    { url = "https://files.pythonhosted.org/packages/35/c4/dcd2d62b5944b6d5db53413a5899016ccd57ffcb7278f3f81655d25d2027/pywin32-312-cp311-cp311-win_amd64.whl", hash = "sha256:d11417d84412f859b722fad0841b3614459ed0047f7542d8362e77884f6b6e8a", size = 6928825, upload-time = "2026-06-04T07:49:23.934Z" },
+    { url = "https://files.pythonhosted.org/packages/b7/56/3cbb433fe4501cdba2eb9040f56a4e1a8243faa4186b25295564d1a7a79d/pywin32-312-cp311-cp311-win_arm64.whl", hash = "sha256:b2200a054ca6d6625c4842fc56a4976a4b47f96b73dbe5538c3f813a80359f47", size = 6721875, upload-time = "2026-06-04T07:49:26.416Z" },
+    { url = "https://files.pythonhosted.org/packages/83/ff/32aa7d2ed0ab12b323aaa64f9b75e6ad4f8fd09f9ccfc28c79414d46838d/pywin32-312-cp312-cp312-win32.whl", hash = "sha256:dab4f65ac9c4e48400a2a0530c46c3c579cd5905ecd11b80692373915269208b", size = 6371877, upload-time = "2026-06-04T07:49:28.836Z" },
+    { url = "https://files.pythonhosted.org/packages/03/d9/77040d3b43df3f3be32ea289433d660d2727f5ba327bc73be835127d9d60/pywin32-312-cp312-cp312-win_amd64.whl", hash = "sha256:b457f6d628a47e8a7346ce22acb7e1a46a4a78b52e1d17e1af56871bd19a93bc", size = 6914841, upload-time = "2026-06-04T07:49:31.85Z" },
+    { url = "https://files.pythonhosted.org/packages/e3/cc/7b1ec671775756020a0ee7f4feeaf3c568f0ab86bd3900088cf986937a92/pywin32-312-cp312-cp312-win_arm64.whl", hash = "sha256:6017c58e12f6809fbb0555b75df144c2922a9ffd18e4b9b5afa863b6c1a9d950", size = 6727901, upload-time = "2026-06-04T07:49:34.244Z" },
+    { url = "https://files.pythonhosted.org/packages/2d/41/12fbfd7f36ed2146d8bc9de96c2741296bf0d490b98508496cff322e274c/pywin32-312-cp313-cp313-win32.whl", hash = "sha256:7a27df850933d16a8eabfbaeb73d52b273e2da667f80d70b01a89d1f6828d02c", size = 6370184, upload-time = "2026-06-04T07:49:36.253Z" },
+    { url = "https://files.pythonhosted.org/packages/ba/db/36a78e3403099d31d9746d13fdcde5accc43c1155f375a34d15983a479a7/pywin32-312-cp313-cp313-win_amd64.whl", hash = "sha256:c53e878d15a1c44788082bfe712a905433473aa38f86375b7cf8b45e3acbaaf9", size = 6914298, upload-time = "2026-06-04T07:49:38.876Z" },
+    { url = "https://files.pythonhosted.org/packages/84/37/c1697194092b76de9ed47ca124323f02c57ffc8a45c06f88a3d5acaf01eb/pywin32-312-cp313-cp313-win_arm64.whl", hash = "sha256:59aba5d5940842075343a5ddc6b11f1cdf0d1567fe745290359dfbcc7c2eb831", size = 6727640, upload-time = "2026-06-04T07:49:41.083Z" },
+    { url = "https://files.pythonhosted.org/packages/fc/2b/1f3cded5822fd49c02f40544cbb5f58c7cfd6b1694869fd476cb6170ee97/pywin32-312-cp314-cp314-win32.whl", hash = "sha256:a77a90fbb6881238d2ca9c6fd797b25817f3768fe78d214a90137ff055a75f5b", size = 6468928, upload-time = "2026-06-04T07:49:43.188Z" },
+    { url = "https://files.pythonhosted.org/packages/21/82/3bf86d2e2808902013132e1ce905a7da0da53790f3836c64bf44d55e24f3/pywin32-312-cp314-cp314-win_amd64.whl", hash = "sha256:a4dd3a848290ef724347b19f301045831d8e802fa4464f491b98b1e0a081432e", size = 7024157, upload-time = "2026-06-04T07:49:45.34Z" },
+    { url = "https://files.pythonhosted.org/packages/a4/0e/73f6d6800b4f27655abd9e9f6aaeaefcddb2b946e4674efa2bab184a7f7b/pywin32-312-cp314-cp314-win_arm64.whl", hash = "sha256:9fce94568364e0155e6dfb781ac5d95903be8baf28670632beab1b523f300daa", size = 6839598, upload-time = "2026-06-04T07:49:47.613Z" },
+    { url = "https://files.pythonhosted.org/packages/eb/61/caa39686032d2ebdd04ff0ab5cbe163126c0066d98e00c9018646e42393b/pywin32-312-cp315-cp315-win32.whl", hash = "sha256:5c1fbe4a937a73ae9297384a3da38518cbc694c68ad8a809b2e19acd350f03ed", size = 6471159, upload-time = "2026-06-04T07:49:50.035Z" },
+    { url = "https://files.pythonhosted.org/packages/0f/cd/7e1de64a4a6f69c04214169657ccab0d93a670ea50e35eb8f489d7378249/pywin32-312-cp315-cp315-win_amd64.whl", hash = "sha256:c2f03a0f73f804a13c2735b99392b0cd426bb4f2c4d0178e5ac966a0f21618d5", size = 7025293, upload-time = "2026-06-04T07:49:54.857Z" },
+    { url = "https://files.pythonhosted.org/packages/23/ed/4532e9388e65fa16b46776ef47ad631a64eda1631884488af707666350ed/pywin32-312-cp315-cp315-win_arm64.whl", hash = "sha256:a8597d28f267b39074aef51fa593530082b39cbe5a074226096857b1fed2dfb9", size = 6840337, upload-time = "2026-06-04T07:49:57.531Z" },
 ]
 
 [[package]]
@@ -3822,6 +3967,20 @@ wheels = [
 ]
 
 [[package]]
+name = "referencing"
+version = "0.37.0"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "attrs" },
+    { name = "rpds-py" },
+    { name = "typing-extensions", marker = "python_full_version < '3.13'" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/22/f5/df4e9027acead3ecc63e50fe1e36aca1523e1719559c499951bb4b53188f/referencing-0.37.0.tar.gz", hash = "sha256:44aefc3142c5b842538163acb373e24cce6632bd54bdb01b21ad5863489f50d8", size = 78036, upload-time = "2025-10-13T15:30:48.871Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/2c/58/ca301544e1fa93ed4f80d724bf5b194f6e4b945841c5bfd555878eea9fcb/referencing-0.37.0-py3-none-any.whl", hash = "sha256:381329a9f99628c9069361716891d34ad94af76e461dcb0335825aecc7692231", size = 26766, upload-time = "2025-10-13T15:30:47.625Z" },
+]
+
+[[package]]
 name = "regex"
 version = "2025.11.3"
 source = { registry = "https://pypi.org/simple" }
@@ -3952,6 +4111,129 @@ dependencies = [
 sdist = { url = "https://files.pythonhosted.org/packages/53/2e/734e1813f929ce562702f59283d5e585655eb2208ba97987549a5fc7fb68/resampy-0.4.2.tar.gz", hash = "sha256:0a469e6ddb89956f4fd6c88728300e4bbd186fae569dd4fd17dae51a91cbaa15", size = 3077273, upload-time = "2022-09-13T16:32:07.693Z" }
 wheels = [
     { url = "https://files.pythonhosted.org/packages/f2/d3/5209fd2132452f199b1ddf0d084f9fd5f5f910840e3b282f005b48a503e1/resampy-0.4.2-py3-none-any.whl", hash = "sha256:4340b6c4e685a865621dfcf016e2a3dd49d865446b6025e30fe88567f22e052e", size = 3076436, upload-time = "2022-09-13T16:32:06.163Z" },
+]
+
+[[package]]
+name = "rpds-py"
+version = "2026.6.3"
+source = { registry = "https://pypi.org/simple" }
+sdist = { url = "https://files.pythonhosted.org/packages/aa/2a/9618a122aeb2a169a28b03889a2995fe297588964333d4a7d67bdf46e147/rpds_py-2026.6.3.tar.gz", hash = "sha256:1cebd1337c242e4ec2293e541f712b2da849b29f48f0c293684b71c0632625d4", size = 64051, upload-time = "2026-06-30T07:17:53.009Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/94/1f/a2dca5ffdbf1d475ffc4e80e4d5d720ff3a00f691795910116960ee12511/rpds_py-2026.6.3-cp311-cp311-macosx_10_12_x86_64.whl", hash = "sha256:7b689145a1485c335569bd056464f3243a29af7ed3871c7be31ad624ba239bc7", size = 342174, upload-time = "2026-06-30T07:14:54.821Z" },
+    { url = "https://files.pythonhosted.org/packages/4d/dc/323d08583c0832911768663d1944f0107fcd4088704858d84b5e06d105a0/rpds_py-2026.6.3-cp311-cp311-macosx_11_0_arm64.whl", hash = "sha256:db08f45aecde626498fb3df07bcf6d2ec040af42e859a4f5040d79c200342911", size = 345513, upload-time = "2026-06-30T07:14:56.515Z" },
+    { url = "https://files.pythonhosted.org/packages/0b/2a/e31989834d18d2f26ec1d2774c5b1eb3331df4ea8ada525175294c94b48a/rpds_py-2026.6.3-cp311-cp311-manylinux_2_17_aarch64.manylinux2014_aarch64.whl", hash = "sha256:acc992ab27b15f852c76755eb2ab7dce86585ddadba6fa5946e58556088845b4", size = 373783, upload-time = "2026-06-30T07:14:57.736Z" },
+    { url = "https://files.pythonhosted.org/packages/87/fe/e80107ee3639585c9941c17d6a42cd65325022f656c023191fce78c324c8/rpds_py-2026.6.3-cp311-cp311-manylinux_2_17_armv7l.manylinux2014_armv7l.whl", hash = "sha256:7f88d653e7b3b779d71ae7454e20dcc9b6bae903f33c269db9f2be41bda3f261", size = 378316, upload-time = "2026-06-30T07:14:59.077Z" },
+    { url = "https://files.pythonhosted.org/packages/22/6f/81e3adf81acfb6fa694de2a6e4e7d8863121e3e0799e0a7725e6cf5679c4/rpds_py-2026.6.3-cp311-cp311-manylinux_2_17_ppc64le.manylinux2014_ppc64le.whl", hash = "sha256:e52655eaf81e32593abedaa4bfe33170c8cfedf3365ed9be6e11e07f148f0278", size = 499423, upload-time = "2026-06-30T07:15:00.488Z" },
+    { url = "https://files.pythonhosted.org/packages/2d/9a/41263969df0ce3d9af2a96d5005a288200af1989aed3354bfceb5fc0b21f/rpds_py-2026.6.3-cp311-cp311-manylinux_2_17_s390x.manylinux2014_s390x.whl", hash = "sha256:dfcc8b909769d19db55c7cc9541eb64b9b774b1057ffffb4f1048070475bb9f9", size = 386077, upload-time = "2026-06-30T07:15:01.911Z" },
+    { url = "https://files.pythonhosted.org/packages/5e/19/7e98f468bd50346faff5b10e5297374b443bfdddacc8e9fbc65984539597/rpds_py-2026.6.3-cp311-cp311-manylinux_2_17_x86_64.manylinux2014_x86_64.whl", hash = "sha256:9c1255b302953c86a486b81d330d5ee1d5bd937691ce271b6be0ef0e299eaab7", size = 371315, upload-time = "2026-06-30T07:15:03.317Z" },
+    { url = "https://files.pythonhosted.org/packages/99/3c/2b973b4d371906a134b03decfea7f5d9835a2c6d263454392e15b64b5b18/rpds_py-2026.6.3-cp311-cp311-manylinux_2_31_riscv64.whl", hash = "sha256:8d2294a31386bfa251d8c8a39472beee17db67d4f1a6eabea665d35c9a4461c3", size = 383502, upload-time = "2026-06-30T07:15:04.627Z" },
+    { url = "https://files.pythonhosted.org/packages/98/2a/12e2799500af0a307bca76b63361c51f9fe479223561489c29eea1f2ee41/rpds_py-2026.6.3-cp311-cp311-manylinux_2_5_i686.manylinux1_i686.whl", hash = "sha256:f8f23ead891a3b762f35ab3b04623da7056545b48aa60d59957e6789914545da", size = 402673, upload-time = "2026-06-30T07:15:05.856Z" },
+    { url = "https://files.pythonhosted.org/packages/2d/e3/21e5872d165fe08be4f229e3d5ee9d90019c0bf0e5538de60dbd54009450/rpds_py-2026.6.3-cp311-cp311-musllinux_1_2_aarch64.whl", hash = "sha256:421aba32367055614287a4292b6a17f1939c9452299f7a0209c117e990b646d4", size = 549964, upload-time = "2026-06-30T07:15:07.159Z" },
+    { url = "https://files.pythonhosted.org/packages/1a/d0/5ee0fe36844297de8123bee27bc12078c1a7416ad9f1b8a8ca18d6b0c0ac/rpds_py-2026.6.3-cp311-cp311-musllinux_1_2_i686.whl", hash = "sha256:1e5822dfc2f0d4ab7e745eaa6d85945069329beeccef965af3f3bb26058fcab6", size = 615446, upload-time = "2026-06-30T07:15:08.531Z" },
+    { url = "https://files.pythonhosted.org/packages/b1/80/1ea5873cb683f2fbe5f21b23ea1f6d179ead19f3c5b249b7eb5dca568ef2/rpds_py-2026.6.3-cp311-cp311-musllinux_1_2_x86_64.whl", hash = "sha256:83e35b57523816c8613fd0776b40cd8bb9f596b37ddd2692eb4a6bb5ab2f8c93", size = 576975, upload-time = "2026-06-30T07:15:09.97Z" },
+    { url = "https://files.pythonhosted.org/packages/c9/e1/90ef639217a5ddb15b7f4f61b1c33911fd044ad03c311bafdd2bcab85582/rpds_py-2026.6.3-cp311-cp311-win32.whl", hash = "sha256:de3eceba0b683bcbb1ab93da016d0270df1f9ae7be716b40214c5dafac6ea45a", size = 204453, upload-time = "2026-06-30T07:15:11.324Z" },
+    { url = "https://files.pythonhosted.org/packages/f2/b7/b7a1695d7af36f521fb11e80d6d3adbd744f73b921859bd3c2a2c0dc706f/rpds_py-2026.6.3-cp311-cp311-win_amd64.whl", hash = "sha256:2c54a076ca4d370980ab57bc0e31df57bbe8d41340436a90ef8b1219a3cbb127", size = 223219, upload-time = "2026-06-30T07:15:12.476Z" },
+    { url = "https://files.pythonhosted.org/packages/d7/a2/145afacf796e4506062825941176ad9445c2dcf2b3b6a1f13d3030a15e19/rpds_py-2026.6.3-cp311-cp311-win_arm64.whl", hash = "sha256:168c733a7112e071bb7a66460e667edfcff06c017a3c523f7a8a8e08d0140804", size = 219137, upload-time = "2026-06-30T07:15:13.631Z" },
+    { url = "https://files.pythonhosted.org/packages/5c/be/2e8974163072e7bab7df1a5acd54c4498e75e35d6d18b864d3a9d5dadc92/rpds_py-2026.6.3-cp312-cp312-macosx_10_12_x86_64.whl", hash = "sha256:a0811d33247c3d6128a3001d763f2aa056bb3425204335400ac54f89eec3a0d0", size = 343691, upload-time = "2026-06-30T07:15:14.96Z" },
+    { url = "https://files.pythonhosted.org/packages/a4/73/319dfa745dd668efe89309141ded489126461fcecd2b8f3a3cda185129b6/rpds_py-2026.6.3-cp312-cp312-macosx_11_0_arm64.whl", hash = "sha256:538949e262e46caa31ac01bdb3c1e8f642622922cacbabbae6a8445d9dc33eaf", size = 338542, upload-time = "2026-06-30T07:15:16.267Z" },
+    { url = "https://files.pythonhosted.org/packages/21/63/4239893be1c4d09b709b1a8f6be4188f0870084ff547f46606b8a75f1b03/rpds_py-2026.6.3-cp312-cp312-manylinux_2_17_aarch64.manylinux2014_aarch64.whl", hash = "sha256:55927d532399c2c646100ff7feb48eaa940ad70f42cd68e1328f3ded9f81ca24", size = 368180, upload-time = "2026-06-30T07:15:17.62Z" },
+    { url = "https://files.pythonhosted.org/packages/1c/ca/9c5de382225234ceb37b1844ebdb140db12b2a278bb9efe2fcd19f6c82ce/rpds_py-2026.6.3-cp312-cp312-manylinux_2_17_armv7l.manylinux2014_armv7l.whl", hash = "sha256:f56f1695bc5c0871cbc33dc0130fcf503aab0c57dcc5a6700a4f49eba4f2652e", size = 375067, upload-time = "2026-06-30T07:15:18.952Z" },
+    { url = "https://files.pythonhosted.org/packages/87/dc/863f69d1bf04ade34b7fe0d59b9fdf6f0135fe2d7cbca74f1d665589559d/rpds_py-2026.6.3-cp312-cp312-manylinux_2_17_ppc64le.manylinux2014_ppc64le.whl", hash = "sha256:270b293dae9058fc9fcedab50f13cebf46fb8ed1d1d54e0521a9da5d6b211975", size = 490509, upload-time = "2026-06-30T07:15:20.434Z" },
+    { url = "https://files.pythonhosted.org/packages/ce/ef/eac16a12048b45ec7c7fa94f2be3438a5f26bf9cc8580b18a1cfd609b7f6/rpds_py-2026.6.3-cp312-cp312-manylinux_2_17_s390x.manylinux2014_s390x.whl", hash = "sha256:127565fead0a10943b282957bd5447804ff3160ad79f2ad2635e6d249e380680", size = 382754, upload-time = "2026-06-30T07:15:21.831Z" },
+    { url = "https://files.pythonhosted.org/packages/04/8f/d2f3f532616be4d06c316ef119683e832bd3d41e112bf3a88f4151c95b17/rpds_py-2026.6.3-cp312-cp312-manylinux_2_17_x86_64.manylinux2014_x86_64.whl", hash = "sha256:ecabd69db66de867690f9797f2f8fa27ba501bbc24540cbdbdc649cd15888ba6", size = 366189, upload-time = "2026-06-30T07:15:23.371Z" },
+    { url = "https://files.pythonhosted.org/packages/e3/29/41a7b0e98a4b44cd676ab7598419623373eb43b20be68c084935c1a8cf88/rpds_py-2026.6.3-cp312-cp312-manylinux_2_31_riscv64.whl", hash = "sha256:58eadac9cd119677b60e1cf8ac4052f35949d71b8a9e5556efccbe82533cf22a", size = 377750, upload-time = "2026-06-30T07:15:24.659Z" },
+    { url = "https://files.pythonhosted.org/packages/2e/05/ecda0bec46f9a1565090bcdc941d023f6a25aff85fda28f89f8d19878152/rpds_py-2026.6.3-cp312-cp312-manylinux_2_5_i686.manylinux1_i686.whl", hash = "sha256:7491ee23305ac3eb59e492b6945881f5cd77a6f731061a3f25b77fd40f9e99a4", size = 395576, upload-time = "2026-06-30T07:15:25.987Z" },
+    { url = "https://files.pythonhosted.org/packages/68/a8/6ed52f03ee6cb854ce78785cc9a9a672eb880e83fd7224d471f667d151f1/rpds_py-2026.6.3-cp312-cp312-musllinux_1_2_aarch64.whl", hash = "sha256:2c99f7e8ccb3dd6e3e4bfeac657a7b208c9bac8075f4b078c02d7404c34107fa", size = 543807, upload-time = "2026-06-30T07:15:27.356Z" },
+    { url = "https://files.pythonhosted.org/packages/8f/d6/156c0d3eea27ba09b92562ba2364ba124c0a061b199e17eac637cd25a5e2/rpds_py-2026.6.3-cp312-cp312-musllinux_1_2_i686.whl", hash = "sha256:62698275682bf121181861295c9181e789030a2d516071f5b8f3c23c170cd0fc", size = 611187, upload-time = "2026-06-30T07:15:28.931Z" },
+    { url = "https://files.pythonhosted.org/packages/f1/31/774212ed989c62f7f310220089f9b0a3fb8f40f5443d1727abd5d9f52bc9/rpds_py-2026.6.3-cp312-cp312-musllinux_1_2_x86_64.whl", hash = "sha256:a214c993455f99a89aaeadc9b21241900037adc9d97203e374d75513c5911822", size = 573030, upload-time = "2026-06-30T07:15:30.553Z" },
+    { url = "https://files.pythonhosted.org/packages/c9/50/22f73127a41f1ce4f87fe39aadfb9a126345801c274aa93ae88456249327/rpds_py-2026.6.3-cp312-cp312-win32.whl", hash = "sha256:501f9f04a588d6a09179368c57071301445191767c64e4b52a6aa9871f1ef5ed", size = 202185, upload-time = "2026-06-30T07:15:32.027Z" },
+    { url = "https://files.pythonhosted.org/packages/04/3a/f0ee4d4dde9d3b69dedf1b5f74e7a40017046d55052d173e418c6a94f960/rpds_py-2026.6.3-cp312-cp312-win_amd64.whl", hash = "sha256:2c958bf94822e9290a40aaf2a822d4bc5c88099093e3948ad6c571eca9272e5f", size = 220394, upload-time = "2026-06-30T07:15:33.359Z" },
+    { url = "https://files.pythonhosted.org/packages/f3/83/3382fe37f809b59f02aac04dbc4e765b480b46ee0227ed516e3bdc4d3dfc/rpds_py-2026.6.3-cp312-cp312-win_arm64.whl", hash = "sha256:22bffe6042b9bcb0822bcd1955ec00e245daf17b4344e4ed8e9551b976b63e96", size = 215753, upload-time = "2026-06-30T07:15:34.778Z" },
+    { url = "https://files.pythonhosted.org/packages/a4/9e/b818ee580026ec578138e961027a68820c40afeb1ec8f6819b54fb99e196/rpds_py-2026.6.3-cp313-cp313-macosx_10_12_x86_64.whl", hash = "sha256:3cfe765c1da0072636ca06628261e0ea05688e160d5c8a03e0217c3854037223", size = 343012, upload-time = "2026-06-30T07:15:36.005Z" },
+    { url = "https://files.pythonhosted.org/packages/f3/6b/686d9dc4359a8f163cfbbf89ee0b4e586431de22fe8248edb63a8cf50d49/rpds_py-2026.6.3-cp313-cp313-macosx_11_0_arm64.whl", hash = "sha256:f4d78253f6996be4901669ad25319f842f740eccf4d58e3c7f3dd39e6dde1d8f", size = 338203, upload-time = "2026-06-30T07:15:37.462Z" },
+    { url = "https://files.pythonhosted.org/packages/9e/9b/069aa329940f8207615e091f5eedbbd40e1e15eac68a0790fd05ccdf796c/rpds_py-2026.6.3-cp313-cp313-manylinux_2_17_aarch64.manylinux2014_aarch64.whl", hash = "sha256:54f45a148e28767bf343d33a684693c70e451c6f4c0e9904709a723fafbdfc1f", size = 367984, upload-time = "2026-06-30T07:15:39.008Z" },
+    { url = "https://files.pythonhosted.org/packages/14/db/34c203e4becff3703e4d3bc121842c00b8689197f398161203a880052f4e/rpds_py-2026.6.3-cp313-cp313-manylinux_2_17_armv7l.manylinux2014_armv7l.whl", hash = "sha256:842e7b070435622248c7a2c44ae53fa1440e073cc3023bc919fed570884097a7", size = 374815, upload-time = "2026-06-30T07:15:40.253Z" },
+    { url = "https://files.pythonhosted.org/packages/ee/7d/8071067d2cc453d916ad836e828c943f575e8a44612537759002a1e07381/rpds_py-2026.6.3-cp313-cp313-manylinux_2_17_ppc64le.manylinux2014_ppc64le.whl", hash = "sha256:8020133a74bd81b4572dd8e4be028a6b1ebcd70e6726edc3918008c08bee6ee6", size = 490545, upload-time = "2026-06-30T07:15:41.729Z" },
+    { url = "https://files.pythonhosted.org/packages/a3/42/da06c5aa8f0484ff07f270787434204d9f4535e2f8c3b51ed402267e63c3/rpds_py-2026.6.3-cp313-cp313-manylinux_2_17_s390x.manylinux2014_s390x.whl", hash = "sha256:cdc7e35386f3847df728fbcb5e887e2d79c19e2fa1eba9e51b6621d23e3243af", size = 382828, upload-time = "2026-06-30T07:15:43.327Z" },
+    { url = "https://files.pythonhosted.org/packages/57/d7/fe978efc2ae50abe48eb7464668ea99f53c010c60aeebb7b35ad27f23661/rpds_py-2026.6.3-cp313-cp313-manylinux_2_17_x86_64.manylinux2014_x86_64.whl", hash = "sha256:acac386b453c2516111b50985d60ce46e7fadb5ea71ae7b25f4c946935bf27cf", size = 365678, upload-time = "2026-06-30T07:15:44.992Z" },
+    { url = "https://files.pythonhosted.org/packages/69/9d/1d8922e1990b2a6eb532b6ff53d3e73d2b3bbffc84116c75826bee73dfc6/rpds_py-2026.6.3-cp313-cp313-manylinux_2_31_riscv64.whl", hash = "sha256:425560c6fa0415f27261727bb20bd097568485e5eb0c121f1949417d1c516885", size = 377811, upload-time = "2026-06-30T07:15:46.523Z" },
+    { url = "https://files.pythonhosted.org/packages/b1/3d/198dceafb4fb034a6a47347e1b0735d34e0bd4a50be4e898d408ee66cb14/rpds_py-2026.6.3-cp313-cp313-manylinux_2_5_i686.manylinux1_i686.whl", hash = "sha256:a550fb4950a06dde3beb4721f5ad4b25bf4513784665b0a8522c792e2bd822a4", size = 395382, upload-time = "2026-06-30T07:15:47.955Z" },
+    { url = "https://files.pythonhosted.org/packages/1f/f1/13968e49655d40b6b19d8b9140296bbc6f1d86b3f0f6c346cf9f1adddf4b/rpds_py-2026.6.3-cp313-cp313-musllinux_1_2_aarch64.whl", hash = "sha256:4f4bca01b63096f606e095734dd56e74e175f94cfbf24ff3d63281cec61f7bb7", size = 543832, upload-time = "2026-06-30T07:15:49.33Z" },
+    { url = "https://files.pythonhosted.org/packages/ac/ab/289bcb1b90bd3e40a2900c561fa0e2087345ecbb094f0b870f2345142b7c/rpds_py-2026.6.3-cp313-cp313-musllinux_1_2_i686.whl", hash = "sha256:ccffae9a092a00deb7efd545fe5e2c33c33b88e7c054337e9a74c179347d0b7d", size = 611011, upload-time = "2026-06-30T07:15:50.847Z" },
+    { url = "https://files.pythonhosted.org/packages/1e/16/5043105e679436ccfbc8e5e0dd2d663ed18a8b8113515fd06a5e5d77c83e/rpds_py-2026.6.3-cp313-cp313-musllinux_1_2_x86_64.whl", hash = "sha256:1cf01971c4f2c5553b772a542e4aaf191789cd331bc2cd4ff0e6e65ba49e1e97", size = 572431, upload-time = "2026-06-30T07:15:52.394Z" },
+    { url = "https://files.pythonhosted.org/packages/85/ed/adab103321c0a6565d5ae1c2998349bc3ee175b82ccc5ae8fc04cc413075/rpds_py-2026.6.3-cp313-cp313-win32.whl", hash = "sha256:8c3d1e9c15b9d51ca0391e13da1a25a0a4df3c58a37c9dc368e0736cf7f69df0", size = 201710, upload-time = "2026-06-30T07:15:53.894Z" },
+    { url = "https://files.pythonhosted.org/packages/7b/ed/a03b09668e74e5dabbf2e211f6468e1820c0552f7b0500082da31841bf7b/rpds_py-2026.6.3-cp313-cp313-win_amd64.whl", hash = "sha256:9250a9a0a6fd4648b3f868da8d91a4c52b5811a62df58e753d50ae4454a36f80", size = 219454, upload-time = "2026-06-30T07:15:55.25Z" },
+    { url = "https://files.pythonhosted.org/packages/27/17/b8642c12930b71bc2b25831f6708ccf0f75abcd11883932ec9ce54ba3a78/rpds_py-2026.6.3-cp313-cp313-win_arm64.whl", hash = "sha256:900a67df3fd1660b035a4761c4ce73c382ea6b35f90f9863c36c6fd8bf8b09bb", size = 215063, upload-time = "2026-06-30T07:15:56.573Z" },
+    { url = "https://files.pythonhosted.org/packages/b6/36/7fbe9dcdaf857fb3f63c2a2284b62492d95f5e8334e947e5fb6e7f68c9be/rpds_py-2026.6.3-cp314-cp314-macosx_10_12_x86_64.whl", hash = "sha256:931908d9fc855d8f74783377822be318edb6dcb19e47169dc038f9a1bf60b06e", size = 344510, upload-time = "2026-06-30T07:15:57.921Z" },
+    { url = "https://files.pythonhosted.org/packages/ba/54/f785cc3d3f60839ca57a5af4927a9f347b07b2799c373fc20f7949f87c7e/rpds_py-2026.6.3-cp314-cp314-macosx_11_0_arm64.whl", hash = "sha256:d7469697dce35be237db177d42e2a2ee26e6dcc5fc052078a6fefabd288c6edd", size = 339495, upload-time = "2026-06-30T07:15:59.238Z" },
+    { url = "https://files.pythonhosted.org/packages/63/ef/d4cdaf309e6b095b43597103cf8c0b951d6cca2acce68c474f75ec12e0c7/rpds_py-2026.6.3-cp314-cp314-manylinux_2_17_aarch64.manylinux2014_aarch64.whl", hash = "sha256:bcfbcf66006befb9fd2aeaa9e01feaf881b4dc330a02ba07d2322b1c11be7b5d", size = 369454, upload-time = "2026-06-30T07:16:01.021Z" },
+    { url = "https://files.pythonhosted.org/packages/96/4a/9559a68b7ee15db09d7981212e8c2e219d2a1d6d4faa0391d813c3496a36/rpds_py-2026.6.3-cp314-cp314-manylinux_2_17_armv7l.manylinux2014_armv7l.whl", hash = "sha256:847927daf4cffbd4e90e42bc890069897101edd015f956cb8721b3473372edda", size = 374583, upload-time = "2026-06-30T07:16:02.287Z" },
+    { url = "https://files.pythonhosted.org/packages/ef/75/8964aa7d2c6e8ac43eba8eb6e6b0fdda1f46d39f2fc3e6aa9f2cb17f485d/rpds_py-2026.6.3-cp314-cp314-manylinux_2_17_ppc64le.manylinux2014_ppc64le.whl", hash = "sha256:aca6c1ef08a82bfe327cc156da694660f599923e2e6665b6d81c9c2d0ac9ffc8", size = 492919, upload-time = "2026-06-30T07:16:03.723Z" },
+    { url = "https://files.pythonhosted.org/packages/8f/97/6908094ac804115e65aedfd90f1b5fee4eebebd3f6c4cfc5419939267565/rpds_py-2026.6.3-cp314-cp314-manylinux_2_17_s390x.manylinux2014_s390x.whl", hash = "sha256:ae50181a047c871561212bb97f7932a2d45fb53e947bd9b57ebad85b529cbc53", size = 383725, upload-time = "2026-06-30T07:16:05.305Z" },
+    { url = "https://files.pythonhosted.org/packages/d1/9c/0d1fdc2e7aba23e290d603bc494e97bd205bae262ce33c6b32a69768ed5e/rpds_py-2026.6.3-cp314-cp314-manylinux_2_17_x86_64.manylinux2014_x86_64.whl", hash = "sha256:dc319e5a1de4b6913aac94bf6a2f9e847371e0a140a43dd4991db1a09bc2d504", size = 367255, upload-time = "2026-06-30T07:16:07.086Z" },
+    { url = "https://files.pythonhosted.org/packages/c4/fe/f0209ca4a9ed074bc8acb44dfd0e81c3122e94c9689f5645b7973a866719/rpds_py-2026.6.3-cp314-cp314-manylinux_2_31_riscv64.whl", hash = "sha256:e4316bf32babbed84e691e352faf967ce2f0f024174a8643c37c94a1080374fc", size = 379060, upload-time = "2026-06-30T07:16:08.525Z" },
+    { url = "https://files.pythonhosted.org/packages/c6/8d/f1cc54c616b9d8897de8738aac148d20afca93f68187475fe194d09a71b9/rpds_py-2026.6.3-cp314-cp314-manylinux_2_5_i686.manylinux1_i686.whl", hash = "sha256:8c6e5a2f750cc71c3e3b11d71661f21d6f9bc6cebc6564b1466417a1ec03ec77", size = 395960, upload-time = "2026-06-30T07:16:09.989Z" },
+    { url = "https://files.pythonhosted.org/packages/fb/04/aafff00f73aeca2945f734f1d483c64ab8f472d0864ab02377fd8e89c3b2/rpds_py-2026.6.3-cp314-cp314-musllinux_1_2_aarch64.whl", hash = "sha256:4470ce197d4090875cf6affbf1f853338387428df97c4fb7b7106317b8214698", size = 545356, upload-time = "2026-06-30T07:16:11.816Z" },
+    { url = "https://files.pythonhosted.org/packages/fd/cc/e229663b9e4ddac5a4acbe9085dd80a71af2a5d356b8b39d6bff233f24b0/rpds_py-2026.6.3-cp314-cp314-musllinux_1_2_i686.whl", hash = "sha256:ea964164cc9afa72d4d9b23cc28dafae93693c0a53e0b42acbff15b22c3f9ddd", size = 612319, upload-time = "2026-06-30T07:16:13.586Z" },
+    { url = "https://files.pythonhosted.org/packages/e3/7a/8a0e6d3e6cd066af108b71b43122c3fe158dd9eb86acac626593a2582eb1/rpds_py-2026.6.3-cp314-cp314-musllinux_1_2_x86_64.whl", hash = "sha256:639c8929aa0afe81be836b04de888460d6bed38b9c54cfc18da8f6bfabf5af5d", size = 573508, upload-time = "2026-06-30T07:16:15.23Z" },
+    { url = "https://files.pythonhosted.org/packages/87/03/2a69ab618a789cf6cf85c86bb844c62d090e700ab1a2aa676b3741b6c516/rpds_py-2026.6.3-cp314-cp314-win32.whl", hash = "sha256:882076c00c0a608b131187055ddc5ae29f2e7eaf870d6168980420d58528a5c8", size = 202504, upload-time = "2026-06-30T07:16:16.893Z" },
+    { url = "https://files.pythonhosted.org/packages/85/62/a3892ba945f4e24c78f352e5de3c7620d8479f73f211406a97263d13c7d2/rpds_py-2026.6.3-cp314-cp314-win_amd64.whl", hash = "sha256:0be972be84cfcaf46c8c6edf690ca0f154ac17babf1f6a955a51579b34ad2dc5", size = 220380, upload-time = "2026-06-30T07:16:18.108Z" },
+    { url = "https://files.pythonhosted.org/packages/3d/e7/c2bd44dc831931815ad11ebb5f430b5a0a4d3caa9de837107876c30c3432/rpds_py-2026.6.3-cp314-cp314-win_arm64.whl", hash = "sha256:2a9c6f195058cb45335e8cc3802745c603d716eb96bc9625950c1aac71c0c703", size = 215976, upload-time = "2026-06-30T07:16:19.654Z" },
+    { url = "https://files.pythonhosted.org/packages/79/9c/fff7b74bce9a091ec9a012a03f9ff5f69364eaf9451060dfc4486da2ffdd/rpds_py-2026.6.3-cp314-cp314t-macosx_10_12_x86_64.whl", hash = "sha256:f90938e92afda60266da758ee7d363447f7f0138c9559f9e1811629580582d90", size = 346840, upload-time = "2026-06-30T07:16:21.268Z" },
+    { url = "https://files.pythonhosted.org/packages/e9/44/77bcb1168b33704908295533d27f10eb811e9e3e193e8993dc99572211d3/rpds_py-2026.6.3-cp314-cp314t-macosx_11_0_arm64.whl", hash = "sha256:ec829541c45bca16e61c7ae50c20501f213605beb75d1aba91a6ee37fbbb56a4", size = 340282, upload-time = "2026-06-30T07:16:22.875Z" },
+    { url = "https://files.pythonhosted.org/packages/87/3c/7a9081c7c9e645b39efe19e4ffbeccd80add246327cd9b888aecffd72317/rpds_py-2026.6.3-cp314-cp314t-manylinux_2_17_aarch64.manylinux2014_aarch64.whl", hash = "sha256:afd70d95892096cdb26f15a00c45907b17817577aa8d1c76b2dcc2788391f9e9", size = 370403, upload-time = "2026-06-30T07:16:24.415Z" },
+    { url = "https://files.pythonhosted.org/packages/f7/69/af47021eb7dad6ff3396cb001c08f0f3c4d06c20253f75be6421a59fe6b7/rpds_py-2026.6.3-cp314-cp314t-manylinux_2_17_armv7l.manylinux2014_armv7l.whl", hash = "sha256:29dfa0533a5d4c94d4dfa1b694fcb56c9c63aad8330ffdd816fd225d0a7a162f", size = 376055, upload-time = "2026-06-30T07:16:26.111Z" },
+    { url = "https://files.pythonhosted.org/packages/81/fc/a3bcf517084396a6dd258c592567a3c011ba4557f2fde23dceaf26e74f2e/rpds_py-2026.6.3-cp314-cp314t-manylinux_2_17_ppc64le.manylinux2014_ppc64le.whl", hash = "sha256:af05d726809bff6b141be124d4c7ce998f9c9c7f30edb1f46c07aa103d540b41", size = 494419, upload-time = "2026-06-30T07:16:27.596Z" },
+    { url = "https://files.pythonhosted.org/packages/c9/eb/13d529d1788135425c7bf207f8463458ca5d92e43f3f701365b83e9dffc1/rpds_py-2026.6.3-cp314-cp314t-manylinux_2_17_s390x.manylinux2014_s390x.whl", hash = "sha256:9826217f048f620d9a712672818bf231442c1b35d96b227a07eabd11b4bb6945", size = 384848, upload-time = "2026-06-30T07:16:29.183Z" },
+    { url = "https://files.pythonhosted.org/packages/8e/f4/b7ac49f30013aba8f7b9566b1dd07e81de95e708c1374b7bacc5b9bc5c9c/rpds_py-2026.6.3-cp314-cp314t-manylinux_2_17_x86_64.manylinux2014_x86_64.whl", hash = "sha256:536bceea4fa4acf7e1c61da2b5786304367c816c8895be71b8f537c480b0ea1f", size = 371369, upload-time = "2026-06-30T07:16:30.912Z" },
+    { url = "https://files.pythonhosted.org/packages/31/86/6260bafa622f788b07ddec0e52d810305c8b9b0b8c27f58a2ab04bf62b4f/rpds_py-2026.6.3-cp314-cp314t-manylinux_2_31_riscv64.whl", hash = "sha256:bc0011654b91cc4fb2ae701bec0a0ba1e552c0714247fa7af6c59e0ccfa3a4e1", size = 379673, upload-time = "2026-06-30T07:16:32.486Z" },
+    { url = "https://files.pythonhosted.org/packages/19/c3/03f1ee79a047b48daeca157c89a18509cde22b6b951d642b9b0af1be660a/rpds_py-2026.6.3-cp314-cp314t-manylinux_2_5_i686.manylinux1_i686.whl", hash = "sha256:539d75de9e0d536c84ff18dfeb805398e58227001ce09231a26a08b9aed1ee0e", size = 397500, upload-time = "2026-06-30T07:16:34.471Z" },
+    { url = "https://files.pythonhosted.org/packages/f0/95/8ed0cd8c377dca12aea498f119fe639fc474d1461545c39d2b5872eb1c0f/rpds_py-2026.6.3-cp314-cp314t-musllinux_1_2_aarch64.whl", hash = "sha256:166cf54d9f44fc6ceb53c7860258dde44a81406646de79f8ed3234fca3b6e538", size = 545978, upload-time = "2026-06-30T07:16:36.45Z" },
+    { url = "https://files.pythonhosted.org/packages/d3/f2/0eb57f0eaa83f8fc152a7e03de968ab77e1f00732bebc892b190c6eebde7/rpds_py-2026.6.3-cp314-cp314t-musllinux_1_2_i686.whl", hash = "sha256:d34c20167764fbcf927194d532dd7e0c56772f0a5f943fa5ef9e9afbba8fb9db", size = 613350, upload-time = "2026-06-30T07:16:38.213Z" },
+    { url = "https://files.pythonhosted.org/packages/5b/de/e0674bdbc3ef7634989b3f854c3f34bc1f587d36e5bfdc5c378d57034619/rpds_py-2026.6.3-cp314-cp314t-musllinux_1_2_x86_64.whl", hash = "sha256:ea7bb13b7c9a29791f87a0387ba7d3ad3a6d783d827e4d3f27b40a0ff44495e2", size = 576486, upload-time = "2026-06-30T07:16:39.797Z" },
+    { url = "https://files.pythonhosted.org/packages/f2/f6/21101359743cd136ada781e8210a85769578422ba460672eea0e29739200/rpds_py-2026.6.3-cp314-cp314t-win32.whl", hash = "sha256:6de4744d05bd1aa1be4ed7ea1189e3979196808008113bbbf899a460966b925e", size = 201068, upload-time = "2026-06-30T07:16:41.316Z" },
+    { url = "https://files.pythonhosted.org/packages/a6/b2/9574d4d44f7760c2aa32d92a0a4f41698e33f5b204a0bf5c9758f52c79d5/rpds_py-2026.6.3-cp314-cp314t-win_amd64.whl", hash = "sha256:c7b9a2f8f4d8e90af72571d3d495deebdd7e3c75451f5b41719aee166e940fc2", size = 220600, upload-time = "2026-06-30T07:16:43.091Z" },
+    { url = "https://files.pythonhosted.org/packages/08/ae/f23a2697e6ee6340a578b0f136be6483657bef0c6f9497b752bb5c0964bb/rpds_py-2026.6.3-cp315-cp315-macosx_10_12_x86_64.whl", hash = "sha256:e059c5dde6452b44424bd1834557556c226b57781dee1227af23518459722b13", size = 344726, upload-time = "2026-06-30T07:16:44.5Z" },
+    { url = "https://files.pythonhosted.org/packages/c3/63/e7b3a1a5358dd32c930a1062d8e15b67fd6e8922e81df9e91706d66ee5c8/rpds_py-2026.6.3-cp315-cp315-macosx_11_0_arm64.whl", hash = "sha256:2f7c26fbc5acd2522b95d4177fe4710ffd8e9b20529e703ffbf8db4d93903f05", size = 339587, upload-time = "2026-06-30T07:16:46.255Z" },
+    { url = "https://files.pythonhosted.org/packages/ec/64/10a85681916ca55fffb91b0a211f84e34297c109243484dd6394660a8a7c/rpds_py-2026.6.3-cp315-cp315-manylinux_2_17_aarch64.manylinux2014_aarch64.whl", hash = "sha256:a3086b538543802f84c843911242db20447de00d8752dd0efc936dbcf02218ba", size = 369585, upload-time = "2026-06-30T07:16:48.101Z" },
+    { url = "https://files.pythonhosted.org/packages/76/c2/baf95c7c38823e12ba34407c5f5767a89e5cf2233895e56f608167ae9493/rpds_py-2026.6.3-cp315-cp315-manylinux_2_17_armv7l.manylinux2014_armv7l.whl", hash = "sha256:8f2e5c5ee828d42cb11760761c0af6507927bec42d0ad5458f97c9203b054617", size = 375479, upload-time = "2026-06-30T07:16:49.93Z" },
+    { url = "https://files.pythonhosted.org/packages/6a/94/0aad06c72d65101e11d33528d438cda99a39ce0da99466e156158f2541d3/rpds_py-2026.6.3-cp315-cp315-manylinux_2_17_ppc64le.manylinux2014_ppc64le.whl", hash = "sha256:ed0c1e5d10cdc7135537988c74a0188da68e2f3c30813ba3744ab1e42e0480f9", size = 492418, upload-time = "2026-06-30T07:16:51.641Z" },
+    { url = "https://files.pythonhosted.org/packages/b5/17/de3f5a479a1f056535d7489819639d8cd591ea6281d700390b43b1abd745/rpds_py-2026.6.3-cp315-cp315-manylinux_2_17_s390x.manylinux2014_s390x.whl", hash = "sha256:8c2642a7603ec0b16ed77da4555db3b4b472341904873788327c0b0d7b95f1bb", size = 384123, upload-time = "2026-06-30T07:16:53.622Z" },
+    { url = "https://files.pythonhosted.org/packages/46/7d/bf09bd1b145bb2671c03e1e6d1ab8651858d90d8c7dfeadd85a37a934fd8/rpds_py-2026.6.3-cp315-cp315-manylinux_2_17_x86_64.manylinux2014_x86_64.whl", hash = "sha256:8e4320744c1ffdd95a603def63344bfab2d33edeab301c5007e7de9f9f5b3885", size = 367351, upload-time = "2026-06-30T07:16:55.241Z" },
+    { url = "https://files.pythonhosted.org/packages/a3/ea/1bb734f314b8be319149ddee80b18bd41372bdcfbdf88d28131c0cd37719/rpds_py-2026.6.3-cp315-cp315-manylinux_2_31_riscv64.whl", hash = "sha256:a9f4645593036b81bbdb36b9c8e0ea0d1c3fee968c4d59db0344c14087ef143a", size = 378827, upload-time = "2026-06-30T07:16:56.841Z" },
+    { url = "https://files.pythonhosted.org/packages/4b/93/d9611e5b25e26df9a3649813ed66193ace9347a7c7fc4ab7cf70e94851c0/rpds_py-2026.6.3-cp315-cp315-manylinux_2_5_i686.manylinux1_i686.whl", hash = "sha256:e55d236be29255554da47abe5c577637db7c24a02b8b46f0ca9524c855801868", size = 395966, upload-time = "2026-06-30T07:16:58.557Z" },
+    { url = "https://files.pythonhosted.org/packages/c3/cb/99d77e16e5534ae1d90629bbe419ba6ee170833a6a85e3aa1cc41726fbbc/rpds_py-2026.6.3-cp315-cp315-musllinux_1_2_aarch64.whl", hash = "sha256:24e9c5386e16669b674a69c156c8eeefcb578f3b3397b713b08e6d60f3c7b187", size = 545680, upload-time = "2026-06-30T07:17:00.164Z" },
+    { url = "https://files.pythonhosted.org/packages/59/15/11a29755f790cef7a2f755e8e14f4f0c33f39489e1893a632a2eee59672b/rpds_py-2026.6.3-cp315-cp315-musllinux_1_2_i686.whl", hash = "sha256:c60924535c75f1566b6eb75b5c31a48a43fef04fa2d0d201acbad8a9969c6107", size = 611853, upload-time = "2026-06-30T07:17:01.962Z" },
+    { url = "https://files.pythonhosted.org/packages/68/86/0c27547e21644da938fb530f7e1a8148dd24d02db07e7a5f2567a17ce710/rpds_py-2026.6.3-cp315-cp315-musllinux_1_2_x86_64.whl", hash = "sha256:38a2fea2787428f811719ceb9114cb78964a3138838320c29ac39526c79c16ba", size = 573715, upload-time = "2026-06-30T07:17:03.693Z" },
+    { url = "https://files.pythonhosted.org/packages/29/71/4d8fcf700931815594bce892255bbd973b94efaf0fc1932b0590df18d886/rpds_py-2026.6.3-cp315-cp315-win32.whl", hash = "sha256:d483fe17f01ad64b7bf7cc38fcefff1ca9fb83f8c2b2542b68f97ffe0611b369", size = 202864, upload-time = "2026-06-30T07:17:05.746Z" },
+    { url = "https://files.pythonhosted.org/packages/eb/62/b577562de0edbb55b2be85ce5fd09c33e386b9b13eee09833af4240fd5c4/rpds_py-2026.6.3-cp315-cp315-win_amd64.whl", hash = "sha256:67e3a721ffc5d8d2210d3671872298c4a84e4b8035cfe42ffd7cde35d772b146", size = 220430, upload-time = "2026-06-30T07:17:07.471Z" },
+    { url = "https://files.pythonhosted.org/packages/c8/95/d6d0b2509825141eef60669a5739eec88dbc6a48053d6c92993a5704defe/rpds_py-2026.6.3-cp315-cp315-win_arm64.whl", hash = "sha256:6e84adbcf4bf841aed8116a8264b9f50b4cb3e7bd89b516122e616ac56ca269e", size = 215877, upload-time = "2026-06-30T07:17:09.008Z" },
+    { url = "https://files.pythonhosted.org/packages/b7/bf/f3ea278f0afd615c1d0f19cb69043a41526e2bb600c2b536eb192218eb27/rpds_py-2026.6.3-cp315-cp315t-macosx_10_12_x86_64.whl", hash = "sha256:ae6dd8f10bd17aad820876d24caec9efdafd80a318d16c0a48edb5e136902c6b", size = 346933, upload-time = "2026-06-30T07:17:10.762Z" },
+    { url = "https://files.pythonhosted.org/packages/9d/29/9907bdf1c5346763cf10b7f6852aad86652168c259def904cbe0082c5864/rpds_py-2026.6.3-cp315-cp315t-macosx_11_0_arm64.whl", hash = "sha256:bdbd97738551fca3917c1bd7188bec1920bb520104f28e7e1007f9ceb17b7690", size = 340274, upload-time = "2026-06-30T07:17:12.266Z" },
+    { url = "https://files.pythonhosted.org/packages/6f/2c/8e03767b5778ef25cebf74a7a91a2c3806f8eced4c92cb7406bbe060756d/rpds_py-2026.6.3-cp315-cp315t-manylinux_2_17_aarch64.manylinux2014_aarch64.whl", hash = "sha256:8b95977e7211527ab0ba576e286d023389fbeeb32a6b7b771665d333c60e5342", size = 370763, upload-time = "2026-06-30T07:17:14.107Z" },
+    { url = "https://files.pythonhosted.org/packages/2e/e1/df2a7e1ba2efd796af26194250b8d42c821b46592311595162af9ef0528d/rpds_py-2026.6.3-cp315-cp315t-manylinux_2_17_armv7l.manylinux2014_armv7l.whl", hash = "sha256:d15fde0e6fb0d88a60d221204873743e5d9f0b7d29165e62cd86d0413ad74ba6", size = 376467, upload-time = "2026-06-30T07:17:15.76Z" },
+    { url = "https://files.pythonhosted.org/packages/6b/de/8a0814d1946af29cb068fb259aa8622f856df1d0bab58429448726b537f5/rpds_py-2026.6.3-cp315-cp315t-manylinux_2_17_ppc64le.manylinux2014_ppc64le.whl", hash = "sha256:a136d453475ac0fcbda502ef1e6504bd28d6d904700915d278deeab0d00fe140", size = 496689, upload-time = "2026-06-30T07:17:17.308Z" },
+    { url = "https://files.pythonhosted.org/packages/df/f3/f19e0c852ba13694f5a79f3b719331051573cb5693feacf8a88ffffc3a71/rpds_py-2026.6.3-cp315-cp315t-manylinux_2_17_s390x.manylinux2014_s390x.whl", hash = "sha256:f826877d462181e5eb1c26a0026b8d0cab05d99844ecb6d8bf3627a2ca0c0442", size = 385340, upload-time = "2026-06-30T07:17:18.928Z" },
+    { url = "https://files.pythonhosted.org/packages/e2/ae/7ec3a9d2d4351f99e37bcb06b6b6f954512646bfdbf9742e1de727865daf/rpds_py-2026.6.3-cp315-cp315t-manylinux_2_17_x86_64.manylinux2014_x86_64.whl", hash = "sha256:79486287de1730dbaff3dbd124d0ca4d2ef7f9d29bf2544f1f93c09b5bcbbd12", size = 372179, upload-time = "2026-06-30T07:17:20.539Z" },
+    { url = "https://files.pythonhosted.org/packages/d3/ac/9cee911dff2aaa9a5a8354f6610bf2e6a616de9197c5fff4f54f82585f1e/rpds_py-2026.6.3-cp315-cp315t-manylinux_2_31_riscv64.whl", hash = "sha256:808345f53cb952433ca2816f1604ff3515608a81784954f38d4452acfe8e61d5", size = 379993, upload-time = "2026-06-30T07:17:22.212Z" },
+    { url = "https://files.pythonhosted.org/packages/83/6b/7c2a07ba88d1e9a936612f7a5d067467ed03d971d5a06f7d309dff044a7e/rpds_py-2026.6.3-cp315-cp315t-manylinux_2_5_i686.manylinux1_i686.whl", hash = "sha256:1967debc37f64f2c4dc90a7f563aec558b471966e12adcac4e1c4240496b6ebf", size = 398909, upload-time = "2026-06-30T07:17:23.66Z" },
+    { url = "https://files.pythonhosted.org/packages/97/0b/776ffcb66783637b0031f6d58d6fb55913c8b5abf00aeecd46bf933fb477/rpds_py-2026.6.3-cp315-cp315t-musllinux_1_2_aarch64.whl", hash = "sha256:f0840b5b17057f7fd918b76183a4b5a0635f43e14eb2ce60dce1d4ee4707ea00", size = 546584, upload-time = "2026-06-30T07:17:25.264Z" },
+    { url = "https://files.pythonhosted.org/packages/55/33/ba3bc04d7092bd553c9b2b195624992d2cc4f3de1f380b7b93cbee67bd79/rpds_py-2026.6.3-cp315-cp315t-musllinux_1_2_i686.whl", hash = "sha256:faa679d19a6696fd54259ad321251ad77a13e70e03dd834daa762a44fb6196ef", size = 614357, upload-time = "2026-06-30T07:17:26.888Z" },
+    { url = "https://files.pythonhosted.org/packages/8b/71/14edf065f04630b1a8472f7653cad03f6c478bcf95ea0e6aed55451e33ea/rpds_py-2026.6.3-cp315-cp315t-musllinux_1_2_x86_64.whl", hash = "sha256:23a439f31ccbeff1574e24889128821d1f7917470e830cf6544dced1c662262a", size = 576533, upload-time = "2026-06-30T07:17:28.546Z" },
+    { url = "https://files.pythonhosted.org/packages/ba/76/65002b08596c389105720a8c0d22298b8dc25a4baf89b2ce431343c8b1de/rpds_py-2026.6.3-cp315-cp315t-win32.whl", hash = "sha256:913ca42ccad3f8cc6e292b587ae8ae49c8c823e5dce51a736252fc7c7cdfa577", size = 201204, upload-time = "2026-06-30T07:17:30.193Z" },
+    { url = "https://files.pythonhosted.org/packages/8c/97/d855d6b3c322d1f27e26f5241c42016b56cf01377ea8ed348285f54652f0/rpds_py-2026.6.3-cp315-cp315t-win_amd64.whl", hash = "sha256:ae3d4fe8c0b9213624fdce7279d70e3b148b682ca20719ebd193a23ebfa47324", size = 220719, upload-time = "2026-06-30T07:17:31.788Z" },
+    { url = "https://files.pythonhosted.org/packages/b4/9c/f0d19ac587fd0e4ab6b72cda355e9c5a6166b01ef7e064e437aef8eb9fef/rpds_py-2026.6.3-pp311-pypy311_pp73-macosx_10_12_x86_64.whl", hash = "sha256:4cf2d36a2357e4d07bb5a4f98801265327b48256867816cfd2ceb001e9754a8f", size = 349791, upload-time = "2026-06-30T07:17:33.315Z" },
+    { url = "https://files.pythonhosted.org/packages/38/c7/1d49d204c9fd2ee6c537601dc4c1ba921e03363ca576bfab94a00254ac9a/rpds_py-2026.6.3-pp311-pypy311_pp73-macosx_11_0_arm64.whl", hash = "sha256:30c6dc199b24a5e3e81d50da0f00858c5bbdb2617a750395687f4339c5818171", size = 352842, upload-time = "2026-06-30T07:17:34.897Z" },
+    { url = "https://files.pythonhosted.org/packages/ac/e5/c0b5dc93cd0d4c06ce1f438907649514e2ea077bcd911e3154a51e96c38e/rpds_py-2026.6.3-pp311-pypy311_pp73-manylinux_2_17_aarch64.manylinux2014_aarch64.whl", hash = "sha256:9891e594296ab9dada6551c8e7b387b2721f27a67eecd528412e8906247a7b90", size = 382094, upload-time = "2026-06-30T07:17:36.514Z" },
+    { url = "https://files.pythonhosted.org/packages/0d/54/ec0e907b4ca8d541112db352409bd15f871c9b243e0c92c9b5a46ae96f01/rpds_py-2026.6.3-pp311-pypy311_pp73-manylinux_2_17_armv7l.manylinux2014_armv7l.whl", hash = "sha256:b5c2dc92304aa48a4a60443b548bb12f12e119d4b72f314015e67b9e1be97fca", size = 388662, upload-time = "2026-06-30T07:17:38.235Z" },
+    { url = "https://files.pythonhosted.org/packages/d3/f4/921c22a4fd0f1c1ac13a3996ffbf0aa67951e2c8ad0d1d9574938a2932e8/rpds_py-2026.6.3-pp311-pypy311_pp73-manylinux_2_17_ppc64le.manylinux2014_ppc64le.whl", hash = "sha256:127e08c0642d880cf32ca47ec2a4a77b901f7e2dd1ad9762adb13955d72ffcc9", size = 504896, upload-time = "2026-06-30T07:17:39.689Z" },
+    { url = "https://files.pythonhosted.org/packages/0b/1b/a114b972cefa1ab1cdb3c7bb177cd3844a12826c507c722d3a73516dbbaf/rpds_py-2026.6.3-pp311-pypy311_pp73-manylinux_2_17_s390x.manylinux2014_s390x.whl", hash = "sha256:8bb68f03f395eb793220b45c097bd4d8c32944393da0fad8b999efac0868fc8c", size = 391545, upload-time = "2026-06-30T07:17:41.336Z" },
+    { url = "https://files.pythonhosted.org/packages/4e/98/af9b3db77d47fcbe6c8c1f36e2c2147ec70292819e99c325f871584a1c11/rpds_py-2026.6.3-pp311-pypy311_pp73-manylinux_2_17_x86_64.manylinux2014_x86_64.whl", hash = "sha256:a3450b693fde92133e9f51060568a4c31fcca76d5e53bbd611e689ca446517e9", size = 380059, upload-time = "2026-06-30T07:17:42.857Z" },
+    { url = "https://files.pythonhosted.org/packages/c9/ba/0efd8668b97c1d26a61566386c636a7a7a09829e474fdf807caa15a2c844/rpds_py-2026.6.3-pp311-pypy311_pp73-manylinux_2_31_riscv64.whl", hash = "sha256:5e8d07bddee435a2ff6f1920e18feff28d0bc4533e42f4bf6927fbd073312c41", size = 393235, upload-time = "2026-06-30T07:17:44.637Z" },
+    { url = "https://files.pythonhosted.org/packages/62/90/8c139ee9690f73b0829f32647de6f40d826f8f443af6fa72644f96351aac/rpds_py-2026.6.3-pp311-pypy311_pp73-manylinux_2_5_i686.manylinux1_i686.whl", hash = "sha256:3a83ae6c67b7676b9878378547ca8e93ed77a580037bcbcd1d32f739e1e6089c", size = 413008, upload-time = "2026-06-30T07:17:46.225Z" },
+    { url = "https://files.pythonhosted.org/packages/9c/97/0043896fdd7828ce09a1d9a8b06433714d0960fc4ff3fc4aa72b666b764e/rpds_py-2026.6.3-pp311-pypy311_pp73-musllinux_1_2_aarch64.whl", hash = "sha256:2bfd04c19ddbd6640de0b51894d764bd2758854d5b75bd102d2ef10cb9c293a9", size = 558118, upload-time = "2026-06-30T07:17:47.759Z" },
+    { url = "https://files.pythonhosted.org/packages/f6/40/02355f0e134f783a8f9814c4680a1bd311d37671577a5964ea838573ff37/rpds_py-2026.6.3-pp311-pypy311_pp73-musllinux_1_2_i686.whl", hash = "sha256:ca6546b66be9dc4738b1b043d5ebd5488c66c578c5ff0fd0e8065313fe3afb76", size = 623138, upload-time = "2026-06-30T07:17:49.355Z" },
+    { url = "https://files.pythonhosted.org/packages/10/85/48f0abdcef5cce4e034c7a5b0ceeceba0b01bf0d942824f4bb720afe2dec/rpds_py-2026.6.3-pp311-pypy311_pp73-musllinux_1_2_x86_64.whl", hash = "sha256:8e65860d238379ed982fd9ba690579b5e95af2f4840f99c772816dbe573cb826", size = 586486, upload-time = "2026-06-30T07:17:51.141Z" },
 ]
 
 [[package]]
@@ -4309,6 +4591,19 @@ wheels = [
 ]
 
 [[package]]
+name = "sse-starlette"
+version = "3.4.8"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "anyio" },
+    { name = "starlette" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/f8/00/b42a44342a054d58cb1115d7c8aa9cb4290dd9442f9c1b91a4b8173dba22/sse_starlette-3.4.8.tar.gz", hash = "sha256:ed89ffbb75cbf78a5fe2f2109cd584792ee7f9dfac96f791db546df8f15f3f9c", size = 32548, upload-time = "2026-08-05T11:19:49.982Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/dd/3a/764912c58293d95b6dcdf4cc255f9d10de310580ced547b082eb9d72018c/sse_starlette-3.4.8-py3-none-any.whl", hash = "sha256:6e82314c786709a3cd9520f2285cf9fff90e181e598e8a357b0cf80f66afba0d", size = 16516, upload-time = "2026-08-05T11:19:48.748Z" },
+]
+
+[[package]]
 name = "standard-aifc"
 version = "3.13.0"
 source = { registry = "https://pypi.org/simple" }
@@ -4652,6 +4947,15 @@ dependencies = [
 sdist = { url = "https://files.pythonhosted.org/packages/dd/70/d42a739e8dfde3d92bb2fff5819cbf331fe9657323221e79415cd5eb65ee/transformers-4.57.3.tar.gz", hash = "sha256:df4945029aaddd7c09eec5cad851f30662f8bd1746721b34cc031d70c65afebc", size = 10139680, upload-time = "2025-11-25T15:51:30.139Z" }
 wheels = [
     { url = "https://files.pythonhosted.org/packages/6a/6b/2f416568b3c4c91c96e5a365d164f8a4a4a88030aa8ab4644181fdadce97/transformers-4.57.3-py3-none-any.whl", hash = "sha256:c77d353a4851b1880191603d36acb313411d3577f6e2897814f333841f7003f4", size = 11993463, upload-time = "2025-11-25T15:51:26.493Z" },
+]
+
+[[package]]
+name = "truststore"
+version = "0.10.4"
+source = { registry = "https://pypi.org/simple" }
+sdist = { url = "https://files.pythonhosted.org/packages/53/a3/1585216310e344e8102c22482f6060c7a6ea0322b63e026372e6dcefcfd6/truststore-0.10.4.tar.gz", hash = "sha256:9d91bd436463ad5e4ee4aba766628dd6cd7010cf3e2461756b3303710eebc301", size = 26169, upload-time = "2025-08-12T18:49:02.73Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/19/97/56608b2249fe206a67cd573bc93cd9896e1efb9e98bce9c163bcdc704b88/truststore-0.10.4-py3-none-any.whl", hash = "sha256:adaeaecf1cbb5f4de3b1959b42d41f6fab57b2b1666adb59e89cb0b53361d981", size = 18660, upload-time = "2025-08-12T18:49:01.46Z" },
 ]
 
 [[package]]

--- a/scripts/deploy-dev.sh
+++ b/scripts/deploy-dev.sh
@@ -68,7 +68,7 @@ ssh jeff@$NAS_HOST "docker restart familiar-api"
 echo "Installing additional dependencies..."
 ssh jeff@$NAS_HOST "docker exec familiar-api sh -c 'which pg_dump > /dev/null 2>&1 || apt-get update -qq && apt-get install -y -qq postgresql-client > /dev/null 2>&1'" || true
 ssh jeff@$NAS_HOST "docker exec familiar-api sh -c 'which deno > /dev/null 2>&1 || (apt-get update -qq && apt-get install -y -qq curl unzip > /dev/null 2>&1 && curl -fsSL https://deno.land/install.sh | DENO_INSTALL=/usr/local sh)'" || true
-ssh jeff@$NAS_HOST "docker exec familiar-api uv pip install 'curl_cffi>=0.7.0' 'trafilatura>=1.6.0' 'boto3>=1.34.0' 'yt-dlp[default]' 'bcrypt>=4.0.0' 'pyloudnorm>=0.1.0' 'soundfile>=0.12.0' 'basic-pitch[onnx]>=0.3.0' 'matplotlib>=3.5.0' 'async-upnp-client>=0.47.0' --python /app/.venv/bin/python -q" || true
+ssh jeff@$NAS_HOST "docker exec familiar-api uv pip install 'curl_cffi>=0.7.0' 'trafilatura>=1.6.0' 'boto3>=1.34.0' 'yt-dlp[default]' 'bcrypt>=4.0.0' 'pyloudnorm>=0.1.0' 'soundfile>=0.12.0' 'basic-pitch[onnx]>=0.3.0' 'matplotlib>=3.5.0' 'async-upnp-client>=0.47.0' 'mcp>=2.0.0' --python /app/.venv/bin/python -q" || true
 
 # Copy code into container (container runs from /app/, not host filesystem)
 if [ "$DEPLOY_BACKEND" = true ]; then


### PR DESCRIPTION
26 tools at `/mcp`, in-process, so the host the listener already uses drives Familiar's analysis instead of Familiar shipping a chat client.

**Depends on #114** for the ADRs. The code stands alone and changes no existing behaviour — nothing is deleted here, and `openapi.json` is untouched.

## It's an adapter, not a reimplementation

`ToolExecutor.execute(name, arguments)` already takes a tool name and a dict — exactly what MCP's `tools/call` provides. So schemas come straight from `MUSIC_TOOLS` and handlers from `services/llm/handlers/` **unchanged**.

I used the **low-level** `Server` API rather than the ergonomic one specifically because it takes JSON schemas directly. The ergonomic API derives schemas from Python signatures, which would have meant retyping 26 of them — including `filter_tracks`' 46 properties — with drift guaranteed. A test asserts the exposed schemas are identical to `MUSIC_TOOLS`.

**Excluded** (ADR-0043 point 2): `get_visible_tracks`, `queue_tracks`, `control_playback` need a Familiar client and belong to ADR-0044. `fetch_webpage` is withheld outright — a server-side URL fetcher on an API with no inbound auth.

## Four traps, none of which look like wiring problems

1. **The session manager needs a lifespan** chained into the app's, or every request fails *at request time* with `Task group is not initialized`.
2. **DNS-rebinding protection ships with no default allowlist** — it rejects every `Host`, including `localhost`, with **421**. `mcp_allowed_hosts` configures it; empty disables it with a startup warning, because a server that 421s out of the box teaches people to disable security they never understood.
3. **The SPA catch-all would swallow it, asymmetrically.** Streamable HTTP uses POST for requests and GET for the server-initiated stream, so a late mount leaves **POST working while GET returns `index.html` with HTTP 200** — half the transport dead and looking healthy. `mcp` joins `NON_SPA_PREFIXES`.
4. **`app.mount("/mcp", ...)` does not work at all** — the ADR didn't anticipate this. Starlette's `Mount` pattern requires a trailing segment, so `/mcp` never matches and the router answers **307 → `/mcp/`**. Clients POST their handshake, and a redirected POST isn't reliably replayed. `MCPDispatch` runs as middleware, before routing, and serves both spellings with no redirect.

## Profile binding

Point 9 is enforced in `list_tools` as well as `call_tool`. Listing is the first thing every host does, so an unbound connection fails immediately and **says why** — rather than presenting a working-looking surface that fails on the first call, which is the "Listening Ideas" defect moved one step later.

`create_playlist_from_items` gains `generation_prompt` as an argument, because a host never passes the listener's raw turn and `Playlist.generation_prompt` would otherwise always be empty.

## Verification

- **End to end over the real transport**: `initialize` → 200, `text/event-stream`, instructions present; `tools/list` unbound → refused with the reason.
- **The guard was seen to fail**: removing `"mcp"` from `NON_SPA_PREFIXES` fails two tests.
- 17 new tests; `ruff check .` clean; `dump_openapi.py --check` reports no drift.
- Full suite: **851 passed, 0 failed.** The 558 errors are all "connection to server at localhost:5432 refused" — no local Postgres here, and CI has one.

## Also

`scripts/mcp_stdio.py` — the same tools over stdio, so tuning tool descriptions (the work ADR-0043 point 3 says decides whether this is any good) is a file save rather than a `make deploy-dev`.

## Not done here

The chat clients are **not** deleted. ADR-0043 point 5 retires them, but only once this surface is proven against the real library — and that needs a deploy plus a host pointed at it.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
