### PR TITLE
Record that the MCP surface is proven, and what it cannot do

### DIFF
--- a/docs/decisions/ADR-0043-the-llm-surface-is-an-mcp-server.md
+++ b/docs/decisions/ADR-0043-the-llm-surface-is-an-mcp-server.md
@@ -17,6 +17,21 @@ Implementation:
 - Point 3's risk was measured before acceptance rather than after — see the table in Context and
   `scripts/spike_mcp_arms.py`. Two of its three worries were unfounded; the whole effect is
   calibration, which narrows the work.
+- **Point 5's condition is met.** The surface was proven from Claude Desktop against the real
+  library on 2026-08-09 — library questions, semantic search, playlist creation and playback,
+  ending in sound. Retiring the chat clients was deliberately gated on this and is now unblocked;
+  see [ADR-0044](ADR-0044-mcp-clients-actuate-playback-through-a-command-channel.md)'s notes for
+  the trace.
+- **The host prefers the tools over the screen, which was the point.** Asked the same question the
+  day before, with no connector, it drove the computer and opened the web app. With the tools
+  present it said *"Familiar has a proper data API — let me pull your library stats directly
+  instead of poking at the screen."*
+- **Claude Desktop's *custom connector* cannot be used**, and that is not a defect in this ADR. Its
+  flow requires an OAuth-capable server, which Familiar deliberately is not
+  ([ADR-0045](ADR-0045-familiar-authenticates-inbound-requests.md) point 6). `scripts/mcp_bridge.py`
+  is the way in until then, because stdio needs no auth. Two red herrings were fixed on the way to
+  establishing that, both real: `.well-known` probes were being answered `200 text/html` by the SPA
+  catch-all, which reads as "yes, I have an authorisation server".
 
 ## Context
 

--- a/docs/decisions/ADR-0044-mcp-clients-actuate-playback-through-a-command-channel.md
+++ b/docs/decisions/ADR-0044-mcp-clients-actuate-playback-through-a-command-channel.md
@@ -13,6 +13,31 @@ Implementation:
   push transport at all.** Not one WebSocket route exists. `useListeningSession.ts:100` opens a
   socket to `/api/v1/sessions/ws`, a route that was deleted — so a client is already calling a
   channel that is not there, which is the fourth instance of that shape found in this codebase.
+- **Proven end to end on 2026-08-09**, from Claude Desktop to sound. The whole trace, from the
+  server's own log:
+
+  ```
+  get_library_stats → get_library_genres → search_library("Ambient") → 30 matched
+  list_players ×3
+  select_diverse_tracks → 12
+  SENT queue → player p1
+  SENT play  → player p1
+  ```
+
+  Three things in that are worth keeping. The Mac **attached on its own** seconds after launch,
+  declaring exactly the three capabilities it implements (`play`, `queue`, `crossfade`) — point 12
+  working, and validated against the server's set rather than hoped at. The host called
+  `list_players` three times rather than assuming, which is point 4's tool surface being used the
+  way it was meant to be. And `select_diverse_tracks` was reached for unprompted, so the ambient set
+  was not twelve tracks by one artist.
+- **The first real limitation is the one this ADR predicted, and it is not fixable here.** Asked to
+  play with Familiar closed, the host correctly reported no player attached — then offered to *drive
+  the screen* to open the app, because none of its thirty tools can. The server cannot open a
+  client: it addresses a subscription that already exists, and ADR-0029 point 5 leaves device
+  identity uninvented, so there is no way to knock on the door of a machine where nothing is
+  running. Point 5 is what makes that read as "your app is closed" rather than a spinner. Whether to
+  close the gap — a `launch` tool on the local stdio bridge, or autostart at login — is left open;
+  both live outside this channel.
 - **The server half shipped in `familiar` #121**: `GET /api/v1/playback/commands`,
   `services/playback_commands.py`, and the MCP tools in `app/mcp/playback.py`. `queue_tracks` and
   `control_playback` return to the surface, joined by `list_players` and `get_now_playing`.


### PR DESCRIPTION
Claude Desktop drove Familiar end to end on 2026-08-09 — library questions, semantic search, a diverse ambient selection, queue, play, **sound**.

The trace, from the server's own log:

```
get_library_stats → get_library_genres → search_library("Ambient") → 30 matched
list_players ×3
select_diverse_tracks → 12
SENT queue → player p1
SENT play  → player p1
```

Three things in that are worth keeping:

- The Mac **attached on its own** seconds after launch, declaring exactly the three capabilities it implements (`play`, `queue`, `crossfade`) — point 12 working against the server's *named* set rather than freeform strings.
- The host called `list_players` **three times rather than assuming**, which is point 4's tool surface used as intended.
- `select_diverse_tracks` was reached for **unprompted**, so the ambient set wasn't twelve tracks by one artist.

## What this unblocks

**ADR-0043 point 5's condition is met.** Retiring the chat clients was deliberately gated on the surface being proven. It now is.

## The first real limitation, and it is the one ADR-0044 predicted

Asked to play with Familiar closed, the host correctly reported no player attached — then offered to **drive the screen** to open the app, because none of its thirty tools can.

The server cannot open a client. It addresses a subscription that already exists, and ADR-0029 point 5 leaves device identity uninvented, so there is no door to knock on. Point 5 is what makes that read as *"your app is closed"* rather than a spinner.

Closing the gap would mean a `launch` tool on the local stdio bridge, or autostart at login. Both live outside this channel and neither is decided here.

## Not a defect in these ADRs

Claude Desktop's **custom connector cannot be used at all** — its flow requires an OAuth-capable server, which Familiar deliberately is not (ADR-0045 point 6). The stdio bridge is the way in until then, because stdio needs no auth.

Docs only.