### PR TITLE
Send track ids on the queue command, not track objects

### DIFF
--- a/backend/app/mcp/playback.py
+++ b/backend/app/mcp/playback.py
@@ -161,9 +161,14 @@ async def handle(
         # `clear` is read here rather than from the executor, whose `clear_existing` never
         # reaches `_clear_queue` — it is accepted, echoed and dropped. Fixing that in the chat
         # path would be fixing a path being retired; this one carries the listener's actual intent.
+        # Ids, not track objects. The clients already fetch tracks by id through the generated
+        # client — `ServerTrackMetadataSource.loadTracks(ids:)` on the Mac, fifty at a time — and
+        # putting a second, untyped copy of the Track shape on this channel is exactly the
+        # hand-parsed surface ADR-0007 exists to prevent, which already cost ADR-0022 a bug. The
+        # tool's *reply* still carries the resolved tracks, because that is for the model to read.
         player = channel.send(
             profile_id,
-            {"type": "queue", "tracks": tracks, "clear": clear},
+            {"type": "queue", "track_ids": [t["id"] for t in tracks], "clear": clear},
             target=target,
             requires=_REQUIRES[name],
         )

--- a/backend/tests/test_mcp_playback_tools.py
+++ b/backend/tests/test_mcp_playback_tools.py
@@ -108,7 +108,7 @@ class TestQueueTracks:
         assert result["queued"] == 1
         command = player.queue.get_nowait()
         assert command["type"] == "queue"
-        assert command["tracks"] == [TRACK]
+        assert command["track_ids"] == ["t1"], "ids travel, not a second copy of the Track shape"
 
     @pytest.mark.asyncio
     async def test_clear_existing_actually_reaches_the_client(self, profile):


### PR DESCRIPTION
**A mismatch between two things merged an hour apart.**

The Mac client merged in `familiar-apple` #87 decodes a queue command as `{"type":"queue","track_ids":[...]}`. The server merged in #121 was still sending `"tracks"`.

`PlaybackCommand.decode` returns `nil` for a queue frame without `track_ids`, so **queueing would have silently done nothing** — the command arrives, is ignored, and the tool still reports `delivered: true`. Exactly the failure shape this whole channel was built to avoid.

I wrote this change while building the Mac side and never committed it, so #121 merged without it. It surfaced because `--delete-branch` complained about a dirty tree, which is a poor substitute for noticing.

## Ids are the right shape regardless

The clients already fetch tracks by id through the generated client — `ServerTrackMetadataSource.loadTracks(ids:)` on the Mac, fifty at a time, the same path a queue restored from disk uses. A second, untyped copy of the Track shape on this channel is precisely the hand-parsed surface ADR-0007 exists to prevent, and that tradeoff already cost ADR-0022 a bug.

The tool's *reply* still carries the resolved tracks, because that part is for the model to read.

## Verification

17 tests pass; the queue test now asserts `track_ids` explicitly, with the reason in the assertion message. Lint clean.

Needs to land before any end-to-end test of playback — without it, "play something" reaches the Mac and does nothing.

🤖 Generated with [Claude Code](https://claude.com/claude-code)