### PR TITLE
Lyric Storm, and a correction about drei

### DIFF
--- a/docs/decisions/ADR-0034-visualizers-are-drop-in-bundles.md
+++ b/docs/decisions/ADR-0034-visualizers-are-drop-in-bundles.md
@@ -253,15 +253,17 @@ handed across another boundary — rebuilding ADR-0033's channel a second time, 
 - **Tradeoff:** Shipped and local bundles can declare the same `id`. Which wins has to be decided
   in implementation, and whichever it is will surprise someone. *Decided: local wins, and the
   shipped one is listed as shadowed rather than disappearing. See Implementation.*
-- **Tradeoff:** **Point 3 costs 1.59 MB, measured.** Handing `@react-three/drei` to plugins means
-  `import * as Drei`, which defeats tree-shaking: the inlined visualizer document is 1,782 kB
-  without it and 3,375 kB with it. Nothing in the repo needs it — the only built-in that imports
-  drei is `LyricWordField`, which is not registered — and neither does either sample visualizer, so
-  today this is paid by every install to support a plugin nobody has written. It is also the one of
-  the four that a plugin could reasonably carry itself: two Reacts genuinely do not work and two
+- **Tradeoff:** **Point 3 costs 1.59 MB on top of what drei already costs, measured.** Handing
+  `@react-three/drei` to plugins means `import * as Drei`, and a namespace import cannot be
+  tree-shaken: the inlined visualizer document is 1,782 kB without it and 3,375 kB with it.
+  *Corrected from the first version of this line, which claimed nothing in the repo used drei.*
+  `ScrollingLyrics` renders `LyricWordField`, which imports drei's `Text`, and `LyricStorm` renders
+  the same field — so drei ships regardless. What the namespace import buys is the rest of the
+  library, which point 3 promises plugins and which no first-party visualizer needs. It is also the
+  one of the four a plugin could reasonably carry itself: two Reacts genuinely do not work and two
   three.js in one context is waste plus a shared-context problem, but a second drei is only bytes.
-  Worth revisiting if no plugin ever uses it. The document is read from local disk rather than
-  fetched, so the price is app-bundle size and parse time, not download time.
+  The document is read from local disk rather than fetched, so the price is app-bundle size and
+  parse time, not download time.
 - **Tradeoff:** `familiar-plugin-non-places` is not under version control anywhere, and it is the
   only sample that exercises the shared three.js globals — which is to say the only one that would
   catch point 3 being broken. If that directory is lost, the evidence for the part of the contract

--- a/packages/frontend/src/components/Visualizer/VisualizerPicker.tsx
+++ b/packages/frontend/src/components/Visualizer/VisualizerPicker.tsx
@@ -4,7 +4,7 @@
  * Dropdown/popup for selecting between visualizers.
  */
 import { useState, useRef, useEffect } from 'react';
-import { ChevronDown, Sparkles, Image, Type, Video, AlertTriangle } from 'lucide-react';
+import { ChevronDown, Sparkles, Image, Type, Video, AlertTriangle, CloudLightning } from 'lucide-react';
 import { getVisualizers } from './types';
 import { useVisualizerStore } from '../../stores/visualizerStore';
 import { useVisualizerPluginStore } from '../../stores/visualizerPluginStore';
