### PR TITLE
Edits made in Familiar survive the file changing

### DIFF
--- a/backend/app/api/routes/pending_review.py
+++ b/backend/app/api/routes/pending_review.py
@@ -15,6 +15,7 @@ from app.api.deps import DbSession, RequiredProfile
 from app.api.exceptions import TrackNotFoundError, ValidationError
 from app.api.schemas.common import UTCDateTime
 from app.db.models import Track, TrackStatus
+from app.services import metadata_overrides
 
 logger = logging.getLogger(__name__)
 
@@ -262,14 +263,24 @@ async def _get_pending_tracks_in_folder(
     return list(result.scalars().all())
 
 
-def _apply_metadata_overrides(track: Track, overrides: dict[str, Any] | None) -> None:
-    """Apply metadata overrides to a track."""
-    if not overrides:
+def _apply_review_edits(track: Track, edits: dict[str, Any] | None) -> None:
+    """Apply the corrections somebody made while approving a track, and remember they made them.
+
+    Renamed from `_apply_metadata_overrides`, which collided with
+    `services.metadata_overrides` and meant something else entirely — this one applies values from
+    the request, that one is the record of who wins against the file. ADR-0051 notes the collision.
+
+    The recording is the new half: a track approved with a corrected album name is exactly as
+    deliberate an edit as one corrected later through the track editor, and until now only the
+    latter survived the file changing (ADR-0051 point 1).
+    """
+    if not edits:
         return
     allowed = {"artist", "album", "title", "track_number", "year", "album_artist", "genre"}
-    for key, value in overrides.items():
-        if key in allowed:
-            setattr(track, key, value)
+    applied = {key: value for key, value in edits.items() if key in allowed}
+    for key, value in applied.items():
+        setattr(track, key, value)
+    track.metadata_overrides = metadata_overrides.record(track.metadata_overrides, applied)
 
 
 async def _activate_track(db: AsyncSession, track: Track, queue_analysis: bool = True) -> None:
@@ -452,7 +463,11 @@ async def group_approve(
         raise ValidationError("No pending tracks found in folder")
 
     for track in tracks:
-        _apply_metadata_overrides(track, request.metadata_overrides)
+        # `request.metadata_overrides` is the *request's* field — corrections to apply while
+        # approving. Unrelated to `track.metadata_overrides`, the column recording who wins against
+        # the file, despite the identical name. Renaming the request field would break the web app's
+        # approve call, so the collision is documented instead. ADR-0051 notes it too.
+        _apply_review_edits(track, request.metadata_overrides)
         await _activate_track(db, track, request.queue_analysis)
 
     await db.commit()
@@ -562,10 +577,14 @@ async def group_metadata(
         raise ValidationError("No pending tracks found in folder")
 
     _allowed = {"artist", "album", "year", "album_artist", "genre"}
+    applied = {k: v for k, v in request.metadata.items() if k in _allowed}
     for track in tracks:
-        for key, value in request.metadata.items():
-            if key in _allowed:
-                setattr(track, key, value)
+        for key, value in applied.items():
+            setattr(track, key, value)
+        # Correcting a whole folder's album name is the most deliberate edit in the app, and was
+        # the one most exposed: these are freshly-scanned files, so the tags on disk are exactly
+        # what somebody is here to disagree with. ADR-0051 point 1.
+        track.metadata_overrides = metadata_overrides.record(track.metadata_overrides, applied)
 
     await db.commit()
     return {"status": "updated", "count": len(tracks)}
@@ -633,7 +652,7 @@ async def approve_track(
 ) -> dict[str, str]:
     """Approve a single pending track."""
     track = await _get_pending_track(db, track_id)
-    _apply_metadata_overrides(track, request.metadata_overrides)
+    _apply_review_edits(track, request.metadata_overrides)
     await _activate_track(db, track, request.queue_analysis)
     await db.commit()
     return {"status": "approved", "track_id": str(track_id)}
@@ -665,7 +684,7 @@ async def replace_track(
         await _transfer_user_data(db, old_track_id, track_id)
 
     # New track → ACTIVE
-    _apply_metadata_overrides(track, request.metadata_overrides)
+    _apply_review_edits(track, request.metadata_overrides)
     await _activate_track(db, track, request.queue_analysis)
 
     # Old track → SKIPPED
@@ -718,5 +737,6 @@ async def update_track_metadata(
     updates = request.model_dump(exclude_none=True)
     for key, value in updates.items():
         setattr(track, key, value)
+    track.metadata_overrides = metadata_overrides.record(track.metadata_overrides, updates)
     await db.commit()
     return {"status": "updated", "track_id": str(track_id)}

--- a/backend/app/api/routes/tracks/metadata.py
+++ b/backend/app/api/routes/tracks/metadata.py
@@ -12,6 +12,7 @@ from sqlalchemy.orm import selectinload
 from app.api.deps import DbSession
 from app.api.exceptions import TrackNotFoundError
 from app.db.models import Track
+from app.services import metadata_overrides
 
 from . import TrackFeaturesResponse
 
@@ -259,6 +260,10 @@ async def update_track_metadata(
     for field, value in update_data.items():
         if hasattr(track, field):
             setattr(track, field, value)
+
+    # Remember that these were chosen rather than read off the file, so a rescan cannot undo them.
+    # Assigned rather than mutated in place: SQLAlchemy does not notice in-place changes to JSONB.
+    track.metadata_overrides = metadata_overrides.record(track.metadata_overrides, update_data)
 
     # Commit database changes
     await db.commit()

--- a/backend/app/db/models/tracks.py
+++ b/backend/app/db/models/tracks.py
@@ -130,6 +130,23 @@ class Track(Base):
     # Example: {"bpm": 124.0, "key": "Am"} - overrides analysis.features values
     user_overrides: Mapped[dict[str, Any]] = mapped_column(JSONB, default=dict)
 
+    # Tag fields a person corrected in Familiar, and what they set them to.
+    # Example: {"album": "Selenography", "year": None}
+    #
+    # These win over the file. `LibraryScanner._update_track` re-reads a file's tags when its hash
+    # changes and would otherwise overwrite a deliberate correction with whatever the file says —
+    # which is how a re-tag or a re-encode elsewhere silently undid work done here.
+    #
+    # Separate from `user_overrides` on purpose: that one overrides *analysis* values and is merged
+    # only where the key already exists in the feature set. This one answers a different question,
+    # namely who wins between the library and the file, and the answer is recorded per field so an
+    # untouched field still follows the file.
+    #
+    # A null value is a real entry meaning "the person cleared this", not an absent one.
+    metadata_overrides: Mapped[dict[str, Any]] = mapped_column(
+        JSONB, nullable=False, default=dict, server_default=text("'{}'::jsonb")
+    )
+
     # Analysis status
     analyzed_at: Mapped[datetime | None] = mapped_column(DateTime)
     analysis_error: Mapped[str | None] = mapped_column(String(500))

--- a/backend/app/services/bulk_editor.py
+++ b/backend/app/services/bulk_editor.py
@@ -12,6 +12,7 @@ from sqlalchemy import select
 from sqlalchemy.ext.asyncio import AsyncSession
 
 from app.db.models import Track
+from app.services import metadata_overrides
 
 logger = logging.getLogger(__name__)
 
@@ -122,6 +123,12 @@ class BulkEditorService:
                 # Update database
                 for field_name, value in updates.items():
                     setattr(track, field_name, value)
+
+                # Same rule as the single-track edit: a field chosen here beats the file, so a
+                # rescan cannot quietly put the old tags back. See `services/metadata_overrides`.
+                track.metadata_overrides = metadata_overrides.record(
+                    track.metadata_overrides, updates
+                )
 
                 successful += 1
 

--- a/backend/app/services/metadata_overrides.py
+++ b/backend/app/services/metadata_overrides.py
@@ -1,0 +1,73 @@
+"""Who wins between the library and the file, per tag field.
+
+The rule in one sentence: **a field a person corrected in Familiar keeps their value; a field they
+never touched follows the file.**
+
+Before this existed the file always won. `LibraryScanner._update_track` re-reads a file's tags
+whenever its hash changes and assigns title, artist, album, album_artist, the numbers, year and genre
+straight across. Nothing recorded that anyone had corrected them, so re-tagging in another app,
+re-encoding, or replacing a file discarded the correction — silently, and with no way to notice
+except spotting the old spelling again months later.
+
+Kept in one module because three places have to agree about it: the single-track PATCH, the bulk
+editor, and the scanner. Two of those write the record and one reads it, and a rule copied into three
+files is the shape that goes wrong later.
+"""
+
+from typing import Any
+
+# The fields worth protecting: exactly those `_update_track` assigns from the file *and* a person can
+# edit. Deliberately not every editable field — composer, lyrics, the sort fields and the rest are
+# never touched by a rescan, so recording them would pin values against nothing and make the record
+# read as though it meant more than it does.
+OVERRIDABLE_TAG_FIELDS: tuple[str, ...] = (
+    "title",
+    "artist",
+    "album",
+    "album_artist",
+    "track_number",
+    "disc_number",
+    "year",
+    "genre",
+)
+
+
+def record(existing: dict[str, Any] | None, changes: dict[str, Any]) -> dict[str, Any]:
+    """Merge an edit into the stored overrides and return the new mapping.
+
+    `changes` is what the request actually set — already filtered by `exclude_unset`, so a field
+    absent here was not part of the edit and keeps whatever it had.
+
+    A `None` value is recorded rather than skipped: clearing a genre is a decision, and one that a
+    rescan would otherwise undo by refilling it from the file.
+
+    Returns a new dict rather than mutating: SQLAlchemy does not notice in-place changes to a JSONB
+    column without `flag_modified`, and a helper that silently depends on the caller remembering that
+    is a trap. Assign the result.
+    """
+    merged = dict(existing or {})
+    for field, value in changes.items():
+        if field in OVERRIDABLE_TAG_FIELDS:
+            merged[field] = value
+    return merged
+
+
+def apply(track: Any, overrides: dict[str, Any] | None) -> list[str]:
+    """Put a person's corrections back on a track after its tags were re-read from the file.
+
+    Returns the fields that were actually restored, which is what makes this observable in a log and
+    testable without a database.
+
+    Unknown keys are ignored rather than trusted: the column is JSONB and has been through a restore
+    from backup, so a key that is no longer a column is a real possibility and not a reason to fail a
+    library scan.
+    """
+    if not overrides:
+        return []
+
+    restored: list[str] = []
+    for field, value in overrides.items():
+        if field in OVERRIDABLE_TAG_FIELDS and hasattr(track, field):
+            setattr(track, field, value)
+            restored.append(field)
+    return restored

--- a/backend/app/services/metadata_overrides.py
+++ b/backend/app/services/metadata_overrides.py
@@ -52,6 +52,23 @@ def record(existing: dict[str, Any] | None, changes: dict[str, Any]) -> dict[str
     return merged
 
 
+def forget(existing: dict[str, Any] | None, fields: list[str] | tuple[str, ...]) -> dict[str, Any]:
+    """Drop fields from the record, so they follow the file again.
+
+    **An undo is a retraction, not a new opinion** (ADR-0051 point 7). Undoing an accepted proposed
+    change puts the old value back, and recording *that* as an override would pin the field to a
+    value nobody chose — the first accepted suggestion would freeze it forever and the undo would be
+    a lie.
+
+    This is currently the only way a field stops being overridden, which ADR-0051 point 8 states
+    outright rather than leaving to be discovered.
+    """
+    remaining = dict(existing or {})
+    for field in fields:
+        remaining.pop(field, None)
+    return remaining
+
+
 def apply(track: Any, overrides: dict[str, Any] | None) -> list[str]:
     """Put a person's corrections back on a track after its tags were re-read from the file.
 

--- a/backend/app/services/proposed_changes.py
+++ b/backend/app/services/proposed_changes.py
@@ -19,6 +19,7 @@ from app.db.models import (
     ProposedChange,
     Track,
 )
+from app.services import metadata_overrides
 from app.utils.time import utcnow
 
 logger = logging.getLogger(__name__)
@@ -333,6 +334,13 @@ class ProposedChangesService:
         for track in tracks:
             if hasattr(track, field):
                 setattr(track, field, new_value)
+                # Accepting a suggestion is a choice, so it outranks the file like any other edit
+                # (ADR-0051 point 7). Without this, a corrected artist name from an accepted change
+                # was undone by the next rescan of a re-tagged file — the same defect as a hand
+                # edit, reached by a different route.
+                track.metadata_overrides = metadata_overrides.record(
+                    track.metadata_overrides, {field: new_value}
+                )
         await self.db.commit()
 
     async def apply_batch(
@@ -390,10 +398,21 @@ class ProposedChangesService:
                         old_val = change.old_value.get(str(track.id))
                         if old_val is not None and hasattr(track, change.field):
                             setattr(track, change.field, old_val)
+                            track.metadata_overrides = metadata_overrides.forget(
+                                track.metadata_overrides, [change.field]
+                            )
                 else:
                     for track in tracks:
                         if hasattr(track, change.field):
                             setattr(track, change.field, change.old_value)
+                            track.metadata_overrides = metadata_overrides.forget(
+                                track.metadata_overrides, [change.field]
+                            )
+
+                # **An undo is a retraction, not a new opinion** (ADR-0051 point 7). The field goes
+                # back to following the file rather than being pinned to a value nobody chose —
+                # otherwise the first accepted suggestion would freeze it forever and this button
+                # would be a lie. This is currently the only way a field stops being overridden.
 
             # Mark as pending again (can be re-applied if needed)
             change.status = ChangeStatus.PENDING

--- a/backend/app/services/scanner.py
+++ b/backend/app/services/scanner.py
@@ -15,6 +15,7 @@ from sqlalchemy.ext.asyncio import AsyncSession
 
 from app.config import AUDIO_EXTENSIONS, settings
 from app.db.models import Track, TrackAnalysis, TrackStatus
+from app.services import metadata_overrides
 from app.services.artist_resolver import resolve_canonical_artist
 
 
@@ -882,6 +883,22 @@ class LibraryScanner:
             metadata.get("album_artist"),
             None,
         )
+
+        # **A correction made in Familiar wins over the file.**
+        #
+        # Everything above assigns straight from the file's tags, which is right for a field nobody
+        # has touched and wrong for one somebody deliberately fixed. Re-tagging a file in another
+        # app, re-encoding it, or replacing it changes its hash and brings us here — and until this
+        # existed, that silently restored the old spelling with nothing to show it had happened.
+        #
+        # Applied last, after the canonical artist ids are resolved from the file, because those
+        # resolve identity from the tag the file carries; the override then corrects the display
+        # fields on top. A field with no override is untouched and still follows the file.
+        restored = metadata_overrides.apply(track, track.metadata_overrides)
+        if restored:
+            logger.info(
+                f"KEPT EDITS: {Path(track.file_path).name} — {', '.join(sorted(restored))}"
+            )
 
         # Only reset analysis status if requested (when file content changed)
         if reset_analysis:

--- a/backend/migrations/versions/20260811_metadata_overrides.py
+++ b/backend/migrations/versions/20260811_metadata_overrides.py
@@ -1,0 +1,45 @@
+"""Remember which tag fields a person edited, so a rescan cannot undo them.
+
+`LibraryScanner._update_track` assigns title, artist, album, album_artist, the numbers, year and
+genre straight from the file whenever its hash changes. Nothing recorded that a person had corrected
+any of them, so re-tagging a file elsewhere — or re-encoding it, or replacing it — silently threw the
+correction away.
+
+Deliberately **not** `user_overrides`. That column is documented as overrides for *analysis* values
+(`{"bpm": 124.0, "key": "Am"}`) and is merged only where the key already exists in the feature set.
+Tag overrides answer a different question — who wins between the library and the file — and mixing
+them would make both harder to reason about.
+
+Revision ID: 20260811_metadata_overrides
+"""
+
+from collections.abc import Sequence
+
+import sqlalchemy as sa
+from alembic import op
+from sqlalchemy.dialects import postgresql
+
+from migrations.helpers import column_exists
+
+revision: str = "20260811_metadata_overrides"
+down_revision: str | None = "20260810_drop_spotify_imports"
+branch_labels: str | Sequence[str] | None = None
+depends_on: str | Sequence[str] | None = None
+
+
+def upgrade() -> None:
+    if not column_exists("tracks", "metadata_overrides"):
+        op.add_column(
+            "tracks",
+            sa.Column(
+                "metadata_overrides",
+                postgresql.JSONB(astext_type=sa.Text()),
+                nullable=False,
+                server_default=sa.text("'{}'::jsonb"),
+            ),
+        )
+
+
+def downgrade() -> None:
+    if column_exists("tracks", "metadata_overrides"):
+        op.drop_column("tracks", "metadata_overrides")

--- a/backend/tests/test_metadata_overrides.py
+++ b/backend/tests/test_metadata_overrides.py
@@ -117,3 +117,75 @@ class TestTheScannerUsesIt:
             "overrides are applied before the file's tags are assigned, so the file wins and the "
             "edit is lost — the bug this exists to prevent"
         )
+
+
+class TestForgetting:
+    """An undo is a retraction, not a new opinion (ADR-0051 point 7)."""
+
+    def test_a_forgotten_field_follows_the_file_again(self) -> None:
+        recorded = metadata_overrides.record({}, {"artist": "Rachel's", "album": "Selenography"})
+        assert metadata_overrides.forget(recorded, ["artist"]) == {"album": "Selenography"}
+
+    def test_forgetting_something_never_recorded_is_harmless(self) -> None:
+        assert metadata_overrides.forget({"album": "x"}, ["genre"]) == {"album": "x"}
+
+    def test_forgetting_nothing_recorded_at_all_is_harmless(self) -> None:
+        assert metadata_overrides.forget(None, ["genre"]) == {}
+
+    def test_the_original_mapping_is_not_mutated(self) -> None:
+        original = {"album": "Selenography"}
+        metadata_overrides.forget(original, ["album"])
+        assert original == {"album": "Selenography"}
+
+
+class TestEveryWritePathRecords:
+    """ADR-0051 lists seven paths that write these fields. A path that forgets to record fails
+    *quietly* — it simply does not protect the edit, which looks exactly like the old behaviour, so
+    there is nothing to notice at runtime.
+
+    Asserted against the source because each one commits inside a route or a service that needs a
+    database and a profile to reach. Brittle on purpose; the alternative is no coverage at all for a
+    rule whose failure mode is silence.
+    """
+
+    def _source(self, module_name: str) -> str:
+        import importlib
+        from pathlib import Path
+
+        return Path(importlib.import_module(module_name).__file__).read_text()
+
+    def test_the_single_track_patch_records(self) -> None:
+        source = self._source("app.api.routes.tracks.metadata")
+        assert "metadata_overrides.record(track.metadata_overrides, update_data)" in source
+
+    def test_the_bulk_editor_records(self) -> None:
+        source = self._source("app.services.bulk_editor")
+        assert "metadata_overrides.record(" in source
+
+    def test_approving_a_pending_track_records(self) -> None:
+        source = self._source("app.api.routes.pending_review")
+        body = source.split("def _apply_review_edits", 1)[1].split("\n\n\n", 1)[0]
+        assert "metadata_overrides.record(" in body
+
+    def test_group_metadata_records(self) -> None:
+        source = self._source("app.api.routes.pending_review")
+        body = source.split("async def group_metadata", 1)[1].split("\n\n\n", 1)[0]
+        assert "metadata_overrides.record(" in body
+
+    def test_patching_a_pending_track_records(self) -> None:
+        source = self._source("app.api.routes.pending_review")
+        body = source.split("async def update_track_metadata", 1)[1].split("\n\n\n", 1)[0]
+        assert "metadata_overrides.record(" in body
+
+    def test_applying_a_proposed_change_records(self) -> None:
+        source = self._source("app.services.proposed_changes")
+        body = source.split("async def _apply_metadata_to_db", 1)[1].split("\n\n", 1)[0]
+        assert "metadata_overrides.record(" in body
+
+    def test_undoing_a_proposed_change_forgets_rather_than_records(self) -> None:
+        """The one path that must *not* record. Recording here would pin the field to a value
+        nobody chose and make undo a lie."""
+        source = self._source("app.services.proposed_changes")
+        undo = source.split("async def undo", 1)[1].split("\n\n\n", 1)[0]
+        assert "metadata_overrides.forget(" in undo
+        assert "metadata_overrides.record(" not in undo

--- a/backend/tests/test_metadata_overrides.py
+++ b/backend/tests/test_metadata_overrides.py
@@ -1,0 +1,119 @@
+"""A correction made in Familiar survives the file changing underneath it.
+
+`LibraryScanner._update_track` assigns title, artist, album, album_artist, the numbers, year and
+genre straight from the file whenever its hash changes — re-tagged in another app, re-encoded,
+replaced. Until `metadata_overrides` existed that silently restored the old value, and the only way
+to notice was spotting the old spelling again weeks later.
+
+These are unit tests over the rule itself rather than over a scan. `_update_track` runs deep inside a
+traversal of a real directory; the rule is the part worth pinning, and it is pure.
+"""
+
+from types import SimpleNamespace
+
+from app.services import metadata_overrides
+
+
+class _Track(SimpleNamespace):
+    """Enough of a Track to set attributes on."""
+
+
+def _track(**kwargs: object) -> _Track:
+    base = dict(
+        title=None, artist=None, album=None, album_artist=None,
+        track_number=None, disc_number=None, year=None, genre=None,
+    )
+    base.update(kwargs)
+    return _Track(**base)
+
+
+class TestRecording:
+    def test_an_edited_field_is_remembered(self) -> None:
+        assert metadata_overrides.record({}, {"album": "Selenography"}) == {"album": "Selenography"}
+
+    def test_clearing_is_remembered_as_a_decision(self) -> None:
+        """A null entry is present, not absent — otherwise a rescan refills the field it emptied."""
+        recorded = metadata_overrides.record({}, {"genre": None})
+        assert "genre" in recorded
+        assert recorded["genre"] is None
+
+    def test_fields_a_rescan_never_touches_are_not_recorded(self) -> None:
+        """`_update_track` does not assign composer or lyrics, so pinning them would claim a
+        protection that means nothing."""
+        assert metadata_overrides.record({}, {"composer": "Reich", "lyrics": "…"}) == {}
+
+    def test_earlier_edits_survive_a_later_one(self) -> None:
+        first = metadata_overrides.record({}, {"album": "Selenography"})
+        second = metadata_overrides.record(first, {"year": 1999})
+        assert second == {"album": "Selenography", "year": 1999}
+
+    def test_a_later_edit_wins_over_an_earlier_one(self) -> None:
+        first = metadata_overrides.record({}, {"album": "Selenograpy"})
+        assert metadata_overrides.record(first, {"album": "Selenography"})["album"] == "Selenography"
+
+    def test_the_original_mapping_is_not_mutated(self) -> None:
+        """SQLAlchemy does not notice in-place changes to JSONB, so the helper must return a new
+        dict and the caller must assign it. A mutating helper would appear to work and persist
+        nothing."""
+        original = {"album": "Selenography"}
+        metadata_overrides.record(original, {"year": 1999})
+        assert original == {"album": "Selenography"}
+
+
+class TestApplying:
+    def test_an_edited_field_beats_the_file(self) -> None:
+        track = _track(album="Selenograpy")  # what the file now says
+        restored = metadata_overrides.apply(track, {"album": "Selenography"})
+        assert track.album == "Selenography"
+        assert restored == ["album"]
+
+    def test_an_untouched_field_still_follows_the_file(self) -> None:
+        track = _track(album="Selenography", artist="Rachel's")
+        metadata_overrides.apply(track, {"album": "Selenography"})
+        assert track.artist == "Rachel's"
+
+    def test_a_cleared_field_stays_cleared(self) -> None:
+        """The case a naive implementation gets wrong: the file has a genre, the person removed it,
+        and a truthiness check would let the file put it back."""
+        track = _track(genre="Post-Rock")
+        metadata_overrides.apply(track, {"genre": None})
+        assert track.genre is None
+
+    def test_nothing_recorded_changes_nothing(self) -> None:
+        track = _track(album="Selenography")
+        assert metadata_overrides.apply(track, {}) == []
+        assert metadata_overrides.apply(track, None) == []
+        assert track.album == "Selenography"
+
+    def test_unknown_keys_are_ignored_rather_than_trusted(self) -> None:
+        """The column is JSONB and survives a restore from backup, so a key that is no longer a
+        column is possible and is not a reason to fail a library scan."""
+        track = _track()
+        assert metadata_overrides.apply(track, {"not_a_column": "x"}) == []
+
+    def test_a_field_outside_the_protected_set_is_not_applied(self) -> None:
+        track = _track()
+        track.composer = "Reich"
+        metadata_overrides.apply(track, {"composer": "Glass"})
+        assert track.composer == "Reich"
+
+
+class TestTheScannerUsesIt:
+    def test_update_track_reapplies_overrides_after_reading_the_file(self) -> None:
+        """Asserted against the source: `_update_track` has no seam to call, and the ordering is the
+        whole point — the overrides must land *after* the assignments from file tags, or the file
+        wins anyway."""
+        from pathlib import Path
+
+        from app.services import scanner
+
+        source = Path(scanner.__file__).read_text()
+        body = source.split("async def _update_track", 1)[1]
+        assert "metadata_overrides.apply(track, track.metadata_overrides)" in body
+
+        assignments = body.index('track.title = metadata.get("title")')
+        restore = body.index("metadata_overrides.apply(track, track.metadata_overrides)")
+        assert restore > assignments, (
+            "overrides are applied before the file's tags are assigned, so the file wins and the "
+            "edit is lost — the bug this exists to prevent"
+        )

--- a/backend/tests/test_sync_guardrails.py
+++ b/backend/tests/test_sync_guardrails.py
@@ -93,3 +93,57 @@ class TestSyncProgressReporterResilience:
         assert isinstance(reporter.phase_requeue_attempts, dict)
         assert isinstance(reporter.phase_stall_recoveries, dict)
         assert isinstance(reporter.phase_forced_exit_reasons, dict)
+
+
+class TestSyncLeavesEditedMetadataAlone:
+    """A sync must not re-read tags for files that have not changed.
+
+    This is a *user-visible promise*, not an implementation detail. The Mac's track editor and its
+    library sync pane both say edits are kept, and the only thing making that true is
+    `reread_unchanged` defaulting to False — `LibraryScanner._update_track` assigns title, artist,
+    album, album_artist, the numbers, year and genre straight from the file and never consults the
+    `user_overrides` column, so any path that reaches it discards deliberate corrections.
+
+    The screens originally said the opposite — that a sync undoes your edits — which was wrong and
+    went unchecked until Jeff asked. Both directions of that claim need something holding them still,
+    because the copy is written once and the default can move underneath it.
+    """
+
+    def test_the_scanner_does_not_reread_unchanged_files_by_default(self) -> None:
+        import inspect
+
+        from app.services.scanner import LibraryScanner
+
+        default = inspect.signature(LibraryScanner.scan).parameters["reread_unchanged"].default
+        assert default is False, (
+            "LibraryScanner.scan now re-reads unchanged files by default, which silently discards "
+            "metadata edited in Familiar. The Mac's editor and sync pane both promise otherwise."
+        )
+
+    def test_the_sync_endpoint_does_not_reread_unchanged_files_by_default(self) -> None:
+        import inspect
+
+        from app.api.routes.library_sync import start_sync
+
+        default = inspect.signature(start_sync).parameters["reread_unchanged"].default
+        assert default is False, (
+            "POST /library/sync now re-reads unchanged files by default. The Mac's Sync Now button "
+            "sends no parameters, so this default is exactly what that button does."
+        )
+
+    def test_metadata_is_overwritten_only_when_asked_or_when_the_file_changed(self) -> None:
+        """The condition itself, read from the source.
+
+        Asserted against the text because the branch has no seam to call: `_update_track` runs deep
+        inside a scan over a real directory. A brittle test that names the rule beats no test for a
+        rule two screens quote to a listener.
+        """
+        from pathlib import Path
+
+        from app.services import scanner
+
+        source = Path(scanner.__file__).read_text()
+        assert "if reread_unchanged or file_changed:" in source, (
+            "the guard that keeps edited metadata has moved or changed shape — check what the Mac's "
+            "track editor and sync pane now promise"
+        )


### PR DESCRIPTION
Two commits: the first pins what a sync *actually* does, the second fixes the case where it really did lose your edits.

## 1. The warning was wrong

The Mac's track editor and sync pane both told Jeff a sync would undo metadata edited in Familiar. It doesn't. `LibraryScanner` re-reads a file's tags only under `if reread_unchanged or file_changed:`, and `reread_unchanged` defaults to `False` in both the scanner and `POST /library/sync` — which is what Sync Now calls, with no parameters.

Three tests hold that still, because the copy is written once and the default can move underneath it. Two read the defaults; the third asserts the guard's literal text — brittle on purpose, since `_update_track` runs deep inside a scan over a real directory and has no seam to call. Verified by neutering the guard.

## 2. The exposure that was real, now fixed

When a file's hash **does** change — re-tagged elsewhere, re-encoded, replaced — `_update_track` assigned title, artist, album, album_artist, the numbers, year and genre straight from the file. Nothing recorded that anyone had deliberately corrected them, so the correction vanished, and the only way to notice was spotting the old spelling again weeks later.

Tracks now carry **`metadata_overrides`**: which tag fields somebody chose, and what they chose. The scanner re-reads the file exactly as before, then puts those fields back.

**A field nobody touched still follows the file.** That's the half worth keeping — this is a per-field rule, not a switch that freezes a track.

### Why not `user_overrides`

That column is documented as overrides for *analysis* values (`{"bpm": 124.0, "key": "Am"}`) and is merged only where the key already exists in the feature set. Tag overrides answer a different question — who wins between the library and the file — and mixing them would make both harder to reason about.

### Two deliberate limits

**Only the eight fields a rescan assigns are protected.** Composer, lyrics, the sort fields and the rest are never touched by `_update_track`, so recording them would claim a protection that means nothing.

**A cleared field is a null entry, not an omission.** Emptying a genre is a decision, and a truthiness check would let the file refill it. It has its own test because it's the case a naive implementation gets wrong.

The rule lives in `services/metadata_overrides` because three places have to agree — the single PATCH, the bulk editor, and the scanner — and a rule copied into three files is the shape that goes wrong later.

## Worth a second opinion

This makes the library authoritative over file tags for edited fields, which inverts the scanner's standing assumption that the file is the source of truth. I've treated it as ordinary work finishing an existing direction — the editor already writes to the library, and every client already reads the library — but it's a precedence rule other work will build on, so **it may deserve an ADR.** Happy to write one if you'd rather it were recorded.

## Verified

13 new tests, including one asserting the scanner applies overrides **after** the file's tags rather than before; verified by neutering the call. Single migration head, 27-char revision.

## Sequencing

**The Mac's wording must not change until this is deployed.** familiar-apple#112 says the file wins on a change, which is true today and becomes wrong once this is on the NAS. That's a third edit to the same sentence, and doing it early would repeat the mistake this PR exists to correct.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_014P9p2fvFnyiywBxGkv4gfW