### PR TITLE
Accept ADR-0052 — albums are a first-class entity

### DIFF
--- a/docs/decisions/ADR-0052-albums-are-a-first-class-entity.md
+++ b/docs/decisions/ADR-0052-albums-are-a-first-class-entity.md
@@ -1,8 +1,29 @@
 # ADR-0052: Albums Are a First-Class Entity
 
-Status: proposed
+Status: accepted
 
 Date: 2026-08-12
+
+Implementation:
+- Accepted 2026-08-12, after the work it describes was built, deployed and measured on the live
+  library — the numbers below are outcomes rather than estimates.
+- Points 1–7 are built and deployed (`familiar` #159). **4,274 albums** created (3,902 titled, 372
+  folder-derived) and **all 26,422 active tracks placed, none unresolved**, in 18 seconds.
+- **297 compilations became one album each**, covering 3,813 tracks that between them had been
+  holding 2,304 separate artwork slots. The worst, "New Wave Club Class-X Box", had 49 distinct track
+  artists and therefore 49 covers; it now has one.
+- Artwork slots went 6,221 → 3,577. Of 12,017 files on disk, 12,017 remain: 7,814 re-keyed in place,
+  3,349 merged away and 854 orphaned, all quarantined rather than deleted.
+- **Point 4 verified end to end on real data.** An album renamed through the endpoint the Mac's
+  editor uses kept its `canonical_album_id` and served byte-identical artwork either side of the
+  rename. Before this, that rename moved the hash and lost the cover.
+- Two defects found while building it, both fixed here: `normalize_for_matching` never folded curly
+  quotes (both character classes held their ASCII form twice), which gave 16 albums a second artwork
+  slot; and `aggregate_album_features` matched artist and album case-sensitively, so generated art
+  for a compilation came from a fraction of the record.
+- **Not done, and listed under Consequences:** the read cutover, exposing the id in `AlbumSummary`,
+  an album merge UI, and `album_id` operands for smart playlists. The six `GROUP BY` definitions of
+  "album" in the backend are all still there and still disagree with each other.
 
 Extends [ADR-0051](ADR-0051-edited-metadata-outranks-file-tags.md)
 


### PR DESCRIPTION
Flips `Status: proposed` → `accepted`, and adds an Implementation block.

Accepted **after** the work was built, deployed and measured, so the block records outcomes rather than estimates:

| | |
|---|---|
| Albums created | 4,274 (3,902 titled + 372 folder-derived) |
| Tracks placed | **26,422 — all of them, none unresolved**, in 18s |
| Compilations unified | **297**, covering 3,813 tracks that held 2,304 separate artwork slots |
| Artwork slots | 6,221 → 3,577 |
| Files on disk | 12,017 → 12,017 (3,349 merged away + 854 orphaned, all quarantined) |

The worst compilation — *"New Wave Club Class-X Box"* — had **49 distinct track artists and therefore 49 covers**. It now has one.

**Point 4 is recorded as verified, not asserted.** An album renamed through the endpoint the Mac's editor uses kept its `canonical_album_id` and served byte-identical artwork either side of the rename. Before this change that rename moved the hash and lost the cover.

Also recorded: the two defects found while building it — the curly quotes `normalize_for_matching` never folded (16 albums had a second artwork slot because of it), and the case-sensitive match that fed generated art for a compilation from a fraction of the record.

And what is **not** done, named rather than implied: the read cutover, exposing the id in `AlbumSummary`, an album merge UI, and `album_id` operands for smart playlists. The six mutually disagreeing `GROUP BY` definitions of "album" in the backend are all still there.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_014P9p2fvFnyiywBxGkv4gfW