@@ -15,6 +15,7 @@ const visualizerIcons: Record<string, typeof Sparkles> = {
   'beat-tiles': Image,
   'lyrics': Type,
   'music-video': Video,
+  'lyric-storm': CloudLightning,
 };
 
 export function VisualizerPicker() {

--- a/packages/frontend/src/components/Visualizer/visualizers/LyricStorm.tsx
+++ b/packages/frontend/src/components/Visualizer/visualizers/LyricStorm.tsx
@@ -1,0 +1,75 @@
+/**
+ * Lyric Storm — the song's own words, drifting, and nothing else.
+ *
+ * **The word field has existed since the `LyricStorm` "WordParticles" effect, but only ever as a
+ * layer.** `ScrollingLyrics` renders `LyricWordField` behind a synced DOM lyric column, an aurora
+ * glow and a vignette dark enough to keep the column legible — which is right for a lyrics
+ * visualizer and wrong for the field itself. Everything that makes the words readable also makes
+ * them recede.
+ *
+ * This is the same scene with all of that removed: no column, no vignette, no darkening. The words
+ * are the subject rather than the background, so they come forward and stay bright, and the effect
+ * finally gets the name it was originally built under.
+ *
+ * It shares `LyricWordField` rather than copying it. A second implementation would drift from the
+ * first, and the whole point is that this is the same field.
+ */
+import type { VisualizerProps } from '../types';
+import { LyricWordField } from './LyricWordField';
+
+export function LyricStorm({ lyrics, track, artworkUrl }: VisualizerProps) {
+  return (
+    <div className="w-full h-full relative bg-[#050308]">
+      {/*
+        A backdrop, not a scrim. `ScrollingLyrics` puts a heavy radial vignette *over* the field so
+        text stays readable on top of it; here there is nothing on top, so the field gets a plain
+        dark ground and full contrast.
+      */}
+      <div className="absolute inset-0">
+        <LyricWordField lyrics={lyrics} track={track} artworkUrl={artworkUrl} />
+      </div>
+
+      {/*
+        **The empty state is a real state, not an edge case.** `LyricWordField` returns null when it
+        has no words to float, which for a lyrics-driven visualizer is common: an instrumental, or
+        any track whose lyrics have not been fetched. Inside `ScrollingLyrics` that is invisible
+        because the aurora and the lyric column are still there. Here it would be a black rectangle
+        with no explanation — the failure shape this codebase keeps producing — so it says what is
+        happening instead.
+      */}
+      {!hasWords(lyrics, track) && (
+        <div className="absolute inset-0 flex items-center justify-center px-8">
+          <p className="text-zinc-500 text-sm text-center max-w-sm">
+            Lyric Storm floats the song's own words. This track has no lyrics yet — try one with
+            synced lyrics, or pick another visualizer.
+          </p>
+        </div>
+      )}
+    </div>
+  );
+}
+
+/**
+ * Whether `LyricWordField` will find anything to float.
+ *
+ * **This has to match `useWordPool` or the message is a lie in both directions** — claiming no
+ * lyrics over a working field, or a black rectangle with nothing said. So it applies the same three
+ * steps: same source and same fallback to title and artist, same punctuation strip, same
+ * "longer than one character" filter. A track called "4" has a title and still produces no words.
+ *
+ * Duplicated rather than shared because the alternative is exporting a hook and running the whole
+ * pool construction — memoised arrays, `Set` dedupe — to answer a yes/no question. The coupling is
+ * real, and is why it is spelled out here rather than approximated.
+ */
+function hasWords(lyrics: VisualizerProps['lyrics'], track: VisualizerProps['track']): boolean {
+  const source =
+    lyrics && lyrics.length > 0
+      ? lyrics.map((l) => l.text).join(' ')
+      : `${track?.title ?? ''} ${track?.artist ?? ''}`;
+
+  return source
+    .split(/\s+/)
+    .some((word) => word.replace(/[^\p{L}\p{N}']/gu, '').length > 1);
+}
+
+export default LyricStorm;

--- a/packages/frontend/src/components/Visualizer/visualizers/index.ts
+++ b/packages/frontend/src/components/Visualizer/visualizers/index.ts
@@ -23,3 +23,9 @@ registerVisualizer(
   { id: 'music-video', name: 'Music Video', description: 'Search and play synced music videos from YouTube', usesMetadata: false },
   lazy(() => import('./MusicVideo'))
 );
+// The word field on its own, without the lyric column and vignette `ScrollingLyrics` layers over
+// it. Same `LyricWordField` scene, so the two cannot drift apart.
+registerVisualizer(
+  { id: 'lyric-storm', name: 'Lyric Storm', description: 'The song\'s own words drifting through a dark 3D space, reacting to the music', usesMetadata: true },
+  lazy(() => import('./LyricStorm'))
+);

--- a/packages/frontend/src/services/visualizerPluginHost.ts
+++ b/packages/frontend/src/services/visualizerPluginHost.ts
@@ -14,13 +14,15 @@
 import React from 'react';
 import * as THREE from 'three';
 import * as ReactThreeFiber from '@react-three/fiber';
-// **This one import costs 1.59 MB**, measured: the inlined visualizer document is 1,782 kB without
-// it and 3,375 kB with it, because `import *` defeats tree-shaking and no built-in visualizer pulls
-// drei in (`LyricWordField` does, and is not registered). ADR-0034 point 3 names drei as part of the
-// contract, so it is here — but nothing in the repo needs it yet, and the document is inlined into
-// both app bundles, so the price is paid by every install. Worth revisiting if no plugin ever uses
-// it: unlike React and three, a second copy of drei is not *broken*, only wasteful, so it is the one
-// of the four that a plugin could reasonably bundle itself.
+// **This one import costs 1.59 MB on top of what drei already costs**, measured: the inlined
+// visualizer document is 1,782 kB without it and 3,375 kB with it.
+//
+// The earlier version of this comment said "nothing pulls drei in", and that was wrong.
+// `ScrollingLyrics` — registered as `lyrics` — renders `LyricWordField`, which imports drei's
+// `Text`; `LyricStorm` now renders the same field. So drei ships either way. What `import *` adds
+// is the *rest* of the library, because a namespace import cannot be tree-shaken, and ADR-0034
+// point 3 promises plugins the whole of drei rather than the one component this repo happens to
+// use.
 import * as Drei from '@react-three/drei';
 
 import { createLogger } from '../utils/logger';


### PR DESCRIPTION
Keeps `@react-three/drei` and gives it a second first-party consumer. Pairs with [`familiar-apple#92`](https://github.com/seethroughlab/familiar-apple/pull/92).

## First, a correction

**I said twice — and wrote into ADR-0034's tradeoffs and a code comment — that nothing in the repo used drei. That was wrong.** `ScrollingLyrics`, registered as `lyrics`, renders `LyricWordField`, which imports drei's `Text`.

The 1.59 MB measurement was right; the characterisation wasn't. `ScrollingLyrics` pulls one tree-shaken component. `import * as Drei` pulls the whole library, because a namespace import can't be tree-shaken — and that is what point 3 actually costs: plugins get the rest of drei rather than the one component this repo happens to use. Both the comment at the import and the ADR tradeoff now say so, with the correction marked rather than quietly swapped.

## Lyric Storm

`LyricWordField`'s own header describes it as *"a revival of the old LyricStorm WordParticles effect"* — but it has only ever existed as a **layer**, behind a synced DOM lyric column, an aurora glow, and a vignette dark enough to keep that column legible. Everything that makes the words readable also makes them recede.

This is the same scene with all of that removed, under the name it was originally built with. It **shares** `LyricWordField` rather than copying it: a second implementation would drift, and the point is that it's the same field. The vendored bundle grew **2 kB**.

### The empty state

`LyricWordField` returns `null` when it finds no words — ordinary for a lyrics-driven visualizer, on an instrumental or a track whose lyrics haven't been fetched. Inside `ScrollingLyrics` that's invisible, because the aurora and the column are still there. Alone it's a black rectangle with no explanation, which is the failure shape this repo keeps producing. So it says what happened.

`hasWords` duplicates `useWordPool`'s filtering rather than approximating it — same source, same fallback to title and artist, same punctuation strip, same "longer than one character" rule. My first pass only checked that a title existed, which would have claimed "no lyrics" over a perfectly working field for a track called `4`. Sharing a hook to answer a yes/no question would mean running the whole pool construction, so the coupling is spelled out where it lives.

## Testing

1,016 frontend tests, 893 Swift, both apps build, lint at baseline, web build clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_014P9p2fvFnyiywBxGkv4gfW