### PR TITLE
The visualizer page: flux envelope, self-contained bundle, and a host that can choose

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -100,3 +100,6 @@ AuthKey*.p8
 # and scripts/analyze-demo-library.sh; not for git).
 demo-library/
 .demo-analysis/
+
+# Intermediate output of the visualizer bundle build; the artifact is vendored into familiar-apple.
+packages/web/dist-visualizer/

--- a/artifacts/perf/bundle-metrics.json
+++ b/artifacts/perf/bundle-metrics.json
@@ -1,99 +1,115 @@
 {
-  "generatedAt": "2026-03-13T12:41:50.262Z",
+  "generatedAt": "2026-08-08T23:22:15.521Z",
   "budgets": {
     "entryGzipTargetKb": 300,
-    "entryGzipHardKb": 460,
+    "entryGzipHardKb": 350,
     "lazyGzipTargetKb": 120,
     "lazyGzipHardKb": 180,
     "mainCssGzipTargetKb": 18,
     "mainCssGzipHardKb": 25
   },
+  "entries": [
+    {
+      "src": "index.html",
+      "file": "assets/index-D7LJTutN.js",
+      "gzipBytes": 99242,
+      "gzipKb": 96.92
+    },
+    {
+      "src": "embed.html",
+      "file": "assets/embed-CuVKRiqH.js",
+      "gzipBytes": 1340,
+      "gzipKb": 1.31
+    },
+    {
+      "src": "visualizer.html",
+      "file": "assets/visualizer-CLAqlN0_.js",
+      "gzipBytes": 1042,
+      "gzipKb": 1.02
+    }
+  ],
   "entry": {
-    "file": "assets/index-Dvy_qw_U.js",
-    "rawBytes": 1694224,
-    "gzipBytes": 465790,
-    "gzipKb": 454.87
+    "file": "assets/index-D7LJTutN.js",
+    "rawBytes": 387602,
+    "gzipBytes": 99242,
+    "gzipKb": 96.92
   },
   "largestLazy": {
-    "file": "assets/index-B_PCgeGB.js",
-    "gzipBytes": 73036,
-    "gzipKb": 71.32
+    "file": "assets/PlaylistRow-kG_ggIRt.js",
+    "gzipBytes": 29018,
+    "gzipKb": 28.34
   },
-  "mainCss": {
-    "file": "assets/index-9hqiJINH.css",
-    "gzipBytes": 13961,
-    "gzipKb": 13.63
-  },
+  "mainCss": null,
   "topJsAssets": [
     {
-      "file": "assets/index-Dvy_qw_U.js",
-      "rawBytes": 1694224,
-      "rawKb": 1654.52,
-      "gzipBytes": 465790,
-      "gzipKb": 454.87
+      "file": "assets/vendor-three-D8DgyZ8I.js",
+      "rawBytes": 1065232,
+      "rawKb": 1040.27,
+      "gzipBytes": 297561,
+      "gzipKb": 290.59
     },
     {
-      "file": "assets/index-B_PCgeGB.js",
-      "rawBytes": 223056,
-      "rawKb": 217.83,
-      "gzipBytes": 73036,
-      "gzipKb": 71.32
+      "file": "assets/index-D7LJTutN.js",
+      "rawBytes": 387602,
+      "rawKb": 378.52,
+      "gzipBytes": 99242,
+      "gzipKb": 96.92
     },
     {
-      "file": "assets/vendor-audio-CXPx7eTM.js",
+      "file": "assets/vendor-react-qEhzO5Dk.js",
+      "rawBytes": 230311,
+      "rawKb": 224.91,
+      "gzipBytes": 73442,
+      "gzipKb": 71.72
+    },
+    {
+      "file": "assets/vendor-audio-alqlCz7y.js",
       "rawBytes": 94964,
       "rawKb": 92.74,
-      "gzipBytes": 31919,
+      "gzipBytes": 31921,
       "gzipKb": 31.17
     },
     {
-      "file": "assets/index-gmKv4Kgd.js",
-      "rawBytes": 140179,
-      "rawKb": 136.89,
-      "gzipBytes": 28659,
-      "gzipKb": 27.99
+      "file": "assets/PlaylistRow-kG_ggIRt.js",
+      "rawBytes": 99614,
+      "rawKb": 97.28,
+      "gzipBytes": 29018,
+      "gzipKb": 28.34
     },
     {
-      "file": "assets/vendor-react-Bq1UMS2s.js",
-      "rawBytes": 40855,
-      "rawKb": 39.9,
-      "gzipBytes": 14555,
-      "gzipKb": 14.21
+      "file": "assets/index-DaEA4nrL.js",
+      "rawBytes": 134808,
+      "rawKb": 131.65,
+      "gzipBytes": 27058,
+      "gzipKb": 26.42
     },
     {
-      "file": "assets/vendor-query-CcIar6DF.js",
-      "rawBytes": 44822,
-      "rawKb": 43.77,
-      "gzipBytes": 13690,
-      "gzipKb": 13.37
+      "file": "assets/uiStore-Cfjqt7mo.js",
+      "rawBytes": 44105,
+      "rawKb": 43.07,
+      "gzipBytes": 17434,
+      "gzipKb": 17.03
     },
     {
-      "file": "assets/vendor-icons-DeeEANVr.js",
-      "rawBytes": 30241,
-      "rawKb": 29.53,
-      "gzipBytes": 9781,
-      "gzipKb": 9.55
+      "file": "assets/playerStore-CoIc_o-d.js",
+      "rawBytes": 42870,
+      "rawKb": 41.87,
+      "gzipBytes": 13442,
+      "gzipKb": 13.13
     },
     {
-      "file": "assets/index-Bm4932vQ.js",
-      "rawBytes": 22072,
-      "rawKb": 21.55,
-      "gzipBytes": 7330,
-      "gzipKb": 7.16
+      "file": "assets/vendor-icons-Cj_N8uHg.js",
+      "rawBytes": 34158,
+      "rawKb": 33.36,
+      "gzipBytes": 11034,
+      "gzipKb": 10.78
     },
     {
-      "file": "assets/PlaylistDetail-Demhifen.js",
-      "rawBytes": 15402,
-      "rawKb": 15.04,
-      "gzipBytes": 4994,
-      "gzipKb": 4.88
-    },
-    {
-      "file": "assets/ArtistDetail-DXgxmG5Y.js",
-      "rawBytes": 15090,
-      "rawKb": 14.74,
-      "gzipBytes": 4648,
-      "gzipKb": 4.54
+      "file": "assets/vendor-query-D1pqjCy3.js",
+      "rawBytes": 36452,
+      "rawKb": 35.6,
+      "gzipBytes": 10715,
+      "gzipKb": 10.46
     }
   ]
 }

--- a/artifacts/perf/bundle-metrics.md
+++ b/artifacts/perf/bundle-metrics.md
@@ -1,28 +1,28 @@
 # Bundle Metrics
 
-Generated: 2026-03-13T12:41:50.262Z
+Generated: 2026-08-08T23:22:15.521Z
 
 ## Summary
 
-- Entry: `assets/index-Dvy_qw_U.js` (454.87 kB gzip)
-- Largest Lazy: `assets/index-B_PCgeGB.js` (71.32 kB gzip)
-- Main CSS: `assets/index-9hqiJINH.css` (13.63 kB gzip)
+- Entry: `assets/index-D7LJTutN.js` (96.92 kB gzip)
+- Largest Lazy: `assets/PlaylistRow-kG_ggIRt.js` (28.34 kB gzip)
+- Main CSS: N/A
 
 ## Top JS Assets (gzip)
 
 | File | Raw (kB) | Gzip (kB) |
 |---|---:|---:|
-| assets/index-Dvy_qw_U.js | 1654.52 | 454.87 |
-| assets/index-B_PCgeGB.js | 217.83 | 71.32 |
-| assets/vendor-audio-CXPx7eTM.js | 92.74 | 31.17 |
-| assets/index-gmKv4Kgd.js | 136.89 | 27.99 |
-| assets/vendor-react-Bq1UMS2s.js | 39.9 | 14.21 |
-| assets/vendor-query-CcIar6DF.js | 43.77 | 13.37 |
-| assets/vendor-icons-DeeEANVr.js | 29.53 | 9.55 |
-| assets/index-Bm4932vQ.js | 21.55 | 7.16 |
-| assets/PlaylistDetail-Demhifen.js | 15.04 | 4.88 |
-| assets/ArtistDetail-DXgxmG5Y.js | 14.74 | 4.54 |
+| assets/vendor-three-D8DgyZ8I.js | 1040.27 | 290.59 |
+| assets/index-D7LJTutN.js | 378.52 | 96.92 |
+| assets/vendor-react-qEhzO5Dk.js | 224.91 | 71.72 |
+| assets/vendor-audio-alqlCz7y.js | 92.74 | 31.17 |
+| assets/PlaylistRow-kG_ggIRt.js | 97.28 | 28.34 |
+| assets/index-DaEA4nrL.js | 131.65 | 26.42 |
+| assets/uiStore-Cfjqt7mo.js | 43.07 | 17.03 |
+| assets/playerStore-CoIc_o-d.js | 41.87 | 13.13 |
+| assets/vendor-icons-Cj_N8uHg.js | 33.36 | 10.78 |
+| assets/vendor-query-D1pqjCy3.js | 35.6 | 10.46 |
 
 ## Budget Results
 
