### PR TITLE
Listening sessions signal through your own server (ADR-0036)

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -118,7 +118,6 @@ jobs:
           platforms: ${{ matrix.platform }}
           build-args: |
             VERSION=${{ steps.version.outputs.value }}
-            VITE_SESSIONS_RELAY_URL=https://familiar-sessions.fly.dev
           outputs: type=image,name=${{ env.REGISTRY }}/${{ env.IMAGE_NAME }},push-by-digest=true,name-canonical=true,push=true
           cache-from: type=gha,scope=${{ steps.prep.outputs.pair }}
           cache-to: type=gha,mode=max,scope=${{ steps.prep.outputs.pair }}

--- a/backend/app/api/routes/sessions.py
+++ b/backend/app/api/routes/sessions.py
@@ -1,0 +1,520 @@
+"""Listening sessions: WebRTC signalling on the listener's own server (ADR-0036).
+
+Revived from `ceeb926`, which shelved it for scope on 2026-03-06. The client half was rebuilt
+afterwards against `https://familiar-sessions.fly.dev` — so every released build has signalled
+through a box the listener does not run, and every development build has 404ed against the route
+this file restores. ADR-0036 point 2 is the argument for bringing it back rather than keeping the
+relay, and it is a values decision: the relay works.
+
+**The split here is ADR-0036 point 5.** The REST half is typed to ADR-0007's rules so the Apple
+clients generate it; the WebSocket is hand-written on every client, because the generator has
+nothing to generate for a socket. That is the same exclusion ADR-0007 point 8 already makes for the
+two SSE map variants.
+
+**The server signals and never carries audio** (point 4). Every message below is an offer, an
+answer, an ICE candidate or a piece of session bookkeeping. Peers connect directly; a listening
+party must not turn a NAS into a streaming host.
+"""
+
+from __future__ import annotations
+
+import logging
+from typing import Any
+from uuid import UUID
+
+from fastapi import APIRouter, WebSocket, WebSocketDisconnect
+from pydantic import BaseModel, Field
+
+from app.api.exceptions import NotFoundError
+from app.api.schemas.common import error_responses
+from app.config import settings
+from app.services.sessions import SessionRole, get_session_manager
+
+logger = logging.getLogger(__name__)
+
+router = APIRouter(prefix="/sessions", tags=["sessions"])
+
+
+# ── Response schemas ────────────────────────────────────────────────────────
+#
+# Typed rather than `dict[str, Any]` because ADR-0036 point 5 puts this tag on the generated
+# surface. The service's `to_dict()` predates that and still returns a dict; these models are
+# built from it rather than replacing it, so the WebSocket — which sends the same payloads and is
+# not generated — keeps one source of truth for the shape.
+
+
+class SessionPlaybackState(BaseModel):
+    """What the host is playing, as guests last heard it."""
+
+    track_id: str | None = None
+    is_playing: bool = False
+    position_ms: int = 0
+
+
+class SessionParticipant(BaseModel):
+    user_id: str
+    username: str
+    role: str
+    joined_at: str
+    webrtc_connected: bool = False
+
+
+class SessionResponse(BaseModel):
+    """A listening session, as looked up by its join code."""
+
+    id: str
+    code: str
+    name: str
+    host_id: str
+    created_at: str
+    participant_count: int
+    webrtc_enabled: bool
+    playback_state: SessionPlaybackState
+    participants: list[SessionParticipant] = Field(default_factory=list)
+
+
+class IceServer(BaseModel):
+    """One entry of an `RTCConfiguration.iceServers` array, in the browser's own shape."""
+
+    urls: str
+    username: str | None = None
+    credential: str | None = None
+
+
+class IceServersResponse(BaseModel):
+    ice_servers: list[IceServer]
+    #: False when only STUN is configured, which is the default. Clients show this rather than
+    #: discovering it by failing — ADR-0036 point 7.
+    has_turn: bool
+
+
+def get_ice_servers() -> list[dict[str, Any]]:
+    """ICE configuration: Google STUN by default, TURN by configuration (ADR-0036 point 6).
+
+    Familiar does not run a TURN server and does not promise one. Behind symmetric NAT with no TURN
+    configured, a session will fail for reasons no amount of retrying fixes — which is why
+    `has_turn` is reported rather than left to be inferred.
+    """
+    servers: list[dict[str, Any]] = [
+        {"urls": "stun:stun.l.google.com:19302"},
+        {"urls": "stun:stun1.l.google.com:19302"},
+    ]
+
+    if settings.turn_server_url:
+        turn_config: dict[str, Any] = {"urls": settings.turn_server_url}
+        if settings.turn_server_username:
+            turn_config["username"] = settings.turn_server_username
+        if settings.turn_server_credential:
+            turn_config["credential"] = settings.turn_server_credential
+        servers.append(turn_config)
+
+    return servers
+
+
+def has_turn_configured() -> bool:
+    return bool(settings.turn_server_url)
+
+
+@router.get(
+    "/ice-servers",
+    operation_id="sessions_get_ice_servers",
+    response_model=IceServersResponse,
+)
+async def read_ice_servers() -> IceServersResponse:
+    """The ICE configuration a client should use when establishing a session peer connection.
+
+    A REST route rather than only the join payload, because the Apple clients need it before they
+    have joined anything (ADR-0037), and because a client that wants to warn about symmetric NAT
+    up front should not have to open a socket to find out.
+    """
+    return IceServersResponse(
+        ice_servers=[IceServer(**server) for server in get_ice_servers()],
+        has_turn=has_turn_configured(),
+    )
+
+
+@router.get(
+    "/by-code/{code}",
+    operation_id="sessions_get_by_code",
+    response_model=SessionResponse,
+    responses=error_responses(404),
+)
+async def get_session_by_code(code: str) -> SessionResponse:
+    """Look up a session by its six-character join code.
+
+    Case-insensitive, because the code is something one person reads aloud to another.
+    """
+    manager = get_session_manager()
+    session = manager.get_session_by_code(code.upper())
+
+    if not session:
+        raise NotFoundError("Session not found")
+
+    return SessionResponse.model_validate(session.to_dict())
+
+
+@router.websocket("/ws")
+async def session_websocket(websocket: WebSocket) -> None:
+    """Signalling for listening sessions.
+
+    Deliberately not part of the generated surface (ADR-0036 point 5). Messages:
+
+    - `create`: `{"type": "create", "name": ..., "user_id": ..., "username": ...}`
+    - `join`: `{"type": "join", "code": "ABC123", "user_id": ..., "username": ...}`
+    - `join_guest`: `{"type": "join_guest", "code": "ABC123", "guest_name": ...}`
+    - `playback`: `{"type": "playback", "track_id": ..., "is_playing": ..., "position_ms": ...}`
+    - `sync_request`, `chat`, `leave`
+
+    WebRTC signalling: `webrtc_request`, `webrtc_offer`, `webrtc_answer`, `webrtc_ice`,
+    `webrtc_connected`.
+
+    **This is the only WebSocket route in the backend.** `services/outputs.py` has a docstring
+    describing signalling "to the frontend via WebSocket" for browser outputs, and carries a
+    `websocket_id` field — but no such route exists and never has. So this is not a socket beside
+    others; it is the one, and whatever a long-lived connection implies for deployment arrives
+    with it.
+    """
+    await websocket.accept()
+    manager = get_session_manager()
+    current_user_id: UUID | None = None
+
+    try:
+        while True:
+            data = await websocket.receive_json()
+            msg_type = data.get("type")
+
+            if msg_type == "create":
+                user_id = UUID(data["user_id"])
+                username = data.get("username", "Anonymous")
+                name = data.get("name", "Listening Session")
+
+                session = manager.create_session(
+                    host_id=user_id,
+                    host_username=username,
+                    name=name,
+                    websocket=websocket,
+                )
+                current_user_id = user_id
+
+                await websocket.send_json({
+                    "type": "session_created",
+                    "session": session.to_dict(),
+                    # Sent at creation as well as at join: a host behind symmetric NAT with no TURN
+                    # should learn that before inviting anyone, not after they fail to connect.
+                    "ice_servers": get_ice_servers(),
+                    "has_turn": has_turn_configured(),
+                })
+
+            elif msg_type == "join":
+                code = data.get("code", "").upper()
+                user_id = UUID(data["user_id"])
+                username = data.get("username", "Anonymous")
+
+                session = manager.get_session_by_code(code)
+                if session is None:
+                    await websocket.send_json({
+                        "type": "error",
+                        "message": "Session not found",
+                    })
+                    continue
+
+                participant = manager.join_session(
+                    session=session,
+                    user_id=user_id,
+                    username=username,
+                    websocket=websocket,
+                )
+                current_user_id = user_id
+
+                await websocket.send_json({
+                    "type": "session_joined",
+                    "session": session.to_dict(),
+                    "ice_servers": get_ice_servers(),
+                    "has_turn": has_turn_configured(),
+                })
+
+                await manager.broadcast(
+                    session,
+                    {
+                        "type": "user_joined",
+                        "user": {
+                            "user_id": str(user_id),
+                            "username": username,
+                            "role": participant.role.value,
+                        },
+                        "participant_count": len(session.participants),
+                    },
+                    exclude_user=user_id,
+                )
+
+            elif msg_type == "playback":
+                if not current_user_id:
+                    continue
+
+                session = manager.get_user_session(current_user_id)
+                if session is None:
+                    continue
+
+                if session.host_id != current_user_id:
+                    await websocket.send_json({
+                        "type": "error",
+                        "message": "Only the host can control playback",
+                    })
+                    continue
+
+                track_id = UUID(data["track_id"]) if data.get("track_id") else None
+                is_playing = data.get("is_playing")
+                position_ms = data.get("position_ms")
+
+                manager.update_playback(
+                    session,
+                    track_id=track_id,
+                    is_playing=is_playing,
+                    position_ms=position_ms,
+                )
+
+                await manager.broadcast(
+                    session,
+                    {
+                        "type": "playback_update",
+                        "track_id": str(track_id) if track_id else None,
+                        "is_playing": is_playing,
+                        "position_ms": position_ms,
+                    },
+                    exclude_user=current_user_id,
+                )
+
+            elif msg_type == "sync_request":
+                if not current_user_id:
+                    continue
+
+                session = manager.get_user_session(current_user_id)
+                if session is None:
+                    continue
+
+                await websocket.send_json({
+                    "type": "sync_response",
+                    "track_id": (
+                        str(session.playback_state.track_id)
+                        if session.playback_state.track_id
+                        else None
+                    ),
+                    "is_playing": session.playback_state.is_playing,
+                    "position_ms": session.playback_state.position_ms,
+                })
+
+            elif msg_type == "chat":
+                if not current_user_id:
+                    continue
+
+                session = manager.get_user_session(current_user_id)
+                if session is None:
+                    continue
+
+                participant = session.participants.get(current_user_id)
+                if participant is None:
+                    continue
+
+                await manager.broadcast(
+                    session,
+                    {
+                        "type": "chat",
+                        "user_id": str(current_user_id),
+                        "username": participant.username,
+                        "message": data.get("message", ""),
+                    },
+                )
+
+            elif msg_type == "join_guest":
+                code = data.get("code", "").upper()
+                guest_name = data.get("guest_name", "Guest")
+
+                session = manager.get_session_by_code(code)
+                if session is None:
+                    await websocket.send_json({
+                        "type": "error",
+                        "message": "Session not found",
+                    })
+                    continue
+
+                if not session.webrtc_enabled:
+                    await websocket.send_json({
+                        "type": "error",
+                        "message": "This session does not allow guest listeners",
+                    })
+                    continue
+
+                participant = manager.join_as_guest(
+                    session=session,
+                    guest_name=guest_name,
+                    websocket=websocket,
+                )
+                current_user_id = participant.user_id
+
+                await websocket.send_json({
+                    "type": "session_joined",
+                    "session": session.to_dict(),
+                    "your_user_id": str(current_user_id),
+                    "your_peer_id": participant.peer_id,
+                    "ice_servers": get_ice_servers(),
+                    "has_turn": has_turn_configured(),
+                })
+
+                await manager.send_to_host(
+                    session,
+                    {
+                        "type": "guest_joined",
+                        "user_id": str(current_user_id),
+                        "username": guest_name,
+                        "peer_id": participant.peer_id,
+                        "participant_count": len(session.participants),
+                    },
+                )
+
+                await manager.broadcast(
+                    session,
+                    {
+                        "type": "user_joined",
+                        "user": {
+                            "user_id": str(current_user_id),
+                            "username": guest_name,
+                            "role": SessionRole.GUEST.value,
+                        },
+                        "participant_count": len(session.participants),
+                    },
+                    exclude_user=current_user_id,
+                )
+
+            elif msg_type == "webrtc_request":
+                if not current_user_id:
+                    continue
+
+                session = manager.get_user_session(current_user_id)
+                if session is None:
+                    continue
+
+                participant = session.participants.get(current_user_id)
+                if participant is None:
+                    continue
+
+                await manager.send_to_host(
+                    session,
+                    {
+                        "type": "webrtc_create_offer",
+                        "target_user_id": str(current_user_id),
+                        "peer_id": participant.peer_id,
+                    },
+                )
+
+            elif msg_type == "webrtc_offer":
+                if not current_user_id:
+                    continue
+
+                session = manager.get_user_session(current_user_id)
+                if session is None or session.host_id != current_user_id:
+                    continue
+
+                await manager.send_to_user(
+                    session,
+                    UUID(data.get("target_user_id")),
+                    {
+                        "type": "webrtc_offer",
+                        "sdp": data.get("sdp"),
+                        "from_user_id": str(current_user_id),
+                    },
+                )
+
+            elif msg_type == "webrtc_answer":
+                if not current_user_id:
+                    continue
+
+                session = manager.get_user_session(current_user_id)
+                if session is None:
+                    continue
+
+                await manager.send_to_host(
+                    session,
+                    {
+                        "type": "webrtc_answer",
+                        "sdp": data.get("sdp"),
+                        "from_user_id": str(current_user_id),
+                    },
+                )
+
+            elif msg_type == "webrtc_ice":
+                if not current_user_id:
+                    continue
+
+                session = manager.get_user_session(current_user_id)
+                if session is None:
+                    continue
+
+                target_user_id = data.get("target_user_id")
+                if target_user_id:
+                    await manager.send_to_user(
+                        session,
+                        UUID(target_user_id),
+                        {
+                            "type": "webrtc_ice",
+                            "candidate": data.get("candidate"),
+                            "from_user_id": str(current_user_id),
+                        },
+                    )
+                else:
+                    await manager.send_to_host(
+                        session,
+                        {
+                            "type": "webrtc_ice",
+                            "candidate": data.get("candidate"),
+                            "from_user_id": str(current_user_id),
+                        },
+                    )
+
+            elif msg_type == "webrtc_connected":
+                if not current_user_id:
+                    continue
+
+                connected = data.get("connected", False)
+                manager.update_webrtc_state(current_user_id, connected)
+
+                session = manager.get_user_session(current_user_id)
+                if session is not None:
+                    await manager.broadcast(
+                        session,
+                        {
+                            "type": "webrtc_state_changed",
+                            "user_id": str(current_user_id),
+                            "connected": connected,
+                        },
+                        exclude_user=current_user_id,
+                    )
+
+            elif msg_type == "leave":
+                if current_user_id:
+                    session = manager.remove_user(current_user_id)
+                    if session is not None and session.participants:
+                        await manager.broadcast(
+                            session,
+                            {
+                                "type": "user_left",
+                                "user_id": str(current_user_id),
+                                "participant_count": len(session.participants),
+                            },
+                        )
+                    current_user_id = None
+
+                await websocket.send_json({"type": "left"})
+
+    except WebSocketDisconnect:
+        if current_user_id:
+            session = manager.remove_user(current_user_id)
+            if session is not None and session.participants:
+                await manager.broadcast(
+                    session,
+                    {
+                        "type": "user_left",
+                        "user_id": str(current_user_id),
+                        "participant_count": len(session.participants),
+                        "reason": "disconnected",
+                    },
+                )

