### PR TITLE
An MCP host can drive and photograph the interface

### DIFF
--- a/backend/app/api/routes/playback.py
+++ b/backend/app/api/routes/playback.py
@@ -1,11 +1,14 @@
-"""The playback command channel's HTTP surface (ADR-0044).
+"""The playback command channel's HTTP surface (ADR-0044, ADR-0053).
 
-One endpoint: a client subscribes and receives imperatives until it goes away. There is no send
-endpoint — the sender is the MCP tool layer, in-process (ADR-0043), and adding an HTTP way to make
-somebody else's music play is a decision nothing has taken.
+Two endpoints now. A client subscribes and receives imperatives until it goes away; and, since
+ADR-0053, it uploads anything a command asked it to produce. There is still no *send* endpoint —
+the sender is the MCP tool layer, in-process (ADR-0043), and adding an HTTP way to make somebody
+else's music play is a decision nothing has taken.
 
-SSE rather than a WebSocket (point 2): commands are one-way, so a socket's return half would go
-unused, and this codebase already runs three SSE endpoints while having no WebSocket route at all.
+SSE rather than a WebSocket (ADR-0044 point 2): commands are one-way, so a socket's return half
+would go unused. **That is still true of the stream.** A screenshot travels the other way as an
+ordinary upload the client makes when it has something to send, which is why the transport did not
+have to change to gain a return path (ADR-0053 point 3).
 """
 
 from __future__ import annotations
@@ -16,17 +19,21 @@ import logging
 import time
 from collections.abc import AsyncIterator
 
-from fastapi import APIRouter, HTTPException, Query, Request
+from fastapi import APIRouter, HTTPException, Query, Request, UploadFile
 from fastapi.responses import StreamingResponse
 
 from app.api.deps import DbSession, RequiredProfile, release_connection
 from app.services.playback_commands import (
     AttachedPlayer,
     UnknownCapability,
+    get_artifact_store,
     get_channel,
 )
 
 logger = logging.getLogger(__name__)
+
+# A window capture at Retina scale is a few hundred KB; this is a bound, not a target.
+_MAX_ARTIFACT_BYTES = 25 * 1024 * 1024
 
 router = APIRouter(prefix="/playback", tags=["playback"])
 
@@ -126,3 +133,39 @@ async def playback_commands(
             "X-Accel-Buffering": "no",
         },
     )
+
+
+@router.post("/artifacts/{request_id}", status_code=204)
+async def upload_artifact(request_id: str, file: UploadFile) -> None:
+    """Hand back something a command asked this client to produce (ADR-0053 point 3).
+
+    The return half of the channel, and deliberately not on the channel: the SSE stream stays
+    one-way, and this is a request the client makes when it has something to send. That keeps
+    ADR-0044 point 2's reasoning intact rather than reversing it.
+
+    `request_id` names one outstanding question. It is minted by the server when it issues the
+    command, it is not a device identity, and it dies when the question is answered or times out —
+    which is why this does not reopen ADR-0029 point 5.
+
+    A late or unknown upload is **discarded, not stored** (point 8). The question it answers has
+    already been answered with a timeout, and keeping the image would mean keeping it forever.
+    204 either way: the client cannot do anything useful with the difference, and telling it its
+    screenshot was too slow would only invite a retry nothing is waiting for.
+    """
+    data = await file.read()
+    if not data:
+        raise HTTPException(status_code=422, detail="Empty artifact")
+    if len(data) > _MAX_ARTIFACT_BYTES:
+        raise HTTPException(
+            status_code=413,
+            detail=f"Artifact exceeds {_MAX_ARTIFACT_BYTES // 1024 // 1024}MB",
+        )
+
+    delivered = get_artifact_store().deliver(
+        request_id, data, file.content_type or "application/octet-stream"
+    )
+    if not delivered:
+        logger.info(
+            "playback_artifact_discarded",
+            extra={"request_id": request_id, "bytes": len(data)},
+        )

--- a/backend/app/api/routes/playback.py
+++ b/backend/app/api/routes/playback.py
@@ -136,7 +136,9 @@ async def playback_commands(
 
 
 @router.post("/artifacts/{request_id}", status_code=204)
-async def upload_artifact(request_id: str, file: UploadFile) -> None:
+async def upload_artifact(
+    profile: RequiredProfile, request_id: str, file: UploadFile
+) -> None:
     """Hand back something a command asked this client to produce (ADR-0053 point 3).
 
     The return half of the channel, and deliberately not on the channel: the SSE stream stays
@@ -146,6 +148,10 @@ async def upload_artifact(request_id: str, file: UploadFile) -> None:
     `request_id` names one outstanding question. It is minted by the server when it issues the
     command, it is not a device identity, and it dies when the question is answered or times out —
     which is why this does not reopen ADR-0029 point 5.
+
+    **Profile-scoped, and checked rather than merely required.** The store remembers which profile
+    asked, so holding *a* profile is not enough to answer somebody else's question. Caught by
+    `lint_profile_contracts.py`, which is the rule this route was quietly outside.
 
     A late or unknown upload is **discarded, not stored** (point 8). The question it answers has
     already been answered with a timeout, and keeping the image would mean keeping it forever.