-- Warning: Entry gzip 454.87 kB exceeds target 300 kB
+- All budgets within target thresholds.

--- a/backend/app/main.py
+++ b/backend/app/main.py
@@ -533,6 +533,23 @@ async def serve_embed() -> FileResponse:
     return FileResponse(embed)
 
 
+async def serve_visualizer() -> FileResponse:
+    """Serve the embedded visualizer's own document (ADR-0033).
+
+    A sibling of :func:`serve_embed`, and separate for the same reason: the SPA fallback answers any
+    unknown path with ``index.html`` — HTTP 200, the whole web app, ``WebAudioEngine`` and all. A
+    native host loading that would get a second audio engine inside a web view inside an app that is
+    already playing, which is the one thing ADR-0016 point 4 exists to prevent.
+
+    404s rather than falling through when the build predates this surface, so the app can say the
+    server is too old instead of showing a visualizer that will never receive a frame.
+    """
+    visualizer = STATIC_DIR / "visualizer.html"
+    if not visualizer.exists():
+        raise NotFoundError("This server has no embedded visualizer build.")
+    return FileResponse(visualizer)
+
+
 async def spa_fallback(full_path: str) -> FileResponse:
     """Serve index.html for SPA routing (catches all non-API routes).
 
@@ -583,9 +600,10 @@ if STATIC_DIR.exists():
         """Serve index.html for root path."""
         return FileResponse(STATIC_DIR / "index.html")
 
-    # Registered before the catch-all below, which would otherwise swallow it and hand the web view
-    # the full app.
+    # Registered before the catch-all below, which would otherwise swallow them and hand the web
+    # view the full app.
     app.get("/embed", response_model=None)(serve_embed)
+    app.get("/visualizer", response_model=None)(serve_visualizer)
 
     # SPA fallback - serve index.html for all non-API routes
     app.get("/{full_path:path}", response_model=None)(spa_fallback)

--- a/backend/tests/test_contract_error_shapes.py
+++ b/backend/tests/test_contract_error_shapes.py
@@ -172,6 +172,44 @@ async def test_embed_route_serves_its_own_document_not_the_app() -> None:
     assert response.path.name == "embed.html", "the embed route must not serve index.html"
 
 
+async def test_visualizer_route_serves_its_own_document_not_the_app() -> None:
+    """And the visualizer surface must never be handed `index.html` either (ADR-0033).
+
+    Same failure as the Discover surface's, with an extra edge: this document is loaded while the
+    native app is *already playing*, so a `WebAudioEngine` arriving here would contend for the audio
+    session with audio in progress rather than merely being available to.
+    """
+    from pathlib import Path
+    from unittest.mock import patch
+
+    from fastapi.responses import FileResponse
+
+    from app import main
+
+    with patch.object(main, "STATIC_DIR", Path(__file__).parent):
+        with patch.object(Path, "exists", lambda self: True):
+            response = await main.serve_visualizer()
+
+    assert isinstance(response, FileResponse)
+    assert response.path.name == "visualizer.html", "the visualizer route must not serve index.html"
+
+
+async def test_visualizer_route_404s_when_the_build_predates_it() -> None:
+    """A server too old to have the visualizer document says so.
+
+    The native side turns this into "redeploy the server" rather than a black screen that never
+    receives a frame — which is what a 200 with the wrong document would produce.
+    """
+    import pytest
+
+    from app import main
+    from app.api.exceptions import NotFoundError
+
+    with pytest.raises(NotFoundError) as caught:
+        await main.serve_visualizer()
+    assert caught.value.status_code == 404
+
+
 async def test_embed_route_404s_when_the_build_predates_it() -> None:
     """A server built before the embedded surface existed says so, rather than 500ing.
 

--- a/packages/frontend/src/components/Embed/EmbedVisualizer.tsx
+++ b/packages/frontend/src/components/Embed/EmbedVisualizer.tsx
@@ -1,124 +1,39 @@
-import { useEffect, useState } from 'react';
+import { useSyncExternalStore } from 'react';
 import { AudioVisualizer } from '../Visualizer/AudioVisualizer';
-import { setNativeAnalysisBuffers, clearNativeAnalysisBuffers } from '../../player/audio/nativeAnalysisBuffers';
+import { getVisualizerState, subscribeToVisualizerState } from '../../services/visualizerSink';
 import { tracksApi } from '../../api/tracks';
 import type { Track } from '../../types';