--- a/backend/app/config.py
+++ b/backend/app/config.py
@@ -58,6 +58,17 @@ class Settings(BaseSettings):
     lastfm_api_secret: str | None = None
     acoustid_api_key: str | None = None
 
+    # Listening sessions: TURN, by configuration only (ADR-0036 point 6).
+    #
+    # STUN alone gets two peers connected in most homes. It does not behind symmetric NAT, and no
+    # amount of retrying changes that — a relay is required, and Familiar does not run one and does
+    # not promise one. Set these to point at your own (coturn, or a hosted provider) and the server
+    # will hand them to clients; leave them unset and `GET /sessions/ice-servers` reports
+    # `has_turn: false` so the failure is named up front rather than discovered as a hang.
+    turn_server_url: str | None = None
+    turn_server_username: str | None = None
+    turn_server_credential: str | None = None
+
     # Network audio outputs (Sonos / WiiM / AirPlay / Chromecast).
     # DEVICE_STREAM_BASE_URL: LAN-reachable base URL (e.g. http://192.168.1.50:4400) that network
     # devices use to fetch the audio stream. Needed when the browser reaches the app via a network

--- a/backend/app/main.py
+++ b/backend/app/main.py
@@ -56,6 +56,7 @@ from app.api.routes import (
     proposed_changes,
     queue,
     s3_backup,
+    sessions,
     smart_playlists,
     spotify_import,
     tracks,
@@ -518,6 +519,9 @@ app.include_router(spotify_import.router, prefix="/api/v1", responses=DEFAULT_ER
 app.include_router(ambient.router, prefix="/api/v1", responses=DEFAULT_ERROR_RESPONSES)
 app.include_router(playback.router, prefix="/api/v1", responses=DEFAULT_ERROR_RESPONSES)
 app.include_router(queue.router, prefix="/api/v1", responses=DEFAULT_ERROR_RESPONSES)
+# Listening sessions (ADR-0036). Carries this backend's only WebSocket route, which rides on the
+# same router as the two typed REST operations.
+app.include_router(sessions.router, prefix="/api/v1", responses=DEFAULT_ERROR_RESPONSES)
 app.include_router(external_albums.router, prefix="/api/v1", responses=DEFAULT_ERROR_RESPONSES)
 app.include_router(new_releases.router, prefix="/api/v1", responses=DEFAULT_ERROR_RESPONSES)
 app.include_router(admin_artists.router, prefix="/api/v1", responses=DEFAULT_ERROR_RESPONSES)

--- a/backend/app/services/sessions.py
+++ b/backend/app/services/sessions.py
@@ -1,0 +1,319 @@
+"""Listening sessions service for synchronized playback with WebRTC."""
+
+import secrets
+from dataclasses import dataclass, field
+from datetime import datetime
+from enum import Enum
+from typing import Any
+from uuid import UUID, uuid4
+
+from fastapi import WebSocket
+
+from app.utils.time import utcnow
+
+
+class SessionRole(str, Enum):
+    """User's role in a session."""
+    HOST = "host"
+    LISTENER = "listener"
+    GUEST = "guest"  # Anonymous listener via WebRTC
+
+
+@dataclass
+class Participant:
+    """A participant in a listening session."""
+    user_id: UUID
+    username: str
+    websocket: WebSocket
+    role: SessionRole
+    joined_at: datetime = field(default_factory=datetime.utcnow)
+    # WebRTC connection state
+    webrtc_connected: bool = False
+    peer_id: str | None = None  # For WebRTC peer identification
+
+
+@dataclass
+class PlaybackState:
+    """Current playback state for a session."""
+    track_id: UUID | None = None
+    is_playing: bool = False
+    position_ms: int = 0
+    updated_at: datetime = field(default_factory=datetime.utcnow)
+
+
+@dataclass
+class ListeningSession:
+    """A listening session where users can listen together."""
+    id: str
+    code: str  # 6-char join code
+    name: str
+    host_id: UUID
+    created_at: datetime = field(default_factory=datetime.utcnow)
+    participants: dict[UUID, Participant] = field(default_factory=dict)
+    playback_state: PlaybackState = field(default_factory=PlaybackState)
+    # WebRTC streaming settings
+    webrtc_enabled: bool = True  # Whether to offer WebRTC audio streaming
+
+    def to_dict(self, include_participants: bool = True) -> dict[str, Any]:
+        """Convert to API response format."""
+        result = {
+            "id": self.id,
+            "code": self.code,
+            "name": self.name,
+            "host_id": str(self.host_id),
+            "created_at": self.created_at.isoformat(),
+            "participant_count": len(self.participants),
+            "webrtc_enabled": self.webrtc_enabled,
+            "playback_state": {
+                "track_id": str(self.playback_state.track_id) if self.playback_state.track_id else None,
+                "is_playing": self.playback_state.is_playing,
+                "position_ms": self.playback_state.position_ms,
+            },
+        }
+        if include_participants:
+            result["participants"] = [
+                {
+                    "user_id": str(p.user_id),
+                    "username": p.username,
+                    "role": p.role.value,
+                    "joined_at": p.joined_at.isoformat(),
+                    "webrtc_connected": p.webrtc_connected,
+                }
+                for p in self.participants.values()
+            ]
+        return result
+
+
+class SessionManager:
+    """Manages active listening sessions in memory."""
+
+    def __init__(self) -> None:
+        self._sessions: dict[str, ListeningSession] = {}
+        self._user_sessions: dict[UUID, str] = {}  # user_id -> session_id
+        self._code_to_session: dict[str, str] = {}  # code -> session_id
+
+    def _generate_code(self) -> str:
+        """Generate a unique 6-character join code."""
+        while True:
+            code = secrets.token_hex(3).upper()
+            if code not in self._code_to_session:
+                return code
+
+    def create_session(
+        self,
+        host_id: UUID,
+        host_username: str,
+        name: str,
+        websocket: WebSocket,
+    ) -> ListeningSession:
+        """Create a new listening session."""
+        # Remove user from any existing session
+        self.remove_user(host_id)
+
+        session_id = secrets.token_urlsafe(16)
+        code = self._generate_code()
+
+        session = ListeningSession(
+            id=session_id,
+            code=code,
+            name=name,
+            host_id=host_id,
+        )
+
+        # Add host as first participant
+        host = Participant(
+            user_id=host_id,
+            username=host_username,
+            websocket=websocket,
+            role=SessionRole.HOST,
+        )
+        session.participants[host_id] = host
+
+        self._sessions[session_id] = session
+        self._user_sessions[host_id] = session_id
+        self._code_to_session[code] = session_id
+
+        return session
+
+    def get_session(self, session_id: str) -> ListeningSession | None:
+        """Get session by ID."""
+        return self._sessions.get(session_id)
+
+    def get_session_by_code(self, code: str) -> ListeningSession | None:
+        """Get session by join code."""
+        session_id = self._code_to_session.get(code.upper())
+        if session_id:
+            return self._sessions.get(session_id)
+        return None
+
+    def get_user_session(self, user_id: UUID) -> ListeningSession | None:
+        """Get the session a user is currently in."""
+        session_id = self._user_sessions.get(user_id)
+        if session_id:
+            return self._sessions.get(session_id)
+        return None
+
+    def join_session(
+        self,
+        session: ListeningSession,
+        user_id: UUID,
+        username: str,
+        websocket: WebSocket,
+        role: SessionRole = SessionRole.LISTENER,
+    ) -> Participant:
+        """Add a user to an existing session."""
+        # Remove from any existing session
+        self.remove_user(user_id)
+
+        # Generate peer_id for WebRTC
+        peer_id = secrets.token_urlsafe(8)
+
+        participant = Participant(
+            user_id=user_id,
+            username=username,
+            websocket=websocket,
+            role=role,
+            peer_id=peer_id,
+        )
+
+        session.participants[user_id] = participant
+        self._user_sessions[user_id] = session.id
+
+        return participant
+
+    def join_as_guest(
+        self,
+        session: ListeningSession,
+        guest_name: str,
+        websocket: WebSocket,
+    ) -> Participant:
+        """Add an anonymous guest to a session for WebRTC streaming."""
+        # Generate a random UUID for the guest
+        guest_id = uuid4()
+
+        return self.join_session(
+            session=session,
+            user_id=guest_id,
+            username=guest_name,
+            websocket=websocket,
+            role=SessionRole.GUEST,
+        )
+
+    def get_host(self, session: ListeningSession) -> Participant | None:
+        """Get the host participant for a session."""
+        return session.participants.get(session.host_id)
+
+    async def send_to_user(
+        self,
+        session: ListeningSession,
+        user_id: UUID,
+        message: dict[str, Any],
+    ) -> bool:  # type: ignore[return]
+        """Send a message to a specific user in a session."""
+        participant = session.participants.get(user_id)
+        if not participant:
+            return False
+
+        try:
+            await participant.websocket.send_json(message)
+            return True
+        except Exception:
+            self.remove_user(user_id)
+            return False
+
+    async def send_to_host(
+        self,
+        session: ListeningSession,
+        message: dict[str, Any],
+    ) -> bool:  # type: ignore[no-untyped-call]
+        """Send a message to the session host."""
+        return await self.send_to_user(session, session.host_id, message)
+
+    def update_webrtc_state(
+        self,
+        user_id: UUID,
+        connected: bool,
+    ) -> None:  # type: ignore[return]
+        """Update a participant's WebRTC connection state."""
+        session = self.get_user_session(user_id)
+        if session:
+            participant = session.participants.get(user_id)
+            if participant:
+                participant.webrtc_connected = connected
+
+    def remove_user(self, user_id: UUID) -> ListeningSession | None:
+        """Remove a user from their current session."""
+        session_id = self._user_sessions.pop(user_id, None)
+        if not session_id:
+            return None
+
+        session = self._sessions.get(session_id)
+        if not session:
+            return None
+
+        session.participants.pop(user_id, None)
+
+        # If host left or no participants, end session
+        if user_id == session.host_id or not session.participants:
+            self._end_session(session)
+
+        return session
+
+    def _end_session(self, session: ListeningSession) -> None:  # type: ignore[return]
+        """Clean up and remove a session."""
+        self._code_to_session.pop(session.code, None)
+        self._sessions.pop(session.id, None)
+
+        # Remove all user mappings
+        for user_id in list(session.participants.keys()):
+            self._user_sessions.pop(user_id, None)
+
+    def update_playback(
+        self,
+        session: ListeningSession,
+        track_id: UUID | None = None,
+        is_playing: bool | None = None,
+        position_ms: int | None = None,
+    ) -> None:  # type: ignore[return]
+        """Update the playback state for a session."""
+        if track_id is not None:
+            session.playback_state.track_id = track_id
+        if is_playing is not None:
+            session.playback_state.is_playing = is_playing
+        if position_ms is not None:
+            session.playback_state.position_ms = position_ms
+        session.playback_state.updated_at = utcnow()
+
+    async def broadcast(
+        self,
+        session: ListeningSession,
+        message: dict[str, Any],
+        exclude_user: UUID | None = None,
+    ) -> None:  # type: ignore[return]
+        """Broadcast a message to all participants in a session."""
+        disconnected = []
+
+        for user_id, participant in session.participants.items():
+            if user_id == exclude_user:
+                continue
+
+            try:
+                await participant.websocket.send_json(message)
+            except Exception:
+                disconnected.append(user_id)
+
+        # Clean up disconnected users
+        for user_id in disconnected:
+            self.remove_user(user_id)
+
+
+# Global session manager instance
+_session_manager: SessionManager | None = None
+
+
+def get_session_manager() -> SessionManager:  # type: ignore[return]
+    """Get the global session manager instance."""
+    global _session_manager
+    if _session_manager is None:
+        _session_manager = SessionManager()
+    return _session_manager

--- a/backend/openapi.json
+++ b/backend/openapi.json
@@ -4038,6 +4038,55 @@
         "title": "HealthCheckResponse",
         "type": "object"
       },
+      "IceServer": {
+        "description": "One entry of an `RTCConfiguration.iceServers` array, in the browser's own shape.",
+        "properties": {
+          "credential": {
+            "title": "Credential",
+            "type": [
+              "string",
+              "null"
+            ]
+          },
+          "urls": {
+            "title": "Urls",
+            "type": "string"
+          },
+          "username": {
+            "title": "Username",
+            "type": [
+              "string",
+              "null"
+            ]
+          }
+        },
+        "required": [
+          "urls"
+        ],
+        "title": "IceServer",
+        "type": "object"
+      },
+      "IceServersResponse": {
+        "properties": {
+          "has_turn": {
+            "title": "Has Turn",
+            "type": "boolean"
+          },
+          "ice_servers": {
+            "items": {
+              "$ref": "#/components/schemas/IceServer"
+            },
+            "title": "Ice Servers",
+            "type": "array"
+          }
+        },
+        "required": [
+          "ice_servers",
+          "has_turn"
+        ],
+        "title": "IceServersResponse",
+        "type": "object"
+      },
       "IdentifyCandidateResponse": {
         "description": "A candidate match from audio fingerprint identification.",
         "properties": {
@@ -8290,6 +8339,118 @@
           "status"
         ],
         "title": "ServiceStatus",
+        "type": "object"
+      },
+      "SessionParticipant": {
+        "properties": {
+          "joined_at": {
+            "title": "Joined At",
+            "type": "string"
+          },
+          "role": {
+            "title": "Role",
+            "type": "string"
+          },
+          "user_id": {
+            "title": "User Id",
+            "type": "string"
+          },
+          "username": {
+            "title": "Username",
+            "type": "string"
+          },
+          "webrtc_connected": {
+            "default": false,
+            "title": "Webrtc Connected",
+            "type": "boolean"
+          }
+        },
+        "required": [
+          "user_id",
+          "username",
+          "role",
+          "joined_at"
+        ],
+        "title": "SessionParticipant",
+        "type": "object"
+      },
+      "SessionPlaybackState": {
+        "description": "What the host is playing, as guests last heard it.",
+        "properties": {
+          "is_playing": {
+            "default": false,
+            "title": "Is Playing",
+            "type": "boolean"
+          },
+          "position_ms": {
+            "default": 0,
+            "title": "Position Ms",
+            "type": "integer"
+          },
+          "track_id": {
+            "title": "Track Id",
+            "type": [
+              "string",
+              "null"
+            ]
+          }
+        },
+        "title": "SessionPlaybackState",
+        "type": "object"
+      },
+      "SessionResponse": {
+        "description": "A listening session, as looked up by its join code.",
+        "properties": {
+          "code": {
+            "title": "Code",
+            "type": "string"
+          },
+          "created_at": {
+            "title": "Created At",
+            "type": "string"
+          },
+          "host_id": {
+            "title": "Host Id",
+            "type": "string"
+          },
+          "id": {
+            "title": "Id",
+            "type": "string"
+          },
+          "name": {
+            "title": "Name",
+            "type": "string"
+          },
+          "participant_count": {
+            "title": "Participant Count",
+            "type": "integer"
+          },
+          "participants": {
+            "items": {
+              "$ref": "#/components/schemas/SessionParticipant"
+            },
+            "title": "Participants",
+            "type": "array"
+          },
+          "playback_state": {
+            "$ref": "#/components/schemas/SessionPlaybackState"
+          },
+          "webrtc_enabled": {
+            "title": "Webrtc Enabled",
+            "type": "boolean"
+          }
+        },
+        "required": [
+          "id",
+          "code",
+          "name",
+          "host_id",
+          "created_at",
+          "participant_count",
+          "webrtc_enabled",
+          "playback_state"
+        ],
+        "title": "SessionResponse",
         "type": "object"
       },
       "SettingsResponse": {
@@ -28413,6 +28574,161 @@
         "summary": "Validate Credentials",
         "tags": [
           "s3-backup"
+        ]
+      }
+    },
+    "/api/v1/sessions/by-code/{code}": {
+      "get": {
+        "description": "Look up a session by its six-character join code.\n\nCase-insensitive, because the code is something one person reads aloud to another.",
+        "operationId": "sessions_get_by_code",
+        "parameters": [
+          {
+            "in": "path",
+            "name": "code",
+            "required": true,
+            "schema": {
+              "title": "Code",
+              "type": "string"
+            }
+          }
+        ],
+        "responses": {
+          "200": {
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/SessionResponse"
+                }
+              }
+            },
+            "description": "Successful Response"
+          },
+          "400": {
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/ErrorEnvelope"
+                }
+              }
+            },
+            "description": "Bad Request"
+          },
+          "401": {
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/ErrorEnvelope"
+                }
+              }
+            },
+            "description": "Unauthorized"
+          },
+          "404": {
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/ErrorEnvelope"
+                }
+              }
+            },
+            "description": "Not Found"
+          },
+          "422": {
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/ErrorEnvelope"
+                }
+              }
+            },
+            "description": "Unprocessable Entity"
+          },
+          "500": {
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/ErrorEnvelope"
+                }
+              }
+            },
+            "description": "Internal Server Error"
+          }
+        },
+        "summary": "Get Session By Code",
+        "tags": [
+          "sessions"
+        ]
+      }
+    },
+    "/api/v1/sessions/ice-servers": {
+      "get": {
+        "description": "The ICE configuration a client should use when establishing a session peer connection.\n\nA REST route rather than only the join payload, because the Apple clients need it before they\nhave joined anything (ADR-0037), and because a client that wants to warn about symmetric NAT\nup front should not have to open a socket to find out.",
+        "operationId": "sessions_get_ice_servers",
+        "responses": {
+          "200": {
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/IceServersResponse"
+                }
+              }
+            },
+            "description": "Successful Response"
+          },
+          "400": {
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/ErrorEnvelope"
+                }
+              }
+            },
+            "description": "Bad Request"
+          },
+          "401": {
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/ErrorEnvelope"
+                }
+              }
+            },
+            "description": "Unauthorized"
+          },
+          "404": {
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/ErrorEnvelope"
+                }
+              }
+            },
+            "description": "Not Found"
+          },
+          "422": {
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/ErrorEnvelope"
+                }
+              }
+            },
+            "description": "Unprocessable Entity"
+          },
+          "500": {
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/ErrorEnvelope"
+                }
+              }
+            },
+            "description": "Internal Server Error"
+          }
+        },
+        "summary": "Read Ice Servers",
+        "tags": [
+          "sessions"
         ]
       }
     },