@@ -162,7 +168,10 @@ async def upload_artifact(request_id: str, file: UploadFile) -> None:
         )
 
     delivered = get_artifact_store().deliver(
-        request_id, data, file.content_type or "application/octet-stream"
+        request_id,
+        data,
+        file.content_type or "application/octet-stream",
+        profile_id=profile.id,
     )
     if not delivered:
         logger.info(

--- a/backend/app/mcp/playback.py
+++ b/backend/app/mcp/playback.py
@@ -242,7 +242,7 @@ async def handle(
         request_id = uuid4().hex
         store = get_artifact_store()
         # Opened *before* the command goes out, or a fast client could answer into nothing.
-        store.open(request_id)
+        store.open(request_id, profile_id)
         try:
             player = channel.send(
                 profile_id,

--- a/backend/app/mcp/playback.py
+++ b/backend/app/mcp/playback.py
@@ -13,24 +13,68 @@ never needed it, since it was itself the player.
 
 from __future__ import annotations
 
+import base64
 import logging
 import time
 from copy import deepcopy
 from typing import Any
-from uuid import UUID
+from uuid import UUID, uuid4
 
 import mcp.types as types
 
 from app.services.now_playing import get_registry as get_now_playing_registry
-from app.services.playback_commands import NoPlayerAttached, get_channel
+from app.services.playback_commands import (
+    ArtifactTimeout,
+    NoPlayerAttached,
+    get_artifact_store,
+    get_channel,
+)
 
 logger = logging.getLogger(__name__)
 
 #: Handled here rather than dispatched to `ToolExecutor`.
-PLAYBACK_TOOLS = {"queue_tracks", "control_playback", "list_players", "get_now_playing"}
+PLAYBACK_TOOLS = {
+    "queue_tracks",
+    "control_playback",
+    "list_players",
+    "get_now_playing",
+    # ADR-0053: driving and photographing the interface, not just the audio.
+    "navigate_app",
+    "capture_screenshot",
+}
+
+#: The destinations a client can be rooted on. Mirrors `LibraryRoute` in FamiliarKit — a closed
+#: list on purpose, so an unknown destination is refused by the schema instead of accepted and
+#: quietly dropped (ADR-0053 point 2).
+NAVIGATION_DESTINATIONS = [
+    "home",
+    "tracks",
+    "albums",
+    "artists",
+    "playlists",
+    "smart_playlists",
+    "music_map",
+    "discover",
+    "pending_review",
+    "proposed_changes",
+    "mixtapes",
+    "favorites",
+    "downloads",
+    "settings",
+]
 
 #: What a client must have declared to receive each command (ADR-0044 point 12).
-_REQUIRES = {"queue_tracks": "queue", "control_playback": "play"}
+_REQUIRES = {
+    "queue_tracks": "queue",
+    "control_playback": "play",
+    "navigate_app": "navigate",
+    "capture_screenshot": "screenshot",
+}
+
+#: How long to wait for a client to send a screenshot back. Generous — the app has to draw and
+#: encode a window — but bounded, because a tool that never answers is the defect ADR-0044 point 5
+#: exists to prevent.
+_CAPTURE_TIMEOUT_SECONDS = 15.0
 
 _TARGET_PROPERTY = {
     "type": "string",
@@ -52,6 +96,48 @@ def list_players_tool() -> types.Tool:
             "when the listener has more than one device and you need to name one."
         ),
         input_schema={"type": "object", "properties": {}},
+    )
+
+
+def navigate_tool() -> types.Tool:
+    return types.Tool(
+        name="navigate_app",
+        description=(
+            "Show a particular screen in the listener's Familiar app — the Mac or phone client, "
+            "not the web page. Use it to put the app somewhere before asking about it or "
+            "photographing it, or when the listener asks to be taken to a part of their library. "
+            "Delivered to a running client, so it needs one attached; call list_players if this "
+            "reports none. This roots the app on a destination and does not open a specific album "
+            "or playlist."
+        ),
+        input_schema=add_target_property(
+            "target",
+            {
+                "type": "object",
+                "properties": {
+                    "destination": {
+                        "type": "string",
+                        "enum": NAVIGATION_DESTINATIONS,
+                        "description": "Which screen to show.",
+                    }
+                },
+                "required": ["destination"],
+            },
+        ),
+    )
+
+
+def capture_screenshot_tool() -> types.Tool:
+    return types.Tool(
+        name="capture_screenshot",
+        description=(
+            "Photograph the listener's Familiar app window and return the image. The app draws "
+            "its own window, so this captures Familiar and nothing else on their machine — no "
+            "other applications, no desktop, no menu bar. Use it to see what a screen actually "
+            "looks like, to check your own work after navigating, or to produce images of the "
+            "interface. Pair it with navigate_app to choose the screen first."
+        ),
+        input_schema=add_target_property("target", {"type": "object", "properties": {}}),
     )
 
 
@@ -130,6 +216,70 @@ async def handle(
         }
 
     target = arguments.pop("player", None) or None
+
+    if name == "navigate_app":
+        destination = str(arguments.get("destination", "")).strip()
+        if destination not in NAVIGATION_DESTINATIONS:
+            # Refused rather than sent. A destination the app has no case for would arrive, be
+            # decoded to nothing, and leave the tool reporting success against a screen that never
+            # changed (ADR-0053 point 2).
+            return {
+                "error": f"Unknown destination {destination!r}.",
+                "destinations": NAVIGATION_DESTINATIONS,
+            }
+        try:
+            player = channel.send(
+                profile_id,
+                {"type": "navigate", "destination": destination},
+                target=target,
+                requires=_REQUIRES[name],
+            )
+        except NoPlayerAttached as exc:
+            return _no_player_answer(exc, profile_id)
+        return {"delivered": True, "destination": destination, "player": player.describe()}
+
+    if name == "capture_screenshot":
+        request_id = uuid4().hex
+        store = get_artifact_store()
+        # Opened *before* the command goes out, or a fast client could answer into nothing.
+        store.open(request_id)
+        try:
+            player = channel.send(
+                profile_id,
+                {"type": "screenshot", "request_id": request_id},
+                target=target,
+                requires=_REQUIRES[name],
+            )
+        except NoPlayerAttached as exc:
+            store.cancel(request_id)
+            return _no_player_answer(exc, profile_id)
+
+        try:
+            data, content_type = await store.wait(request_id, _CAPTURE_TIMEOUT_SECONDS)
+        except ArtifactTimeout as exc:
+            # Answers rather than hanging (ADR-0044 point 5). The client is attached and declared
+            # the capability, so this is worth reporting as a fault rather than as "unavailable".
+            return {
+                "error": str(exc),
+                "player": player.describe(),
+                "note": (
+                    "The client is attached and says it can take screenshots, so it either failed "
+                    "to draw its window or could not upload the result."
+                ),
+            }
+
+        return {
+            "image": {
+                "data": base64.b64encode(data).decode("ascii"),
+                "mime_type": content_type,
+                "bytes": len(data),
+            },
+            "player": player.describe(),
+            "note": (
+                "This is the Familiar window as the app drew it — no other application, desktop "
+                "or menu bar is in it."
+            ),
+        }
 
     if name == "control_playback":
         action = str(arguments.get("action", "")).strip()

--- a/backend/app/mcp/server.py
+++ b/backend/app/mcp/server.py
@@ -35,7 +35,9 @@ from app.mcp.guidance import GUIDANCE, INSTRUCTIONS
 from app.mcp.playback import (
     PLAYBACK_TOOLS,
     add_target_property,
+    capture_screenshot_tool,
     list_players_tool,
+    navigate_tool,
     now_playing_tool,
 )
 from app.services.llm.tools import MUSIC_TOOLS
@@ -105,6 +107,9 @@ def exposed_tools() -> list[types.Tool]:
     # because it was the player. An MCP host has to ask (ADR-0044 point 4).
     tools.append(list_players_tool())
     tools.append(now_playing_tool())
+    # ADR-0053: the channel drives and observes the interface, not only the audio.
+    tools.append(navigate_tool())
+    tools.append(capture_screenshot_tool())
     return tools
 
 

--- a/backend/app/services/playback_commands.py
+++ b/backend/app/services/playback_commands.py
@@ -265,13 +265,20 @@ class ArtifactStore:
 
     def __init__(self) -> None:
         self._waiting: dict[str, asyncio.Future[tuple[bytes, str]]] = {}
+        # Whose question each id belongs to. The upload endpoint is profile-scoped like every
+        # other mutating route here, and this is what lets it check rather than merely require:
+        # holding *a* profile is not the same as holding the one that asked.
+        self._owners: dict[str, UUID] = {}
 
-    def open(self, request_id: str) -> asyncio.Future[tuple[bytes, str]]:
+    def open(self, request_id: str, profile_id: UUID) -> asyncio.Future[tuple[bytes, str]]:
         future: asyncio.Future[tuple[bytes, str]] = asyncio.get_running_loop().create_future()
         self._waiting[request_id] = future
+        self._owners[request_id] = profile_id
         return future
 
-    def deliver(self, request_id: str, data: bytes, content_type: str) -> bool:
+    def deliver(
+        self, request_id: str, data: bytes, content_type: str, *, profile_id: UUID
+    ) -> bool:
         """Hand an upload to whoever asked. False when nobody did — a late or unknown answer.
 
         **The entry is left in place rather than popped**, and `wait` removes it once it has read
@@ -285,6 +292,11 @@ class ArtifactStore:
         """
         future = self._waiting.get(request_id)
         if future is None or future.done():
+            return False
+        if self._owners.get(request_id) != profile_id:
+            # A profile answering somebody else's question. Refused rather than accepted, and
+            # reported to the caller the same way a late upload is — there is nothing useful it
+            # could do with the difference, and saying "wrong profile" would confirm the id exists.
             return False
         future.set_result((data, content_type))
         return True
@@ -303,9 +315,11 @@ class ArtifactStore:
             # Read or not, the question is over: nothing is kept for a later reader, because there
             # is never a later reader and the artifact is a picture of somebody's library.
             self._waiting.pop(request_id, None)
+            self._owners.pop(request_id, None)
 
     def cancel(self, request_id: str) -> None:
         self._waiting.pop(request_id, None)
+        self._owners.pop(request_id, None)
 
 
 _artifacts = ArtifactStore()

--- a/backend/app/services/playback_commands.py
+++ b/backend/app/services/playback_commands.py
@@ -55,6 +55,11 @@ KNOWN_CAPABILITIES = frozenset(
         "visualizer",
         "shuffle_weights",
         "normalization",
+        # ADR-0053. `navigate` roots the client's interface on a `LibraryRoute`; `screenshot` has
+        # it draw its own window and upload the result. Both are declared, not assumed, so a tool
+        # is offered only where something can actually carry it out.
+        "navigate",
+        "screenshot",
     }
 )
 
@@ -231,3 +236,80 @@ _channel = PlaybackCommandChannel()
 
 def get_channel() -> PlaybackCommandChannel:
     return _channel
+
+
+# ---------------------------------------------------------------------------
+# Artifacts (ADR-0053)
+# ---------------------------------------------------------------------------
+
+
+class ArtifactTimeout(Exception):
+    """The client never uploaded what it was asked for.
+
+    Raised so a tool can *answer* — "the client did not respond in time" — rather than hang.
+    ADR-0044 point 5's rule, which nothing on this channel is exempt from.
+    """
+
+
+class ArtifactStore:
+    """Outstanding requests for something the client has to send back.
+
+    **Held in memory and dropped once read** (ADR-0053 point 8). A screenshot of somebody's
+    library is not a thing to accumulate on a server because deleting it was more work than
+    keeping it: there is no table, no directory, and therefore no retention rule to get wrong.
+
+    One entry is one unanswered question. The id names the question, not the device — it lives
+    for as long as the asking does, which is why this does not reopen ADR-0029 point 5's decision
+    to leave device identity uninvented.
+    """
+
+    def __init__(self) -> None:
+        self._waiting: dict[str, asyncio.Future[tuple[bytes, str]]] = {}
+
+    def open(self, request_id: str) -> asyncio.Future[tuple[bytes, str]]:
+        future: asyncio.Future[tuple[bytes, str]] = asyncio.get_running_loop().create_future()
+        self._waiting[request_id] = future
+        return future
+
+    def deliver(self, request_id: str, data: bytes, content_type: str) -> bool:
+        """Hand an upload to whoever asked. False when nobody did — a late or unknown answer.
+
+        **The entry is left in place rather than popped**, and `wait` removes it once it has read
+        the result. Popping here looked tidier and lost screenshots: a client fast enough to upload
+        before the tool reached its `await` would resolve a future nobody was holding any more, and
+        the tool would then find no outstanding request and report a timeout for an image that had
+        already arrived. Rare, load-dependent, and invisible — the worst combination.
+
+        A late upload is still discarded. The question it answered has been answered with a
+        timeout, and keeping the image would be keeping it forever (point 8).
+        """
+        future = self._waiting.get(request_id)
+        if future is None or future.done():
+            return False
+        future.set_result((data, content_type))
+        return True
+
+    async def wait(self, request_id: str, timeout: float) -> tuple[bytes, str]:
+        future = self._waiting.get(request_id)
+        if future is None:
+            raise ArtifactTimeout(f"No outstanding request {request_id}")
+        try:
+            return await asyncio.wait_for(asyncio.shield(future), timeout=timeout)
+        except TimeoutError as exc:
+            raise ArtifactTimeout(
+                f"The client did not answer within {timeout:.0f}s"
+            ) from exc
+        finally:
+            # Read or not, the question is over: nothing is kept for a later reader, because there
+            # is never a later reader and the artifact is a picture of somebody's library.
+            self._waiting.pop(request_id, None)
+
+    def cancel(self, request_id: str) -> None:
+        self._waiting.pop(request_id, None)
+
+
+_artifacts = ArtifactStore()
+
+
+def get_artifact_store() -> ArtifactStore:
+    return _artifacts

--- a/backend/openapi.json
+++ b/backend/openapi.json
@@ -1814,6 +1814,20 @@
         "title": "Body_library_import_preview",
         "type": "object"
       },
