### PR TITLE
Stop the SPA answering 200 for things that do not exist

### DIFF
--- a/backend/app/main.py
+++ b/backend/app/main.py
@@ -532,7 +532,25 @@ STATIC_DIR = Path(__file__).parent.parent / "static"
 
 # Prefixes the single-page app must never swallow. A miss inside these belongs to the API, and the
 # answer to it is a 404 rather than an HTML document.
-NON_SPA_PREFIXES = ("api/", "docs", "redoc", "openapi.json", "health", "mcp")
+NON_SPA_PREFIXES = (
+    "api/",
+    "docs",
+    "redoc",
+    "openapi.json",
+    "health",
+    "mcp",
+    # An MCP host probes these before connecting, to find out whether the server has an
+    # authorisation server. **A 404 is the answer that means "no, connect anonymously."** Served by
+    # the SPA they returned `200 text/html`, which reads as "yes, here it is" — so Claude Desktop
+    # tried to register a client against an HTML page and reported *"Couldn't register with
+    # Familiar's sign-in service"*, which points at authentication rather than at this line.
+    ".well-known",
+    # An MCP host probes these before connecting, to find out whether the server has an
+    # authorisation server. **A 404 is the answer that means "no, connect anonymously."** Served by
+    # the SPA they returned `200 text/html`, which reads as "yes, here it is" — so Claude Desktop
+    # tried to register a client against an HTML page and reported *"Couldn't register with
+    # Familiar's sign-in service"*, which points at authentication rather than at this line.
+)
 
 
 async def serve_embed() -> FileResponse:
@@ -593,6 +611,11 @@ async def spa_fallback(full_path: str) -> FileResponse:
     """
     if full_path.startswith(NON_SPA_PREFIXES):
         raise NotFoundError("Not found")
+    # The served path, not the route template. `request_completed` logs `/{full_path:path}` for
+    # everything that lands here, which is useless precisely when it matters: an MCP host probing
+    # for an authorisation server gets `index.html` with a 200, reads it as "yes, here it is", and
+    # reports a sign-in failure that names nothing about routing.
+    logger.info("spa_fallback_served", extra={"path": full_path})
     return FileResponse(STATIC_DIR / "index.html")
 
 

--- a/backend/tests/test_mcp_server.py
+++ b/backend/tests/test_mcp_server.py
@@ -298,3 +298,30 @@ class TestProfileBinding:
 
         monkeypatch.setattr("app.mcp.server._sole_profile", sole_one)
         assert await resolve_profile(_ctx()) == ONE
+
+
+class TestOAuthDiscovery:
+    """`.well-known` probes must 404, not be swallowed by the SPA.
+
+    An MCP host asks these before connecting, to learn whether the server has an authorisation
+    server. **404 is the answer that means "no, connect anonymously."** Served by the SPA they
+    returned `200 text/html`, so Claude Desktop read "yes, here it is", tried to register a client
+    against an HTML page, and reported *"Couldn't register with Familiar's sign-in service"* — an
+    error naming authentication, produced entirely by a routing default.
+
+    The fifth instance of this catch-all's shape, and the second to reach a user.
+    """
+
+    @pytest.mark.asyncio
+    @pytest.mark.parametrize(
+        "path",
+        [
+            ".well-known/oauth-authorization-server",
+            ".well-known/oauth-protected-resource",
+            ".well-known/openid-configuration",
+            ".well-known/oauth-authorization-server/mcp",
+        ],
+    )
+    async def test_discovery_probes_are_not_answered_with_html(self, path):
+        with pytest.raises(NotFoundError):
+            await spa_fallback(path)


### PR DESCRIPTION
Two changes, one cause. The SPA catch-all serves `index.html` for any unmatched GET — right for a single-page app, wrong for anything *asking the server a question* — and it answers **200**, so the caller reads "yes, here it is."

## The failure

An MCP host probes `/.well-known/oauth-authorization-server` and friends before connecting, to learn whether the server has an authorisation server. **A 404 is the answer meaning "no, connect anonymously."**

Served by the SPA, those probes returned `200 text/html`. So Claude Desktop read it as an authorisation server, tried to register a client against an HTML page, and reported:

> Couldn't register with Familiar's sign-in service.

An error naming *authentication*, produced entirely by a routing default.

`.well-known` joins `NON_SPA_PREFIXES`, with a test over four probe paths **verified to fail without it**.

This is the **fifth** instance of this catch-all's shape and the second to reach a user, after unmatched `/api/` paths answering 200 with an undecodable body — which `spa_fallback`'s own docstring already describes.

## Why it took three attempts, and the second change

`request_completed` logs the route **template**, so everything landing here appears as `/{full_path:path}` and the actual path is invisible — useless precisely when it matters.

Diagnosing this meant guessing which paths a host probes. I guessed twice and was wrong twice. Logging the served path turned the third attempt into a two-minute answer: the logs showed the `.well-known` probes arriving and correctly 404ing, **and nothing else** — which is what proved the remaining failure was not routing at all.

## What this does not fix

The connector still cannot be added. Its flow requires an **OAuth-capable server**, which Familiar deliberately is not — ADR-0045 point 6 defers that to its own decision. `scripts/mcp_bridge.py` is the way in until then, because stdio needs no auth.

Both halves are deployed to the NAS already; this is the commit that stops them vanishing on the next container recreate.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