--- a/backend/scripts/lint_openapi.py
+++ b/backend/scripts/lint_openapi.py
@@ -73,6 +73,10 @@ VENDORED_TAGS = {
     "pending-review",
     "proposed-changes",
     "mixtapes",
+    # Listening sessions (ADR-0036, consumed by ADR-0037). Only the REST half is here — session
+    # lookup and ICE configuration. The `WebSocket /sessions/ws` on the same router is not an
+    # operation and never appears in the schema, which is ADR-0036 point 5 rather than an omission.
+    "sessions",
 }
 
 # Casting (ADR-0031), by operation rather than by tag: nine of the twenty-four `outputs` operations

--- a/backend/tests/test_api_sessions.py
+++ b/backend/tests/test_api_sessions.py
@@ -1,9 +1,20 @@
-"""Tests for listening sessions service."""
+"""Tests for listening sessions: the service's model, and the REST half ADR-0036 typed."""
 
 from unittest.mock import MagicMock
 from uuid import uuid4
 
-from app.services.sessions import ListeningSession, Participant, PlaybackState, SessionRole
+import pytest
+from httpx import ASGITransport, AsyncClient
+
+from app.api.routes import sessions as sessions_routes
+from app.main import app
+from app.services.sessions import (
+    ListeningSession,
+    Participant,
+    PlaybackState,
+    SessionRole,
+    get_session_manager,
+)
 
 
 class TestSessionRole:
