### PR TITLE
The web app opens on Settings, and stops duplicating the native clients

### DIFF
--- a/packages/frontend/src/App.tsx
+++ b/packages/frontend/src/App.tsx
@@ -19,19 +19,15 @@ import { initializeProfile, type Profile } from './services/profileService';
 // Layout
 import { AppShell } from './components/AppShell';
 import { LibraryBrowser } from './components/Library/LibraryBrowser';
-import { HomeScreen } from './components/Home';
 
 // Lazy-loaded route components
+const SettingsPanel = lazy(() => import('./components/Settings').then(m => ({ default: m.SettingsPanel })));
 const ArtistDetail = lazy(() => import('./components/Library/ArtistDetail').then(m => ({ default: m.ArtistDetail })));
 const AlbumDetail = lazy(() => import('./components/Library/AlbumDetail').then(m => ({ default: m.AlbumDetail })));
 const PlaylistDetail = lazy(() => import('./components/Playlists/PlaylistDetail').then(m => ({ default: m.PlaylistDetail })));
 // The guest listener (ADR-0036). Lazy like every other route component, and worth it here: a guest
 // loads this page and nothing else, and everyone else never loads it at all.
 const GuestListener = lazy(() => import('./components/Guest/GuestListener').then(m => ({ default: m.GuestListener })));
-const FavoritesDetail = lazy(() => import('./components/Playlists/FavoritesDetail').then(m => ({ default: m.FavoritesDetail })));
-const DownloadsDetail = lazy(() => import('./components/Playlists/DownloadsDetail').then(m => ({ default: m.DownloadsDetail })));
-const SmartPlaylistDetail = lazy(() => import('./components/SmartPlaylists/SmartPlaylistDetail').then(m => ({ default: m.SmartPlaylistDetail })));
-const MixTapesList = lazy(() => import('./components/MixTape').then(m => ({ default: m.MixTapesList })));
 
 import { MixTapeProgressWatcher } from './components/MixTape';
 
