### PR TITLE
Give every self-hosted job a timeout

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -30,6 +30,7 @@ jobs:
   macos-compose-check:
     name: macOS Compose Check
     runs-on: self-hosted
+    timeout-minutes: 15
     steps:
       - uses: actions/checkout@v4
 
@@ -193,6 +194,7 @@ jobs:
   migration-lint:
     name: Migration Lint
     runs-on: self-hosted
+    timeout-minutes: 10
     steps:
       - uses: actions/checkout@v4
 
@@ -215,6 +217,7 @@ jobs:
   backend-lint:
     name: Backend Lint
     runs-on: self-hosted
+    timeout-minutes: 10
     env:
       UV_HTTP_TIMEOUT: '120'
     defaults:
@@ -528,6 +531,7 @@ jobs:
   frontend-lint:
     name: Frontend Lint
     runs-on: self-hosted
+    timeout-minutes: 10
     env:
       NPM_CONFIG_FETCH_RETRIES: '5'
       NPM_CONFIG_FETCH_RETRY_MAXTIMEOUT: '120000'
@@ -561,6 +565,7 @@ jobs:
   frontend-test:
     name: Frontend Test
     runs-on: self-hosted
+    timeout-minutes: 15
     env:
       NPM_CONFIG_FETCH_RETRIES: '5'
       NPM_CONFIG_FETCH_RETRY_MAXTIMEOUT: '120000'
@@ -588,6 +593,7 @@ jobs:
   frontend-build:
     name: Frontend Build
     runs-on: self-hosted
+    timeout-minutes: 15
     env:
       NPM_CONFIG_FETCH_RETRIES: '5'
       NPM_CONFIG_FETCH_RETRY_MAXTIMEOUT: '120000'
@@ -733,6 +739,7 @@ jobs:
     # whether the browser tests run.
     if: ${{ github.event_name != 'push' && !cancelled() }}
     runs-on: [self-hosted, Linux]
+    timeout-minutes: 30
     needs: [docker-build]
     # **Deliberately not `continue-on-error`.** It was, and the reason was sound: the job inherited
     # docker-build's flakiness, so a NAS hiccup would have blocked unrelated merges. Decoupling the


### PR DESCRIPTION
The macOS runner wedged **twice today**. Both times a `Runner.Worker` sat with zero children and a log that had stopped mid-setup — once fetching an action tarball, once inside `ProcessInvokerWrapper` — and both times it held the runner until someone noticed and killed it by hand. The second held it 51 minutes and blocked five PRs across two repos.

**Nothing failed, which is the problem.** A job that has stopped is indistinguishable from one that is slow, and there was no deadline to tell them apart.

## What changed

Seven jobs had no `timeout-minutes`: `macos-compose-check`, `migration-lint`, `backend-lint`, `frontend-lint`, `frontend-test`, `frontend-build`, `e2e-test`. Six already did, so this also makes the file consistent.

Budgets are set from **measured durations across six recent runs**, not guessed:

| Job | Longest observed | Budget |
|---|---|---|
| E2E Tests | 5m | 30 |
| Backend Test (Contract) | 2m | *(already 10)* |
| Frontend Test / Lint | 1m | 15 / 10 |
| Frontend Build | <1m | 15 |
| everything else | <1m | 10–15 |

They only fire when something has stopped, not when it is merely slow.

## What this fixes, and what it doesn't

`timeout-minutes` starts when a job **begins executing**, so it does nothing for jobs *queued* behind a wedge. familiar-apple's build already had a 20-minute budget and still sat pending for most of an hour — it had never started.

What this does is kill the **running** job, which frees the runner, which drains the queue. The help is real but indirect, and worth stating plainly so nobody expects more from it.

## A correction

I had been treating this as a macOS-app-build problem. `frontend-build` runs on `jeffbook`, not the NAS — the self-hosted Mac picks up ordinary frontend work too, so a wedge there blocks anything in the matrix, not just Xcode jobs. That's why the timeouts go on all seven rather than the Xcode ones.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_014P9p2fvFnyiywBxGkv4gfW