### PR TITLE
Make the schema drift test actually able to fail

### DIFF
--- a/backend/migrations/versions/20260810_spotify_imported_at_nn.py
+++ b/backend/migrations/versions/20260810_spotify_imported_at_nn.py
@@ -1,0 +1,55 @@
+"""Make spotify_imports.imported_at NOT NULL, as the model has always said.
+
+`SpotifyImport.imported_at` is `Mapped[datetime]` — not `Mapped[datetime | None]` — so the model
+declares NOT NULL. `20260309_spotify_imports.py` created the column with a `server_default` but no
+`nullable=False`, and in SQLAlchemy a `Column` without `nullable` is nullable.
+
+**Nothing caught this for five months**, because the only guard was
+`test_models_in_sync_with_migrations`, which runs `alembic check` against a freshly migrated
+database — and the baseline migration builds fresh databases with `Base.metadata.create_all()`, so
+their schema comes from the models rather than from this DDL. The two never disagreed *there*. On
+the production database, which got the column from the migration, `imported_at` is nullable.
+
+The replacement test in `tests/test_migrations.py` is what would have caught it.
+
+Revision ID: 20260810_spotify_imported_at_nn
+Revises: 20260802_bad_release_dates
+Create Date: 2026-08-10
+"""
+
+from collections.abc import Sequence
+
+import sqlalchemy as sa
+from alembic import op
+
+from migrations.helpers import column_exists, table_exists
+
+revision: str = "20260810_spotify_imported_at_nn"
+down_revision: str | None = "20260802_bad_release_dates"
+branch_labels: str | Sequence[str] | None = None
+depends_on: str | Sequence[str] | None = None
+
+
+def upgrade() -> None:
+    if not (table_exists("spotify_imports") and column_exists("spotify_imports", "imported_at")):
+        return
+
+    # Backfill before tightening. The `server_default` means rows written through the app always
+    # have a value, but a row inserted with an explicit NULL would block the ALTER — and failing a
+    # deploy over one nullable timestamp is a worse outcome than stamping it with now().
+    op.execute(
+        sa.text("UPDATE spotify_imports SET imported_at = now() WHERE imported_at IS NULL")
+    )
+    op.alter_column(
+        "spotify_imports",
+        "imported_at",
+        existing_type=sa.DateTime(timezone=True),
+        existing_server_default=sa.text("now()"),
+        nullable=False,
+    )
+
+
+def downgrade() -> None:
+    # One-way: widening the column back to nullable would restore the defect, and nothing can be
+    # written that depends on it being nullable in between.
+    pass

--- a/backend/tests/test_migrations.py
+++ b/backend/tests/test_migrations.py
@@ -7,6 +7,7 @@ survive downgrade/upgrade round-trip cycles.
 """
 
 import ast
+import os
 import re
 import subprocess
 import sys
@@ -98,38 +99,161 @@ def test_migrations_history() -> None:
     assert "baseline" in output.lower() or "->" in output, f"Expected migration history: {output}"
 
 
-def test_models_in_sync_with_migrations(client: TestClient) -> None:
-    """Verify SQLAlchemy models match the database schema after migrations.
+def test_fresh_database_migrates_to_head_cleanly(client: TestClient) -> None:
+    """A fresh database ends up at head with a schema matching the models.
 
-    This catches schema drift - when model columns don't have corresponding
-    migrations. Runs alembic autogenerate and fails if changes are detected.
+    **This cannot detect schema drift, and used to claim it could.** The baseline migration runs
+    `Base.metadata.create_all()`, so a fresh database's schema is generated from the very models
+    `alembic check` then compares it against — they agree by construction, whatever the incremental
+    migrations say. It stayed green for five months while `spotify_imports.imported_at` was NOT NULL
+    in the model and nullable in every real database.
+
+    What it does verify is still worth having: a new install reaches head without a migration
+    erroring, and nothing in the model layer is unrepresentable in Postgres. The drift question is
+    `test_incremental_migrations_match_the_models` below.
     """
