### PR TITLE
A blank metadata field clears the tag

### DIFF
--- a/backend/app/api/routes/tracks/metadata.py
+++ b/backend/app/api/routes/tracks/metadata.py
@@ -5,7 +5,7 @@ from typing import Any
 from uuid import UUID
 
 from fastapi import APIRouter
-from pydantic import BaseModel, ConfigDict
+from pydantic import BaseModel, ConfigDict, field_validator
 from sqlalchemy import select
 from sqlalchemy.orm import selectinload
 
@@ -53,6 +53,48 @@ class TrackMetadataUpdateRequest(BaseModel):
 
     # User overrides for analysis values (bpm, key, etc.)
     user_overrides: dict[str, Any] | None = None
+
+    @field_validator(
+        "title",
+        "artist",
+        "album",
+        "album_artist",
+        "genre",
+        "composer",
+        "conductor",
+        "lyricist",
+        "grouping",
+        "comment",
+        "sort_artist",
+        "sort_album",
+        "sort_title",
+        "lyrics",
+        mode="before",
+    )
+    @classmethod
+    def _blank_means_absent(cls, value: Any) -> Any:
+        """A blank string clears the tag rather than storing an empty one.
+
+        Two reasons, and the second is why this lives on the server.
+
+        An empty genre is not a genre. Stored as ``""`` it sorts and groups apart from every track
+        that simply has none, so "no genre" quietly becomes two different things depending on
+        whether somebody once typed in the box and changed their mind.
+
+        And it is the only way the Swift client can clear anything at all.
+        ``Components.Schemas.TrackMetadataUpdateRequest.genre`` is a plain ``String?`` with
+        synthesised ``Codable``, which omits a nil rather than writing ``null`` — so setting the
+        property to nil was indistinguishable from never touching it, and clearing a tag on the Mac
+        reported success and did nothing. The client now sends ``""`` and means it. See
+        ``MetadataClearingTests`` in familiar-apple, which asserts that encoding directly.
+
+        Numeric fields are deliberately not covered: ``year`` and the track and disc numbers are
+        ``int | None``, an empty string is not a number, and there is no blank to interpret.
+        """
+        if not isinstance(value, str):
+            return value
+        stripped = value.strip()
+        return stripped or None
 
 
 class TrackMetadataResponse(BaseModel):

--- a/backend/tests/test_api_tracks.py
+++ b/backend/tests/test_api_tracks.py
@@ -310,3 +310,53 @@ async def test_paging_a_tie_group_returns_every_track_exactly_once(
 
     assert len(seen) == len(set(seen)), "OFFSET paging returned the same row twice"
     assert sorted(seen) == sorted(expected), "paging did not cover every track exactly once"
+
+
+class TestMetadataBlankClears:
+    """A blank field clears the tag rather than storing an empty one.
+
+    The bug this pins was on the client: the Swift `TrackMetadataUpdateRequest.genre` is a plain
+    `String?` with synthesised `Codable`, so a nil is omitted rather than sent as `null`, and
+    "clear this genre" was byte-identical to "change nothing". Clearing a tag on the Mac reported
+    success and did nothing. The client now sends `""`; this is the half that gives it meaning.
+
+    Worth having on this side regardless of the client: an empty-string genre sorts and groups
+    apart from every track that simply has none.
+    """
+
+    def test_a_blank_string_becomes_none(self) -> None:
+        from app.api.routes.tracks.metadata import TrackMetadataUpdateRequest
+
+        assert TrackMetadataUpdateRequest(genre="").genre is None
+
+    def test_whitespace_only_is_also_blank(self) -> None:
+        from app.api.routes.tracks.metadata import TrackMetadataUpdateRequest
+
+        assert TrackMetadataUpdateRequest(genre="   \t ").genre is None
+
+    def test_the_cleared_field_still_counts_as_set(self) -> None:
+        """The load-bearing half. The handler dumps with `exclude_unset=True`, so a field that
+        validated to None must still be *set* or the clear is dropped one layer later."""
+        from app.api.routes.tracks.metadata import TrackMetadataUpdateRequest
+
+        dumped = TrackMetadataUpdateRequest(genre="").model_dump(exclude_unset=True)
+        assert "genre" in dumped
+        assert dumped["genre"] is None
+
+    def test_an_untouched_field_stays_absent(self) -> None:
+        from app.api.routes.tracks.metadata import TrackMetadataUpdateRequest
+
+        dumped = TrackMetadataUpdateRequest(artist="Rachel's").model_dump(exclude_unset=True)
+        assert "genre" not in dumped
+
+    def test_surrounding_whitespace_is_trimmed(self) -> None:
+        from app.api.routes.tracks.metadata import TrackMetadataUpdateRequest
+
+        assert TrackMetadataUpdateRequest(album="  Selenography ").album == "Selenography"
+
+    def test_numbers_are_left_alone(self) -> None:
+        """There is no blank to interpret in an `int | None`, and coercing one would invent a rule."""
+        from app.api.routes.tracks.metadata import TrackMetadataUpdateRequest
+
+        assert TrackMetadataUpdateRequest(year=1999).year == 1999
+        assert TrackMetadataUpdateRequest().model_dump(exclude_unset=True) == {}


### PR DESCRIPTION
Emptying a genre on the Mac reported success and **changed nothing**.

The cause is on the client: the generated `TrackMetadataUpdateRequest.genre` is a plain `Swift.String?` with synthesised `Codable`, so assigning nil **omits the key** rather than writing `null` — making "clear this field" byte-identical to "change nothing". The compiler had been saying so since the editor shipped this morning, in a warning that only surfaced in a TestFlight archive log:

```
warning: left side of nil coalescing operator '??' has non-optional type 'String?',
         so the right side is never used
```

The client now sends `""`. This is the half that gives that meaning.

## Worth having regardless of the client

An empty-string genre sorts and groups apart from every track that simply has none, so "no genre" becomes two different things depending on whether somebody once typed in the box and changed their mind. Values are trimmed for the same reason.

## The load-bearing test

`test_the_cleared_field_still_counts_as_set`. The handler dumps with `exclude_unset=True`, so a field that *validates* to None must still be **set**, or the clear is dropped one layer further down than the one being fixed. Verified by neutering the validator: 4 of the 6 fail, including that one.

## Not covered

Numeric fields. An empty string is not an `int | None` and there is no blank to interpret — the Mac now reports that it can't empty a year rather than quietly dropping the edit.

Paired with familiar-apple's client half; `MetadataClearingTests` there pins the encoding, `TestMetadataBlankClears` here pins the meaning.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_014P9p2fvFnyiywBxGkv4gfW