+      "Body_playback_upload_artifact": {
+        "properties": {
+          "file": {
+            "format": "binary",
+            "title": "File",
+            "type": "string"
+          }
+        },
+        "required": [
+          "file"
+        ],
+        "title": "Body_playback_upload_artifact",
+        "type": "object"
+      },
       "Body_profiles_upload_avatar": {
         "properties": {
           "file": {
@@ -23400,6 +23414,97 @@
         "summary": "Unskip Track",
         "tags": [
           "pending-review"
+        ]
+      }
+    },
+    "/api/v1/playback/artifacts/{request_id}": {
+      "post": {
+        "description": "Hand back something a command asked this client to produce (ADR-0053 point 3).\n\nThe return half of the channel, and deliberately not on the channel: the SSE stream stays\none-way, and this is a request the client makes when it has something to send. That keeps\nADR-0044 point 2's reasoning intact rather than reversing it.\n\n`request_id` names one outstanding question. It is minted by the server when it issues the\ncommand, it is not a device identity, and it dies when the question is answered or times out \u2014\nwhich is why this does not reopen ADR-0029 point 5.\n\n**Profile-scoped, and checked rather than merely required.** The store remembers which profile\nasked, so holding *a* profile is not enough to answer somebody else's question. Caught by\n`lint_profile_contracts.py`, which is the rule this route was quietly outside.\n\nA late or unknown upload is **discarded, not stored** (point 8). The question it answers has\nalready been answered with a timeout, and keeping the image would mean keeping it forever.\n204 either way: the client cannot do anything useful with the difference, and telling it its\nscreenshot was too slow would only invite a retry nothing is waiting for.",
+        "operationId": "playback_upload_artifact",
+        "parameters": [
+          {
+            "in": "path",
+            "name": "request_id",
+            "required": true,
+            "schema": {
+              "title": "Request Id",
+              "type": "string"
+            }
+          }
+        ],
+        "requestBody": {
+          "content": {
+            "multipart/form-data": {
+              "schema": {
+                "$ref": "#/components/schemas/Body_playback_upload_artifact"
+              }
+            }
+          },
+          "required": true
+        },
+        "responses": {
+          "204": {
+            "description": "Successful Response"
+          },
+          "400": {
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/ErrorEnvelope"
+                }
+              }
+            },
+            "description": "Bad Request"
+          },
+          "401": {
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/ErrorEnvelope"
+                }
+              }
+            },
+            "description": "Unauthorized"
+          },
+          "404": {
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/ErrorEnvelope"
+                }
+              }
+            },
+            "description": "Not Found"
+          },
+          "422": {
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/ErrorEnvelope"
+                }
+              }
+            },
+            "description": "Unprocessable Entity"
+          },
+          "500": {
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/ErrorEnvelope"
+                }
+              }
+            },
+            "description": "Internal Server Error"
+          }
+        },
+        "security": [
+          {
+            "ProfileHeader": []
+          }
+        ],
+        "summary": "Upload Artifact",
+        "tags": [
+          "playback"
         ]
       }
     },