@@ -105,13 +116,6 @@ class TestParticipant:
 # Added on revival. The shelved file tested the service's dataclasses and nothing that goes over the
 # wire — which is the half that now has to satisfy ADR-0007, and the half the Apple clients generate
 # from.
-
-import pytest
-from httpx import ASGITransport, AsyncClient
-
-from app.api.routes import sessions as sessions_routes
-from app.main import app
-from app.services.sessions import get_session_manager
 
 
 @pytest.fixture

--- a/backend/tests/test_api_sessions.py
+++ b/backend/tests/test_api_sessions.py
@@ -1,0 +1,217 @@
+"""Tests for listening sessions service."""
+
+from unittest.mock import MagicMock
+from uuid import uuid4
+
+from app.services.sessions import ListeningSession, Participant, PlaybackState, SessionRole
+
+
+class TestSessionRole:
+    def test_host_role(self):
+        assert SessionRole.HOST.value == "host"
+
+    def test_listener_role(self):
+        assert SessionRole.LISTENER.value == "listener"
+
+    def test_guest_role(self):
+        assert SessionRole.GUEST.value == "guest"
+
+
+class TestPlaybackState:
+    def test_default_state(self):
+        state = PlaybackState()
+        assert state.track_id is None
+        assert state.is_playing is False
+        assert state.position_ms == 0
+
+    def test_custom_state(self):
+        track_id = uuid4()
+        state = PlaybackState(track_id=track_id, is_playing=True, position_ms=5000)
+        assert state.track_id == track_id
+        assert state.is_playing is True
+        assert state.position_ms == 5000
+
+
+class TestListeningSession:
+    def test_code_format(self):
+        session = ListeningSession(
+            id="session-1",
+            code="ABC123",
+            name="Test Session",
+            host_id=uuid4(),
+        )
+        assert session.code == "ABC123"
+
+    def test_initial_playback_state(self):
+        session = ListeningSession(
+            id="session-1",
+            code="ABC123",
+            name="Test Session",
+            host_id=uuid4(),
+        )
+        assert session.playback_state.is_playing is False
+
+    def test_to_dict_includes_basic_fields(self):
+        host_id = uuid4()
+        session = ListeningSession(
+            id="session-1",
+            code="ABC123",
+            name="Test Session",
+            host_id=host_id,
+        )
+        d = session.to_dict()
+        assert d["id"] == "session-1"
+        assert d["code"] == "ABC123"
+        assert d["name"] == "Test Session"
+        assert d["host_id"] == str(host_id)
+
+    def test_to_dict_playback_state(self):
+        session = ListeningSession(
+            id="session-1",
+            code="ABC123",
+            name="Test Session",
+            host_id=uuid4(),
+        )
+        d = session.to_dict()
+        assert d["playback_state"]["is_playing"] is False
+        assert d["playback_state"]["track_id"] is None
+
+    def test_webrtc_enabled_default(self):
+        session = ListeningSession(
+            id="session-1",
+            code="ABC123",
+            name="Test Session",
+            host_id=uuid4(),
+        )
+        assert session.webrtc_enabled is True
+
+
+class TestParticipant:
+    def test_create_participant(self):
+        ws = MagicMock()
+        p = Participant(
+            user_id=uuid4(),
+            username="User 1",
+            websocket=ws,
+            role=SessionRole.HOST,
+        )
+        assert p.username == "User 1"
+        assert p.role == SessionRole.HOST
+        assert p.webrtc_connected is False
+
+
+# ── The REST half, revived and typed (ADR-0036 point 5) ─────────────────────
+#
+# Added on revival. The shelved file tested the service's dataclasses and nothing that goes over the
+# wire — which is the half that now has to satisfy ADR-0007, and the half the Apple clients generate
+# from.
+
+import pytest
+from httpx import ASGITransport, AsyncClient
+
+from app.api.routes import sessions as sessions_routes
+from app.main import app
+from app.services.sessions import get_session_manager
+
+
+@pytest.fixture
+def manager():
+    """The process-wide manager, emptied between tests.
+
+    Sessions are in-process by decision (ADR-0036 point 8), so the singleton persists across tests
+    in a way a database fixture would not — an earlier test's session is visible to a later one.
+    """
+    mgr = get_session_manager()
+    mgr._sessions.clear()
+    mgr._code_to_session.clear()
+    mgr._user_sessions.clear()
+    return mgr
+
+
+@pytest.fixture
+async def client():
+    async with AsyncClient(transport=ASGITransport(app=app), base_url="http://test") as c:
+        yield c
+
+
+class TestIceServers:
+    def test_stun_only_by_default(self, monkeypatch):
+        monkeypatch.setattr(sessions_routes.settings, "turn_server_url", None)
+        servers = sessions_routes.get_ice_servers()
+        assert len(servers) == 2
+        assert all(s["urls"].startswith("stun:") for s in servers)
+        assert sessions_routes.has_turn_configured() is False
+
+    def test_turn_appended_when_configured(self, monkeypatch):
+        monkeypatch.setattr(sessions_routes.settings, "turn_server_url", "turn:relay.example:3478")
+        monkeypatch.setattr(sessions_routes.settings, "turn_server_username", "user")
+        monkeypatch.setattr(sessions_routes.settings, "turn_server_credential", "secret")
+
+        servers = sessions_routes.get_ice_servers()
+        assert servers[-1] == {
+            "urls": "turn:relay.example:3478",
+            "username": "user",
+            "credential": "secret",
+        }
+        assert sessions_routes.has_turn_configured() is True
+
+    def test_turn_without_credentials_is_still_offered(self, monkeypatch):
+        # An open TURN server is unusual but legal, and dropping it because there is no username
+        # would leave the client with STUN and no explanation.
+        monkeypatch.setattr(sessions_routes.settings, "turn_server_url", "turn:open.example:3478")
+        monkeypatch.setattr(sessions_routes.settings, "turn_server_username", None)
+        monkeypatch.setattr(sessions_routes.settings, "turn_server_credential", None)
+
+        assert sessions_routes.get_ice_servers()[-1] == {"urls": "turn:open.example:3478"}
+
+    @pytest.mark.anyio
+    async def test_endpoint_reports_whether_turn_exists(self, client, monkeypatch):
+        # ADR-0036 point 7: behind symmetric NAT with no TURN this fails for reasons retrying does
+        # not fix, so the client is told rather than left to discover it as a hang.
+        monkeypatch.setattr(sessions_routes.settings, "turn_server_url", None)
+
+        response = await client.get("/api/v1/sessions/ice-servers")
+
+        assert response.status_code == 200
+        body = response.json()
+        assert body["has_turn"] is False
+        assert len(body["ice_servers"]) == 2
+
+
+class TestSessionLookup:
+    @pytest.mark.anyio
+    async def test_unknown_code_is_404_not_an_empty_session(self, client, manager):
+        response = await client.get("/api/v1/sessions/by-code/NOPE12")
+        assert response.status_code == 404
+
+    @pytest.mark.anyio
+    async def test_lookup_returns_the_typed_shape(self, client, manager):
+        session = manager.create_session(
+            host_id=uuid4(),
+            host_username="Jeff",
+            name="Friday Night",
+            websocket=MagicMock(),
+        )
+
+        response = await client.get(f"/api/v1/sessions/by-code/{session.code}")
+
+        assert response.status_code == 200
+        body = response.json()
+        assert body["code"] == session.code
+        assert body["name"] == "Friday Night"
+        assert body["participant_count"] == 1
+        # Nested, and typed rather than a bare dict — this is what the generated client models.
+        assert body["playback_state"] == {"track_id": None, "is_playing": False, "position_ms": 0}
+        assert body["participants"][0]["role"] == "host"
+
+    @pytest.mark.anyio
+    async def test_lookup_is_case_insensitive(self, client, manager):
+        # The code is something one person reads aloud to another.
+        session = manager.create_session(
+            host_id=uuid4(), host_username="Jeff", name="S", websocket=MagicMock()
+        )
+
+        response = await client.get(f"/api/v1/sessions/by-code/{session.code.lower()}")
+
+        assert response.status_code == 200
+        assert response.json()["code"] == session.code

