### PR TITLE
Playlists, favourites, listening history and radio — 36 MCP tools

### DIFF
--- a/backend/app/services/llm/executor.py
+++ b/backend/app/services/llm/executor.py
@@ -88,6 +88,12 @@ class ToolExecutor(
             # Web page reading tools
             "fetch_webpage": self._fetch_webpage,
             "create_playlist_from_items": self._create_playlist_from_items,
+            "list_playlists": self._list_playlists,
+            "get_playlist": self._get_playlist,
+            "add_tracks_to_playlist": self._add_tracks_to_playlist,
+            "set_favorite": self._set_favorite,
+            "get_recently_played": self._get_recently_played,
+            "get_radio_suggestions": self._get_radio_suggestions,
             # Track identification tools
             "identify_track": self._identify_track,
             # Analysis tools

--- a/backend/app/services/llm/handlers/discovery.py
+++ b/backend/app/services/llm/handlers/discovery.py
@@ -4,6 +4,7 @@ from __future__ import annotations
 
 import asyncio
 import logging
+from datetime import timedelta
 from typing import TYPE_CHECKING, Any
 
 from sqlalchemy import func, select
@@ -19,6 +20,138 @@ logger = logging.getLogger(__name__)
 
 class DiscoveryHandlersMixin:
     """Mixin providing discovery-related tool handlers."""
+
+    async def _get_recently_played(
+        self: "ToolExecutor",
+        limit: int = 20,
+        days: int | None = None,
+    ) -> dict[str, Any]:
+        """What the listener has actually been playing, newest first.
+
+        **Written against `PlayEvent` rather than reusing anything, because nothing existed.** No
+        endpoint, service or query in this codebase orders listening by time — `get_play_stats`
+        answers "most played", which `filter_tracks(sort_by="play_count")` already reaches. The gap
+        was recency.
+
+        `PlayEvent` is the right source: one row per play, and `ix_play_events_profile_started_at`
+        is exactly this query. `ProfilePlayHistory.last_played_at` holds a single timestamp per
+        track, so it would collapse a track played five times today into one line.
+        """
+        from app.db.models import PlayEvent
+        from app.utils.time import utcnow
+
+        if not self.profile_id:
+            return {"error": "No profile is bound to this session."}
+
+        query = (
+            select(PlayEvent, Track)
+            .join(Track, PlayEvent.track_id == Track.id)
+            .where(
+                PlayEvent.profile_id == self.profile_id,
+                # A file that failed to play is not listening, and treating it as taste would be
+                # actively wrong — the listener never heard it.
+                PlayEvent.outcome != "errored",
+            )
+            .order_by(PlayEvent.started_at.desc())
+            .limit(max(1, min(limit, 100)))
+        )
+        if days:
+            cutoff = utcnow() - timedelta(days=days)
+            query = query.where(PlayEvent.started_at >= cutoff)
+
+        rows = (await self.db.execute(query)).all()
+        plays = []
+        for event, track in rows:
+            entry = self._track_to_dict(track)
+            # `started_at` is naive UTC in the column. Marked explicitly, or the model has no way
+            # to know whether a bare timestamp is local or not.
+            entry["played_at"] = event.started_at.isoformat() + "Z"
+            entry["outcome"] = event.outcome
+            entry["completion_ratio"] = round(event.completion_ratio or 0.0, 2)
+            plays.append(entry)
+
+        return {
+            "plays": plays,
+            "count": len(plays),
+            "note": (
+                "Newest first. `outcome` is 'completed' or 'skipped' — a skip is a weaker signal "
+                "of taste than a completed play, and repeats of the same track appear separately."
+            ),
+        }
+
+    async def _get_radio_suggestions(
+        self: "ToolExecutor",
+        seed_track_id: str,
+        limit: int = 10,
+        profile: str = "radio",
+    ) -> dict[str, Any]:
+        """Familiar's own recommender, seeded from one track.
+
+        Distinct from `find_similar_tracks`, which is a bare cosine-distance neighbour search over
+        the audio embeddings. This runs the ranking engine: the same similarity, **plus** the
+        listener's taste and the negative signal of what they have skipped. It scores better, and
+        the two tools are kept apart in their descriptions so the model is not choosing between
+        them at random.
+
+        Cheaper than it looks — roughly four queries and a 150-row vector search over precomputed
+        embeddings, with no embedding inference and no model load.
+        """
+        from app.services.ambient import get_candidates
+        from app.services.ranking_profiles import get_profile
+
+        ids = self._safe_parse_uuids([seed_track_id])
+        if not ids:
+            return {"error": f"{seed_track_id!r} is not a valid track id."}
+
+        ranking = get_profile(profile if profile in ("radio", "ambient") else "radio")
+        candidates, pool_size, collapsed = await get_candidates(
+            self.db,
+            current_track_id=ids[0],
+            limit=max(1, min(limit, 20)),
+            profile=ranking,
+            profile_id=self.profile_id,
+        )
+        if not candidates:
+            return {
+                "suggestions": [],
+                "note": (
+                    "The recommender found nothing from that seed. Usually it has no audio "
+                    "embedding yet, so there is nothing to be similar to."
+                ),
+            }
+
+        by_id = {
+            t.id: t
+            for t in (
+                await self.db.execute(
+                    select(Track).where(Track.id.in_([c.descriptor.track_id for c in candidates]))
+                )
+            )
+            .scalars()
+            .all()
+        }
+        suggestions = []
+        for candidate in candidates:
+            track = by_id.get(candidate.descriptor.track_id)
+            if track is None:
+                continue
+            entry = self._track_to_dict(track)
+            entry["score"] = round(candidate.compatibility_score, 4)
+            suggestions.append(entry)
+
+        result: dict[str, Any] = {
+            "suggestions": suggestions,
+            "count": len(suggestions),
+            "pool_size": pool_size,
+        }
+        if collapsed:
+            # Said plainly: without an embedding the pool is drawn at random, so the ordering
+            # means nothing and presenting it as a recommendation would be a lie.
+            result["note"] = (
+                "The candidate pool collapsed — the seed has no embedding, so these are close to "
+                "random rather than similar."
+            )
+        return result
 
     async def _search_bandcamp(
         self: "ToolExecutor",

--- a/backend/app/services/llm/handlers/playlists.py
+++ b/backend/app/services/llm/handlers/playlists.py
@@ -21,7 +21,147 @@ logger = logging.getLogger(__name__)
 
 
 class PlaylistHandlersMixin:
-    """Mixin providing playlist-related tool handlers."""
+    """Mixin providing playlist-related tool handlers.
+
+    The read and append handlers below **call the route functions directly** rather than repeating
+    their queries. That is already how this codebase composes them — `crud.py` and `tracks.py` call
+    each other the same way — and it keeps one implementation of dedupe, ordering and the ownership
+    check. The only adaptation needed is loading the `Profile`: routes take the ORM object, and a
+    tool handler holds only `self.profile_id`.
+    """
+
+    async def _profile(self: "ToolExecutor") -> Any:
+        """The `Profile` row the route functions expect."""
+        from app.db.models import Profile
+
+        return await self.db.get(Profile, self.profile_id)
+
+    async def _list_playlists(
+        self: "ToolExecutor",
+        include_auto: bool = True,
+        limit: int = 50,
+    ) -> dict[str, Any]:
+        """The listener's playlists, most recently updated first."""
+        from app.api.routes.playlists.crud import list_playlists
+
+        profile = await self._profile()
+        if profile is None:
+            return {"error": "No profile is bound to this session."}
+
+        # `include_auto` is passed explicitly: the route defaults it with `Query(...)`, which
+        # arrives as a FastAPI object rather than a bool when the function is called directly.
+        playlists = await list_playlists(self.db, profile, include_auto=include_auto)
+
+        # Bounded here because the route is not. It paginates in a UI; a tool result cannot, and a
+        # library with hundreds of auto-generated playlists would bury the answer.
+        shown = [p.model_dump(mode="json") for p in playlists[:limit]]
+        result: dict[str, Any] = {"playlists": shown, "count": len(shown)}
+        if len(playlists) > limit:
+            result["note"] = (
+                f"Showing {limit} of {len(playlists)} playlists, most recently updated first."
+            )
+        return result
+
+    async def _get_playlist(self: "ToolExecutor", playlist_id: str) -> dict[str, Any]:
+        """One playlist and the tracks on it, in order."""
+        from app.api.exceptions import PlaylistNotFoundError
+        from app.api.routes.playlists.crud import get_playlist
+
+        profile = await self._profile()
+        if profile is None:
+            return {"error": "No profile is bound to this session."}
+        ids = self._safe_parse_uuids([playlist_id])
+        if not ids:
+            return {"error": f"{playlist_id!r} is not a valid playlist id."}
+
+        try:
+            detail = await get_playlist(ids[0], self.db, profile)
+        except PlaylistNotFoundError:
+            # Caught rather than raised: the executor's catch-all would render an HTTP exception,
+            # which tells the model nothing it can act on. "No such playlist" is actionable.
+            return {"error": f"No playlist {playlist_id} belongs to this listener."}
+        return detail.model_dump(mode="json")
+
+    async def _add_tracks_to_playlist(
+        self: "ToolExecutor",
+        playlist_id: str,
+        track_ids: list[str],
+    ) -> dict[str, Any]:
+        """Append tracks to a playlist that already exists."""
+        from app.api.exceptions import PlaylistNotFoundError
+        from app.api.routes.playlists.tracks import add_tracks_to_playlist
+
+        profile = await self._profile()
+        if profile is None:
+            return {"error": "No profile is bound to this session."}
+        ids = self._safe_parse_uuids([playlist_id])
+        if not ids:
+            return {"error": f"{playlist_id!r} is not a valid playlist id."}
+        if not track_ids:
+            return {"error": "No track ids were given."}
+
+        before = len(await self._playlist_track_ids(ids[0]))
+        try:
+            detail = await add_tracks_to_playlist(
+                ids[0], self.db, profile, track_ids=track_ids
+            )
+        except PlaylistNotFoundError:
+            return {"error": f"No playlist {playlist_id} belongs to this listener."}
+
+        # Summarised rather than returned whole: the route re-reads the entire playlist, which for
+        # a long one is far more than the model asked for or needs.
+        added = len(detail.tracks) - before
+        return {
+            "playlist_id": str(detail.id),
+            "name": detail.name,
+            "added": added,
+            "track_count": len(detail.tracks),
+            "note": (
+                f"Added {added} of {len(track_ids)} requested; the rest were already on the "
+                f"playlist or matched no track."
+                if added < len(track_ids)
+                else f"Added {added} tracks."
+            ),
+        }
+
+    async def _playlist_track_ids(self: "ToolExecutor", playlist_id: UUID) -> list[UUID]:
+        """Current members, for reporting how many an append actually added."""
+        rows = await self.db.execute(
+            select(PlaylistTrack.track_id).where(PlaylistTrack.playlist_id == playlist_id)
+        )
+        return list(rows.scalars().all())
+
+    async def _set_favorite(
+        self: "ToolExecutor",
+        track_id: str,
+        favorite: bool = True,
+    ) -> dict[str, Any]:
+        """Mark or unmark a track as a favourite.
+
+        **Set semantics, deliberately not a toggle.** `_toggle_local_favorite` is the obvious thing
+        to reuse — it is the only function in that module taking a raw `profile_id` — and it is the
+        wrong primitive here: a tool call that is retried, which happens routinely, would flip the
+        state back, so asking twice to favourite something would un-favourite it. `add_favorite` and
+        `remove_favorite` are already idempotent, which is what a retryable tool needs.
+        """
+        from app.api.exceptions import TrackNotFoundError
+        from app.api.routes.favorites import add_favorite, remove_favorite
+
+        profile = await self._profile()
+        if profile is None:
+            return {"error": "No profile is bound to this session."}
+        ids = self._safe_parse_uuids([track_id])
+        if not ids:
+            return {"error": f"{track_id!r} is not a valid track id."}
+
+        try:
+            if favorite:
+                await add_favorite(ids[0], self.db, profile)
+            else:
+                await remove_favorite(ids[0], self.db, profile)
+        except TrackNotFoundError:
+            return {"error": f"No track {track_id} is in the library."}
+        return {"track_id": track_id, "is_favorite": favorite}
 
     async def _select_diverse_tracks(
         self: "ToolExecutor",

--- a/backend/app/services/llm/tools.py
+++ b/backend/app/services/llm/tools.py
@@ -25,7 +25,7 @@ MUSIC_TOOLS: list[dict[str, Any]] = [
     },
     {
         "name": "find_similar_tracks",
-        "description": "Find tracks sonically similar to a given track, using audio embeddings. Great for 'play more like this' requests.",
+        "description": "Find tracks that SOUND like a given track — nearest neighbours in the audio embedding space, and nothing else. Use it for 'what else sounds like this?'. For a listening session rather than a similarity list, prefer get_radio_suggestions, which adds this listener's taste and what they have skipped.",
         "input_schema": {
             "type": "object",
             "properties": {
@@ -614,6 +614,121 @@ MUSIC_TOOLS: list[dict[str, Any]] = [
             },
             "required": ["url"]
         }
+    },
+    {
+        "name": "list_playlists",
+        "description": (
+            "List this listener's playlists, most recently updated first. Call this BEFORE "
+            "creating a playlist when they refer to one they already have — 'add these to my "
+            "Ambient playlist' needs its id, and creating a second playlist with the same name is "
+            "not what was asked for."
+        ),
+        "input_schema": {
+            "type": "object",
+            "properties": {
+                "include_auto": {
+                    "type": "boolean",
+                    "description": "Include auto-generated playlists. Default true.",
+                },
+                "limit": {"type": "integer", "description": "Maximum playlists to return."},
+            },
+        },
+    },
+    {
+        "name": "get_playlist",
+        "description": (
+            "The tracks on one playlist, in order. Use it to see what is already there before "
+            "adding, and to check what you just created."
+        ),
+        "input_schema": {
+            "type": "object",
+            "properties": {
+                "playlist_id": {"type": "string", "description": "Playlist UUID, from list_playlists."},
+            },
+            "required": ["playlist_id"],
+        },
+    },
+    {
+        "name": "add_tracks_to_playlist",
+        "description": (
+            "Append tracks to a playlist that already exists. Tracks already on the playlist are "
+            "skipped, so this is safe to repeat. Use this rather than create_playlist_from_items "
+            "whenever the listener names a playlist they already have."
+        ),
+        "input_schema": {
+            "type": "object",
+            "properties": {
+                "playlist_id": {"type": "string", "description": "Playlist UUID, from list_playlists."},
+                "track_ids": {
+                    "type": "array",
+                    "items": {"type": "string"},
+                    "description": "Local track UUIDs to append.",
+                },
+            },
+            "required": ["playlist_id", "track_ids"],
+        },
+    },
+    {
+        "name": "set_favorite",
+        "description": (
+            "Mark or unmark a track as a favourite. Setting, not toggling: calling it twice with "
+            "the same value leaves the track in that state, so it is safe to retry. To read "
+            "favourites, use filter_tracks with is_favorite."
+        ),
+        "input_schema": {
+            "type": "object",
+            "properties": {
+                "track_id": {"type": "string", "description": "Local track UUID."},
+                "favorite": {
+                    "type": "boolean",
+                    "description": "True to favourite, false to un-favourite. Default true.",
+                },
+            },
+            "required": ["track_id"],
+        },
+    },
+    {
+        "name": "get_recently_played",
+        "description": (
+            "What this listener has actually played, newest first, one entry per play. Use it for "
+            "'what have I been listening to?' and to ground recommendations in recent listening "
+            "rather than all-time counts. Each entry carries an outcome: a skip is a much weaker "
+            "signal of liking something than a completed play. For all-time favourites use "
+            "filter_tracks with sort_by play_count instead."
+        ),
+        "input_schema": {
+            "type": "object",
+            "properties": {
+                "limit": {"type": "integer", "description": "Maximum plays to return, up to 100."},
+                "days": {
+                    "type": "integer",
+                    "description": "Only plays within this many days. Omit for the most recent regardless of age.",
+                },
+            },
+        },
+    },
+    {
+        "name": "get_radio_suggestions",
+        "description": (
+            "Familiar's own recommender, seeded from one track — what to play NEXT. Unlike "
+            "find_similar_tracks, which is pure sonic similarity, this also weighs this listener's "
+            "taste and the tracks they have skipped, so it is the better choice for building a "
+            "listening session. Needs a seed track id: get one from get_now_playing, "
+            "identify_track, or a previous search."
+        ),
+        "input_schema": {
+            "type": "object",
+            "properties": {
+                "seed_track_id": {"type": "string", "description": "Local track UUID to seed from."},
+                "limit": {"type": "integer", "description": "How many suggestions, up to 20."},
+                "profile": {
+                    "type": "string",
+                    "enum": ["radio", "ambient"],
+                    "description": "'radio' follows taste more strongly; 'ambient' favours continuity and low disruption.",
+                },
+            },
+            "required": ["seed_track_id"],
+        },
     },
     {
         "name": "create_playlist_from_items",

--- a/backend/tests/test_llm_library_tools.py
+++ b/backend/tests/test_llm_library_tools.py
@@ -1,0 +1,179 @@
+"""Tests for the playlist, favourite, history and radio tools.
+
+Most of what these tools do is delegate to route functions that are already tested. What is *not*
+covered elsewhere are the two decisions specific to being called by a language model, and both fail
+silently if they regress:
+
+1. **`set_favorite` sets; it does not toggle.** Tool calls get retried. A toggle turns a retry into
+   an undo, so asking twice to favourite a track would leave it un-favourited — and nothing would
+   report that, because both calls succeeded.
+2. **`get_recently_played` excludes failed playback.** An `errored` event means the listener never
+   heard the track. Counting it as listening feeds a taste signal that is not merely noisy but
+   backwards.
+
+The wiring is checked too — a tool in `MUSIC_TOOLS` with no dispatch entry is a tool the model can
+see, call, and always get an error from.
+"""
+
+from __future__ import annotations
+
+from uuid import uuid4
+
+import pytest
+
+from app.services.llm.executor import ToolExecutor
+from app.services.llm.tools import MUSIC_TOOLS
+
+NEW_TOOLS = [
+    "list_playlists",
+    "get_playlist",
+    "add_tracks_to_playlist",
+    "set_favorite",
+    "get_recently_played",
+    "get_radio_suggestions",
+]
+
+
+class TestWiring:
+    def test_every_new_tool_has_a_schema(self):
+        names = {t["name"] for t in MUSIC_TOOLS}
+        for tool in NEW_TOOLS:
+            assert tool in names, f"{tool} is not in MUSIC_TOOLS"
+
+    def test_every_tool_has_a_dispatch_entry(self):
+        """A schema without a handler is a tool the model can call and never use.
+
+        Checked across the whole list rather than just the new ones: the dispatch map is a dict
+        literal, and nothing else notices when the two drift apart.
+        """
+        executor = ToolExecutor(db=None, profile_id=uuid4())  # type: ignore[arg-type]
+        # `execute` builds the map from `self`, so an unbound name raises here rather than at runtime.
+        import inspect
+
+        source = inspect.getsource(type(executor).execute)
+        for spec in MUSIC_TOOLS:
+            assert f'"{spec["name"]}"' in source, f'{spec["name"]} has no dispatch entry'
+
+    def test_the_new_tools_reach_the_mcp_surface(self):
+        from app.mcp import exposed_tools
+
+        exposed = {t.name for t in exposed_tools()}
+        for tool in NEW_TOOLS:
+            assert tool in exposed
+
+
+class TestFavouriteIsSetNotToggle:
+    """The failure mode: a retried call quietly undoing itself."""
+
+    @pytest.mark.asyncio
+    async def test_favouriting_twice_leaves_it_favourited(self, monkeypatch):
+        calls: list[str] = []
+
+        async def fake_add(track_id, db, profile):
+            calls.append("add")
+
+        async def fake_remove(track_id, db, profile):
+            calls.append("remove")
+
+        monkeypatch.setattr("app.api.routes.favorites.add_favorite", fake_add)
+        monkeypatch.setattr("app.api.routes.favorites.remove_favorite", fake_remove)
+
+        executor = ToolExecutor(db=None, profile_id=uuid4())  # type: ignore[arg-type]
+        monkeypatch.setattr(type(executor), "_profile", _returning(object()))
+
+        track = str(uuid4())
+        first = await executor._set_favorite(track, favorite=True)
+        second = await executor._set_favorite(track, favorite=True)
+
+        assert first["is_favorite"] is True
+        assert second["is_favorite"] is True, "a retry must not undo the first call"
+        assert calls == ["add", "add"], f"expected two adds, got {calls}"
+
+    @pytest.mark.asyncio
+    async def test_unfavouriting_removes(self, monkeypatch):
+        calls: list[str] = []
+
+        async def fake_remove(track_id, db, profile):
+            calls.append("remove")
+
+        monkeypatch.setattr("app.api.routes.favorites.remove_favorite", fake_remove)
+        executor = ToolExecutor(db=None, profile_id=uuid4())  # type: ignore[arg-type]
+        monkeypatch.setattr(type(executor), "_profile", _returning(object()))
+
+        result = await executor._set_favorite(str(uuid4()), favorite=False)
+        assert result["is_favorite"] is False
+        assert calls == ["remove"]
+
+    @pytest.mark.asyncio
+    async def test_a_malformed_id_is_an_answer_not_a_crash(self, monkeypatch):
+        executor = ToolExecutor(db=None, profile_id=uuid4())  # type: ignore[arg-type]
+        monkeypatch.setattr(type(executor), "_profile", _returning(object()))
+        result = await executor._set_favorite("not-a-uuid")
+        assert "error" in result
+
+
+def _returning(value):
+    async def _impl(self):
+        return value
+
+    return _impl
+
+
+class TestRadioReadsTheRealCandidateShape:
+    """This one reached the live server, which is why it is here.
+
+    `_get_radio_suggestions` maps `AmbientCandidate` objects into tool results, and the first
+    version read `candidate.score` — a field that does not exist. The attribute is
+    `compatibility_score`, as `queue.py:643` has always read it. Nothing caught it because the
+    other tests cover *decisions* and this was an assumption about a shape.
+
+    Constructed from the real dataclass rather than a stub, so a rename breaks the test rather than
+    the tool.
+    """
+
+    @pytest.mark.asyncio
+    async def test_maps_a_real_candidate(self, monkeypatch):
+        from app.services.ambient import AmbientCandidate, AmbientDescriptor
+
+        track_id = uuid4()
+        descriptor = AmbientDescriptor.__new__(AmbientDescriptor)
+        object.__setattr__(descriptor, "track_id", track_id)
+        candidate = AmbientCandidate(
+            descriptor=descriptor,
+            compatibility_score=0.87654,
+            key_compatibility=1.0,
+            suggested_start_pct=0.0,
+            suggested_end_pct=1.0,
+        )
+
+        async def fake_candidates(*args, **kwargs):
+            return [candidate], 150, False
+
+        monkeypatch.setattr("app.services.ambient.get_candidates", fake_candidates)
+
+        class FakeTrack:
+            id = track_id
+            title = "Serpentskirt"
+            artist = "Cocteau Twins"
+            album = None
+            genre = None
+            duration_seconds = 200.0
+            year = 1996
+
+        class FakeResult:
+            def scalars(self):
+                class S:
+                    def all(self_inner):
+                        return [FakeTrack()]
+                return S()
+
+        class FakeDB:
+            async def execute(self, *_args, **_kwargs):
+                return FakeResult()
+
+        executor = ToolExecutor(db=FakeDB(), profile_id=uuid4())  # type: ignore[arg-type]
+        result = await executor._get_radio_suggestions(str(track_id), limit=4)
+
+        assert "error" not in result, result
+        assert result["suggestions"][0]["score"] == 0.8765
+        assert result["pool_size"] == 150

--- a/docs/decisions/ADR-0043-the-llm-surface-is-an-mcp-server.md
+++ b/docs/decisions/ADR-0043-the-llm-surface-is-an-mcp-server.md
@@ -32,6 +32,22 @@ Implementation:
   is the way in until then, because stdio needs no auth. Two red herrings were fixed on the way to
   establishing that, both real: `.well-known` probes were being answered `200 text/html` by the SPA
   catch-all, which reads as "yes, I have an authorisation server".
+- **The surface is now 36 tools, not the 26 point 2 counts.** Point 2's *rule* is unchanged and
+  still produces the surface — everything in `MUSIC_TOOLS` except the client-bound and the withheld
+  — but three things have moved under it since acceptance, and the arithmetic in the Decision is a
+  snapshot of the day it was written rather than a cap. `MUSIC_TOOLS` grew from 30 to 36 (playlist
+  read and append, favourites, listening history, radio); `get_now_playing` and `list_players` are
+  MCP-only and are not in `MUSIC_TOOLS` at all, which is why the exposed count equals it exactly
+  rather than falling two short. The exclusions are still exactly two: `get_visible_tracks` and
+  `fetch_webpage`.
+- **Adding those six required no change to the MCP layer**, which is the strongest evidence for
+  point 2's design so far. `exposed_tools()` iterates `MUSIC_TOOLS`, so a schema, a handler and a
+  dispatch line were the whole cost; nothing under `app/mcp/` was touched. The chat-era tool
+  registry turning out to be the right seam is why the port was cheap in the direction this ADR did
+  not have to argue.
+- **Nothing destructive is exposed, by decision rather than by omission** — no delete, no removal,
+  no reorder. An LLM acting on a misread has no undo, and the same operation in the app takes two
+  seconds. Read this as a standing constraint on the additions point 2 permits, not as a gap.
 
 ## Context
 


### PR DESCRIPTION
**Playlists were write-only.** `create_playlist_from_items` was the only playlist tool, so the model could not list, read or append to any playlist — including the one it made thirty seconds earlier. Every request became a *new* playlist, and "add these to my Ambient playlist" was impossible.

Six tools: `list_playlists`, `get_playlist`, `add_tracks_to_playlist`, `set_favorite`, `get_recently_played`, `get_radio_suggestions`. **Nothing destructive** — no delete, no remove, no reorder.

Because `exposed_tools()` iterates `MUSIC_TOOLS`, these needed **no MCP-layer change at all**.

## Four decisions worth reviewing

**`set_favorite` sets; it does not toggle.** `_toggle_local_favorite` is the obvious reuse — the only function in that module taking a raw `profile_id` — and it is the wrong primitive. Tool calls get retried, so a toggle turns a retry into an *undo*: asking twice to favourite something un-favourites it, with both calls reporting success. `add_favorite`/`remove_favorite` are already idempotent. A test fails if anyone switches it back — verified by switching it back.

**`get_recently_played` is written fresh, because nothing existed.** No endpoint, service or query in this codebase orders listening by time. `PlayEvent` is the right source — one row per play, and `ix_play_events_profile_started_at` is exactly this query — where `ProfilePlayHistory.last_played_at` holds one timestamp per track and would collapse repeats.

It deliberately does **not** reuse `get_play_stats`, which has **no `LIMIT` in SQL**: it materialises every play-history row joined to full `Track` entities before slicing in Python. "Most played" is already reachable via `filter_tracks(sort_by="play_count")`, so the gap was recency.

**`get_radio_suggestions` overlaps `find_similar_tracks` and scores better**, so both descriptions now say which is which — one is bare cosine similarity over embeddings, the other runs the ranking engine and adds taste plus negative signal. Without that the model picks between them at random.

**Lists are bounded here because the routes are not.** A route paginates in a UI; a tool result cannot.

## Verified against the real library

```
36 tools
list_playlists      -> Binary Dreamscape (12), Demo Analysis (26), Echoes of Stillness (18)
append round-trip   -> 12 -> 13, repeat added 0   (dedupe holds)
get_recently_played -> today's listening, with outcomes and UTC timestamps
get_radio_suggestions seeded from Cocteau Twins:
   0.8103  Beach House — Levitation
   0.7935  Autumn's Grey Solace — Síscéal
   0.7855  Cocteau Twins — Pandora (for Cindy)
```

The playlist used for the round-trip was restored to its original 12 tracks.

## The one that got away

Radio only worked on the second try. The first version read `candidate.score`, which does not exist — the attribute is `compatibility_score`, as `queue.py:643` has always read it. **My tests covered the two decisions and not the shape assumptions, and a shape assumption is what broke.** There is now a test built from the real `AmbientCandidate` dataclass, so a rename breaks the test rather than the tool.

`dump_openapi.py --check` reports no drift — no REST route changed.

🤖 Generated with [Claude Code](https://claude.com/claude-code)