--- a/backend/tests/test_mcp_server.py
+++ b/backend/tests/test_mcp_server.py
@@ -42,7 +42,15 @@ def _ctx(headers: dict[str, str] | None = None) -> SimpleNamespace:
 
 
 #: Tools this layer adds that have no MUSIC_TOOLS entry.
-MCP_ONLY_TOOLS = {"list_players", "get_now_playing"}
+# Tools that exist only on the MCP surface, with no MUSIC_TOOLS ancestor: the chat client was the
+# player and the interface, so it never had to ask which device to reach or what a screen looked
+# like. An MCP host does (ADR-0044 point 4, ADR-0053).
+MCP_ONLY_TOOLS = {
+    "list_players",
+    "get_now_playing",
+    "navigate_app",
+    "capture_screenshot",
+}
 
 
 class TestToolSurface:

--- a/backend/tests/test_playback_artifacts.py
+++ b/backend/tests/test_playback_artifacts.py
@@ -11,21 +11,24 @@ an image that outlives the question it answered.
 from __future__ import annotations
 
 import asyncio
+from uuid import uuid4
 
 import pytest
 
 from app.services.playback_commands import ArtifactStore, ArtifactTimeout
+
+PROFILE = uuid4()
 
 
 class TestDelivery:
     @pytest.mark.asyncio
     async def test_an_upload_reaches_the_waiter(self) -> None:
         store = ArtifactStore()
-        store.open("req-1")
+        store.open("req-1", PROFILE)
 
         async def upload() -> None:
             await asyncio.sleep(0)
-            assert store.deliver("req-1", b"PNGDATA", "image/png")
+            assert store.deliver("req-1", b"PNGDATA", "image/png", profile_id=PROFILE)
 
         async with asyncio.TaskGroup() as group:
             group.create_task(upload())
@@ -46,7 +49,7 @@ class TestTheDeadline:
         """The load-bearing one. A tool that hangs is the failure ADR-0044 point 5 exists to
         prevent, and it fails invisibly — the host simply waits."""
         store = ArtifactStore()
-        store.open("req-2")
+        store.open("req-2", PROFILE)
         with pytest.raises(ArtifactTimeout):
             await store.wait("req-2", timeout=0.05)
 
@@ -55,33 +58,33 @@ class TestTheDeadline:
         """Point 8. The question has already been answered with a timeout; keeping the image would
         mean keeping it forever, and it is a picture of somebody's library."""
         store = ArtifactStore()
-        store.open("req-3")
+        store.open("req-3", PROFILE)
         with pytest.raises(ArtifactTimeout):
             await store.wait("req-3", timeout=0.05)
 
-        assert store.deliver("req-3", b"LATE", "image/png") is False
+        assert store.deliver("req-3", b"LATE", "image/png", profile_id=PROFILE) is False
         assert not store._waiting
 
 
 class TestHousekeeping:
     @pytest.mark.asyncio
     async def test_an_unknown_upload_is_refused(self) -> None:
-        assert ArtifactStore().deliver("nobody-asked", b"x", "image/png") is False
+        assert ArtifactStore().deliver("nobody-asked", b"x", "image/png", profile_id=PROFILE) is False
 
     @pytest.mark.asyncio
     async def test_cancelling_drops_the_request(self) -> None:
         """The path taken when no player is attached: the command never went out, so nothing should
         be left waiting for an answer that cannot come."""
         store = ArtifactStore()
-        store.open("req-4")
+        store.open("req-4", PROFILE)
         store.cancel("req-4")
-        assert store.deliver("req-4", b"x", "image/png") is False
+        assert store.deliver("req-4", b"x", "image/png", profile_id=PROFILE) is False
 
     @pytest.mark.asyncio
     async def test_nothing_is_retained_after_a_successful_read(self) -> None:
         store = ArtifactStore()