--- a/docker/Dockerfile
+++ b/docker/Dockerfile
@@ -26,11 +26,9 @@ COPY packages/web/package.json packages/web/
 RUN pnpm install --frozen-lockfile --filter @familiar/web...
 
 # Copy source and build.
-# VITE_SESSIONS_RELAY_URL is baked in at build time; defaults to the public
-# Fly.io relay. Override with --build-arg VITE_SESSIONS_RELAY_URL=... if you
-# self-host familiar-sessions.
-ARG VITE_SESSIONS_RELAY_URL=https://familiar-sessions.fly.dev
-ENV VITE_SESSIONS_RELAY_URL=${VITE_SESSIONS_RELAY_URL}
+# There is no sessions relay build argument. Listening sessions signal through the Familiar server
+# this image *is* (ADR-0036); a build argument that silently sent listeners' session codes, chat and
+# reactions to a third party was the thing that decision removed.
 COPY packages/frontend/ packages/frontend/
 COPY packages/web/ packages/web/
 RUN pnpm --filter @familiar/web run build

--- a/docs/decisions/ADR-0036-listening-sessions-signal-through-familiars-own-server.md
+++ b/docs/decisions/ADR-0036-listening-sessions-signal-through-familiars-own-server.md
@@ -1,8 +1,38 @@
 # ADR-0036: Listening Sessions Signal Through Familiar's Own Server
 
-Status: proposed
+Status: accepted
 
 Date: 2026-08-06
+
+## Implementation
+
+All eight points shipped together; ADR-0037 is the client half and follows.
+
+`backend/app/services/sessions.py` came back from `ceeb926^` unchanged — it was removed for scope
+and there was no finding against it. `backend/app/api/routes/sessions.py` did not: the REST half is
+typed to ADR-0007 (`SessionResponse`, `IceServersResponse`, `operation_id`s, `NotFoundError` rather
+than a bare `HTTPException`), and `sessions` is now in `VENDORED_TAGS` and in the Swift generator
+config — twelve tags, 265 operations, lint green, and both operations generate.
+
+**ICE became a route as well as a join payload.** The shelved code exposed `get_ice_servers()` only
+inside the socket's join responses, which is too late for two callers: the Apple clients need it
+before joining (ADR-0037), and point 7 wants a client to be able to say "no TURN is configured" up
+front rather than after a handshake hangs. `GET /sessions/ice-servers` reports `has_turn`
+explicitly for that reason, and the socket now sends the same pair on `create` as well as on join —
+a host behind symmetric NAT should learn that before inviting anyone.
+
+**The guest page had to become a route, which the ADR filed as a follow-up.** It could not stay one:
+`buildShareLink` produces `/listen/{code}` against this origin once the relay is gone, and there has
+*never* been such a route in `App.tsx` — the relay served that page itself. Shipping point 3 without
+it would have made the one thing a host hands to a friend a 404. `GuestListener.tsx` is restored
+from `ceeb926^` and mounted **outside `AppShell`**, since a guest has no profile, no library and no
+player. Two things in it were repaired rather than restored: it read the join code from nowhere, and
+its WebSocket URL rewrote port 3000 to 8000 — a guess at a backend that has been on 4400 for a long
+time, wrong for as long as it was unreachable. Both now use the same origin every other request
+uses.
+
+18 backend tests. The shelved file tested the service's dataclasses and nothing that crosses the
+wire, which is precisely the half that now has a contract.
 
 ## Context
 
@@ -59,6 +89,14 @@ nothing.
 sessions, WebRTC streaming, and guest listener features. Code preserved on
 feature/listening-sessions branch"*, made the same afternoon as `dbdef05` shelved the plugin
 system. Nothing in either commit says the code was wrong.
+
+**But `feature/listening-sessions` does not exist**, and this was checked rather than assumed:
+not on `origin`, not locally, under any name. `dbdef05`'s counterpart branch —
+`feature/community-plugins` — *is* still there, locally only, so the convention was real and this
+one was simply lost. The code survives at **`ceeb926^`** and reads out intact
+(`sessions.py` 425 lines, `GuestListener.tsx` 475), so nothing is gone; but the recovery path is
+history, not a branch, and a plan written against the branch would have failed at its first step.
+Recorded because the same sentence is in the commit message, where it will be read again.
 
 **Two properties of the shelved implementation are worth surfacing before it comes back.**
 

--- a/docs/decisions/ADR-0036-listening-sessions-signal-through-familiars-own-server.md
+++ b/docs/decisions/ADR-0036-listening-sessions-signal-through-familiars-own-server.md
@@ -6,7 +6,24 @@ Date: 2026-08-06
 
 ## Implementation
 
-All eight points shipped together; ADR-0037 is the client half and follows.
+All eight points shipped together.
+
+**ADR-0037, the Apple half, was rejected** — a Mac cannot host, because `RTCAudioDevice` is not
+exposed in `stasel/WebRTC`'s macOS slice. That matters here for one reason worth naming: this ADR's
+Alternatives rejected *"Delete listening sessions properly rather than reviving them"* partly on the
+grounds that "the feature is being asked for on the Apple clients (ADR-0037), and reviving it
+correctly is the prerequisite for that." **That prerequisite no longer has anything to be a
+prerequisite for.**
+
+This decision still stands on the rest of its own argument, which never depended on ADR-0037: the
+one feature involving other people was routing through a box the listener does not run, and it had
+been broken in `pnpm dev` for five months. Both are fixed, in the web app, where the feature lives
+and works. But anyone re-reading that Alternative should know half its reasoning has expired.
+
+Point 5's generated `sessions` surface is the other casualty: it is generated for the Apple clients
+and now has no Apple consumer. It is left in place — the backend lint cross-checks `VENDORED_TAGS`
+against the Swift config, so removing it is a change on both sides, and iOS already compiles
+management operations it never calls. Worth deciding deliberately rather than inheriting.
 
 `backend/app/services/sessions.py` came back from `ceeb926^` unchanged — it was removed for scope
 and there was no finding against it. `backend/app/api/routes/sessions.py` did not: the REST half is

--- a/docs/decisions/ADR-0037-the-apple-clients-host-and-join-listening-sessions.md
+++ b/docs/decisions/ADR-0037-the-apple-clients-host-and-join-listening-sessions.md
@@ -32,13 +32,22 @@ beside the analysis tap" — unachievable on macOS, and with it **point 1**.
 `NativeAudioEngine` for, so the receive path never needed the custom device. iOS can both host and
 join. **It is only the Mac's outbound path that has no route.**
 
-The judgement, which is a product one rather than a technical one: a listening-party feature that
-the machine holding the library cannot start is not worth a **44 MB** binary framework nobody here
-can rebuild, shipped inside an App Store build. Point 2 asked for that liability to be entered
-knowingly; knowing this, it is not entered.
+**And point 1's premise was wrong, independently of any of this.** It argued that "the phone is
+where listening happens, and a listening party you can only start from a desk is a party in the
+wrong room." That is not how this product is used: **the Mac desktop app is the primary place a
+session would be hosted.** Hosting is a thing you do at the machine with the library, the big
+screen and the good speakers; joining is what happens on a phone. So the platform the binary cannot
+serve is not an unfortunate half of the feature — it is the half that matters.
 
-Worth recording as an irony rather than a lesson: the Alternatives below reject *"Host only on the
-Mac, join on both"*, and the binary forces close to the exact opposite.
+The judgement is therefore a product one rather than a technical one, and it is short: if it cannot
+happen on the Mac, it is not worth pursuing now. Point 2 asked for a 44 MB binary framework nobody
+here can rebuild to be entered knowingly, shipped inside an App Store build. Knowing that it buys
+hosting only on the device where hosting is least likely, it is not entered.
+
+Worth recording rather than smoothing over: the Alternatives below reject *"Host only on the Mac,
+join on both"* on the same mistaken premise as point 1. Read today, that rejected alternative is
+closer to right than the decision was — and the binary forces almost exactly its opposite. Two
+things went wrong at once, and only one of them was WebRTC's fault.
 
 Two things this rejection does **not** say. It is not a finding against libwebrtc — the string
 `RTCAudioDeviceDelegate` appears in the macOS binary, so this reads as a packaging omission in the
@@ -47,10 +56,15 @@ not a finding against listening sessions, which work in the web app against the 
 server under [ADR-0036](ADR-0036-listening-sessions-signal-through-familiars-own-server.md), and
 which shipped.
 
-**What would reopen this:** a maintained macOS WebRTC distribution that exposes `RTCAudioDevice`, or
-a decision that iOS-only hosting is worth the dependency on its own. Either is a new ADR. The
-material below is left exactly as it was proposed — the design was sound, and if the obstacle is
-removed it is still the design.
+**What would reopen this:** a maintained macOS WebRTC distribution that exposes `RTCAudioDevice`.
+That is the one condition, and it is narrower than it was a paragraph ago — "iOS-only hosting is
+worth the dependency anyway" is *not* a route, because hosting on the phone alone is the version of
+this feature nobody asked for. A new ADR either way.
+
+The material below is left exactly as it was proposed, with one caveat now attached to it: the
+design was sound and would still be the design, **but point 1 would need rewriting even if the
+obstacle vanished tomorrow.** "Both platforms host and join" is fine as an outcome; the reasoning
+under it is not.
 
 ## Context
 

--- a/docs/decisions/ADR-0037-the-apple-clients-host-and-join-listening-sessions.md
+++ b/docs/decisions/ADR-0037-the-apple-clients-host-and-join-listening-sessions.md
@@ -1,11 +1,56 @@
 # ADR-0037: The Apple Clients Host and Join Listening Sessions
 
-Status: proposed
+Status: rejected
 
 Date: 2026-08-06
 
 Extends [ADR-0036](ADR-0036-listening-sessions-signal-through-familiars-own-server.md) and
 [ADR-0013](ADR-0013-the-mac-is-a-management-surface-too.md).