-
-/**
- * One frame of analysis, as the native host sends it.
- *
- * Mirrors `VisualizerFrame` in `FamiliarKit`. **Nothing checks these two against each other** —
- * they are in different repositories and different languages, which is the seam ADR-0016 called
- * embedding's main risk. Both sides are pinned by tests to the same written shape; that is the only
- * thing keeping them in step, so a change here is a change there.
- */
-interface AnalysisFrame {
-  /** base64 of the per-bin spectrum, 0-255. */
-  frequency: string;
-  /** base64 of the waveform, 0-255 centred on 128. */
-  timeDomain: string;
-  /** Onset strength per analysis window, oldest first. See `nativeAnalysisBuffers`. */
-  flux: number[];
-  /** Seconds between `flux` values. */
-  fluxInterval: number;
-  /** The host's *measured* frame rate. Not assumed — the assumed figure was wrong by 6x. */
-  cadenceHz: number;
-  playing: boolean;
-  position: number;
-  track?: { id: string; title?: string; artist?: string; album?: string };
-}
-
-function decodeBytes(base64: string): Uint8Array {
-  const binary = atob(base64);
-  const bytes = new Uint8Array(binary.length);
-  for (let i = 0; i < binary.length; i++) bytes[i] = binary.charCodeAt(i);
-  return bytes;
-}
 
 /**
  * The visualizer, drawing what the native app sends it (ADR-0033).
  *
  * **This surface only receives.** The Discover surface posts intents and is never told what is
  * playing; this is the mirror image — it has no buttons, makes no requests of the app, and its
- * entire input is the frames arriving on `window.__familiarAnalysis`.
+ * entire input is the frames arriving on the sink.
  *
- * The buffers go to the same `nativeAnalysisBuffers` seam the iOS Capacitor engine was built
- * against, so `getAudioData()` keeps its signature and all four visualizers run unmodified. That is
- * most of what embedding is being bought for: someone writes Three.js against
- * `docs/VISUALIZER_API.md` and it runs on the Mac without touching Swift.
+ * The sink itself is installed at module load rather than here (see `visualizerSink`). This
+ * component subscribes to the small amount of metadata React needs; the spectrum never passes
+ * through React at all, it goes straight into the analysis buffers that `getAudioData()` reads. So
+ * all four visualizers run unmodified, which is most of what embedding is being bought for.
  */
 export function EmbedVisualizer() {
-  const [track, setTrack] = useState<Track | null>(null);
-  const [isPlaying, setIsPlaying] = useState(false);
-  const [currentTime, setCurrentTime] = useState(0);
-  const [artworkUrl, setArtworkUrl] = useState<string | null>(null);
+  const state = useSyncExternalStore(subscribeToVisualizerState, getVisualizerState);
 
-  useEffect(() => {
-    // Reused across frames so a channel running for the length of an album does not allocate two
-    // arrays ten times a second. The visualizers copy out of these on their own tick.
-    let frequency: Uint8Array | null = null;
-    let timeDomain: Uint8Array | null = null;
-    let flux: Float32Array | null = null;
-    let lastTrackId: string | null = null;
-
-    const sink = (frame: AnalysisFrame) => {
-      const freqBytes = decodeBytes(frame.frequency);
-      const timeBytes = decodeBytes(frame.timeDomain);
-
-      if (!frequency || frequency.length !== freqBytes.length) {
-        frequency = new Uint8Array(freqBytes.length);
-        timeDomain = new Uint8Array(timeBytes.length);
-      }
-      frequency.set(freqBytes);
-      timeDomain!.set(timeBytes);
-
-      if (!flux || flux.length !== frame.flux.length) flux = new Float32Array(frame.flux.length);
-      flux.set(frame.flux);
-
-      setNativeAnalysisBuffers(frequency, timeDomain!, flux, frame.fluxInterval);
-
-      // **React state only when it changes**, not per frame. These drive re-renders, and this runs
-      // ten times a second for as long as music plays — setting them unconditionally would re-render
-      // the whole visualizer tree at the channel's rate, which is the mistake ADR-0041 had to undo
-      // one layer down on the native side.
-      setIsPlaying((was) => (was === frame.playing ? was : frame.playing));
-      setCurrentTime((was) => (Math.abs(was - frame.position) < 0.2 ? was : frame.position));
-
-      const id = frame.track?.id ?? null;
-      if (id !== lastTrackId) {
-        lastTrackId = id;
-        if (frame.track) {
-          setTrack({
-            id: frame.track.id,
-            title: frame.track.title ?? 'Unknown',
-            artist: frame.track.artist ?? 'Unknown artist',
-            album: frame.track.album ?? '',
-          } as Track);
-          setArtworkUrl(tracksApi.getArtworkUrl(frame.track.id));
-        } else {
-          setTrack(null);
-          setArtworkUrl(null);
-        }
-      }
-    };
-
-    // The name the native side calls. Installed before anything else so a frame arriving during
-    // boot lands rather than being dropped — the host optional-chains this call, so an early frame
-    // is a silent no-op and the next one is 100ms away, but there is no reason to miss any.
-    (window as unknown as Record<string, unknown>).__familiarAnalysis = sink;
-
-    return () => {
-      delete (window as unknown as Record<string, unknown>).__familiarAnalysis;
-      clearNativeAnalysisBuffers();
-    };
-  }, []);
+  const track: Track | null = state.track
+    ? ({
+        id: state.track.id,
+        title: state.track.title ?? 'Unknown',
+        artist: state.track.artist ?? 'Unknown artist',
+        album: state.track.album ?? '',
+      } as Track)
+    : null;
 
   return (
     <AudioVisualizer
       track={track}
-      artworkUrl={artworkUrl}
-      isPlaying={isPlaying}
-      currentTime={currentTime}
+      artworkUrl={state.track ? tracksApi.getArtworkUrl(state.track.id) : null}
+      isPlaying={state.playing}
+      currentTime={state.position}
       className="absolute inset-0"
     />
   );

--- a/packages/frontend/src/components/Embed/EmbedVisualizer.tsx
+++ b/packages/frontend/src/components/Embed/EmbedVisualizer.tsx
@@ -1,0 +1,125 @@
+import { useEffect, useState } from 'react';
+import { AudioVisualizer } from '../Visualizer/AudioVisualizer';
+import { setNativeAnalysisBuffers, clearNativeAnalysisBuffers } from '../../player/audio/nativeAnalysisBuffers';
+import { tracksApi } from '../../api/tracks';
+import type { Track } from '../../types';
+
+/**
+ * One frame of analysis, as the native host sends it.
+ *
+ * Mirrors `VisualizerFrame` in `FamiliarKit`. **Nothing checks these two against each other** —
+ * they are in different repositories and different languages, which is the seam ADR-0016 called
+ * embedding's main risk. Both sides are pinned by tests to the same written shape; that is the only
+ * thing keeping them in step, so a change here is a change there.
+ */
+interface AnalysisFrame {
+  /** base64 of the per-bin spectrum, 0-255. */
+  frequency: string;
+  /** base64 of the waveform, 0-255 centred on 128. */
+  timeDomain: string;
+  /** Onset strength per analysis window, oldest first. See `nativeAnalysisBuffers`. */
+  flux: number[];
+  /** Seconds between `flux` values. */
+  fluxInterval: number;
+  /** The host's *measured* frame rate. Not assumed — the assumed figure was wrong by 6x. */
+  cadenceHz: number;
+  playing: boolean;
+  position: number;
+  track?: { id: string; title?: string; artist?: string; album?: string };
+}
+
+function decodeBytes(base64: string): Uint8Array {
+  const binary = atob(base64);
+  const bytes = new Uint8Array(binary.length);
+  for (let i = 0; i < binary.length; i++) bytes[i] = binary.charCodeAt(i);
+  return bytes;
+}
+
+/**
+ * The visualizer, drawing what the native app sends it (ADR-0033).
+ *
+ * **This surface only receives.** The Discover surface posts intents and is never told what is
+ * playing; this is the mirror image — it has no buttons, makes no requests of the app, and its
+ * entire input is the frames arriving on `window.__familiarAnalysis`.
+ *
+ * The buffers go to the same `nativeAnalysisBuffers` seam the iOS Capacitor engine was built
+ * against, so `getAudioData()` keeps its signature and all four visualizers run unmodified. That is
+ * most of what embedding is being bought for: someone writes Three.js against
+ * `docs/VISUALIZER_API.md` and it runs on the Mac without touching Swift.
+ */
+export function EmbedVisualizer() {
+  const [track, setTrack] = useState<Track | null>(null);
+  const [isPlaying, setIsPlaying] = useState(false);
+  const [currentTime, setCurrentTime] = useState(0);
+  const [artworkUrl, setArtworkUrl] = useState<string | null>(null);
+
+  useEffect(() => {
+    // Reused across frames so a channel running for the length of an album does not allocate two
+    // arrays ten times a second. The visualizers copy out of these on their own tick.
+    let frequency: Uint8Array | null = null;
+    let timeDomain: Uint8Array | null = null;
+    let flux: Float32Array | null = null;
+    let lastTrackId: string | null = null;
+
+    const sink = (frame: AnalysisFrame) => {
+      const freqBytes = decodeBytes(frame.frequency);
+      const timeBytes = decodeBytes(frame.timeDomain);
+
+      if (!frequency || frequency.length !== freqBytes.length) {
+        frequency = new Uint8Array(freqBytes.length);
+        timeDomain = new Uint8Array(timeBytes.length);
+      }
+      frequency.set(freqBytes);
+      timeDomain!.set(timeBytes);
+
+      if (!flux || flux.length !== frame.flux.length) flux = new Float32Array(frame.flux.length);
+      flux.set(frame.flux);
+
+      setNativeAnalysisBuffers(frequency, timeDomain!, flux, frame.fluxInterval);
+
+      // **React state only when it changes**, not per frame. These drive re-renders, and this runs
+      // ten times a second for as long as music plays — setting them unconditionally would re-render
+      // the whole visualizer tree at the channel's rate, which is the mistake ADR-0041 had to undo
+      // one layer down on the native side.
+      setIsPlaying((was) => (was === frame.playing ? was : frame.playing));
+      setCurrentTime((was) => (Math.abs(was - frame.position) < 0.2 ? was : frame.position));
+
+      const id = frame.track?.id ?? null;
+      if (id !== lastTrackId) {
+        lastTrackId = id;
+        if (frame.track) {
+          setTrack({
+            id: frame.track.id,
+            title: frame.track.title ?? 'Unknown',
+            artist: frame.track.artist ?? 'Unknown artist',
+            album: frame.track.album ?? '',
+          } as Track);
+          setArtworkUrl(tracksApi.getArtworkUrl(frame.track.id));
+        } else {
+          setTrack(null);
+          setArtworkUrl(null);
+        }
+      }
+    };
+
+    // The name the native side calls. Installed before anything else so a frame arriving during
+    // boot lands rather than being dropped — the host optional-chains this call, so an early frame
+    // is a silent no-op and the next one is 100ms away, but there is no reason to miss any.
+    (window as unknown as Record<string, unknown>).__familiarAnalysis = sink;
+
+    return () => {
+      delete (window as unknown as Record<string, unknown>).__familiarAnalysis;
+      clearNativeAnalysisBuffers();
+    };
+  }, []);
+
+  return (
+    <AudioVisualizer
+      track={track}
+      artworkUrl={artworkUrl}
+      isPlaying={isPlaying}
+      currentTime={currentTime}
+      className="absolute inset-0"
+    />
+  );
+}

--- a/packages/frontend/src/hooks/__tests__/useAudioAnalyser.test.ts
+++ b/packages/frontend/src/hooks/__tests__/useAudioAnalyser.test.ts
@@ -9,12 +9,15 @@ vi.mock('../../player/audio/engineInstance', () => ({
 
 import { getAudioAnalysisDiagnosticsSnapshot, setVisualizerDebugEnabled } from '../../player/audio/analysisDiagnostics';
 import { clearNativeAnalysisBuffers, setNativeAnalysisBuffers } from '../../player/audio/nativeAnalysisBuffers';
-import { getAudioData, useAudioAnalyser } from '../useAudioAnalyser';
+import { getAudioData, resetOnsetDetectorForTesting, useAudioAnalyser } from '../useAudioAnalyser';
 
 describe('useAudioAnalyser native buffer integration', () => {
   beforeEach(() => {
     vi.useFakeTimers();
     clearNativeAnalysisBuffers();
+    // The detector's state is module-level and outlives a test. Without this, an onset in one test
+    // sits inside the next one's refractory window and nothing can fire.
+    resetOnsetDetectorForTesting();
     setVisualizerDebugEnabled(true);
     vi.stubGlobal('requestAnimationFrame', (callback: FrameRequestCallback) => {
       return window.setTimeout(() => callback(performance.now()), 16);
@@ -54,5 +57,61 @@ describe('useAudioAnalyser native buffer integration', () => {
     expect(diagnostics.consumer?.source).toBe('native');
     expect(diagnostics.consumer?.binCount).toBe(128);
     expect(diagnostics.consumer?.variance ?? 0).toBeGreaterThan(0);
+  });
+
+  /**
+   * A host that sends an onset envelope must be believed rather than second-guessed.
+   *
+   * This is the whole reason the envelope exists. Frames from the native app arrive at 10 Hz
+   * against a 60 Hz render loop, so differencing here compares a spectrum against itself five
+   * frames in six: flux reads zero, the adaptive baseline collapses, and the detector fires on
+   * buffer arrivals instead of beats. The test sends an *unchanging* spectrum — under differencing
+   * that is silence, so an onset can only come from the supplied envelope.
+   */
+  it('fires onsets from a supplied flux envelope, not from differencing', () => {
+    const frequency = new Uint8Array(128).fill(40);
+    const time = new Uint8Array(128).fill(128);
+
+    renderHook(() => useAudioAnalyser(true));
+
+    // Quiet envelope first, so the adaptive baseline has something to sit at.
+    act(() => {
+      for (let i = 0; i < 6; i++) {
+        setNativeAnalysisBuffers(frequency, time, new Float32Array([0.001, 0.001, 0.001, 0.001]), 0.023);
+        vi.advanceTimersByTime(40);
+      }
+    });
+    expect(getAudioData()?.beat ?? 1).toBeLessThan(0.2);
+
+    // Then a spike — with the spectrum unchanged, so differencing would still see nothing.
+    act(() => {
+      setNativeAnalysisBuffers(frequency, time, new Float32Array([0.001, 0.9, 0.001, 0.001]), 0.023);
+      vi.advanceTimersByTime(40);
+    });
+
+    expect(getAudioData()?.beat ?? 0).toBeGreaterThan(0.5);
+  });
+
+  /**
+   * And a host that sends no envelope still gets the old behaviour, so the web app and anything
+   * else writing these buffers is untouched.
+   */
+  it('falls back to differencing when no envelope is supplied', () => {
+    const quiet = new Uint8Array(128).fill(10);
+    const loud = new Uint8Array(128).fill(200);
+    const time = new Uint8Array(128).fill(128);
+
+    renderHook(() => useAudioAnalyser(true));
+
+    act(() => {
+      for (let i = 0; i < 4; i++) {
+        setNativeAnalysisBuffers(quiet, time);
+        vi.advanceTimersByTime(40);
+      }
+      setNativeAnalysisBuffers(loud, time);
+      vi.advanceTimersByTime(40);
+    });
+
+    expect(getAudioData()?.beat ?? 0).toBeGreaterThan(0.5);
   });
 });

--- a/packages/frontend/src/hooks/useAudioAnalyser.ts
+++ b/packages/frontend/src/hooks/useAudioAnalyser.ts
@@ -82,12 +82,121 @@ let prevFreq: Uint8Array | null = null;
 let fluxEMA = 0;
 let beatEnv = 0;
 let lastOnsetTime = 0;
+/** The last native frame consumed, so an envelope is never applied twice. */
+let lastNativeSequence = 0;
 let lastBeatUpdate = 0;
 
 // Silence watchdog: warn once if we're "playing" but the analyser reads silence
 // for a sustained period (suspended AudioContext, broken routing, CORS taint…).
 let lastSignalTime = 0;
 let silenceWarned = false;
+
+/**
+ * The tuned half of onset detection: adaptive threshold, refractory, decaying envelope.
+ *
+ * Split out so a *supplied* flux envelope goes through exactly the same constants as a locally
+ * differenced one. This matters more than it looks: ADR-0033 point 5 keeps onset derivation on the
+ * page so there is one tuned implementation, and the moment a native host started sending flux
+ * there were two candidate places to threshold it. This is the one.
+ */
+function applyFlux(flux: number, now: number): void {
+  fluxEMA += FLUX_EMA_ALPHA * (flux - fluxEMA);
+
+  let onset = false;
+  if (
+    flux > ONSET_MIN_FLUX &&
+    flux > fluxEMA * ONSET_SENSITIVITY &&
+    now - lastOnsetTime > ONSET_REFRACTORY_MS
+  ) {
+    onset = true;
+    lastOnsetTime = now;
+    beatEnv = 1;
+  }
+
+  const dt = now - lastBeatUpdate;
+  lastBeatUpdate = now;
+  if (!onset && dt > 0) {
+    beatEnv = Math.max(0, beatEnv - dt / BEAT_DECAY_MS);
+  }
+
+  sharedData!.beat = beatEnv;
+  sharedData!.onset = onset;
+}
+
+/**
+ * Run a supplied envelope through the detector, oldest value first.
+ *
+ * Each value is a separate observation ~23 ms apart, so they are fed in sequence rather than
+ * averaged — averaging would flatten exactly the transient the detector is looking for. The
+ * refractory period then does its usual job of stopping one drum hit firing twice.
+ *
+ * `onset` is left true if *any* value in the envelope fired, because a caller reads it once per
+ * animation frame and would otherwise miss onsets that landed in the same frame.
+ */
+/** Fall the beat envelope by elapsed time, without treating it as a new observation. */
+function decayBeat(now: number): void {
+  const dt = now - lastBeatUpdate;
+  lastBeatUpdate = now;
+  if (dt > 0) beatEnv = Math.max(0, beatEnv - dt / BEAT_DECAY_MS);
+  sharedData!.beat = beatEnv;
+  sharedData!.onset = false;
+}
+
+function applyFluxEnvelope(flux: Float32Array, now: number, intervalSeconds: number): void {
+  if (flux.length === 0) return;
+  // **Milliseconds.** `now` is `performance.now()` and every constant in this file is in ms, where
+  // the interval arrives in seconds because that is the unit an audio hop is naturally expressed
+  // in. Mixing them made the four values of an envelope 0.023 ms apart instead of 23 ms — close
+  // enough to simultaneous that the 110 ms refractory would swallow all but the first.
+  const intervalMs = intervalSeconds * 1000;
+  let fired = false;
+  for (let i = 0; i < flux.length; i++) {
+    // Back-dated so the refractory window measures real time between observations rather than
+    // treating a whole envelope as simultaneous, which would let it swallow every value but one.
+    const at = now - (flux.length - 1 - i) * intervalMs;
+    applyFlux(flux[i], at);
+    if (sharedData!.onset) fired = true;
+  }
+  if (fired) sharedData!.onset = true;
+}
+
+/**
+ * Clear the detector's module-level state.
+ *
+ * **The state is genuinely module-level and genuinely never reset** — not on a track change, not on
+ * a seek, not between tests. That is mostly harmless in the app, where the adaptive baseline
+ * re-converges in under a second, but it makes tests order-dependent in a way that is very hard to
+ * see: `lastOnsetTime` survives, and `performance.now()` is not faked by vitest's defaults, so a
+ * second test running microseconds later sits inside the first one's 110 ms refractory window and
+ * simply cannot fire. Two new tests failed this way and the first one to look at was the *existing*
+ * code path, which had not changed.
+ *
+ * Named `ForTesting` in the idiom `resetPlaybackInterceptorForTesting` already establishes here.
+ */
+export function resetOnsetDetectorForTesting(): void {
+  // **Stop the loop first, and this is the part that actually matters.** The rAF loop is a
+  // module-level singleton guarded by `loopRunning`, and `stopLoop` only runs when the last
+  // subscriber unmounts. A test that renders the hook and never unmounts therefore leaves
+  // `loopRunning` true with a cancelled frame — so every later `startLoop` returns early and the
+  // loop never ticks again. Two tests failed this way and looked for all the world like a broken
+  // detector: the analyser was simply not running.
+  stopLoop();
+  prevFreq = null;
+  fluxEMA = 0;
+  beatEnv = 0;
+  // `-Infinity`, not 0. The refractory test is `now - lastOnsetTime > 110`, so zero means "an onset
+  // fired at time zero" and blocks everything for the first 110 ms of the clock. Harmless in the
+  // app, where the clock starts high; fatal under a faked clock, where it never advances past it —
+  // which is what made two new tests fail on a code path that had not changed.
+  lastOnsetTime = Number.NEGATIVE_INFINITY;
+  lastBeatUpdate = 0;
+  lastNativeSequence = 0;
+  // The mobile throttle's clock. Left stale, a faked clock that restarts lower than it leaves the
+  // loop returning early on every frame — which looks exactly like the analyser not running.
+  lastAnalyseTime = 0;
+  sharedData = null;
+  lastBinCount = 0;
+}
 
 function computeOnset(freq: Uint8Array, now: number): void {
   if (!prevFreq || prevFreq.length !== freq.length) {
@@ -113,27 +222,7 @@ function computeOnset(freq: Uint8Array, now: number): void {
   }
   flux = flux / (n * 255); // normalize to ~0-1
 
-  fluxEMA += FLUX_EMA_ALPHA * (flux - fluxEMA);
-
-  let onset = false;
-  if (
-    flux > ONSET_MIN_FLUX &&
-    flux > fluxEMA * ONSET_SENSITIVITY &&
-    now - lastOnsetTime > ONSET_REFRACTORY_MS
-  ) {
-    onset = true;
-    lastOnsetTime = now;
-    beatEnv = 1;
-  }
-
-  const dt = now - lastBeatUpdate;
-  lastBeatUpdate = now;
-  if (!onset && dt > 0) {
-    beatEnv = Math.max(0, beatEnv - dt / BEAT_DECAY_MS);
-  }
-
-  sharedData!.beat = beatEnv;
-  sharedData!.onset = onset;
+  applyFlux(flux, now);
 
   // Silence watchdog (only meaningful while the player thinks it's playing).
   const playing = usePlayerStore.getState().isPlaying;
@@ -182,7 +271,27 @@ function analyseLoop() {
     sharedData.frequencyData.set(nativeBuffers.frequency);
     sharedData.timeDomainData.set(nativeBuffers.timeDomain);
     computeBands(sharedData.frequencyData);
-    computeOnset(sharedData.frequencyData, now);
+
+    if (nativeBuffers.flux && nativeBuffers.sequence !== lastNativeSequence) {
+      lastNativeSequence = nativeBuffers.sequence;
+      // The host sent an onset envelope, so use it rather than differencing. See
+      // `setNativeAnalysisBuffers` — at 10 Hz, differencing here compares a spectrum against
+      // itself five frames in six and the detector degenerates into a buffer-arrival counter.
+      //
+      // `prevFreq` is still kept in step so that a host which *stops* sending an envelope falls
+      // back to differencing cleanly instead of on a spectrum from minutes ago.
+      if (!prevFreq || prevFreq.length !== sharedData.frequencyData.length) {
+        prevFreq = new Uint8Array(sharedData.frequencyData.length);
+      }
+      prevFreq.set(sharedData.frequencyData);
+      applyFluxEnvelope(nativeBuffers.flux, now, nativeBuffers.fluxInterval || 1 / 43);
+    } else if (!nativeBuffers.flux) {
+      computeOnset(sharedData.frequencyData, now);
+    } else {
+      // Same envelope as last frame — already consumed. Decay the beat envelope on the render
+      // clock so it still falls smoothly at 60 fps between the channel's 10 Hz arrivals.
+      decayBeat(now);
+    }
     sharedAudioDataRef.current = sharedData;
     recordConsumedAnalysisFrame('native', sharedData.frequencyData, sharedData.timeDomainData);
     return;

--- a/packages/frontend/src/player/audio/nativeAnalysisBuffers.ts
+++ b/packages/frontend/src/player/audio/nativeAnalysisBuffers.ts
@@ -1,24 +1,76 @@
 /**
  * Native analysis buffer management.
  *
- * Shared module for native (iOS Capacitor) audio analysis data.
- * CapacitorEngine writes buffers here; useAudioAnalyser reads them.
- * Extracted to avoid CapacitorEngine importing from the hooks layer.
+ * The seam between a native host that has the audio and a page that only draws it. Written by the
+ * embedded visualizer surface, read by `useAudioAnalyser`. Kept out of the hooks layer so a writer
+ * does not have to import from it.
  */
 
 let nativeFrequencyData: Uint8Array | null = null;
 let nativeTimeDomainData: Uint8Array | null = null;
+let nativeFlux: Float32Array | null = null;
+let nativeFluxInterval = 0;
+let nativeSequence = 0;
 
-export function setNativeAnalysisBuffers(freq: Uint8Array, time: Uint8Array): void {
+/**
+ * Onset strength per analysis window, oldest first — the envelope the native side computed.
+ *
+ * **This exists because the page cannot compute it.** `computeOnset` derives flux by differencing
+ * *consecutive spectra*, which works when a fresh spectrum arrives every animation frame. Frames
+ * from a native host arrive at 10 Hz against a 60 Hz render loop — macOS clamps `installTap` to a
+ * 100 ms buffer, measured — so five of every six passes would difference a spectrum against itself,
+ * read zero flux, drag the running baseline to zero, and then fire on every buffer arrival. A
+ * detector reporting the transport rather than the music.
+ *
+ * The native side already computes flux per 1024-sample window while folding the buffer, so it
+ * sends the envelope instead: ~43 Hz of onset resolution inside a 10 Hz channel, and every tuned
+ * constant stays here where it always was.
+ */
+export function setNativeAnalysisBuffers(
+  freq: Uint8Array,
+  time: Uint8Array,
+  flux?: Float32Array | null,
+  /** Seconds between consecutive `flux` values — the analysis hop, not the frame rate. */
+  fluxInterval = 0
+): void {
   nativeFrequencyData = freq;
   nativeTimeDomainData = time;
+  nativeFlux = flux ?? null;
+  nativeFluxInterval = fluxInterval;
+  nativeSequence += 1;
 }
 
 export function clearNativeAnalysisBuffers(): void {
   nativeFrequencyData = null;
   nativeTimeDomainData = null;
+  nativeFlux = null;
+  nativeFluxInterval = 0;
+  nativeSequence = 0;
 }
 
-export function getNativeAnalysisBuffers(): { frequency: Uint8Array | null; timeDomain: Uint8Array | null } {
-  return { frequency: nativeFrequencyData, timeDomain: nativeTimeDomainData };
+export function getNativeAnalysisBuffers(): {
+  frequency: Uint8Array | null;
+  timeDomain: Uint8Array | null;
+  /** Null when the host sends no envelope — the detector then falls back to differencing. */
+  flux: Float32Array | null;
+  /** Seconds between `flux` values. Zero when there is no envelope. */
+  fluxInterval: number;
+  /**
+   * Increments on every write, so a reader can tell a fresh frame from a stale one.
+   *
+   * **The onset envelope must be consumed exactly once**, and nothing else here guarantees that.
+   * These buffers persist between writes, and the render loop runs at 60 fps against a channel
+   * delivering 10 frames a second — so without a sequence the same envelope is replayed about six
+   * times, the refractory masks the repeated onsets, and the decay runs six times too fast. The
+   * symptom is a beat envelope that spikes and vanishes within one frame.
+   */
+  sequence: number;
+} {
+  return {
+    frequency: nativeFrequencyData,
+    timeDomain: nativeTimeDomainData,
+    flux: nativeFlux,
+    fluxInterval: nativeFluxInterval,
+    sequence: nativeSequence,
+  };
 }

--- a/packages/frontend/src/renderVisualizer.tsx
+++ b/packages/frontend/src/renderVisualizer.tsx
@@ -1,0 +1,53 @@
+import { StrictMode } from 'react';
+import { createRoot } from 'react-dom/client';
+import { QueryClient, QueryClientProvider } from '@tanstack/react-query';
+import { initApiOrigin, registerProfileProvider } from './api/base';
+import { profileFromURL } from './services/embedBridge';
+import { EmbedVisualizer } from './components/Embed/EmbedVisualizer';
+import { useUIStore } from './stores/uiStore';
+
+/**
+ * Boots the embedded visualizer surface (ADR-0033).
+ *
+ * The sibling of `renderEmbed`, and thinner still. That one mounts a browsable Discover screen and
+ * needs a `BrowserRouter` because its cards use `Link`; this mounts one component that draws and
+ * has nowhere to go, so there is no router at all. If a visualizer ever wants to navigate it should
+ * post an intent, not push a route — the native app owns navigation (ADR-0020).
+ *
+ * The `QueryClient` is here for artwork and lyrics, which the page fetches itself (ADR-0033 point
+ * 8) rather than having them pushed down the channel. A channel that carries everything has no
+ * shape, and lyrics are a request the page can make perfectly well on its own.
+ */
+export function renderVisualizer(options?: { onReady?: () => void }): void {
+  const profileId = profileFromURL();
+  registerProfileProvider({
+    getSelectedProfileId: async () => profileId,
+    // Same as the Discover surface: it was told a profile, it never chose one, so there is nothing
+    // to clear.
+    clearSelectedProfile: async () => {},
+  });
+
+  // No shell, so nothing renders a chat panel. Declared rather than inferred, so the affordances
+  // that lead to chat stand down instead of each one learning it might be embedded.
+  useUIStore.getState().setChatSurfaceAvailable(false);
+
+  const queryClient = new QueryClient({
+    defaultOptions: {
+      queries: {
+        staleTime: 1000 * 60 * 5,
+        retry: 1,
+      },
+    },
+  });
+
+  initApiOrigin().then(() => {
+    options?.onReady?.();
+    createRoot(document.getElementById('root')!).render(
+      <StrictMode>
+        <QueryClientProvider client={queryClient}>
+          <EmbedVisualizer />
+        </QueryClientProvider>
+      </StrictMode>,
+    );
+  });
+}

--- a/packages/frontend/src/renderVisualizer.tsx
+++ b/packages/frontend/src/renderVisualizer.tsx
@@ -1,10 +1,11 @@
 import { StrictMode } from 'react';
 import { createRoot } from 'react-dom/client';
 import { QueryClient, QueryClientProvider } from '@tanstack/react-query';
-import { initApiOrigin, registerProfileProvider } from './api/base';
+import { initApiOrigin, registerProfileProvider, setApiOrigin } from './api/base';
 import { profileFromURL } from './services/embedBridge';
 import { EmbedVisualizer } from './components/Embed/EmbedVisualizer';
 import { useUIStore } from './stores/uiStore';
+import { installVisualizerSink } from './services/visualizerSink';
 
 /**
  * Boots the embedded visualizer surface (ADR-0033).
@@ -19,7 +20,26 @@ import { useUIStore } from './stores/uiStore';
  * shape, and lyrics are a request the page can make perfectly well on its own.
  */
 export function renderVisualizer(options?: { onReady?: () => void }): void {
+  // **First, before anything async.** The host probes for the sink as soon as the document finishes
+  // loading, which is well before `initApiOrigin` resolves or React mounts — installing it any
+  // later loses that race and the host reports a page that is not listening. It also means frames
+  // arriving during boot land in the buffers instead of being dropped.
+  installVisualizerSink();
+
   const profileId = profileFromURL();
+
+  // **The host tells this page where the server is.**
+  //
+  // Read out of the app bundle over a custom URL scheme (ADR-0034 point 4), this page has no server
+  // in its own location to infer one from. `initApiOrigin` derives the origin from where the
+  // document was served, which is right for the web app and for the embedded Discover page — both
+  // come from the server — and yields an empty string here. Origin-relative URLs would then resolve
+  // against the custom scheme and fetch nothing, so artwork would silently never load.
+  //
+  // `setApiOrigin` is the same function `ServerSettings` uses; it also caches to localStorage,
+  // which the custom scheme has because it is a real origin (a `file://` or `loadHTMLString` page
+  // would not).
+  const api = new URLSearchParams(window.location.search).get('api');
   registerProfileProvider({
     getSelectedProfileId: async () => profileId,
     // Same as the Discover surface: it was told a profile, it never chose one, so there is nothing
@@ -40,7 +60,10 @@ export function renderVisualizer(options?: { onReady?: () => void }): void {
     },
   });
 
-  initApiOrigin().then(() => {
+  // Only when the host did not say — `initApiOrigin` would otherwise overwrite an explicit origin
+  // with an origin-relative empty string.
+  const ready = api ? setApiOrigin(api) : initApiOrigin();
+  ready.then(() => {
     options?.onReady?.();
     createRoot(document.getElementById('root')!).render(
       <StrictMode>

--- a/packages/frontend/src/renderVisualizer.tsx
+++ b/packages/frontend/src/renderVisualizer.tsx
@@ -6,6 +6,7 @@ import { profileFromURL } from './services/embedBridge';
 import { EmbedVisualizer } from './components/Embed/EmbedVisualizer';
 import { useUIStore } from './stores/uiStore';
 import { installVisualizerSink } from './services/visualizerSink';
+import { useVisualizerStore } from './stores/visualizerStore';
 
 /**
  * Boots the embedded visualizer surface (ADR-0033).
@@ -39,7 +40,18 @@ export function renderVisualizer(options?: { onReady?: () => void }): void {
   // `setApiOrigin` is the same function `ServerSettings` uses; it also caches to localStorage,
   // which the custom scheme has because it is a real origin (a `file://` or `loadHTMLString` page
   // would not).
-  const api = new URLSearchParams(window.location.search).get('api');
+  const params = new URLSearchParams(window.location.search);
+
+  // **Which visualizer to draw, chosen by the host.**
+  //
+  // The page persists a choice of its own to `localStorage`, which is right for the web app where
+  // the picker lives beside the visualizer. Embedded, the picker is a native menu, so the app is
+  // the source of truth and says so on the URL — otherwise the two would each remember a different
+  // answer and whichever wrote last would win.
+  const visualizer = params.get('visualizer');
+  if (visualizer) useVisualizerStore.getState().setVisualizerId(visualizer);
+
+  const api = params.get('api');
   registerProfileProvider({
     getSelectedProfileId: async () => profileId,
     // Same as the Discover surface: it was told a profile, it never chose one, so there is nothing

--- a/packages/frontend/src/services/visualizerSink.ts
+++ b/packages/frontend/src/services/visualizerSink.ts
@@ -1,0 +1,110 @@
+import { setNativeAnalysisBuffers } from '../player/audio/nativeAnalysisBuffers';
+
+/**
+ * Receives analysis frames from the native host (ADR-0033).
+ *
+ * **Installed at module load, not from a component.** The host probes for this function as soon as
+ * the document finishes loading, and `didFinish` fires when the HTML and scripts are in — well
+ * before React has mounted anything or run an effect. Installing it in a `useEffect` therefore lost
+ * the race every time: the page was correct, the sink simply did not exist yet, and the host
+ * reported the page as not listening. Frames arriving during boot were dropped for the same reason.
+ *
+ * So the sink is a module-level singleton that exists the moment this module is imported, writes
+ * straight into the analysis buffers, and keeps the small amount of *metadata* React needs in a
+ * store components subscribe to.
+ */
+
+/** One frame, as `VisualizerFrame` in `FamiliarKit` sends it. Nothing checks the two against each
+ * other — different languages, different repositories — so both sides are pinned to this shape by
+ * tests, and a change here is a change there. */
+export interface AnalysisFrame {
+  frequency: string;
+  timeDomain: string;
+  flux: number[];
+  fluxInterval: number;
+  cadenceHz: number;
+  playing: boolean;
+  position: number;
+  track?: { id: string; title?: string; artist?: string; album?: string };
+}
+
+export interface VisualizerState {
+  playing: boolean;
+  position: number;
+  track: { id: string; title?: string; artist?: string; album?: string } | null;
+}
+
+const SINK_NAME = '__familiarAnalysis';
+
+let state: VisualizerState = { playing: false, position: 0, track: null };
+const listeners = new Set<() => void>();
+
+// Reused across frames: this runs for as long as music plays, and allocating two typed arrays ten
+// times a second would be litter for nothing. Visualizers copy out of them on their own tick.
+let frequency: Uint8Array | null = null;
+let timeDomain: Uint8Array | null = null;
+let flux: Float32Array | null = null;
+
+function decodeBytes(base64: string, into: Uint8Array | null): Uint8Array {
+  const binary = atob(base64);
+  const target = into && into.length === binary.length ? into : new Uint8Array(binary.length);
+  for (let i = 0; i < binary.length; i++) target[i] = binary.charCodeAt(i);
+  return target;
+}
+
+function receive(frame: AnalysisFrame): void {
+  frequency = decodeBytes(frame.frequency, frequency);
+  timeDomain = decodeBytes(frame.timeDomain, timeDomain);
+
+  if (!flux || flux.length !== frame.flux.length) flux = new Float32Array(frame.flux.length);
+  flux.set(frame.flux);
+
+  setNativeAnalysisBuffers(frequency, timeDomain, flux, frame.fluxInterval);
+
+  // **Only notify on a change React would care about.** This runs ten times a second for the length
+  // of a track; publishing every frame would re-render the visualizer tree at the channel's rate,
+  // which is the mistake ADR-0041 had to undo one layer down on the native side. Position is
+  // deliberately coarse — a visualizer that needs it precisely should read it per animation frame,
+  // not per React render.
+  const trackChanged = (frame.track?.id ?? null) !== (state.track?.id ?? null);
+  const playingChanged = frame.playing !== state.playing;
+  const positionJumped = Math.abs(frame.position - state.position) >= 0.2;
+
+  if (trackChanged || playingChanged || positionJumped) {
+    state = {
+      playing: frame.playing,
+      position: frame.position,
+      track: frame.track ?? null,
+    };
+    for (const listener of listeners) listener();
+  }
+}
+
+/**
+ * Put the sink on `window`. Idempotent, and safe to call before anything is rendered.
+ *
+ * Returns nothing: the host's only question is whether the function exists, which it asks with
+ * `typeof window.__familiarAnalysis === 'function'`.
+ */
+export function installVisualizerSink(): void {
+  (window as unknown as Record<string, unknown>)[SINK_NAME] = receive;
+}
+
+export function subscribeToVisualizerState(listener: () => void): () => void {
+  listeners.add(listener);
+  return () => { listeners.delete(listener); };
+}
+
+export function getVisualizerState(): VisualizerState {
+  return state;
+}
+
+/** Test seam — the sink and its buffers are module-level and outlive a test otherwise. */
+export function resetVisualizerSinkForTesting(): void {
+  state = { playing: false, position: 0, track: null };
+  listeners.clear();
+  frequency = null;
+  timeDomain = null;
+  flux = null;
+  delete (window as unknown as Record<string, unknown>)[SINK_NAME];
+}

--- a/packages/web/scripts/check-bundle-budgets.mjs
+++ b/packages/web/scripts/check-bundle-budgets.mjs
@@ -51,8 +51,16 @@ if (!fs.existsSync(manifestPath)) {
 const manifest = JSON.parse(fs.readFileSync(manifestPath, 'utf8'));
 const manifestEntries = Object.values(manifest);
 
-const entry = manifestEntries.find((entryMeta) => entryMeta.isEntry && entryMeta.src === 'index.html')
-  ?? manifestEntries.find((entryMeta) => entryMeta.isEntry);
+// `entry` stays the app's, so the headline metric means the same thing it always did and the
+// numbers in `bundle-metrics.json` remain comparable across builds.
+//
+// **But it is no longer the only one measured.** There are three documents now — the app, the
+// embedded Discover surface, and the embedded visualizer — and this script checked whichever came
+// first, which was fine while there was one. `allEntries` below carries the rest into the report,
+// because the visualizer is the entry that pulls `vendor-three`, the largest chunk in the build,
+// and leaving the heaviest surface unwatched is precisely backwards.
+const entries = manifestEntries.filter((entryMeta) => entryMeta.isEntry);
+const entry = entries.find((entryMeta) => entryMeta.src === 'index.html') ?? entries[0];
 
 if (!entry || !entry.file) {
   console.error('[bundle-budget] Could not resolve entry chunk from manifest.');
@@ -96,9 +104,25 @@ const topJsAssets = Array.from(jsAssets)
   .sort((a, b) => b.gzipBytes - a.gzipBytes)
   .slice(0, 10);
 
+// Every entry, measured. Reported rather than budgeted: the visualizer surface legitimately pulls
+// three.js and would fail the app's budget on day one, so a number to watch is honest where a
+// threshold picked today would just be turned off later.
+const allEntries = entries
+  .map((entryMeta) => {
+    const filePath = path.join(distDir, entryMeta.file);
+    const gzipBytes = gzipSize(filePath);
+    return { src: entryMeta.src ?? entryMeta.file, file: entryMeta.file, gzipBytes, gzipKb: toKb(gzipBytes) };
+  })
+  .sort((a, b) => b.gzipBytes - a.gzipBytes);
+
+for (const measured of allEntries) {
+  console.log(`[bundle-budget] Entry ${measured.src}: ${measured.gzipKb} kB gzip (${measured.file})`);
+}
+
 const metrics = {
   generatedAt: new Date().toISOString(),
   budgets: BUDGETS,
+  entries: allEntries,
   entry: {
     file: entry.file,
     rawBytes: fs.statSync(entryPath).size,

--- a/packages/web/scripts/inline-visualizer.mjs
+++ b/packages/web/scripts/inline-visualizer.mjs
@@ -1,0 +1,51 @@
+#!/usr/bin/env node
+/**
+ * Folds the visualizer build's JS and CSS into its HTML, producing one self-contained document.
+ *
+ * Vite inlines *assets* but still emits the entry script and stylesheet as separate files and links
+ * to them. For a document that will be read out of an app bundle over a custom URL scheme, one file
+ * is much simpler than teaching the scheme handler to resolve relative paths — and it makes the
+ * artifact something you can copy with `cp` and reason about by looking at it.
+ */
+import fs from 'node:fs';
+import path from 'node:path';
+
+const dist = path.resolve(process.argv[2] ?? 'dist-visualizer');
+const htmlPath = path.join(dist, 'visualizer.html');
+
+if (!fs.existsSync(htmlPath)) {
+  console.error(`[inline-visualizer] No build at ${htmlPath}. Run the visualizer build first.`);
+  process.exit(1);
+}
+
+let html = fs.readFileSync(htmlPath, 'utf8');
+
+// Scripts: <script type="module" crossorigin src="/assets/x.js"></script>
+html = html.replace(/<script[^>]*src="([^"]+)"[^>]*><\/script>/g, (whole, src) => {
+  const file = path.join(dist, src.replace(/^\//, ''));
+  if (!fs.existsSync(file)) return whole;
+  const code = fs.readFileSync(file, 'utf8');
+  // `type="module"` is kept: the bundle uses module semantics (strict mode, top-level scope).
+  return `<script type="module">\n${code}\n</script>`;
+});
+
+// Stylesheets: <link rel="stylesheet" crossorigin href="/assets/x.css">
+html = html.replace(/<link[^>]*rel="stylesheet"[^>]*href="([^"]+)"[^>]*>/g, (whole, href) => {
+  const file = path.join(dist, href.replace(/^\//, ''));
+  if (!fs.existsSync(file)) return whole;
+  return `<style>\n${fs.readFileSync(file, 'utf8')}\n</style>`;
+});
+
+// Preload hints point at files that no longer exist independently.
+html = html.replace(/<link[^>]*rel="modulepreload"[^>]*>\s*/g, '');
+
+const out = path.join(dist, 'visualizer.inlined.html');
+fs.writeFileSync(out, html);
+
+const remaining = html.match(/(src|href)="\/assets\//g);
+if (remaining) {
+  console.error(`[inline-visualizer] ${remaining.length} unresolved asset reference(s) remain.`);
+  process.exit(1);
+}
+
+console.log(`[inline-visualizer] Wrote ${out} (${(Buffer.byteLength(html) / 1024).toFixed(0)} kB)`);

--- a/packages/web/src/NullAudioEngine.ts
+++ b/packages/web/src/NullAudioEngine.ts
@@ -28,15 +28,25 @@ import type { AudioEngine, AudioEngineCapabilities, EngineEvent } from '@familia
  */
 export class NullAudioEngine implements AudioEngine {
   /**
-   * Declared here *and* registered beside the factory in `embed.tsx`, because the two are read at
-   * different times: the registration answers before anything is built, and this answers if anything
-   * ever is. They must agree, and `assertCapabilitiesMatch` says so out loud if they drift.
+   * Declared here *and* registered beside the factory in the entry point, because the two are read
+   * at different times: the registration answers before anything is built, and this answers if
+   * anything ever is. They must agree, and `assertCapabilitiesMatch` says so out loud if they drift.
+   *
+   * **Injectable because the visualizer surface needs `visualizer: true` and the same silence.**
+   * That combination looks contradictory and is the whole point: `isVisualizerAvailable()` reads
+   * this flag to decide whether to draw a visualizer at all, so a surface declaring `false` would
+   * render album art forever. What keeps ADR-0017's guarantee is not the flag but the omission —
+   * `getAnalyser` and every other optional member are still missing, and `getAudioAnalyser()` calls
+   * `existingEngine()?.getAnalyser?.()`, which cannot construct anything. So the visualizer surface
+   * says it can show a visualizer and still cannot make or analyse a sound.
    */
-  readonly capabilities: AudioEngineCapabilities = {
-    crossfade: false,
-    visualizer: false,
-    effects: 'none',
-  };
+  readonly capabilities: AudioEngineCapabilities;
+
+  constructor(
+    capabilities: AudioEngineCapabilities = { crossfade: false, visualizer: false, effects: 'none' }
+  ) {
+    this.capabilities = capabilities;
+  }
 
   // Lifecycle
   initialize(): boolean {

--- a/packages/web/src/embed.tsx
+++ b/packages/web/src/embed.tsx
@@ -8,10 +8,17 @@ import { NullAudioEngine } from './NullAudioEngine';
 /**
  * The embedded surface's entry point (ADR-0017 point 1).
  *
- * A second entry beside `main.tsx`, not a mode of it. The whole decision rests on this file being
- * the only thing that boots the embedded page: it registers an engine that cannot make sound, so a
+ * A second entry beside `main.tsx`, not a mode of it. The decision rests on this file being the
+ * only thing that boots the *Discover* surface: it registers an engine that cannot make sound, so a
  * play path the bridge fails to intercept is inert rather than a second `WebAudioEngine` competing
  * with the native player for the audio session.
+ *
+ * It used to say "the only thing that boots the embedded page", which stopped being true when
+ * `visualizer.tsx` arrived (ADR-0033). That surface makes the same guarantee the same way — a
+ * `NullAudioEngine`, so nothing can construct an `AudioContext` — but declares
+ * `visualizer: true`, because `isVisualizerAvailable()` reads the registration and a surface
+ * declaring `false` would draw album art forever. The guarantee lives in the omitted `getAnalyser`,
+ * not in the flag.
  *
  * Registering *nothing* was the obvious alternative and is rejected by ADR-0017 point 4:
  * `createEngine()` throws when no factory is registered, which would turn a missed play intent into

--- a/packages/web/src/visualizer.tsx
+++ b/packages/web/src/visualizer.tsx
@@ -1,0 +1,39 @@
+import '@familiar/frontend/src/index.css';
+import { registerEngineFactory } from '@familiar/frontend/src/player/audio/createEngine';
+import { renderVisualizer } from '@familiar/frontend/src/renderVisualizer';
+import { NullAudioEngine } from './NullAudioEngine';
+
+/**
+ * The embedded visualizer surface's entry point (ADR-0033).
+ *
+ * The third entry beside `main.tsx` and `embed.tsx`, and the only one that is *told* things. The
+ * Discover surface posts intents and is never told what is playing — ADR-0016 point 5 made that a
+ * rule, and a visualizer's entire job is to break it, which is why ADR-0033 amends the point rather
+ * than working around it.
+ *
+ * **`visualizer: true` on an engine that cannot make a sound**, and the combination is deliberate.
+ * `isVisualizerAvailable()` reads the *registration*, so a surface declaring `false` would render
+ * album art and never a visualizer. What preserves ADR-0017's guarantee is not the flag but the
+ * omission: `NullAudioEngine` implements none of the sixteen optional members, so
+ * `getAudioAnalyser()` calls `existingEngine()?.getAnalyser?.()` and gets `undefined` — nothing can
+ * construct an `AudioContext` here no matter what the capabilities claim.
+ *
+ * No playback interceptor, unlike `embed.tsx`. This page has no play buttons: it draws what it is
+ * sent. If it ever grows one, it needs the interceptor *and* a bridge message, and ADR-0020 point 3
+ * sets the bar for that.
+ */
+registerEngineFactory(
+  () =>
+    new NullAudioEngine({
+      crossfade: false,
+      visualizer: true,
+      effects: 'none',
+    }),
+  {
+    crossfade: false,
+    visualizer: true,
+    effects: 'none',
+  }
+);
+
+renderVisualizer();

--- a/packages/web/visualizer.html
+++ b/packages/web/visualizer.html
@@ -1,0 +1,36 @@
+<!doctype html>
+<html lang="en">
+  <head>
+    <meta charset="UTF-8" />
+    <meta name="viewport" content="width=device-width, initial-scale=1.0, viewport-fit=cover" />
+    <meta name="theme-color" content="#000000" />
+    <meta name="description" content="Familiar — embedded visualizer surface" />
+
+    <!-- How the native host proves it got *this* document and not the app, and not the Discover
+         surface either. A server built before this existed has no `/visualizer` route, and its
+         single-page-app fallback answers that path with `index.html` — HTTP 200, the full web app,
+         `WebAudioEngine` and all, which would then hold an audio session inside a web view inside
+         an app that is already playing. That is exactly what ADR-0016 point 4 exists to prevent.
+
+         Note the content differs from the Discover surface's `embed`. The marker was a single flat
+         value until this document existed; two surfaces need to be told apart, or the probe cannot
+         tell which one it got. -->
+    <meta name="familiar-surface" content="visualizer" />
+
+    <!-- Deliberately no manifest and no apple-itunes-app banner, for the same reason as the
+         Discover surface: this is only ever loaded inside the app's own web view. -->
+    <link rel="icon" type="image/svg+xml" href="/icons/icon.svg" />
+
+    <title>Visualizer</title>
+    <style>
+      /* Black rather than the app's background: this document is a visualizer and nothing else, and
+         a flash of any other colour while three.js compiles reads as a broken screen. The native
+         host also draws no background of its own so this is the only thing setting it. */
+      html, body, #root { height: 100%; margin: 0; background: #000; overflow: hidden; }
+    </style>
+  </head>
+  <body>
+    <div id="root"></div>
+    <script type="module" src="/src/visualizer.tsx"></script>
+  </body>
+</html>

--- a/packages/web/vite.config.ts
+++ b/packages/web/vite.config.ts
@@ -14,17 +14,19 @@ export default defineConfig({
   build: {
     manifest: true,
     rollupOptions: {
-      // Two documents, not one. `embed.html` is the embedded surface ADR-0017 gives its own entry
-      // point, and naming `index.html` here is required as soon as `input` is set at all — Vite's
-      // default single entry stops applying.
+      // Three documents, not one. `embed.html` is the embedded Discover surface ADR-0017 gives its
+      // own entry point; `visualizer.html` is the embedded visualizer ADR-0033 adds. Naming
+      // `index.html` here is required as soon as `input` is set at all — Vite's default single
+      // entry stops applying.
       //
       // Not built for Capacitor: the iOS app is the listening path (ADR-0013 point 2) and embeds
-      // nothing, so the second document would be dead weight in the bundle it ships.
+      // nothing, so the extra documents would be dead weight in the bundle it ships.
       input: isCapacitorBuild
         ? { index: resolve(__dirname, 'index.html') }
         : {
             index: resolve(__dirname, 'index.html'),
             embed: resolve(__dirname, 'embed.html'),
+            visualizer: resolve(__dirname, 'visualizer.html'),
           },
       output: {
         manualChunks(id) {

--- a/packages/web/vite.visualizer.config.ts
+++ b/packages/web/vite.visualizer.config.ts
@@ -1,0 +1,42 @@
+import { defineConfig } from 'vite';
+import react from '@vitejs/plugin-react';
+import { resolve } from 'path';
+
+/**
+ * Builds the embedded visualizer as **one self-contained HTML file**.
+ *
+ * Separate from `vite.config.ts` because the output is a different kind of artifact: the app's build
+ * produces a site to be served, and this produces a single document to be embedded in the macOS and
+ * iOS app bundles (ADR-0034 point 4 — "shipped bundles live in the app bundle's resources").
+ *
+ * **Why one file rather than a directory.** The Xcode project uses file-system synchronized groups,
+ * which add files individually and flatten a directory's structure — so `assets/index-abc.js` would
+ * land beside `index.html` and every relative path in it would break. Inlining sidesteps the whole
+ * question: nothing to resolve, nothing to flatten, and one resource for the app to copy.
+ *
+ * The size that buys is real — three.js is ~1 MB — but this is read from local disk, not fetched,
+ * so it costs bundle size and no load time.
+ */
+export default defineConfig({
+  plugins: [react()],
+  resolve: {
+    alias: {
+      '@familiar/frontend': resolve(__dirname, '../frontend'),
+    },
+  },
+  build: {
+    outDir: 'dist-visualizer',
+    emptyOutDir: true,
+    // Everything in one chunk: the visualizers are `lazy()`, which would otherwise emit dynamic
+    // chunks that a single document cannot reach.
+    rollupOptions: {
+      input: resolve(__dirname, 'visualizer.html'),
+      output: { inlineDynamicImports: true },
+    },
+    // No separate CSS file, and no asset small enough to be left out.
+    cssCodeSplit: false,
+    assetsInlineLimit: Number.MAX_SAFE_INTEGER,
+    // Sourcemaps would double the file and cannot be opened from inside an app bundle anyway.
+    sourcemap: false,
+  },
+});

--- a/packages/web/vite.visualizer.config.ts
+++ b/packages/web/vite.visualizer.config.ts
@@ -1,5 +1,6 @@
 import { defineConfig } from 'vite';
 import react from '@vitejs/plugin-react';
+import tailwindcss from '@tailwindcss/vite';
 import { resolve } from 'path';
 
 /**
@@ -18,7 +19,11 @@ import { resolve } from 'path';
  * so it costs bundle size and no load time.
  */
 export default defineConfig({
-  plugins: [react()],
+  // **Tailwind is a plugin here, not a PostCSS config**, so a build config that omits it produces
+  // CSS with every utility class silently missing. The symptom is not a styling glitch: the
+  // visualizer's own container is `w-full h-full absolute inset-0`, so without those rules it
+  // collapses to content height and the whole scene renders in a strip at the top of the window.
+  plugins: [react(), tailwindcss()],
   resolve: {
     alias: {
       '@familiar/frontend': resolve(__dirname, '../frontend'),


### PR DESCRIPTION
The page half of ADR-0033. Its native counterpart is `familiar-apple`'s companion PR.

## The detector consumes a supplied envelope

The page derives flux by differencing **consecutive spectra**, which works when a fresh spectrum arrives every animation frame. Frames from a native host arrive at **10 Hz** against a 60 Hz render loop — macOS clamps `installTap` to a 100 ms buffer, measured — so five of every six passes would difference a spectrum against itself, read zero flux, drag the adaptive baseline to zero, and fire on every buffer arrival. A detector reporting the transport, not the music.

So the host sends the envelope it already computes. **ADR-0033 point 5's intent survives intact:** every tuned constant stays here, and `applyFlux` is now the single place a flux value is thresholded whether it was differenced locally or handed over. Only the subtraction moved native, and it had to — the page cannot difference spectra it never receives.

**Writing the tests found three bugs the tests were not looking for:**

- **The envelope was consumed repeatedly.** Buffers persist between writes and the render loop runs six times faster than the channel, so each envelope replayed ~6 times: the refractory masked the duplicate onsets while the decay ran six times too fast, and the beat spiked and vanished inside one frame. There is a sequence number now.
- **A units bug** — the interval arrives in seconds and every constant here is milliseconds, so an envelope's four values were treated as 0.023 ms apart rather than 23 ms.
- **The detector's module state makes tests order-dependent.** `lastOnsetTime = 0` means "an onset fired at time zero", so under a faked clock nothing can fire for 110 ms and the clock never advances past it. Worse, `stopLoop` only runs when the last subscriber unmounts, so a test that never unmounts leaves `loopRunning` true with a cancelled frame and every later `startLoop` returns early — the loop gets **zero ticks**. Two tests failed looking exactly like a broken detector when the analyser simply was not running.

## The document ships in the app bundle

It renders entirely from bridge data, so hosting it on the server bought nothing and cost a route, a marker, a probe, a "redeploy the server" error state, and version skew. Today demonstrated that rather than arguing it: a container restart reverted the route and a screen drawing from local data broke.

Built as **one self-contained file** because the Xcode project uses file-system synchronized groups, which flatten a directory and break every relative path. Inlining means the scheme handler has no paths, no MIME table and no traversal to get wrong.

**The sink is installed at module load**, not from an effect — the host probes for it when the document finishes loading, well before React mounts. That race made a correct page report itself as not listening, and dropped every frame arriving during boot.

## And the standalone build was missing Tailwind entirely

Tailwind is wired here as a **Vite plugin**, not a PostCSS config, so a second build config that omits it emits CSS with every utility purged and no error anywhere. Not a styling glitch: `AudioVisualizer` renders into `w-full h-full absolute inset-0`, so the container collapsed to content height and the whole scene drew in a band across the top of the window. The bundle was 1698 kB before and 1773 kB after — that 75 kB was the entire stylesheet.

## Verification

**983 tests, types clean** on every file touched. The visualizer was confirmed by eye against real music on the Mac.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_014P9p2fvFnyiywBxGkv4gfW