-        store.open("req-5")
-        store.deliver("req-5", b"PNG", "image/png")
+        store.open("req-5", PROFILE)
+        store.deliver("req-5", b"PNG", "image/png", profile_id=PROFILE)
         assert await store.wait("req-5", timeout=1) == (b"PNG", "image/png")
         assert not store._waiting, "the artifact outlived the question it answered"
 
@@ -97,6 +100,35 @@ class TestTheRaceThatLostScreenshots:
     @pytest.mark.asyncio
     async def test_an_upload_that_arrives_before_the_wait_is_still_read(self) -> None:
         store = ArtifactStore()
-        store.open("req-fast")
-        assert store.deliver("req-fast", b"EARLY", "image/png")
+        store.open("req-fast", PROFILE)
+        assert store.deliver("req-fast", b"EARLY", "image/png", profile_id=PROFILE)
         assert await store.wait("req-fast", timeout=1) == (b"EARLY", "image/png")
+
+
+class TestOwnership:
+    """An artifact belongs to the profile that asked for it.
+
+    `lint_profile_contracts.py` caught this route sitting outside the rule every other mutating
+    endpoint follows. Requiring *a* profile would have satisfied the linter; checking it is what
+    actually stops one listener answering another's question.
+    """
+
+    @pytest.mark.asyncio
+    async def test_another_profile_cannot_answer(self) -> None:
+        store = ArtifactStore()
+        store.open("req-owned", PROFILE)
+        assert store.deliver("req-owned", b"PNG", "image/png", profile_id=uuid4()) is False
+
+    @pytest.mark.asyncio
+    async def test_and_the_real_owner_still_can(self) -> None:
+        store = ArtifactStore()
+        store.open("req-owned", PROFILE)
+        assert store.deliver("req-owned", b"PNG", "image/png", profile_id=PROFILE) is True
+        assert await store.wait("req-owned", timeout=1) == (b"PNG", "image/png")
+
+    @pytest.mark.asyncio
+    async def test_ownership_is_forgotten_with_the_request(self) -> None:
+        store = ArtifactStore()
+        store.open("req-gone", PROFILE)
+        store.cancel("req-gone")
+        assert not store._owners

--- a/backend/tests/test_playback_artifacts.py
+++ b/backend/tests/test_playback_artifacts.py
@@ -1,0 +1,102 @@
+"""The command channel's return path (ADR-0053 point 3).
+
+ADR-0044 chose SSE because "commands are one-way, so the return half of a socket would be unused".
+A screenshot is a return, and this is how it comes back without reversing that: the client uploads
+when it has something to send, and the stream stays one-way.
+
+The properties worth pinning are the ones whose absence is silent — a tool that waits forever, and
+an image that outlives the question it answered.
+"""
+
+from __future__ import annotations
+
+import asyncio
+
+import pytest
+
+from app.services.playback_commands import ArtifactStore, ArtifactTimeout
+
+
+class TestDelivery:
+    @pytest.mark.asyncio
+    async def test_an_upload_reaches_the_waiter(self) -> None:
+        store = ArtifactStore()
+        store.open("req-1")
+
+        async def upload() -> None:
+            await asyncio.sleep(0)
+            assert store.deliver("req-1", b"PNGDATA", "image/png")
+
+        async with asyncio.TaskGroup() as group:
+            group.create_task(upload())
+            waited = group.create_task(store.wait("req-1", timeout=2))
+
+        assert waited.result() == (b"PNGDATA", "image/png")
+
+    @pytest.mark.asyncio
+    async def test_waiting_on_a_request_nobody_opened_raises(self) -> None:
+        store = ArtifactStore()
+        with pytest.raises(ArtifactTimeout):
+            await store.wait("never-asked", timeout=0.1)
+
+
+class TestTheDeadline:
+    @pytest.mark.asyncio
+    async def test_a_client_that_never_answers_times_out(self) -> None:
+        """The load-bearing one. A tool that hangs is the failure ADR-0044 point 5 exists to
+        prevent, and it fails invisibly — the host simply waits."""
+        store = ArtifactStore()
+        store.open("req-2")
+        with pytest.raises(ArtifactTimeout):
+            await store.wait("req-2", timeout=0.05)
+
+    @pytest.mark.asyncio
+    async def test_a_late_upload_is_discarded_rather_than_stored(self) -> None:
+        """Point 8. The question has already been answered with a timeout; keeping the image would
+        mean keeping it forever, and it is a picture of somebody's library."""
+        store = ArtifactStore()
+        store.open("req-3")
+        with pytest.raises(ArtifactTimeout):
+            await store.wait("req-3", timeout=0.05)
+
+        assert store.deliver("req-3", b"LATE", "image/png") is False
+        assert not store._waiting
+
+
+class TestHousekeeping:
+    @pytest.mark.asyncio
+    async def test_an_unknown_upload_is_refused(self) -> None:
+        assert ArtifactStore().deliver("nobody-asked", b"x", "image/png") is False
+
+    @pytest.mark.asyncio
+    async def test_cancelling_drops_the_request(self) -> None:
+        """The path taken when no player is attached: the command never went out, so nothing should
+        be left waiting for an answer that cannot come."""
+        store = ArtifactStore()
+        store.open("req-4")
+        store.cancel("req-4")
+        assert store.deliver("req-4", b"x", "image/png") is False
+
+    @pytest.mark.asyncio
+    async def test_nothing_is_retained_after_a_successful_read(self) -> None:
+        store = ArtifactStore()
+        store.open("req-5")
+        store.deliver("req-5", b"PNG", "image/png")
+        assert await store.wait("req-5", timeout=1) == (b"PNG", "image/png")
+        assert not store._waiting, "the artifact outlived the question it answered"
+
+
+class TestTheRaceThatLostScreenshots:
+    """A client fast enough to upload before the tool starts waiting.
+
+    `deliver` used to pop the entry, so this resolved a future nobody held any more; `wait` then
+    found no outstanding request and reported a timeout for an image that had already arrived.
+    Rare, load-dependent and invisible — which is why it is pinned rather than reasoned about.
+    """
+
+    @pytest.mark.asyncio
+    async def test_an_upload_that_arrives_before_the_wait_is_still_read(self) -> None:
+        store = ArtifactStore()
+        store.open("req-fast")
+        assert store.deliver("req-fast", b"EARLY", "image/png")
+        assert await store.wait("req-fast", timeout=1) == (b"EARLY", "image/png")