+
+## Why This Was Rejected
+
+**A Mac cannot host a listening session, and the whole decision rests on it being able to.** This
+was found while building, on 2026-08-09, after points 2, 8 and 11 had shipped as a foundation — that
+work is reverted and `familiar-apple` #90 is closed.
+
+`RTCAudioDevice` is the only public route for feeding `AVAudioEngine`'s output into WebRTC, and
+`stasel/WebRTC` **does not expose it in the macOS slice**:
+
+- The header ships in `ios-arm64`, `ios-x86_64_arm64-simulator` and `ios-…-maccatalyst`. It is
+  absent from `macos-x86_64_arm64`'s `Headers/`, its `Versions/A/Headers/`, and its umbrella header.
+- macOS's `RTCPeerConnectionFactory.h` still declares
+  `initWithEncoderFactory:decoderFactory:audioDevice:`, backed only by a forward
+  `@protocol RTCAudioDevice;`. It compiles. Nothing can conform to it, so `nil` is the only argument
+  available.
+
+Without it, WebRTC uses its default audio device module, which captures **the microphone**. A Mac
+host would stream the room rather than the music. That makes **point 4** — "a host adds one tap,
+beside the analysis tap" — unachievable on macOS, and with it **point 1**.
+
+**Precisely what does and does not work**, because the distinction is easy to lose: a Mac can
+*join*. A guest's audio is played by WebRTC's own device, which is exactly what point 3 stops
+`NativeAudioEngine` for, so the receive path never needed the custom device. iOS can both host and
+join. **It is only the Mac's outbound path that has no route.**
+
+The judgement, which is a product one rather than a technical one: a listening-party feature that
+the machine holding the library cannot start is not worth a **44 MB** binary framework nobody here
+can rebuild, shipped inside an App Store build. Point 2 asked for that liability to be entered
+knowingly; knowing this, it is not entered.
+
+Worth recording as an irony rather than a lesson: the Alternatives below reject *"Host only on the
+Mac, join on both"*, and the binary forces close to the exact opposite.
+
+Two things this rejection does **not** say. It is not a finding against libwebrtc — the string
+`RTCAudioDeviceDelegate` appears in the macOS binary, so this reads as a packaging omission in the
+distribution, and a build that exposed the protocol would remove the obstacle entirely. And it is
+not a finding against listening sessions, which work in the web app against the listener's own
+server under [ADR-0036](ADR-0036-listening-sessions-signal-through-familiars-own-server.md), and
+which shipped.
+
+**What would reopen this:** a maintained macOS WebRTC distribution that exposes `RTCAudioDevice`, or
+a decision that iOS-only hosting is worth the dependency on its own. Either is a new ADR. The
+material below is left exactly as it was proposed — the design was sound, and if the obstacle is
+removed it is still the design.
 
 ## Context
 
@@ -36,9 +81,9 @@ And the render path is closed on purpose.
 [ADR-0024](ADR-0024-the-audio-engine-is-main-actor-except-where-it-cannot-be.md) point 3 made the
 tap closure `@Sendable` and non-isolated after a Swift 6 runtime check crashed the app on the first
 track played — `Thread 8 Crashed:: Dispatch queue: RealtimeMessenger.mServiceQueue`. The analysis
-tap at `NativeAudioEngine.swift:2148` captures a processor and nothing else, and its comment says
-why in eleven lines. A capture tap for a host's outbound stream sits beside it under exactly the
-same rules.
+tap — at `NativeAudioEngine.swift:2408`, not 2148 as first written; the file has grown to 2,494
+lines since — captures a processor and nothing else, and its comment says why in eleven lines. A
+capture tap for a host's outbound stream would sit beside it under exactly the same rules.
 
 **The web app's host path is one line of Web Audio.** `WebAudioEngine.getOutputStream()` lazily
 branches `masterGain` into a `MediaStreamAudioDestinationNode` and hands the result to
@@ -151,6 +196,10 @@ point of ADR-0001 was that listening moves to the native clients — leaving the
 the browser splits the feature across two apps.
 
 ## Consequences
+
+**None of these came to pass — the decision was rejected.** They are kept as written because they
+are the terms on which it would be reconsidered, and the second Tradeoff below is most of why it
+was not.
 
 - **Positive:** The Mac and the phone can start and join a listening session, on a server they are
   already configured against, with the profile they already hold.

