### PR TITLE
Stop is_auto_generated acting as a capability

### DIFF
--- a/backend/app/api/routes/playlists/recommendations.py
+++ b/backend/app/api/routes/playlists/recommendations.py
@@ -6,7 +6,7 @@ from fastapi import APIRouter, Query
 from pydantic import BaseModel
 
 from app.api.deps import DbSession, RequiredProfile
-from app.api.exceptions import PlaylistNotFoundError, ValidationError
+from app.api.exceptions import PlaylistNotFoundError
 from app.api.routes._external_albums_schemas import (
     ExternalAlbumResponse,
     ExternalAlbumsResponse,
@@ -58,16 +58,19 @@ async def get_playlist_recommendations(
 ) -> RecommendationsResponse:
     """Get recommendations based on a playlist's content.
 
-    Only available for auto-generated (AI) playlists.
-    Uses Last.fm for similar artists/tracks, with Bandcamp as fallback.
+    Available for any playlist. Uses Last.fm for similar artists/tracks, with Bandcamp as fallback.
+
+    **This used to answer 400 unless the playlist was auto-generated**, on the assumption that a
+    generated playlist has richer semantics to seed from. It does not — recommendations come from the
+    tracks, and a hand-made playlist has tracks. The gate also contradicted the sibling endpoint
+    below, whose docstring had already noted it worked "for any playlist … unlike the sibling
+    ``/recommendations`` endpoint which is AI-only". Someone documented the inconsistency rather than
+    removing it; this removes it.
     """
     playlist = await db.get(Playlist, playlist_id)
 
     if not playlist or playlist.profile_id != profile.id:
         raise PlaylistNotFoundError()
-
-    if not playlist.is_auto_generated:
-        raise ValidationError("Recommendations only available for AI-generated playlists")
 
     service = RecommendationsService(db)
     try:

--- a/backend/openapi.json
+++ b/backend/openapi.json
@@ -24230,7 +24230,7 @@
     },
     "/api/v1/playlists/{playlist_id}/recommendations": {
       "get": {
-        "description": "Get recommendations based on a playlist's content.\n\nOnly available for auto-generated (AI) playlists.\nUses Last.fm for similar artists/tracks, with Bandcamp as fallback.",
+        "description": "Get recommendations based on a playlist's content.\n\nAvailable for any playlist. Uses Last.fm for similar artists/tracks, with Bandcamp as fallback.\n\n**This used to answer 400 unless the playlist was auto-generated**, on the assumption that a\ngenerated playlist has richer semantics to seed from. It does not \u2014 recommendations come from the\ntracks, and a hand-made playlist has tracks. The gate also contradicted the sibling endpoint\nbelow, whose docstring had already noted it worked \"for any playlist \u2026 unlike the sibling\n``/recommendations`` endpoint which is AI-only\". Someone documented the inconsistency rather than\nremoving it; this removes it.",
         "operationId": "playlists_get_playlist_recommendations",
         "parameters": [
           {

--- a/backend/tests/test_api_playlists_integration.py
+++ b/backend/tests/test_api_playlists_integration.py
@@ -85,7 +85,15 @@ class TestRemoveItem:
 
 class TestRecommendations:
     @pytest.mark.asyncio
-    async def test_recommendations_requires_auto_generated(self, async_db, client, profile_with_headers):
+    async def test_recommendations_work_for_a_hand_made_playlist(self, async_db, client, profile_with_headers):
+        """It used to answer 400 unless the playlist was auto-generated.
+
+        The gate was never defended: recommendations are computed from the playlist's *tracks*, and a
+        hand-made playlist has tracks. The sibling `/recommendations/external-albums` had already
+        documented that it deliberately worked for any playlist "unlike the sibling
+        ``/recommendations`` endpoint which is AI-only" — the inconsistency was written down rather
+        than fixed. This asserts it is gone rather than merely untested.
+        """
         profile, headers = profile_with_headers
         playlist = await insert_test_playlist(
             async_db, profile.id, name="Manual", is_auto_generated=False
@@ -96,7 +104,8 @@ class TestRecommendations:
             f"/api/v1/playlists/{playlist.id}/recommendations",
             headers=headers,
         )
-        assert resp.status_code == 400
+        assert resp.status_code != 400, "a hand-made playlist must not be refused"
+        assert resp.status_code == 200
 
     @pytest.mark.asyncio
     async def test_recommendations_mock_lastfm(self, async_db, client, profile_with_headers):

--- a/docs/decisions/ADR-0049-playlists-are-a-top-level-destination-on-the-mac.md
+++ b/docs/decisions/ADR-0049-playlists-are-a-top-level-destination-on-the-mac.md
@@ -39,11 +39,21 @@ principle — mirror the web sidebar's grouping "rather than inventing a second 
 same two things" — had quietly stopped being followed for playlists while still being followed for
 collections.
 
-**ADR-0048 turned a preference into a scaling problem.** `POST /playlists/generate` saves a playlist
-on *every* "Make a playlist" click. Generated playlists therefore accumulate without bound while
-hand-made ones do not, and each one would otherwise become a permanent sidebar row. On the live
-server today: **6 generated, 1 manual, 3 smart.** A flat list is already dominated by the ones nobody
-chose to keep.
+**ADR-0048 raises a scaling question, and an earlier draft of this ADR answered it with the wrong
+evidence.** `POST /playlists/generate` saves a playlist on *every* "Make a playlist" click, so
+generated playlists can accumulate while hand-made ones do not. Point 3 originally quarantined them
+on that basis, citing **6 generated against 1 manual** as proof it was already happening.
+
+**None of those six came from that mechanism.** Every one is from the retired chat surface, created
+deliberately between 2026-01-27 and 2026-04-30, 9 to 32 tracks each — *Essential IDM Albums*,
+*Crystalline Reverie*, *Neon Pulse Drift*, *Echoes of Stillness*, *Binary Dreamscape*, *Merck Records
+IDM - Like Ilkae*. `select count(*) from playlists where generation_prompt like 'seed:%'` returns
+**0**: nothing has ever been seeded-generated.
+
+So `is_auto_generated` does not mean "disposable byproduct". It means **"made through a feature we
+deleted"**, and those are the listener's real playlists. The single hand-made one, `Demo Analysis`,
+is a test artifact. A count was taken as evidence for a cause that produced none of it, and the
+quarantine built on it hid the collection while leaving the scratch file on show.
 
 ## Decision
 
@@ -55,11 +65,20 @@ chose to keep.
    do. An "All Playlists" row is kept above them, opening the existing `PlaylistsListView`: 200pt of
    sidebar is not where you find one playlist among two hundred, and that list has search.
 
-3. **Generated playlists are quarantined in a collapsible subgroup**, collapsed by default, rather
-   than interleaved with hand-made ones. This is the point that follows from ADR-0048 rather than
-   from taste: a surface that grows by one row per click is not the same kind of thing as a list you
-   curate, and mixing them would make the sidebar mostly disposable within a week of ordinary use.
-   The web app interleaves them today and will meet this problem later.
+3. **Every playlist is listed together, regardless of how it was made.** The sidebar does not group
+   by `is_auto_generated`.
+
+   **This point previously said the opposite** — that generated playlists were quarantined in a
+   collapsed subgroup — and it was wrong on the evidence. See the Context above: the six playlists
+   cited as proof of generate-flooding were not generated that way, and the flag marks a retired
+   feature rather than a disposable playlist. Corrected before acceptance, which is what `proposed`
+   is for.
+
+   The accumulation concern is real but hypothetical, and provenance is the wrong lever for it: how a
+   playlist was made says nothing about whether the listener wants it, and there is **no way to
+   change the flag after creation** — `PlaylistUpdate` carries only `name`, `description` and
+   `auto_download`, so a generated playlist you decide to keep can never become a regular one. A
+   grouping nobody can escape is a filing system, not a preference.
 
 4. **Smart Playlists move into the Playlists section.** They are something you made, not library
    contents. ADR-0013's reason for making them a sidebar item rather than a fifth `BrowseSection`
@@ -100,15 +119,16 @@ chose to keep.
    draws from — at a fraction of the surface area, and because the routing model staying untouched
    is independently verifiable.
 
-2. **A flat list with a `sparkles` badge on generated playlists**, which is what the web app does and
-   what `PlaylistsListView` already does for its rows. Rejected on the arithmetic: 6 of 7 rows would
-   be generated today and the ratio only worsens, so the badge would be marking the majority rather
-   than the exception.
+2. **Quarantining generated playlists in a collapsed subgroup.** This was point 3 as first written,
+   and it shipped before the evidence was checked. Rejected on the numbers above: the flag marks a
+   retired feature rather than a disposable playlist, so the group hid the collection and showed the
+   scratch file. Kept here rather than deleted because the reasoning was plausible and someone will
+   propose it again.
 
-3. **Keep generated playlists out of the sidebar entirely**, reachable only through All Playlists.
-   Rejected because a playlist you just generated would not appear where you would look for it, and
-   ADR-0048 point 6 was explicit that generation *saves* rather than previews precisely so the result
-   is somewhere findable.
+3. **A `sparkles` badge on generated rows in the sidebar**, marking provenance without hiding
+   anything. Rejected as re-asserting a distinction that is only ever interesting once — the badge
+   already exists in `PlaylistsListView`, where a mark on a list you deliberately opened is
+   information rather than a permanent label on a row you use every day.
 
 4. **Leave Playlists as one row and just add a create button.** The smaller change, and it fixes the
    stated complaint. Rejected because it leaves "Library" meaning three things, leaves the Mac
@@ -128,8 +148,8 @@ chose to keep.
   routing model's guarantees are untouched and the claim is checkable rather than asserted.
 - **Positive** — loading the stores at launch also fixes a pre-existing gap: the "Add to playlist"
   submenu was empty until you had visited the Playlists section.
-- **Positive** — the Mac is now ahead of the web app on the one point ADR-0048 makes urgent, so the
-  web has a design to adopt rather than a problem to rediscover.
+- **Positive** — the sidebar shows the listener's actual playlists, which the first version of point
+  3 had collapsed out of sight.
 - **Tradeoff** — the Mac and the phone now arrange playlists differently. This is the same shape as
   ADR-0012 point 1's split between the Mac's sidebar and the phone's `CollectionsView`, and is
   accepted for the same reason: a 200pt column and a 393pt phone are not the same surface.
@@ -140,8 +160,19 @@ chose to keep.
 - **Tradeoff** — the disclosure state is `@State` and resets each launch rather than persisting.
 - **Follow-up** — the phone still cannot create a playlist. Whether it should is an ADR-0013 point 2
   question, not an oversight to be quietly patched.
-- **Follow-up** — the web sidebar still interleaves generated playlists with hand-made ones and will
-  hit point 3's problem. Adopting the same grouping there is the obvious next step.
+- **Follow-up** — the accumulation ADR-0048 makes possible is still unaddressed, and is a real risk
+  once seeded generation is actually used. The lever should be recency, pinning, or an expiry — not
+  provenance, and not a group the listener cannot get out of.
+- **Follow-up** — `is_auto_generated` is read as a *capability* in two places, which nothing defends:
+  `GET /playlists/{id}/recommendations` answers **400** for a hand-made playlist
+  (`recommendations.py:69`), while its sibling `/recommendations/external-albums` documents at
+  `:121-123` that it deliberately works for any playlist; and the web "Add to playlist" picker passes
+  `include_auto=false` (`PlaylistPickerModal.tsx:28`), so on the web a track cannot be added to any
+  of the six playlists above — while the Mac's equivalent menu offers all of them.
+- **Follow-up** — nothing parses `generation_prompt`, and both surfaces that display it
+  (`PlaylistDetail.tsx:526`, `DetailStore.swift:192`) print it raw, so an ADR-0048 playlist shows the
+  listener `seed:album:OK Computer`. The structured form was introduced without updating the two
+  renderers that assumed a sentence.
 - **Follow-up** — two unrelated web defects found while investigating: mobile web filters its
   playlist list to `is_auto_generated`, so a hand-made playlist never appears there
   (`MobileMoreSheet.tsx:49-56`); and the entire "Unsaved" ephemeral-playlist system is unreachable,

--- a/packages/frontend/src/components/MobileNav/MobileMoreSheet.tsx
+++ b/packages/frontend/src/components/MobileNav/MobileMoreSheet.tsx
@@ -19,7 +19,6 @@ import { useOfflineStatus } from '../../hooks/useOfflineStatus';
 import { playlistsApi, smartPlaylistsApi } from '../../api';
 import { queryKeys } from '../../api/queryKeys';
 import { offlineAwareRetry } from '../../api/queryDefaults';
-import type { Playlist } from '../../api';
 
 interface Props {
   onClose: () => void;
@@ -47,11 +46,10 @@ export function MobileMoreSheet({ onClose }: Props) {
   const { isOffline } = useOfflineStatus();
 
   const { data: playlists } = useQuery({
-    queryKey: queryKeys.playlists.ai,
-    queryFn: async () => {
-      const data = await playlistsApi.list(true);
-      return data.filter((p: Playlist) => p.is_auto_generated);
-    },
+    // Every playlist. This filtered to `is_auto_generated`, so a playlist made by hand was
+    // invisible on mobile entirely — the exact inverse of the desktop sidebar, which showed them all.
+    queryKey: queryKeys.playlists.all,
+    queryFn: () => playlistsApi.list(true),
     retry: offlineAwareRetry(isOffline),
   });
 

--- a/packages/frontend/src/components/Playlists/PlaylistDetail.tsx
+++ b/packages/frontend/src/components/Playlists/PlaylistDetail.tsx
@@ -521,7 +521,11 @@ export function PlaylistDetail({ playlistId: playlistIdProp, onBack: onBackProp 
               <Clock className="w-4 h-4" />
               {Math.floor(totalDuration / 60)} min
             </span>
-            {playlist.is_auto_generated && playlist.generation_prompt && (
+            {/* Sentence prompts read as a caption; ADR-0048's `seed:album:OK Computer` does not,
+                and the playlist's own name already says "Based on OK Computer". */}
+            {playlist.is_auto_generated
+              && playlist.generation_prompt
+              && !playlist.generation_prompt.startsWith('seed:') && (
               <span className="text-purple-400/70 truncate max-w-full sm:max-w-xs">
                 "{playlist.generation_prompt}"
               </span>

--- a/packages/frontend/src/components/Playlists/PlaylistPickerModal.tsx
+++ b/packages/frontend/src/components/Playlists/PlaylistPickerModal.tsx
@@ -23,9 +23,17 @@ export function PlaylistPickerModal({ trackIds }: Props) {
   const queryClient = useQueryClient();
   const closePlaylistPicker = useUIStore((s) => s.closePlaylistPicker);
 
+  // `true` — every playlist, including auto-generated ones.
+  //
+  // It passed `false`, which meant "Add to playlist" silently omitted every playlist made through
+  // the old chat surface. Those are real playlists a listener made deliberately, and there is no way
+  // to convert one into a "regular" playlist, so the exclusion was permanent.
+  //
+  // It also collided: this shares `queryKeys.playlists.all` with the sidebar, which asks for `true`.
+  // Same cache key, different parameters — so which set you got depended on which mounted first.
   const { data: playlists = [], isLoading } = useQuery({
     queryKey: queryKeys.playlists.all,
-    queryFn: () => playlistsApi.list(false),
+    queryFn: () => playlistsApi.list(true),
   });
 
   useEffect(() => {


### PR DESCRIPTION
The follow-ups from ADR-0049. Investigating why generated playlists are distinguished at all turned up that the flag is a **provenance label that two pieces of code read as permission** — and neither is defended anywhere.

## Recommendations refused hand-made playlists

`GET /playlists/{id}/recommendations` answered **400** unless `is_auto_generated`, on the assumption that a generated playlist has richer semantics to seed from. It doesn't — recommendations are computed from the playlist's *tracks*, and a hand-made playlist has tracks.

The gate also contradicted the endpoint directly below it, whose docstring already read:

> Available for any playlist (manual, smart, or AI-generated) — unlike the sibling `/recommendations` endpoint which is AI-only.

Someone noticed and documented it rather than removing it. **The test asserting the 400 is inverted rather than deleted**, so the gate's absence is covered rather than merely untested.

## The web picker omitted your real playlists

"Add to playlist" asked for `include_auto=false`, so none of the playlists made through the old chat surface appeared. Since nothing can convert a generated playlist into a regular one, that exclusion was **permanent** — and the Mac's equivalent menu has always offered all of them.

Fixing it resolves a cache collision too: the picker shared `queryKeys.playlists.all` with the sidebar while passing different parameters, so which set you got depended on which component mounted first.

## Mobile web showed *only* generated playlists

The exact inverse of the desktop sidebar. A playlist made by hand was invisible there entirely.

## Both clients printed the raw prompt

ADR-0048 changed `generation_prompt` from a typed sentence to `seed:album:OK Computer` without updating the two renderers that assumed a sentence — so a seeded playlist would show the listener a database value.

Sentences still read as captions (every existing playlist carries one). The structured form is suppressed, because it says in machine vocabulary exactly what the playlist's own title already says in English: ADR-0048's `playlist_name()` calls it "Based on OK Computer".

## Verified

`1465 passed` backend, `990 passed` frontend, `tsc` back to its baseline 13, lint clean, schema regenerated.

Pairs with familiar-apple, which carries the same prompt fix plus the sidebar flattening.

**Not done, deliberately:** the accumulation problem ADR-0048 makes possible. It hasn't happened — nothing has ever been seeded-generated — and the lever should be recency or pinning rather than provenance.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_014P9p2fvFnyiywBxGkv4gfW