--- a/docs/decisions/ADR-0043-the-llm-surface-is-an-mcp-server.md
+++ b/docs/decisions/ADR-0043-the-llm-surface-is-an-mcp-server.md
@@ -32,19 +32,26 @@ Implementation:
   is the way in until then, because stdio needs no auth. Two red herrings were fixed on the way to
   establishing that, both real: `.well-known` probes were being answered `200 text/html` by the SPA
   catch-all, which reads as "yes, I have an authorisation server".
-- **The surface is now 36 tools, not the 26 point 2 counts.** Point 2's *rule* is unchanged and
-  still produces the surface — everything in `MUSIC_TOOLS` except the client-bound and the withheld
-  — but three things have moved under it since acceptance, and the arithmetic in the Decision is a
-  snapshot of the day it was written rather than a cap. `MUSIC_TOOLS` grew from 30 to 36 (playlist
-  read and append, favourites, listening history, radio); `get_now_playing` and `list_players` are
-  MCP-only and are not in `MUSIC_TOOLS` at all, which is why the exposed count equals it exactly
-  rather than falling two short. The exclusions are still exactly two: `get_visible_tracks` and
-  `fetch_webpage`.
-- **Adding those six required no change to the MCP layer**, which is the strongest evidence for
-  point 2's design so far. `exposed_tools()` iterates `MUSIC_TOOLS`, so a schema, a handler and a
-  dispatch line were the whole cost; nothing under `app/mcp/` was touched. The chat-era tool
-  registry turning out to be the right seam is why the port was cheap in the direction this ADR did
-  not have to argue.
+- **The surface is 38 tools, not the 26 point 2 counts** (re-measured 2026-08-13). Point 2's *rule*
+  is unchanged and still produces the surface — everything in `MUSIC_TOOLS` except the client-bound
+  and the withheld — but the arithmetic in the Decision is a snapshot of the day it was written
+  rather than a cap. It reconciles as **34 in `MUSIC_TOOLS` plus 4 that are not in it at all**:
+  `list_players` and `get_now_playing` (ADR-0044), then `navigate_app` and `capture_screenshot`
+  ([ADR-0053](ADR-0053-the-command-channel-drives-and-observes-the-interface.md)). The chat client
+  never needed any of the four, because it was itself the player and the screen.
+
+  **`EXCLUDED` is now empty, and that is the finished state rather than a gap.** An earlier note here
+  said the exclusions were "still exactly two"; that stopped being true when point 5 retired the chat
+  clients, which left `get_visible_tracks` and `fetch_webpage` with no caller at all, so both were
+  deleted rather than left excluded. The set is kept as the seam where a future client-bound tool
+  goes — `exposed_tools()` reads it — and `app/mcp/server.py` carries the same record.
+
+  Do not re-derive this by hand. The counts move, and `exposed_tools()` is the answer.
+- **Adding the six tools of #129 required no change to the MCP layer** — playlist read and append,
+  favourites, listening history and radio — which is the strongest evidence for point 2's design so
+  far. `exposed_tools()` iterates `MUSIC_TOOLS`, so a schema, a handler and a dispatch line were the
+  whole cost; nothing under `app/mcp/` was touched. The chat-era tool registry turning out to be the
+  right seam is why the port was cheap in the direction this ADR did not have to argue.
 - **Nothing destructive is exposed, by decision rather than by omission** — no delete, no removal,
   no reorder. An LLM acting on a misread has no undo, and the same operation in the app takes two
   seconds. Read this as a standing constraint on the additions point 2 permits, not as a gap.

--- a/docs/decisions/ADR-0053-the-command-channel-drives-and-observes-the-interface.md
+++ b/docs/decisions/ADR-0053-the-command-channel-drives-and-observes-the-interface.md
@@ -14,7 +14,7 @@ divided everything an MCP host might want into three categories: server-side sta
 actions, and device-local preferences. Two of those three travel on the channel.
 
 **Navigating the interface is a fourth category, and the vocabulary for it already exists.**
-`LibraryRoute` in `FamiliarKit` enumerates every destination the Mac and phone can be rooted on —
+`SidebarItem` in `FamiliarKit` enumerates every destination the Mac and phone can be rooted on —
 `home`, `section(.tracks/.albums/.artists/.playlists)`, `smartPlaylists`, `musicMap`, `discover`,
 `pendingReview`, `proposedChanges`, `mixtapes`, `favorites`, `downloads`, `settings`. A "show me the
 albums" imperative is the same shape as "play", against a list that is already closed and named.
@@ -44,10 +44,10 @@ render *its own* windows with no permission at all, and that is the only thing t
 ## Decision
 
 1. **The channel gains a fourth category: interface navigation.** An imperative naming a
-   `LibraryRoute`, applied by the client to its own root selection. Server-side state is still
+   `SidebarItem`, applied by the client to its own root selection. Server-side state is still
    written directly and still needs no channel; this joins transient actions and preferences.
 
-2. **The destination vocabulary is `LibraryRoute`, not free text.** The tool advertises exactly the
+2. **The destination vocabulary is `SidebarItem`, not free text.** The tool advertises exactly the
    cases that exist, so an unknown destination is refused by the schema rather than accepted and
    dropped. A "navigate" that lands nowhere is the affordance-with-no-destination defect this
    project has hit five times.

--- a/docs/decisions/ADR-0053-the-command-channel-drives-and-observes-the-interface.md
+++ b/docs/decisions/ADR-0053-the-command-channel-drives-and-observes-the-interface.md
@@ -132,6 +132,23 @@ render *its own* windows with no permission at all, and that is the only thing t
   Anything the window server draws on top — a sheet from another process, a tooltip, the
   title bar — is absent by construction, and a capture is therefore evidence about the app's own
   view tree rather than about what a person saw.
+
+  **Measured, and worse than "no chrome" suggests.** Against the same window in one session, the
+  sidebar rendered on some destinations and came back black on others, and the smart-playlists
+  screen came back blank and byte-identical across two attempts twelve seconds apart —
+  deterministic rather than flaky, and unexplained. A layer walk sees what the app *asked* to be
+  drawn, not what was drawn.
+
+- **The two jobs separate, and only one of them is this ADR's.** For website screenshots,
+  `screencapture -o -x -l <windowid>` — the system tool, aimed at one window — produced every
+  destination correctly on the first attempt, chrome included, with no black sidebars and no blank
+  screens, because it reads what the compositor produced. It needs the Screen Recording permission,
+  which is exactly what point 6 refuses to make the *application* ask for. A person capturing on
+  their own machine is not the application and can grant it to a terminal for a minute.
+
+  So: the in-app capture stays the MCP tool — permission-free, and good enough for an assistant
+  checking its own work. Marketing screenshots use the system tool, with navigation still driven
+  over this channel so nothing has to be clicked.
 - **Tradeoff:** two more capabilities to keep honest. A build that declares `screenshot` and cannot
   produce one is exactly the failure point 7 exists to prevent, and nothing but care enforces it.
 - **Follow-up:** the phone could declare `screenshot` too — `UIGraphicsImageRenderer` over the key