-    backend_dir = Path(__file__).parent.parent
-
-    # First ensure migrations are applied
-    subprocess.run(
-        [sys.executable, "-m", "alembic", "upgrade", "head"],
-        cwd=backend_dir,
-        capture_output=True,
-        text=True,
+    upgrade = _alembic_run("upgrade", "head")
+    # Checked, unlike before — a failed upgrade used to fall through to `alembic check` and be
+    # reported as confusing schema drift rather than as the upgrade failure it was.
+    assert upgrade.returncode == 0, (
+        f"alembic upgrade head failed:\n{upgrade.stdout}\n{upgrade.stderr}"
     )
 
-    # Run alembic check to detect schema drift
-    # This compares models against the actual database schema
-    result = subprocess.run(
-        [sys.executable, "-m", "alembic", "check"],
-        cwd=backend_dir,
-        capture_output=True,
-        text=True,
+    result = _alembic_run("check")
+    assert result.returncode == 0, (
+        f"Fresh database does not match the models!\n{result.stdout}\n{result.stderr}"
     )
 
-    # alembic check returns 0 if no changes needed, 1 if changes detected
-    if result.returncode != 0:
-        assert False, (
-            f"Models are out of sync with migrations!\n"
-            f"Run 'alembic revision --autogenerate -m \"description\"' to create a migration.\n"
-            f"alembic check output:\n{result.stdout}\n{result.stderr}"
+
+def _post_baseline_ddl() -> tuple[set[str], dict[str, set[str]]]:
+    """What the migrations after the baseline are supposed to build.
+
+    Parsed from source rather than executed, because the question is what the *DDL* says — running
+    it is what the test does next.
+    """
+    versions = Path(__file__).parent.parent / "migrations" / "versions"
+    tables: set[str] = set()
+    columns: dict[str, set[str]] = {}
+    for path in versions.glob("*.py"):
+        if "baseline" in path.name:
+            continue
+        source = path.read_text()
+        tables |= set(re.findall(r'create_table\(\s*["\']([a-z_]+)', source))
+        for table, column in re.findall(
+            r'add_column\(\s*["\']([a-z_]+)["\']\s*,\s*sa\.Column\(\s*["\']([a-z_]+)', source
+        ):
+            columns.setdefault(table, set()).add(column)
+    # A column added to a table the same set of migrations creates is already covered by the table.
+    return tables, {t: c for t, c in columns.items() if t not in tables}
+
+
+def test_incremental_migrations_match_the_models() -> None:
+    """The migrations' own DDL agrees with the models it claims to implement.
+
+    **This is the drift guard the suite did not have.** It builds a database the way a *real* one
+    got there: create the full schema from the models so foreign keys resolve, drop exactly what the
+    post-baseline migrations are supposed to build, stamp the baseline instead of running it, then
+    upgrade. Every `create_table` and `add_column` written since the baseline therefore executes for
+    real, and its DDL can be compared against the model.
+
+    Only post-baseline objects are compared. Anything predating the baseline has no frozen DDL to
+    check against — `create_all` is all there is — and pretending otherwise would be the same
+    dishonesty this replaces.
+    """
+    sa = pytest.importorskip("sqlalchemy")
+    from app.config import settings
+    from app.db.models import Base
+
+    sync_url = settings.sync_database_url
+    scratch = "familiar_migration_check"
+    admin_url = sync_url.rsplit("/", 1)[0] + "/postgres"
+
+    admin = sa.create_engine(admin_url, isolation_level="AUTOCOMMIT")
+    try:
+        with admin.connect() as conn:
+            conn.execute(sa.text(f"DROP DATABASE IF EXISTS {scratch}"))
+            conn.execute(sa.text(f"CREATE DATABASE {scratch}"))
+    except Exception as exc:  # pragma: no cover - permissions vary by deployment
+        pytest.skip(f"cannot create a scratch database: {exc}")
+
+    scratch_url = sync_url.rsplit("/", 1)[0] + f"/{scratch}"
+    engine = sa.create_engine(scratch_url, isolation_level="AUTOCOMMIT")
+    try:
+        with engine.connect() as conn:
+            conn.execute(sa.text("CREATE EXTENSION IF NOT EXISTS vector"))
+            conn.execute(sa.text("CREATE EXTENSION IF NOT EXISTS pg_trgm"))
+
+        new_tables, new_columns = _post_baseline_ddl()
+        assert new_tables, "parsed no post-baseline tables — the DDL regex has gone stale"
+
+        Base.metadata.create_all(engine)
+        with engine.connect() as conn:
+            for table in sorted(new_tables):
+                conn.execute(sa.text(f"DROP TABLE IF EXISTS {table} CASCADE"))
+            for table, cols in sorted(new_columns.items()):
+                for column in sorted(cols):
+                    conn.execute(
+                        sa.text(
+                            f"ALTER TABLE IF EXISTS {table} DROP COLUMN IF EXISTS {column} CASCADE"
+                        )
+                    )
+
+        env = {
+            **os.environ,
+            "DATABASE_URL": scratch_url.replace("postgresql://", "postgresql+asyncpg://"),
+        }
+        for args in (("stamp", "20241231_000000_baseline"), ("upgrade", "head")):
+            result = subprocess.run(
+                [sys.executable, "-m", "alembic", *args],
+                cwd=Path(__file__).parent.parent,
+                capture_output=True,
+                text=True,
+                env=env,
+            )
+            assert result.returncode == 0, (
+                f"alembic {args[0]} failed on the scratch database:\n"
+                f"{result.stdout}\n{result.stderr}"
+            )
+
+        inspector = sa.inspect(engine)
+        actual = {
+            table: {c["name"]: c for c in inspector.get_columns(table)}
+            for table in inspector.get_table_names()
+        }
+
+        problems: list[str] = []
+        for name, table in Base.metadata.tables.items():
+            expected = (
+                {c.name for c in table.columns} if name in new_tables
+                else new_columns.get(name, set())
+            )
+            if not expected:
+                continue
+            if name not in actual:
+                problems.append(f"{name}: no migration creates this table")
+                continue
+            for column in table.columns:
+                if column.name not in expected:
+                    continue
+                got = actual[name].get(column.name)
+                if got is None:
+                    problems.append(f"{name}.{column.name}: no migration adds this column")
+                elif bool(got["nullable"]) != bool(column.nullable):
+                    problems.append(
+                        f"{name}.{column.name}: migration says nullable={got['nullable']}, "
+                        f"model says nullable={column.nullable}"
+                    )
+
+        assert not problems, (
+            "Migration DDL disagrees with the models. A fresh install will not notice — its schema "
+            "comes from `create_all` — but every existing database has the migration's version:\n  "
+            + "\n  ".join(sorted(problems))
         )
+    finally:
+        engine.dispose()
+        with admin.connect() as conn:
+            conn.execute(sa.text(f"DROP DATABASE IF EXISTS {scratch}"))
+        admin.dispose()
 
 
 def test_docker_health_check_endpoint(client: TestClient) -> None:


### PR DESCRIPTION
`test_models_in_sync_with_migrations` claimed to catch drift between the models and the migrations, and **could not**.

The baseline migration builds a fresh database with `Base.metadata.create_all()`, so `alembic check` compared the models against a schema generated from those same models. Agreement by construction, whatever the incremental migrations say.

It was green for five months while this was true:

| | `spotify_imports.imported_at` |
|---|---|
| Fresh database (CI) | `NOT NULL` — from `create_all` |
| **Production (NAS)** | **nullable** — from `20260309_spotify_imports.py` |

Both at the same alembic head, `20260802_bad_release_dates`. The migration wrote the column with a `server_default` and no `nullable=False`; the model has always said `Mapped[datetime]`, which is NOT NULL.

## The replacement

`test_incremental_migrations_match_the_models` builds a database the way a real one got there:

1. Create the full schema from the models, so foreign keys resolve (`tracks` references `artists`, which is itself post-baseline).
2. Drop exactly what the post-baseline migrations are supposed to build — 14 tables and 27 added columns, parsed from the migration source.
3. **Stamp** the baseline rather than running it.
4. `upgrade head`, so every `create_table` and `add_column` since the baseline executes for real.
5. Compare each of those objects against the model it implements.

**Verified to fail.** I neutered the accompanying migration and watched it report `spotify_imports.imported_at: migration says nullable=True, model says nullable=False`, then pass with it restored. A guard nobody has ever seen fail is exactly what is being replaced, so this one is not shipping on the assumption that it works.

Only post-baseline objects are compared. Anything older has no frozen DDL to check against — `create_all` is all there is — and pretending otherwise would repeat the dishonesty.

## Also

- `20260810_spotify_imported_at_nn.py` fixes the drift it found. Production has one row with a non-null value, so the tightening is safe; the migration backfills first anyway, because failing a deploy over one nullable timestamp is worse than stamping it.
- The old test stays, renamed to what it actually verifies — a new install reaches head without erroring — with its limits written down.
- It now checks the return code of `alembic upgrade head`, which it previously discarded. A failed upgrade fell through to `alembic check` and got reported as confusing schema drift rather than as the upgrade failure it was.

`37 passed, 9 skipped` in `test_migrations.py`; ruff, mypy, migration lint and `openapi-check` clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_014P9p2fvFnyiywBxGkv4gfW