@@ -309,7 +305,18 @@ function App() {
 
           {/* Main app routes inside AppShell */}
           <Route element={<AppShell />}>
-            <Route path="/home" element={<HomeScreen />} />
+            {/* Settings is the point of the web app now (docs/WEB-PARITY.md), so it is a page
+                with a URL rather than a modal you could not link to or bookmark. */}
+            <Route path="/settings" element={
+              <Suspense fallback={<LazyLoadSpinner />}>
+                <div className="p-4 sm:p-6 max-w-4xl mx-auto">
+                  {/* A page needs a title where the modal had a chrome header. The E2E helper also
+                      waits on this heading, so it is load-bearing as well as ordinary good sense. */}
+                  <h2 className="text-lg font-semibold mb-4">Settings</h2>
+                  <SettingsPanel />
+                </div>
+              </Suspense>
+            } />
             {/* Library browser views */}
             {BROWSER_ROUTES.map(({ path, browserId }) => (
               <Route
@@ -332,16 +339,6 @@ function App() {
             } />
 
             {/* Collections */}
-            <Route path="/favorites" element={
-              <Suspense fallback={<LazyLoadSpinner />}>
-                <FavoritesDetail />
-              </Suspense>
-            } />
-            <Route path="/downloads" element={
-              <Suspense fallback={<LazyLoadSpinner />}>
-                <DownloadsDetail />
-              </Suspense>
-            } />
 
             {/* Playlists */}
             <Route path="/playlists/:id" element={
@@ -349,21 +346,11 @@ function App() {
                 <PlaylistDetail />
               </Suspense>
             } />
-            <Route path="/smart-playlists/:id" element={
-              <Suspense fallback={<LazyLoadSpinner />}>
-                <SmartPlaylistDetail />
-              </Suspense>
-            } />
             {/* Mix Tapes */}
-            <Route path="/mixtapes" element={
-              <Suspense fallback={<LazyLoadSpinner />}>
-                <MixTapesList />
-              </Suspense>
-            } />
 
             {/* Default redirect */}
-            <Route index element={<Navigate to="/home" replace />} />
-            <Route path="*" element={<Navigate to="/home" replace />} />
+            <Route index element={<Navigate to="/settings" replace />} />
+            <Route path="*" element={<Navigate to="/settings" replace />} />
           </Route>
         </Routes>
       </QueryClientProvider>

--- a/packages/frontend/src/__tests__/navigationIntegrity.test.ts
+++ b/packages/frontend/src/__tests__/navigationIntegrity.test.ts
@@ -6,7 +6,7 @@
  * (which silently falls through to the catch-all redirect).
  */
 import { describe, it, expect, beforeAll } from 'vitest';
-import { BROWSER_ROUTES, LIBRARY_ITEMS } from '../routes';
+import { BROWSER_ROUTES, LIBRARY_ITEMS, PARKED_BROWSERS } from '../routes';
 import { getBrowser, getBrowsers } from '../components/Library/types';
 
 // Trigger all browser registrations via side-effect imports
@@ -54,11 +54,41 @@ describe('navigation integrity', () => {
     expect(paths.length).toBe(unique.size);
   });
 
-  it('registered browsers are reachable via at least one route', () => {
+  it('registered browsers are reachable, or explicitly parked', () => {
+    // The web app is being reduced to management (docs/WEB-PARITY.md), so some browsers are
+    // deliberately unmounted while their code stays — one commit to revert if something is missed.
+    //
+    // Naming them in `PARKED_BROWSERS` is what keeps this guard useful: an *accidentally*
+    // unreachable browser still fails, because the allowance is a list rather than a switch.
     const routedBrowserIds = new Set<string>(BROWSER_ROUTES.map((r) => r.browserId));
 
     for (const id of registeredBrowserIds) {
-      expect(routedBrowserIds.has(id), `Registered browser "${id}" has no route in BROWSER_ROUTES — it is unreachable`).toBe(true);
+      const reachable = routedBrowserIds.has(id);
+      const parked = id in PARKED_BROWSERS;
+      expect(
+        reachable || parked,
+        `Registered browser "${id}" has no route and is not in PARKED_BROWSERS — it is unreachable by accident`,
+      ).toBe(true);
+    }
+  });
+
+  it('every parked browser is actually registered', () => {
+    // Otherwise the list becomes a graveyard of names that no longer mean anything — the same rot
+    // that made keeping the whole web app as "documentation" a bad idea.
+    for (const id of Object.keys(PARKED_BROWSERS)) {
+      expect(
+        registeredBrowserIds.has(id),
+        `PARKED_BROWSERS lists "${id}", which is not a registered browser — delete the line`,
+      ).toBe(true);
+    }
+  });
+
+  it('no browser is both routed and parked', () => {
+    for (const route of BROWSER_ROUTES) {
+      expect(
+        route.browserId in PARKED_BROWSERS,
+        `"${route.browserId}" has a route and is also parked — one of the two is wrong`,
+      ).toBe(false);
     }
   });
 });

--- a/packages/frontend/src/components/AppShell.tsx
+++ b/packages/frontend/src/components/AppShell.tsx
@@ -5,7 +5,7 @@
  * PlayerBar (full width, bottom)
  */
 import { useState, useEffect, useRef, lazy, Suspense } from 'react';
-import { Outlet } from 'react-router-dom';
+import { useNavigate, Outlet } from 'react-router-dom';
 import { ScrollContainerContext } from '../hooks/useScrollContainer';
 import { Loader2 } from 'lucide-react';
 import { useLastfmCallback } from '../hooks/useLastfmCallback';
@@ -28,7 +28,6 @@ import { useListeningSession } from '../hooks/useListeningSession';
 
 // Lazy-loaded components
 const FullPlayer = lazy(() => import('./FullPlayer').then(m => ({ default: m.FullPlayer })));
-const SettingsPanel = lazy(() => import('./Settings').then(m => ({ default: m.SettingsPanel })));
 const QueueView = lazy(() => import('./Queue').then(m => ({ default: m.QueueView })));
 const AmbientScreen = lazy(() => import('./Ambient').then(m => ({ default: m.AmbientScreen })));
 const SessionPanel = lazy(() => import('./Sessions/SessionPanel').then(m => ({ default: m.SessionPanel })));
@@ -42,16 +41,15 @@ function LazyLoadSpinner() {
 }
 
 export function AppShell() {
+  const navigate = useNavigate();
   const scrollContainerRef = useRef<HTMLDivElement>(null);
   const [fullPlayerMounted, setFullPlayerMounted] = useState(false);
 
   // UI store
   const rightPanel = useUIStore((s) => s.rightPanel);
-  const showSettings = useUIStore((s) => s.showSettings);
   const showFullPlayer = useUIStore((s) => s.showFullPlayer);
   const toggleRightPanel = useUIStore((s) => s.toggleRightPanel);
   const closeRightPanel = useUIStore((s) => s.closeRightPanel);
-  const setShowSettings = useUIStore((s) => s.setShowSettings);
   const setShowFullPlayer = useUIStore((s) => s.setShowFullPlayer);
   const showAmbientScreen = useUIStore((s) => s.showAmbientScreen);
   const setShowAmbientScreen = useUIStore((s) => s.setShowAmbientScreen);
@@ -70,7 +68,7 @@ export function AppShell() {
   }, [showFullPlayer, fullPlayerMounted]);
 
   // One-time initialization (audio engine, sync, logging, hydration, events, triple-tap)
-  useAppBootstrap({ setShowSettings, setShowFullPlayer, closeRightPanel });
+  useAppBootstrap({ navigate, setShowFullPlayer, closeRightPanel });
 
   // Handle Last.fm OAuth callback token in URL
   useLastfmCallback();
@@ -81,8 +79,6 @@ export function AppShell() {
     onEscape: () => {
       if (showFullPlayer) {
         setShowFullPlayer(false);
-      } else if (showSettings) {
-        setShowSettings(false);
       } else if (rightPanel) {
         closeRightPanel();
       }
@@ -195,30 +191,6 @@ export function AppShell() {
               <AmbientScreen onClose={() => setShowAmbientScreen(false)} />
             </Suspense>
           </ErrorBoundary>
-        )}
-
-        {/* Settings modal */}
-        {showSettings && (
-          <div className="fixed inset-0 z-40 flex items-center justify-center">
-            <div className="absolute inset-0 bg-black/60" onClick={() => setShowSettings(false)} />
-            <div className={`relative w-full max-w-4xl max-h-[85vh] mx-4 rounded-xl overflow-hidden shadow-2xl ${resolvedTheme === 'light' ? 'bg-white' : 'bg-zinc-900'}`}>
-              <div className={`flex items-center justify-between p-4 border-b ${resolvedTheme === 'light' ? 'border-zinc-200' : 'border-zinc-800'}`}>
-                <h2 className="text-lg font-semibold">Settings</h2>
-                <button
-                  onClick={() => setShowSettings(false)}
-                  className={`p-1.5 rounded-lg transition-colors ${resolvedTheme === 'light' ? 'hover:bg-zinc-100' : 'hover:bg-zinc-800'}`}
-                  aria-label="Close settings"
-                >
-                  <svg className="w-5 h-5" viewBox="0 0 24 24" fill="none" stroke="currentColor" strokeWidth="2"><path d="M18 6L6 18M6 6l12 12" /></svg>
-                </button>
-              </div>
-              <div className="overflow-y-auto max-h-[calc(85vh-4rem)]">
-                <Suspense fallback={<LazyLoadSpinner />}>
-                  <SettingsPanel />
-                </Suspense>
-              </div>
-            </div>
-          </div>
         )}
 
         {/* Mobile session overlay */}

--- a/packages/frontend/src/components/MobileNav/MobileMoreSheet.tsx
+++ b/packages/frontend/src/components/MobileNav/MobileMoreSheet.tsx
@@ -7,15 +7,15 @@
 import { useNavigate, useLocation } from 'react-router-dom';
 import { useQuery } from '@tanstack/react-query';
 import {
-  List, Grid3X3, Map, Sparkles, FileText,
-  Download, Settings, Waves,
+  List, FileText,
+  Settings, Waves,
   ListMusic, X,
 } from 'lucide-react';
 import { useUIStore } from '../../stores/uiStore';
 import { getAmbientSynthBridge } from '../../player/ambient/ambientSynthBridge';
 import { useThemeStore } from '../../stores/themeStore';
 import { useOfflineStatus } from '../../hooks/useOfflineStatus';
-import { playlistsApi, smartPlaylistsApi } from '../../api';
+import { playlistsApi } from '../../api';
 import { queryKeys } from '../../api/queryKeys';
 import { offlineAwareRetry } from '../../api/queryDefaults';
 import type { Playlist } from '../../api';
@@ -24,17 +24,14 @@ interface Props {
   onClose: () => void;
 }
 
+// Trimmed with the desktop sidebar (docs/WEB-PARITY.md). ADR-0002 point 3 already made mobile web a
+// non-target; this stops it advertising destinations that no longer exist.
 const LIBRARY_ITEMS = [
   { path: '/library/tracks', label: 'Tracks', icon: List },
-  { path: '/library/albums', label: 'Albums', icon: Grid3X3 },
-  { path: '/library/music-map', label: 'Music Map', icon: Map },
-  { path: '/library/discover', label: 'Discover', icon: Sparkles },
-  { path: '/library/proposed-changes', label: 'Changes', icon: FileText },
+  { path: '/library/artist-cleanup', label: 'Cleanup', icon: FileText },
 ];
 
-const COLLECTION_ITEMS = [
-  { path: '/downloads', label: 'Downloads', icon: Download },
-];
+const COLLECTION_ITEMS: { path: string; label: string; icon: typeof List }[] = [];
 
 export function MobileMoreSheet({ onClose }: Props) {
   const navigate = useNavigate();
@@ -51,12 +48,6 @@ export function MobileMoreSheet({ onClose }: Props) {
       const data = await playlistsApi.list(true);
       return data.filter((p: Playlist) => p.is_auto_generated);
     },
-    retry: offlineAwareRetry(isOffline),
-  });
-
-  const { data: smartPlaylists } = useQuery({
-    queryKey: queryKeys.smartPlaylists.all,
-    queryFn: () => smartPlaylistsApi.list(),
     retry: offlineAwareRetry(isOffline),
   });
 
@@ -148,21 +139,6 @@ export function MobileMoreSheet({ onClose }: Props) {
           )}
 
           {/* Smart playlists */}
-          {smartPlaylists && smartPlaylists.length > 0 && (
-            <>
-              <div className={sectionClass}>Smart Playlists</div>
-              {smartPlaylists.map((pl) => (
-                <button
-                  key={pl.id}
-                  onClick={() => handleNav(`/smart-playlists/${pl.id}`)}
-                  className={itemClass(`/smart-playlists/${pl.id}`)}
-                >
-                  <Sparkles className="w-5 h-5 flex-shrink-0" />
-                  <span className="flex-1 truncate">{pl.name}</span>
-                </button>
-              ))}
-            </>
-          )}
 
           {/* Ambient mode (mobile only, requires native synth) */}
           {hasAmbientSynth && (

--- a/packages/frontend/src/components/Sidebar/Sidebar.tsx
+++ b/packages/frontend/src/components/Sidebar/Sidebar.tsx
@@ -20,9 +20,9 @@ import { useFavorites } from '../../hooks/useFavorites';
 import { useDownloadedTracks } from '../../hooks/useDownloadedTracks';
 import { useOfflineStatus } from '../../hooks/useOfflineStatus';
 import { useContextMenu } from '../../hooks/useContextMenu';
-import { playlistsApi, smartPlaylistsApi, pendingTracksApi } from '../../api';
+import { playlistsApi, smartPlaylistsApi } from '../../api';
 import { queryKeys } from '../../api/queryKeys';
-import { STALE_TIME, offlineAwareRetry } from '../../api/queryDefaults';
+import { offlineAwareRetry } from '../../api/queryDefaults';
 import type { Playlist, SmartPlaylist } from '../../api';
 import { SidebarPlaylistItem } from './SidebarPlaylistItem';
 import { PlaylistContextMenu } from './PlaylistContextMenu';
@@ -64,7 +64,6 @@ export function Sidebar() {
   const resolvedTheme = useThemeStore((s) => s.resolvedTheme);
   const sidebarCollapsed = useUIStore((s) => s.sidebarCollapsed);
   const setSidebarCollapsed = useUIStore((s) => s.setSidebarCollapsed);
-  const setShowSettings = useUIStore((s) => s.setShowSettings);
 
   // Section collapse state
   const [playlistsExpanded, setPlaylistsExpanded] = useState(true);
@@ -97,15 +96,6 @@ export function Sidebar() {
     favorites: favoritesCount,
     downloads: downloadsCount,
   };
-
-  // Pending review count
-  const { data: pendingStats } = useQuery({
-    queryKey: queryKeys.pendingTracks.stats,
-    queryFn: () => pendingTracksApi.getStats(),
-    staleTime: STALE_TIME.MEDIUM,
-    retry: offlineAwareRetry(isOffline, 1),
-  });
-  const pendingReviewCount = pendingStats?.total_tracks ?? 0;
 
   // Playlists
   const { data: playlists } = useQuery({
@@ -188,7 +178,7 @@ export function Sidebar() {
         </div>
         <div className={`border-t p-1 space-y-0.5 ${dividerClass}`}>
           <button
-            onClick={() => setShowSettings(true)}
+            onClick={() => navigate('/settings')}
             className={`flex items-center justify-center w-full p-2 rounded-lg ${textClass} ${hoverClass}`}
             title="Settings"
           >
@@ -255,11 +245,6 @@ export function Sidebar() {
               >
                 <item.icon className="w-4 h-4 flex-shrink-0" />
                 <span className="truncate flex-1">{item.label}</span>
-                {item.path === '/library/pending-review' && pendingReviewCount > 0 && (
-                  <span className="text-xs px-1.5 py-0.5 rounded-full bg-blue-600 text-white min-w-[1.25rem] text-center">
-                    {pendingReviewCount}
-                  </span>
-                )}
               </Link>
             </div>
           ))}
@@ -399,7 +384,7 @@ export function Sidebar() {
       <div className={`border-t p-2 ${dividerClass}`}>
         <div className="space-y-0.5">
           <button
-            onClick={() => setShowSettings(true)}
+            onClick={() => navigate('/settings')}
             className={`flex items-center gap-3 w-full px-2 py-1.5 rounded-lg text-sm transition-colors ${textClass} ${hoverClass}`}
           >
             <Settings className="w-4 h-4" />

--- a/packages/frontend/src/hooks/useAppBootstrap.ts
+++ b/packages/frontend/src/hooks/useAppBootstrap.ts
@@ -1,3 +1,4 @@
+import type { NavigateFunction } from 'react-router-dom';
 import { useEffect, useRef } from 'react';
 import { useAudioEngine } from '../player/useAudioEngine';
 import { useScrobbling } from './useScrobbling';
@@ -14,7 +15,7 @@ import { createLogger } from '../utils/logger';
 const log = createLogger('AppShell');
 
 interface AppBootstrapDeps {
-  setShowSettings: (v: boolean) => void;
+  navigate: NavigateFunction;
   setShowFullPlayer: (v: boolean) => void;
   closeRightPanel: () => void;
 }
@@ -25,7 +26,7 @@ interface AppBootstrapDeps {
  * custom event listeners, and triple-tap recovery.
  */
 export function useAppBootstrap({
-  setShowSettings,
+  navigate,
   setShowFullPlayer,
   closeRightPanel,
 }: AppBootstrapDeps): void {
@@ -71,10 +72,10 @@ export function useAppBootstrap({
 
   // Listen for navigate-to-settings event
   useEffect(() => {
-    const handler = () => setShowSettings(true);
+    const handler = () => navigate('/settings');
     window.addEventListener('navigate-to-settings', handler);
     return () => window.removeEventListener('navigate-to-settings', handler);
-  }, [setShowSettings]);
+  }, [navigate]);
 
 
   // Hydrate player state from IndexedDB
@@ -95,7 +96,6 @@ export function useAppBootstrap({
           log.info('[AppShell] Triple-tap recovery triggered');
           setShowFullPlayer(false);
           closeRightPanel();
-          setShowSettings(false);
           tapCountRef.current = 0;
         }
       } else {
@@ -108,5 +108,5 @@ export function useAppBootstrap({
       document.addEventListener('touchstart', handleTripleTap);
       return () => document.removeEventListener('touchstart', handleTripleTap);
     }
-  }, [setShowFullPlayer, closeRightPanel, setShowSettings]);
+  }, [setShowFullPlayer, closeRightPanel]);
 }

--- a/packages/frontend/src/routes.ts
+++ b/packages/frontend/src/routes.ts
@@ -3,34 +3,54 @@
  *
  * Extracted to a dependency-free module so they can be imported in tests
  * without pulling in the React component tree.
+ *
+ * ## The web app is being reduced to management (see `docs/WEB-PARITY.md`)
+ *
+ * The Mac and iPhone now cover the listening path, so the browser keeps only what it is uniquely
+ * good for. The retired browsers are **unmounted, not deleted** — their components and registrations
+ * stay, so this is one commit to revert if something turns out to be missed. `PARKED_BROWSERS` below
+ * is what keeps that honest rather than silent.
  */
 
 /** Maps URL path segments to browser registry IDs. */
 export const BROWSER_ROUTES = [
   { path: 'tracks', browserId: 'track-list' },
-  { path: 'artists', browserId: 'artist-list' },
-  { path: 'albums', browserId: 'album-grid' },
-  { path: 'music-map', browserId: 'vibe-map' },
-  { path: 'discover', browserId: 'discover' },
-  { path: 'discover/new-releases', browserId: 'new-releases-detail' },
-  { path: 'proposed-changes', browserId: 'proposed-changes' },
-  { path: 'pending-review', browserId: 'pending-review' },
+  // No native equivalent, and its API tag (`Library Organization`) is not in the generated Swift
+  // client — so this is genuinely browser-only work, not a duplicate of something on the Mac.
   { path: 'artist-cleanup', browserId: 'artist-cleanup' },
 ] as const;
 
+/**
+ * Registered browsers deliberately left without a route.
+ *
+ * `navigationIntegrity.test.ts` asserts every registered browser is reachable — the guard against a
+ * component nobody can get to. Unmounting these breaks that guard on purpose, so they are named here
+ * instead: the test allows exactly this set and nothing else, which means an *accidentally*
+ * unreachable browser still fails the suite.
+ *
+ * Each entry says where the capability went. When one of these is deleted for good, delete its line.
+ */
+export const PARKED_BROWSERS: Record<string, string> = {
+  'artist-list': 'Mac and iPhone both browse artists',
+  'album-grid': 'Mac and iPhone both browse albums',
+  'vibe-map': 'Mac has a native Music Map (ADR-0016 point 3)',
+  discover: 'Mac and iPhone embed this same code via /embed (ADR-0016/0017/0019)',
+  'new-releases-detail': 'no native equivalent; the embed bridge cannot reach it either — see WEB-PARITY.md',
+  'proposed-changes': 'Mac has Proposed Changes (ADR-0013)',
+  'pending-review': 'Mac has Pending Review (ADR-0013)',
+};
+
+/** Where the app opens. Settings, because that is what the browser is for now. */
 export const HOME_ROUTE = {
-  path: '/home',
-  label: 'Home',
+  path: '/settings',
+  label: 'Settings',
 } as const;
 
 /** Sidebar library navigation items. */
 export const LIBRARY_ITEMS = [
+  // Kept as the "simple player": a browser can still find a track and play it, which is what a guest
+  // machine or a second computer needs, and it keeps `WebAudioEngine` and the effects chain
+  // exercised rather than rotting untested.
   { path: '/library/tracks', label: 'Tracks' },
-  { path: '/library/artists', label: 'Artists' },
-  { path: '/library/albums', label: 'Albums' },
-  { path: '/library/music-map', label: 'Music Map' },
-  { path: '/library/discover', label: 'Discover' },
-  { path: '/library/proposed-changes', label: 'Changes' },
-  { path: '/library/pending-review', label: 'Review' },
   { path: '/library/artist-cleanup', label: 'Cleanup' },
 ] as const;

--- a/packages/web/e2e/helpers.ts
+++ b/packages/web/e2e/helpers.ts
@@ -117,12 +117,13 @@ export async function navigateToTab(page: Page, tabName: 'Library' | 'Playlists'
       break;
     }
     case 'Settings': {
-      // Open Settings modal via custom event (same mechanism used by the app internally)
-      // Direct button click is unreliable in CI due to player bar overlay
+      // Settings is a page now, not a modal, but the same custom event still reaches it — the
+      // handler navigates instead of toggling a flag. Kept as an event because a direct button
+      // click is unreliable in CI behind the player bar overlay.
       await page.evaluate(() => {
         window.dispatchEvent(new Event('navigate-to-settings'));
       });
-      // Wait for the lazy-loaded Settings modal to render
+      // Wait for the lazy-loaded Settings page to render
       await page.waitForSelector('h2:has-text("Settings")', { timeout: 10000 });
       break;
     }


### PR DESCRIPTION
> Stacked on #149 (the parity matrix). Merge that first.

Stage 2. **Routes are unmounted, not deleted** — every component and registration stays, so this is one commit to revert if something turns out to be missed. That was the point of staging it: a week of living with the smaller app will say more than any amount of predicting.

## Unmounted

Each with a native equivalent verified in `docs/WEB-PARITY.md`: `/home`, `artists`, `albums`, `music-map`, `discover`, `discover/new-releases`, `proposed-changes`, `pending-review`, `/favorites`, `/downloads`, `/smart-playlists/:id`, `/mixtapes`.

## Kept, each for a reason

- **Settings** — now a page at `/settings`, and where the app opens. It was a modal, so it could not be linked to or bookmarked, which is odd for the thing the web app is now *for*.
- **`/library/tracks`** — the simple player you asked about. A browser can still find a track and play it, which is what a guest machine or a second computer needs, and it keeps `WebAudioEngine` and the effects chain exercised rather than rotting untested.
- **`/library/artist-cleanup`** — no native equivalent, and its API tag isn't in the generated Swift client.
- **`/playlists/:id`** — **the route the matrix saved.** The Mac cannot remove a track from a playlist, rename one, delete one, or reorder.
- **`/listen/:code`** — ADR-0037 was rejected, so sessions are web-only by decision.
- **Artist and album detail** — the kept surfaces link to them, and dangling links are the defect class this codebase keeps finding.

## The guard, kept rather than deleted

`navigationIntegrity.test.ts` asserted every registered browser is reachable — exactly the "component nobody can get to" check this repo needs. Unmounting breaks it on purpose.

Rather than delete it, the parked browsers are named in `PARKED_BROWSERS` with where each capability went, and the test allows **exactly that set**. So an *accidentally* unreachable browser still fails the suite. Two more tests keep the list from rotting: every parked id must still be registered, and nothing may be both routed and parked.

## Verified

`980 tests` (2 new integrity ones), `tsc` at its baseline **13**, lint clean, web build succeeds.

And the check that matters most: **`embed.html` and `visualizer.html` still build with the `familiar-surface` markers** the Apple clients verify before rendering. Discover and the visualizer are loaded from this same bundle by both platforms — breaking them would take out two native screens.

## Known, not fixed here

`screenshots.spec.ts` has two cases pointing at `/library/artists`, which is now unmounted. It's excluded from CI (`--grep-invert="screenshot"`), so nothing is red — but the README screenshots of retired surfaces are now stale, and regenerating them against the reduced app is its own pass.

## After a week

Stage 3 is the ADR, written from what you actually missed rather than what I predicted. ADR-0013 point 1 says the web app "costs nothing to keep"; superseding that honestly needs the evidence, not a forecast.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_014P9p2fvFnyiywBxGkv4gfW