--- a/docs/decisions/ADR-0053-the-command-channel-drives-and-observes-the-interface.md
+++ b/docs/decisions/ADR-0053-the-command-channel-drives-and-observes-the-interface.md
@@ -66,10 +66,17 @@ render *its own* windows with no permission at all, and that is the only thing t
    "the client did not answer in time" rather than hanging — ADR-0044 point 5's rule, which is
    ADR-0017 point 4's rule one layer further out. Nothing on this channel may spin.
 
-6. **A capture is the application drawing its own window, never a screen recording.** `cacheDisplay`
-   over the window's own content view. No permission prompt, and by construction it cannot
-   photograph anything but Familiar — which matters because the machine this runs on is somebody's
-   desktop, with their mail on it.
+6. **A capture is the application drawing its own window, never a screen recording.** No permission
+   prompt, and by construction it cannot photograph anything but Familiar — which matters because
+   the machine this runs on is somebody's desktop, with their mail on it.
+
+   **Through the window's `CALayer`, not through `cacheDisplay`.** This was written the other way
+   round and corrected by running it: `cacheDisplay(in:to:)` drives `draw(_:)` down the view tree,
+   and SwiftUI's macOS views are layer-backed and mostly do not implement it — so the capture came
+   back with the sidebar entirely black while the track table, an `NSTableView` underneath, drew
+   fine. Deterministically; two consecutive captures were byte-identical, so it was not a race.
+   `CALayer.render(in:)` walks the tree that actually holds the pixels, and needs its context
+   flipped first or the whole window arrives upside down.
 
 7. **Both are capability-gated**, per ADR-0044 point 12. `navigate` and `screenshot` join the
    declaration a client makes when it subscribes, so the tool surface offers them only when the
@@ -118,8 +125,13 @@ render *its own* windows with no permission at all, and that is the only thing t
 - **Tradeoff:** the channel is no longer purely one-way at the system level, even though the SSE
   stream still is. ADR-0044 point 2's sentence needs reading alongside this ADR rather than alone.
 - **Tradeoff:** a capture is the app's own drawing, so it will not show window chrome, the menu bar,
-  or anything overlapping it. For screenshots of the interface that is arguably better; for
-  reproducing a visual bug involving a system control it is worse.
+  or anything overlapping it — the title-bar strip comes back empty. For screenshots of the
+  interface that is arguably better; for reproducing a visual bug involving a system control it is
+  worse.
+- **Tradeoff:** rendering a layer tree is not the same as what the compositor puts on screen.
+  Anything the window server draws on top — a sheet from another process, a tooltip, the
+  title bar — is absent by construction, and a capture is therefore evidence about the app's own
+  view tree rather than about what a person saw.
 - **Tradeoff:** two more capabilities to keep honest. A build that declares `screenshot` and cannot
   produce one is exactly the failure point 7 exists to prevent, and nothing but care enforces it.
 - **Follow-up:** the phone could declare `screenshot` too — `UIGraphicsImageRenderer` over the key