--- a/packages/frontend/src/App.tsx
+++ b/packages/frontend/src/App.tsx
@@ -26,6 +26,9 @@ const ArtistDetail = lazy(() => import('./components/Library/ArtistDetail').then
 const AlbumDetail = lazy(() => import('./components/Library/AlbumDetail').then(m => ({ default: m.AlbumDetail })));
 const PlaylistDetail = lazy(() => import('./components/Playlists/PlaylistDetail').then(m => ({ default: m.PlaylistDetail })));
 const EphemeralPlaylistDetail = lazy(() => import('./components/Playlists/EphemeralPlaylistDetail').then(m => ({ default: m.EphemeralPlaylistDetail })));
+// The guest listener (ADR-0036). Lazy like every other route component, and worth it here: a guest
+// loads this page and nothing else, and everyone else never loads it at all.
+const GuestListener = lazy(() => import('./components/Guest/GuestListener').then(m => ({ default: m.GuestListener })));
 const FavoritesDetail = lazy(() => import('./components/Playlists/FavoritesDetail').then(m => ({ default: m.FavoritesDetail })));
 const DownloadsDetail = lazy(() => import('./components/Playlists/DownloadsDetail').then(m => ({ default: m.DownloadsDetail })));
 const SmartPlaylistDetail = lazy(() => import('./components/SmartPlaylists/SmartPlaylistDetail').then(m => ({ default: m.SmartPlaylistDetail })));
@@ -286,6 +289,25 @@ function App() {
         {/* Watches in-flight mix tape renders and toasts on terminal state */}
         <MixTapeProgressWatcher />
         <Routes>
+          {/*
+            The guest listener (ADR-0036), and deliberately *outside* `AppShell`.
+
+            A guest has no profile, no library and no player — they have a code someone sent them.
+            Mounting this inside the shell would give them a sidebar to nothing and construct the
+            audio engine for a page whose audio arrives over a peer connection.
+
+            **This route has never existed here before.** The share link used to point at
+            `familiar-sessions.fly.dev/listen/{code}`, which the relay served itself; retiring the
+            relay leaves `buildShareLink` pointing at this origin, and without this the one thing a
+            host hands to a friend would 404. That is the shape of defect this codebase keeps
+            shipping, and it would have been introduced by the fix.
+          */}
+          <Route path="/listen/:code?" element={
+            <Suspense fallback={<LazyLoadSpinner />}>
+              <GuestListener />
+            </Suspense>
+          } />
+
           {/* Main app routes inside AppShell */}
           <Route element={<AppShell />}>
             <Route path="/home" element={<HomeScreen />} />

--- a/packages/frontend/src/components/Guest/GuestListener.tsx
+++ b/packages/frontend/src/components/Guest/GuestListener.tsx
@@ -1,0 +1,487 @@
+/**
+ * Guest listener page - allows unauthenticated users to join
+ * a listening session and receive audio via WebRTC.
+ */
+
+import { useState, useEffect, useCallback, useRef } from 'react';
+import { Radio, Volume2, VolumeX, Users, Music2, Loader2 } from 'lucide-react';
+
+import { useParams } from 'react-router-dom';
+
+import { getApiOrigin, getApiUrl } from '../../api/base';
+import { createLogger } from '../../utils/logger';
+
+const log = createLogger('GuestListener');
+
+interface SessionInfo {
+  id: string;
+  code: string;
+  name: string;
+  host_id: string;
+  participant_count: number;
+  webrtc_enabled: boolean;
+  playback_state: {
+    track_id: string | null;
+    is_playing: boolean;
+    position_ms: number;
+  };
+}
+
+interface IceServer {
+  urls: string;
+  username?: string;
+  credential?: string;
+}
+
+interface TrackInfo {
+  title: string;
+  artist: string;
+  album?: string;
+}
+
+export function GuestListener() {
+  // **The code comes from the share link**, and the field stays editable so someone who was read
+  // the code aloud can type it. `/listen` with no code is a perfectly good entry point.
+  const { code: codeFromLink } = useParams<{ code?: string }>();
+  const [code, setCode] = useState((codeFromLink ?? '').toUpperCase());
+  const [guestName, setGuestName] = useState('');
+  const [session, setSession] = useState<SessionInfo | null>(null);
+  const [isConnecting, setIsConnecting] = useState(false);
+  const [error, setError] = useState<string | null>(null);
+  const [volume, setVolume] = useState(1);
+  const [isMuted, setIsMuted] = useState(false);
+  const [isReceivingAudio, setIsReceivingAudio] = useState(false);
+  const [currentTrack, setCurrentTrack] = useState<TrackInfo | null>(null);
+  const [iceServers, setIceServers] = useState<IceServer[]>([]);
+
+  const wsRef = useRef<WebSocket | null>(null);
+  const peerConnectionRef = useRef<RTCPeerConnection | null>(null);
+  const audioRef = useRef<HTMLAudioElement | null>(null);
+  const userIdRef = useRef<string | null>(null);
+  const reconnectAttemptsRef = useRef<number>(0);
+  const reconnectTimeoutRef = useRef<number | null>(null);
+  const maxReconnectAttempts = 10;
+
+  // Where signalling goes: the host's own Familiar server (ADR-0036).
+  //
+  // **This used to guess.** It rewrote port 3000 to 8000 to bridge the Vite dev server to the
+  // backend — and the backend has been on 4400 for a long time, so the guess had been wrong for as
+  // long as it had been unreachable. `getApiOrigin()` is the same value every other request uses,
+  // and the dev server proxies it, so there is nothing left to infer.
+  const getWsUrl = useCallback(() => {
+    const origin = getApiOrigin() || window.location.origin;
+    return `${origin.replace(/^http/, 'ws').replace(/\/$/, '')}/api/v1/sessions/ws`;
+  }, []);
+
+  // Send WebSocket message
+  const send = useCallback((message: object) => {
+    if (wsRef.current?.readyState === WebSocket.OPEN) {
+      wsRef.current.send(JSON.stringify(message));
+    }
+  }, []);
+
+  // Handle WebRTC offer from host
+  const handleOffer = useCallback(async (sdp: RTCSessionDescriptionInit) => {
+    log.info('Received WebRTC offer from host');
+
+    const rtcConfig: RTCConfiguration = {
+      iceServers: iceServers.length > 0 ? iceServers : [
+        { urls: 'stun:stun.l.google.com:19302' },
+        { urls: 'stun:stun1.l.google.com:19302' },
+      ],
+    };
+
+    const pc = new RTCPeerConnection(rtcConfig);
+    peerConnectionRef.current = pc;
+
+    // Handle incoming audio track
+    pc.ontrack = (event) => {
+      log.info('Received audio track from host');
+      setIsReceivingAudio(true);
+
+      if (!audioRef.current) {
+        audioRef.current = new Audio();
+        audioRef.current.autoplay = true;
+      }
+
+      audioRef.current.srcObject = event.streams[0];
+      audioRef.current.volume = isMuted ? 0 : volume;
+      audioRef.current.play().catch(log.error);
+    };
+
+    // Handle ICE candidates
+    pc.onicecandidate = (event) => {
+      if (event.candidate) {
+        send({
+          type: 'webrtc_ice',
+          candidate: event.candidate.toJSON(),
+        });
+      }
+    };
+
+    // Handle connection state
+    pc.onconnectionstatechange = () => {
+      log.info(`WebRTC connection state: ${pc.connectionState}`);
+      if (pc.connectionState === 'connected') {
+        send({ type: 'webrtc_connected', connected: true });
+      } else if (pc.connectionState === 'disconnected' || pc.connectionState === 'failed') {
+        setIsReceivingAudio(false);
+        send({ type: 'webrtc_connected', connected: false });
+      }
+    };
+
+    try {
+      await pc.setRemoteDescription(new RTCSessionDescription(sdp));
+      const answer = await pc.createAnswer();
+      await pc.setLocalDescription(answer);
+
+      send({
+        type: 'webrtc_answer',
+        sdp: pc.localDescription,
+      });
+    } catch (err) {
+      log.error('Failed to handle WebRTC offer:', err);
+      setError('Failed to establish audio connection');
+    }
+  }, [iceServers, volume, isMuted, send]);
+
+  // Handle ICE candidate from host
+  const handleIceCandidate = useCallback(async (candidate: RTCIceCandidateInit) => {
+    if (peerConnectionRef.current) {
+      try {
+        await peerConnectionRef.current.addIceCandidate(new RTCIceCandidate(candidate));
+      } catch (err) {
+        log.error('Failed to add ICE candidate:', err);
+      }
+    }
+  }, []);
+
+  // Cleanup connections
+  const cleanup = useCallback(() => {
+    if (reconnectTimeoutRef.current) {
+      clearTimeout(reconnectTimeoutRef.current);
+      reconnectTimeoutRef.current = null;
+    }
+    if (peerConnectionRef.current) {
+      peerConnectionRef.current.close();
+      peerConnectionRef.current = null;
+    }
+    if (audioRef.current) {
+      audioRef.current.pause();
+      audioRef.current.srcObject = null;
+    }
+    if (wsRef.current) {
+      wsRef.current.close();
+      wsRef.current = null;
+    }
+    setIsReceivingAudio(false);
+    reconnectAttemptsRef.current = 0;
+  }, []);
+
+  // Handle WebSocket messages
+  const handleMessage = useCallback((event: MessageEvent) => {
+    const data = JSON.parse(event.data);
+
+    switch (data.type) {
+      case 'session_joined':
+        setSession(data.session);
+        userIdRef.current = data.your_user_id;
+        if (data.ice_servers) {
+          setIceServers(data.ice_servers);
+        }
+        setError(null);
+        setIsConnecting(false);
+        // Reset reconnect attempts on successful connection
+        reconnectAttemptsRef.current = 0;
+
+        // Request WebRTC stream
+        setTimeout(() => {
+          send({ type: 'webrtc_request' });
+        }, 500);
+        break;
+
+      case 'webrtc_offer':
+        if (data.sdp) {
+          handleOffer(data.sdp);
+        }
+        break;
+
+      case 'webrtc_ice':
+        if (data.candidate) {
+          handleIceCandidate(data.candidate);
+        }
+        break;
+
+      case 'playback_update':
+        // Track info is synced via WebRTC audio, but we can show what's playing
+        if (data.track_id) {
+          // Raw `fetch`, not the api client: a guest has no profile, and the client attaches a
+          // profile header on every request. Whether this endpoint answers an unauthenticated
+          // caller at all is a separate question — if it does not, the guest simply sees no title,
+          // which is the behaviour this page shipped with.
+          // eslint-disable-next-line no-restricted-globals -- see above
+          fetch(getApiUrl(`/tracks/${data.track_id}`))
+            .then(res => res.json())
+            .then(track => {
+              setCurrentTrack({
+                title: track.title || 'Unknown',
+                artist: track.artist || 'Unknown',
+                album: track.album,
+              });
+            })
+            .catch(() => {});
+        }
+        break;
+
+      case 'user_left':
+        if (data.reason === 'host_left') {
+          setError('The host ended the session');
+          setSession(null);
+          cleanup();
+        }
+        break;
+
+      case 'error':
+        setError(data.message);
+        setIsConnecting(false);
+        break;
+    }
+  }, [handleOffer, handleIceCandidate, send, cleanup]);
+
+  // Join session
+  const joinSession = useCallback(() => {
+    if (!code || !guestName) return;
+
+    setIsConnecting(true);
+    setError(null);
+
+    const ws = new WebSocket(getWsUrl());
+
+    ws.onopen = () => {
+      ws.send(JSON.stringify({
+        type: 'join_guest',
+        code: code.toUpperCase(),
+        guest_name: guestName,
+      }));
+    };
+
+    ws.onmessage = handleMessage;
+
+    ws.onerror = () => {
+      setError('Connection error');
+      setIsConnecting(false);
+    };
+
+    ws.onclose = () => {
+      if (session) {
+        reconnectAttemptsRef.current += 1;
+
+        if (reconnectAttemptsRef.current > maxReconnectAttempts) {
+          setError('Connection lost. Please try rejoining the session.');
+          return;
+        }
+
+        // Exponential backoff: 3s, 6s, 12s, 24s, 48s, max 60s
+        const delay = Math.min(3000 * Math.pow(2, reconnectAttemptsRef.current - 1), 60000);
+        log.info(`Reconnecting in ${delay}ms (attempt ${reconnectAttemptsRef.current}/${maxReconnectAttempts})`);
+        setError(`Connection lost. Reconnecting in ${Math.round(delay / 1000)}s...`);
+
+        reconnectTimeoutRef.current = window.setTimeout(() => {
+          joinSession();
+        }, delay);
+      }
+    };
+
+    wsRef.current = ws;
+  }, [code, guestName, getWsUrl, handleMessage, session]);
+
+  // Leave session
+  const leaveSession = useCallback(() => {
+    send({ type: 'leave' });
+    cleanup();
+    setSession(null);
+    setCurrentTrack(null);
+  }, [send, cleanup]);
+
+  // Update volume
+  useEffect(() => {
+    if (audioRef.current) {
+      audioRef.current.volume = isMuted ? 0 : volume;
+    }
+  }, [volume, isMuted]);
+
+  // Cleanup on unmount
+  useEffect(() => {
+    return () => {
+      cleanup();
+    };
+  }, [cleanup]);
+
+  // Not in session - show join form
+  if (!session) {
+    return (
+      <div className="min-h-screen bg-gradient-to-b from-zinc-900 to-black flex items-center justify-center p-4">
+        <div className="bg-zinc-800/50 rounded-xl border border-zinc-700 p-8 max-w-md w-full">
+          <div className="text-center mb-8">
+            <Radio className="w-16 h-16 mx-auto mb-4 text-green-500" />
+            <h1 className="text-2xl font-bold text-white">Join Listening Session</h1>
+            <p className="text-zinc-400 mt-2">
+              Listen along with a friend without needing an account
+            </p>
+          </div>
+
+          <div className="space-y-4">
+            <div>
+              <label className="block text-sm text-zinc-400 mb-1">Your Name</label>
+              <input
+                type="text"
+                value={guestName}
+                onChange={(e) => setGuestName(e.target.value)}
+                placeholder="Enter your name"
+                className="w-full px-4 py-3 bg-zinc-700 border border-zinc-600 rounded-lg text-white placeholder-zinc-500 focus:outline-none focus:ring-2 focus:ring-green-500"
+              />
+            </div>
+
+            <div>
+              <label className="block text-sm text-zinc-400 mb-1">Session Code</label>
+              <input
+                type="text"
+                value={code}
+                onChange={(e) => setCode(e.target.value.toUpperCase())}
+                placeholder="Enter 6-digit code"
+                maxLength={6}
+                className="w-full px-4 py-3 bg-zinc-700 border border-zinc-600 rounded-lg text-white placeholder-zinc-500 focus:outline-none focus:ring-2 focus:ring-green-500 text-center text-2xl tracking-widest font-mono"
+              />
+            </div>
+
+            {error && (
+              <div className="bg-red-500/10 border border-red-500/50 text-red-400 px-4 py-3 rounded-lg text-sm">
+                {error}
+              </div>
+            )}
+
+            <button
+              onClick={joinSession}
+              disabled={!code || !guestName || isConnecting}
+              className="w-full px-4 py-3 bg-green-600 hover:bg-green-500 disabled:bg-zinc-700 disabled:text-zinc-500 rounded-lg font-medium transition-colors flex items-center justify-center gap-2"
+            >
+              {isConnecting ? (
+                <>
+                  <Loader2 className="w-5 h-5 animate-spin" />
+                  Connecting...
+                </>
+              ) : (
+                <>
+                  <Radio className="w-5 h-5" />
+                  Join Session
+                </>
+              )}
+            </button>
+          </div>
+        </div>
+      </div>
+    );
+  }
+
+  // In session - show player
+  return (
+    <div className="min-h-screen bg-gradient-to-b from-zinc-900 to-black flex flex-col">
+      {/* Header */}
+      <header className="p-4 border-b border-zinc-800">
+        <div className="flex items-center justify-between max-w-2xl mx-auto">
+          <div className="flex items-center gap-3">
+            <Radio className="w-6 h-6 text-green-500" />
+            <div>
+              <h1 className="font-semibold">{session.name}</h1>
+              <div className="text-sm text-zinc-400 flex items-center gap-2">
+                <Users className="w-4 h-4" />
+                {session.participant_count} listeners
+              </div>
+            </div>
+          </div>
+          <button
+            onClick={leaveSession}
+            className="px-4 py-2 text-sm text-zinc-400 hover:text-white hover:bg-zinc-800 rounded-lg transition-colors"
+          >
+            Leave
+          </button>
+        </div>
+      </header>
+
+      {/* Main content */}
+      <main className="flex-1 flex items-center justify-center p-8">
+        <div className="text-center max-w-md">
+          {/* Now playing */}
+          <div className="mb-8">
+            <div className="w-48 h-48 mx-auto mb-6 bg-zinc-800 rounded-xl flex items-center justify-center">
+              {currentTrack ? (
+                <img
+                  src={session.playback_state.track_id
+                    ? getApiUrl(`/tracks/${session.playback_state.track_id}/artwork`)
+                    : undefined}
+                  alt=""
+                  className="w-full h-full object-cover rounded-xl"
+                  onError={(e) => {
+                    e.currentTarget.style.display = 'none';
+                    e.currentTarget.nextElementSibling?.classList.remove('hidden');
+                  }}
+                />
+              ) : null}
+              <Music2 className={`w-16 h-16 text-zinc-600 ${currentTrack ? 'hidden' : ''}`} />
+            </div>
+
+            {currentTrack ? (
+              <div>
+                <h2 className="text-xl font-semibold">{currentTrack.title}</h2>
+                <p className="text-zinc-400">{currentTrack.artist}</p>
+                {currentTrack.album && (
+                  <p className="text-sm text-zinc-500">{currentTrack.album}</p>
+                )}
+              </div>
+            ) : (
+              <div className="text-zinc-400">
+                {isReceivingAudio ? 'Now playing...' : 'Waiting for audio...'}
+              </div>
+            )}
+          </div>
+
+          {/* Connection status */}
+          <div className={`inline-flex items-center gap-2 px-4 py-2 rounded-full text-sm ${
+            isReceivingAudio
+              ? 'bg-green-500/20 text-green-400'
+              : 'bg-yellow-500/20 text-yellow-400'
+          }`}>
+            <span className={`w-2 h-2 rounded-full ${
+              isReceivingAudio ? 'bg-green-500' : 'bg-yellow-500 animate-pulse'
+            }`} />
+            {isReceivingAudio ? 'Connected' : 'Connecting...'}
+          </div>
+
+          {/* Volume control */}
+          <div className="mt-8 flex items-center justify-center gap-4">
+            <button
+              onClick={() => setIsMuted(!isMuted)}
+              className="p-2 text-zinc-400 hover:text-white transition-colors"
+            >
+              {isMuted ? <VolumeX className="w-6 h-6" /> : <Volume2 className="w-6 h-6" />}
+            </button>
+            <input
+              type="range"
+              min={0}
+              max={1}
+              step={0.01}
+              value={volume}
+              onChange={(e) => setVolume(parseFloat(e.target.value))}
+              className="w-32 accent-green-500"
+            />
+          </div>
+        </div>
+      </main>
+
+      {/* Footer */}
+      <footer className="p-4 text-center text-sm text-zinc-500">
+        Listening as <span className="text-white">{guestName}</span> | Code: <span className="font-mono">{session.code}</span>
+      </footer>
+    </div>
+  );
+}

--- a/packages/frontend/src/components/Guest/index.ts
+++ b/packages/frontend/src/components/Guest/index.ts
@@ -1,0 +1,1 @@
+export { GuestListener } from './GuestListener';

--- a/packages/frontend/src/hooks/useListeningSession.ts
+++ b/packages/frontend/src/hooks/useListeningSession.ts
@@ -13,6 +13,7 @@ import {
   type SessionReaction,
   type SessionReactionKind,
 } from '../services/listeningSessionFamiliars';
+import { getApiOrigin } from '../api/base';
 import { createLogger } from '../utils/logger';
 import { showError } from '../stores/toastStore';
 
@@ -25,14 +26,6 @@ const PENDING_SEND_TICK_MS = 100;
 const HANDSHAKE_TIMEOUT_MS = 12000;
 const REACTION_RETENTION_MS = 4000;
 
-/**
- * Public WebRTC signaling relay URL (familiar-sessions service).
- * Override at build time via VITE_SESSIONS_RELAY_URL.
- * Falls back to the same origin as the Familiar app — useful for local dev when
- * running familiar-sessions on the same host.
- */
-const RELAY_URL: string =
-  (import.meta.env?.VITE_SESSIONS_RELAY_URL as string | undefined) ?? '';
 
 export interface SessionParticipant {
   user_id: string;
@@ -97,24 +90,36 @@ function normalizeSession(value: SessionInfo): SessionInfo {
   };
 }
 
+/**
+ * Where signalling goes: the listener's own Familiar server, and nowhere else (ADR-0036).
+ *
+ * **There used to be a build argument here**, `VITE_SESSIONS_RELAY_URL`, defaulting to a public Fly
+ * application. Every released build signalled through it; every development build fell back to a
+ * same-origin route that had been deleted five months earlier, so the panel 404ed in `pnpm dev` and
+ * nothing said so. Both halves of that are gone: there is one path now, it is the server the app is
+ * already talking to, and it is the one the route exists on.
+ *
+ * Derived from `getApiOrigin()` rather than `window.location`, because the two differ whenever the
+ * app is served from somewhere other than the API — which `setApiOrigin` exists to support.
+ */
 function buildWsUrl(): string {
-  let base: string;
-  if (RELAY_URL) {
-    base = RELAY_URL.replace(/^http/, 'ws').replace(/\/$/, '');
-  } else {
-    const proto = window.location.protocol === 'https:' ? 'wss:' : 'ws:';
-    base = `${proto}//${window.location.host}`;
-  }
+  const origin = getApiOrigin() || window.location.origin;
+  const base = origin.replace(/^http/, 'ws').replace(/\/$/, '');
   return `${base}/api/v1/sessions/ws`;
 }
 
-/** Public guest URL the host can share. */
+/**
+ * The URL a host shares with a guest.
+ *
+ * **A guest must be able to reach the host's server**, which is the real cost of ADR-0036 point 2
+ * and is stated in its Consequences. This link used to work from anywhere because it pointed at a
+ * public relay; it now points where the music is, so it works over Tailscale, a tunnel or a public
+ * address, and not otherwise.
+ */
 export function buildShareLink(code: string): string {
   const safe = encodeURIComponent(code);
-  if (RELAY_URL) {
-    return `${RELAY_URL.replace(/\/$/, '')}/listen/${safe}`;
-  }
-  return `${window.location.origin}/listen/${safe}`;
+  const origin = getApiOrigin() || window.location.origin;
+  return `${origin.replace(/\/$/, '')}/listen/${safe}`;
 }
 
 export function useListeningSession({ username }: UseListeningSessionOptions = {}) {

--- a/scripts/deploy-dev.sh
+++ b/scripts/deploy-dev.sh
@@ -29,9 +29,6 @@ done
 # Build frontend if needed
 if [ "$DEPLOY_FRONTEND" = true ]; then
     echo "Building frontend..."
-    # Bake the public listening-sessions relay URL into the bundle. Override by
-    # exporting VITE_SESSIONS_RELAY_URL before invoking this script.
-    export VITE_SESSIONS_RELAY_URL="${VITE_SESSIONS_RELAY_URL:-https://familiar-sessions.fly.dev}"
     pnpm --filter @familiar/web run build
 
     echo "Syncing frontend to $NAS_HOST..."


### PR DESCRIPTION
Accepts and implements [ADR-0036](docs/decisions/ADR-0036-listening-sessions-signal-through-familiars-own-server.md). The Apple half is ADR-0037 and follows separately.

## The finding

Listening sessions are live in the web app and have been signalling through **`familiar-sessions.fly.dev`** — a separate Fly application, outside the user's own server — in every released build since `ceeb926` shelved the server half on 2026-03-06. Every *development* build fell back to same-origin `/api/v1/sessions/ws`, a route deleted the same day: the panel opens, the socket 404s, and the feature has been broken in `pnpm dev` for five months with nothing saying so.

This isn't a defect in WebRTC or in the session code, both of which work. It's that the one feature involving other people routes through a box the listener doesn't run, in a product whose premise is that nothing leaves your network.

## One correction to the ADR first

Its plan rested on `ceeb926`'s claim that the code is *"preserved on feature/listening-sessions branch"*. **That branch does not exist** — not on `origin`, not locally, under any name. I listed every branch in the repo. `dbdef05`'s counterpart, `feature/community-plugins`, *is* still there locally, so the convention was real and this one was simply lost.

Nothing is gone — the code reads out of `ceeb926^` intact — but the recovery path is history, not a branch, and a plan written against the branch would have failed at step one. The ADR now says so, since the same sentence is in the commit message where it'll be read again.

## What changed

`services/sessions.py` came back **unchanged**: removed for scope, no finding against it. The routes did not — the REST half is typed to ADR-0007, so `sessions` joins the generated surface as the twelfth tag and the Apple clients get a signalling endpoint on the server they're already configured against. The WebSocket stays hand-written per client, for the reason ADR-0007 point 8 already excludes the SSE map variants.

Worth knowing: this is the backend's **only** WebSocket route, and always was. `services/outputs.py` has a docstring describing signalling "to the frontend via WebSocket" and carries a `websocket_id` field — no such route has ever existed. So this isn't a socket beside others; whatever a long-lived connection implies for deployment arrives with it.

**ICE became a route, not just a join payload.** The shelved code exposed `get_ice_servers()` only inside the socket's responses, too late for two callers: the Apple clients need it before joining, and point 7 wants "no TURN configured" said up front rather than discovered as a hang behind symmetric NAT. `GET /sessions/ice-servers` reports `has_turn` explicitly, and the socket now sends it on `create` too — a host should learn that before inviting anyone.

## The guest page had to become a route

The ADR filed this as a follow-up. It couldn't stay one.

`buildShareLink` produces `/listen/{code}` against this origin once the relay is gone — and **there has never been such a route in `App.tsx`**, because the relay served that page itself. Shipping the relay's removal without it would make the one thing a host hands to a friend a 404: the exact defect this repo keeps producing, introduced by the fix for another one.

`GuestListener.tsx` is restored and mounted **outside `AppShell`** — a guest has no profile, no library and no player, and the shell would give them a sidebar to nothing plus an audio engine for a page whose audio arrives over a peer connection. Two things in it were repaired rather than restored: it read the join code from nowhere, and its WebSocket URL rewrote port 3000 to 8000 — a guess at a backend that's been on 4400 for a long time, so it had been wrong for as long as it had been unreachable.

## The honest cost

**A guest must now be able to reach the host's server.** A share link used to work from anywhere; it now works over Tailscale, a tunnel or a public address, and not otherwise. For a listener whose server is on a home NAS behind a router, inviting a friend becomes a networking problem. Every host also now answers the TURN question themselves — `turn_server_*` is in `config.py`, unset by default, and Familiar neither runs one nor promises one.

That's a values decision, not a technical one, and ADR-0036's Alternatives says so plainly: the relay is not broken, it is just not ours.

## Testing

18 backend tests — the shelved file tested the service's dataclasses and nothing that crosses the wire, which is precisely the half that now has a contract. OpenAPI lint green at 12 tags / 265 operations, both operations generate into the Swift client and it builds, web build clean, 1,016 frontend tests passing, lint at baseline.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_014P9p2fvFnyiywBxGkv4gfW