--- a/docs/decisions/ADR-0053-the-command-channel-drives-and-observes-the-interface.md
+++ b/docs/decisions/ADR-0053-the-command-channel-drives-and-observes-the-interface.md
@@ -1,0 +1,128 @@
+# ADR-0053: The Command Channel Drives and Observes the Interface
+
+Status: proposed
+
+Date: 2026-08-12
+
+Extends [ADR-0044](ADR-0044-mcp-clients-actuate-playback-through-a-command-channel.md)
+
+## Context
+
+[ADR-0044](ADR-0044-mcp-clients-actuate-playback-through-a-command-channel.md) built a per-profile
+SSE channel from server to client and proved it end to end — Claude Desktop to sound. Its point 11
+divided everything an MCP host might want into three categories: server-side state, transient device
+actions, and device-local preferences. Two of those three travel on the channel.
+
+**Navigating the interface is a fourth category, and the vocabulary for it already exists.**
+`LibraryRoute` in `FamiliarKit` enumerates every destination the Mac and phone can be rooted on —
+`home`, `section(.tracks/.albums/.artists/.playlists)`, `smartPlaylists`, `musicMap`, `discover`,
+`pendingReview`, `proposedChanges`, `mixtapes`, `favorites`, `downloads`, `settings`. A "show me the
+albums" imperative is the same shape as "play", against a list that is already closed and named.
+
+The prompt is narrower than the capability. The website (ADR-0039 point 4 and its screenshot
+follow-up) has no images of the native clients at all — `screenshots/` is entirely the web app,
+captured by a Playwright spec that by construction cannot photograph a Mac app. Meanwhile every
+attempt to drive that app from tooling has failed: synthetic media keys do nothing, accessibility
+traversal finds nothing, and the standing rule in this project is not to guess at click coordinates
+on a real desktop. **The app can do both of these things trivially from the inside**, and there is
+already a channel pointed at its inside.
+
+### The thing this changes
+
+ADR-0044 point 2 chose SSE over a WebSocket with a stated reason: *"Commands are one-way, so the
+return half of a socket would be unused."* A screenshot is a return. That premise is not wrong, but
+it no longer covers everything the channel is asked to carry, and reversing it silently would be
+worse than recording it.
+
+### What a capture must not become
+
+macOS offers screen capture through `ScreenCaptureKit`, which photographs displays and other
+applications and demands the Screen Recording permission to do it. That is the wrong instrument
+twice over: it prompts, and once granted it can see everything on the machine. An application can
+render *its own* windows with no permission at all, and that is the only thing this needs.
+
+## Decision
+
+1. **The channel gains a fourth category: interface navigation.** An imperative naming a
+   `LibraryRoute`, applied by the client to its own root selection. Server-side state is still
+   written directly and still needs no channel; this joins transient actions and preferences.
+
+2. **The destination vocabulary is `LibraryRoute`, not free text.** The tool advertises exactly the
+   cases that exist, so an unknown destination is refused by the schema rather than accepted and
+   dropped. A "navigate" that lands nowhere is the affordance-with-no-destination defect this
+   project has hit five times.
+
+3. **Artifacts return over HTTP, not over the channel.** The client `POST`s a capture to
+   `/playback/artifacts/{request_id}`; the SSE stream stays one-way and ADR-0044 point 2's
+   reasoning survives intact — the return half of a *socket* would still be unused, because the
+   return is a request the client makes when it has something to send.
+
+4. **A request id correlates the two halves**, minted by the server when it issues the command and
+   carried back on the upload. It is not a device identity and does not reopen
+   [ADR-0029](ADR-0029-the-server-stores-no-listener-preferences.md) point 5: it names one
+   outstanding question, lives in memory, and dies when the question is answered or times out.
+
+5. **The tool waits, with a deadline, and answers either way.** A capture that never arrives returns
+   "the client did not answer in time" rather than hanging — ADR-0044 point 5's rule, which is
+   ADR-0017 point 4's rule one layer further out. Nothing on this channel may spin.
+
+6. **A capture is the application drawing its own window, never a screen recording.** `cacheDisplay`
+   over the window's own content view. No permission prompt, and by construction it cannot
+   photograph anything but Familiar — which matters because the machine this runs on is somebody's
+   desktop, with their mail on it.
+
+7. **Both are capability-gated**, per ADR-0044 point 12. `navigate` and `screenshot` join the
+   declaration a client makes when it subscribes, so the tool surface offers them only when the
+   attached client can actually do them. The phone declares navigation and not capture; the web app
+   declares neither.
+
+8. **Artifacts are held in memory and dropped once read.** No table, no directory, no retention
+   rule to get wrong. A screenshot of somebody's library is not something to accumulate on a server
+   because it was easier than deleting it.
+
+## Alternatives Considered
+
+- **Have the MCP host drive the Mac through accessibility APIs.** The obvious answer, needs no
+  Familiar code, and works for any application. Rejected on evidence: this project has already tried
+  it. Synthetic media keys and AX traversal both failed against this app, and the fallback —
+  guessing at screen coordinates on a real desktop — is how a stray click deletes something. The app
+  knows where its own destinations are; asking it is both easier and safer.
+
+- **Screen capture via `ScreenCaptureKit`.** Higher fidelity, captures what a person would actually
+  see including window chrome. Rejected: it requires the Screen Recording permission, which is a
+  prompt and a standing grant to photograph the whole machine, in exchange for pixels this app can
+  produce about itself for free.
+
+- **A WebSocket, replacing SSE.** The honest reading of "we now need a return path" is that the
+  transport should carry it. Rejected because the return is rare, large and binary — a screenshot is
+  hundreds of kilobytes — and multiplexing that into the command stream would make the common case
+  (a four-byte transport imperative) pay for the rare one. An upload is a better fit for an upload.
+
+- **Write captures to disk and return a path.** Simpler to implement and easy to debug. Rejected by
+  point 8: it turns a transient answer into an accumulating pile of images of somebody's library,
+  with a retention policy nobody will write.
+
+- **Do nothing, and screenshot the app by hand.** Genuinely reasonable for the website alone — it is
+  ten minutes of somebody's time. Rejected because the capability is worth more than the errand: an
+  MCP host that can see the interface can also check its own work, and this project has shipped
+  three defects this month whose common shape was a screen that renders and does nothing.
+
+## Consequences
+
+- **Positive:** the native clients can finally be photographed for the website, which ADR-0039's
+  follow-up has been blocked on since it was written.
+- **Positive:** an MCP host can *look* at the app, not only act on it — the first return path this
+  channel has had.
+- **Positive:** navigation reuses a closed enum that already exists, so the tool cannot name a
+  destination the app does not have.
+- **Tradeoff:** the channel is no longer purely one-way at the system level, even though the SSE
+  stream still is. ADR-0044 point 2's sentence needs reading alongside this ADR rather than alone.
+- **Tradeoff:** a capture is the app's own drawing, so it will not show window chrome, the menu bar,
+  or anything overlapping it. For screenshots of the interface that is arguably better; for
+  reproducing a visual bug involving a system control it is worse.
+- **Tradeoff:** two more capabilities to keep honest. A build that declares `screenshot` and cannot
+  produce one is exactly the failure point 7 exists to prevent, and nothing but care enforces it.
+- **Follow-up:** the phone could declare `screenshot` too — `UIGraphicsImageRenderer` over the key
+  window is the same idea — but iOS captures are not what the website needs first.
+- **Follow-up:** navigation is root-level only. Opening a *specific* album or playlist means naming
+  one, which is a larger vocabulary and a second decision.


### PR DESCRIPTION
**ADR-0053** (proposed), plus both halves of the implementation. Paired with familiar-apple's client change.

## What it does

Two tools on the channel ADR-0044 built:

- **`navigate_app`** — root the Mac or phone on a destination, from a closed list mirroring `SidebarItem`
- **`capture_screenshot`** — the app draws its own window and returns the PNG

## Proven end to end, against the real Mac

```
tools: 38
players: [{"id":"p1","name":"jeffbook","platform":"macos",
           "capabilities":["crossfade","navigate","play","queue","screenshot"]}]
navigate(albums): {"delivered": true, "destination": "albums"}
screenshot: 1,097,881 bytes  (1800x1280, image/png)
```

The image is the Albums grid with the sidebar selection on Albums — the command landed and the capture came back.

## The decision worth reading

ADR-0044 point 2 chose SSE over a WebSocket because *"commands are one-way, so the return half of a socket would be unused."* **A screenshot is a return.** Rather than reverse that, artifacts come back as an upload the client makes to `/playback/artifacts/{request_id}` — the stream stays one-way and the sentence stays true.

Artifacts are held in memory and dropped once read. No table, no directory, no retention rule to get wrong.

**A capture is the app drawing its own window**, never a screen recording. `ScreenCaptureKit` would demand the Screen Recording permission — a prompt, then a standing grant to photograph the whole machine — for pixels the app produces about itself for free. This one cannot see another application.

## A race the tests caught

`deliver` popped the entry, so a client fast enough to upload **before** the tool reached its `await` resolved a future nobody held, and the tool then reported a timeout for an image that had already arrived. Rare, load-dependent, invisible. `wait` now owns the removal, and the case is pinned by name.

## Verified

1,552 backend tests. Two existing contract tests failed on this change and were updated — the MCP tool surface and the capability vocabulary, both of which pin values the other repo also holds. That is exactly their job.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_014P9p2fvFnyiywBxGkv4gfW