### PR TITLE
Update playlist parity bookkeeping

### DIFF
--- a/docs/WEB-PARITY.md
+++ b/docs/WEB-PARITY.md
@@ -4,7 +4,7 @@
 nothing is lost on the way to native clients. This document is that record, so the code no longer has
 to be. Code is a poor inventory: you cannot read it as a list, and it rots without saying so.
 
-Written 2026-08-10, last updated 2026-08-11. Verified against the repos at that date — every "no"
+Written 2026-08-10, last updated 2026-08-14. Verified against the repos at that date — every "no"
 below was checked by looking for the call, not by assuming.
 
 **This is maintained, not a snapshot.** ADR-0050 point 6 makes it the reference the code used to be,
@@ -50,26 +50,24 @@ which only holds if it is corrected when a row changes. Update it in the same ch
 
 ## Playlist editing
 
-Was "the biggest gap". Mostly closed on the Mac, 2026-08-11.
+Was "the biggest gap". Mostly closed on the Mac, 2026-08-11, and closed for regular playlists on
+iPhone by `familiar-apple` #118.
 
 | Capability | Web | Mac | iPhone | Notes |
 |---|---|---|---|---|
-| Create a playlist | ✅ | ✅ | ❌ | ADR-0049; both editors are `#if os(macOS)` |
+| Create a playlist | ✅ | ✅ | ✅ | ADR-0049; iPhone uses the same editor sheet with a phone toolbar |
 | Create a smart playlist | ✅ | ✅ | ❌ | |
 | Add a track to a playlist | ✅ | ✅ | ✅ | |
-| Remove a track from a playlist | ✅ | ✅ | ❌ | Row menu, playlist screens only. Removes *every* occurrence, so the view reloads rather than guessing which rows went |
-| Rename / delete a playlist | ✅ | ✅ | ❌ | Sidebar row context menu. Delete is confirmed; removing a track is not |
-| **Reorder playlist tracks** | ✅ | ❌ | ❌ | `playlistsReorderPlaylistTracks` is generated and uncalled — the work is drag-and-drop in `TrackTable`, not the request |
+| Remove a track from a playlist | ✅ | ✅ | ✅ | Row menu, playlist screens only. Removes *every* occurrence, so the view reloads rather than guessing which rows went |
+| Rename / delete a playlist | ✅ | ✅ | ✅ | Sidebar or playlist actions menu. Delete is confirmed; removing a track is not |
+| Reorder playlist tracks | ✅ | ✅ | ✅ | Move up/down row menu, using per-occurrence playlist-track ids |
 | Delete a smart playlist | ✅ | ✅ | ❌ | |
 | **Reorder the queue / remove from it** | ✅ | ❌ | ❌ | `QueueView` has no `onMove`/`onDelete`; the only removal is rejecting a radio suggestion |
 | Save the queue as a playlist | ✅ | ❌ | ❌ | |
 
-**`/playlists/:id` is still mounted in the browser, and reorder is the only reason left.** It was
-kept because the Mac's playlist detail looked equivalent and was nearly read-only — that is no longer
-true, and when reorder lands the route can go.
-
-**iPhone remains unable to edit playlists at all**, or to create one: every editor is
-`#if os(macOS)`. That is ADR-0013 point 2's listening-path rule, not an oversight.
+**`/playlists/:id` no longer has a native-parity reason to stay mounted.** Regular playlist editing is
+now covered by the Apple clients: the Mac has sidebar/list/detail affordances, and iPhone has create,
+rename/delete, remove and move up/down controls. Smart playlists stay Mac-only by design.
 
 ## Library management
 
@@ -144,8 +142,11 @@ auth  health
   `familiar-apple` shipped version 1.2 build 14.
 
 - **2026-08-11** — the Mac gained remove-a-track, rename and delete for playlists
-  (`familiar-apple` #100). Only reorder is still browser-only, and it is the last thing keeping
-  `/playlists/:id` mounted.
+  (`familiar-apple` #100). At that point reorder and iPhone editing still kept `/playlists/:id`
+  mounted.
+- **2026-08-14** — the iPhone gained regular playlist create, rename/delete, remove and move up/down
+  reorder controls (`familiar-apple` #118). The playlist-editing row is no longer part of the
+  "settings only" gate in ADR-0050 point 6.
 - **2026-08-11** — the web app was reduced to management (`familiar` #151, ADR-0050): it opens on
   Settings and twelve listening-path routes are unmounted. **The Web column below still describes
   what the code can do, not what is currently routed** — `PARKED_BROWSERS` in

--- a/docs/decisions/ADR-0050-the-web-app-is-a-management-surface.md
+++ b/docs/decisions/ADR-0050-the-web-app-is-a-management-surface.md
@@ -14,6 +14,9 @@ Implementation:
   landing route. Following those routes found three affordances still pointing at them, including a
   mobile bottom bar whose every button was a dead link.
 - `familiar` #153 — the matrix updated as point 6 requires.
+- `familiar-apple` #118 — the playlist-editing item in point 6's native backlog is closed for
+  regular playlists: iPhone can now create, rename/delete, remove tracks and move tracks up/down,
+  matching the Mac's regular-playlist editing surface. Smart playlists remain Mac-only by design.
 - **Point 4's permission is now live: the parked browsers may be deleted.** They are named in
   `PARKED_BROWSERS` (`packages/frontend/src/routes.ts`) and amount to roughly 169 files and 35,900
   lines. Not yet done, and deliberately its own change — it is a large diff whose only risk is
@@ -123,6 +126,8 @@ them, including a mobile bottom bar whose every button was a dead link.
 6. **`docs/WEB-PARITY.md` is the reference, and is maintained.** It replaces "keep the code so we
    remember what we had". It is also the native backlog: **"settings only" is not reachable** until
    the Apple clients can edit playlists, edit track metadata, trigger a scan, and create a profile.
+   `familiar-apple` #118 closes the playlist-editing item, leaving track metadata, scan and profile
+   creation as the remaining blockers.
 
 ## Alternatives Considered
 
@@ -157,9 +162,8 @@ them, including a mobile bottom bar whose every button was a dead link.
   most. Accepted, because the measurement says nobody was using it.
 - **Tradeoff** — the web app's own surface and the native clients will drift, and ADR-0002 point 4
   already said parity is not a goal. The matrix is what stops that drift being *silent*.
-- **Follow-up** — the four gaps in point 6, of which playlist editing is cheapest:
-  `playlistsUpdatePlaylist` and `playlistsDeletePlaylist` are generated and uncalled, the same shape
-  as the create gap ADR-0049 closed.
+- **Follow-up** — the remaining gaps in point 6 are track metadata editing, scan triggering and
+  profile creation. Playlist editing was the cheapest and is now covered by `familiar-apple` #118.
 - **Follow-up** — `packages/ios`, the Capacitor app, is superseded by ADR-0001, has had no meaningful
   commits since May, and still ships **100% of `frontend/src`**. It is now the largest consumer of
   the code this ADR is trying to stop maintaining, and deserves its own decision.


### PR DESCRIPTION
## Summary

Updates the ADR-0050 bookkeeping for the iOS regular-playlist editing work in `familiar-apple` #118.

- Marks regular playlist create, rename/delete, remove, and reorder as covered on iPhone in `docs/WEB-PARITY.md`.
- Notes that `/playlists/:id` no longer has a native-parity reason to stay mounted.
- Updates ADR-0050 to remove playlist editing from the remaining `settings only` blockers, leaving track metadata editing, scan triggering, and profile creation.

## Validation

- `git diff --check`

## Dependency

This docs PR should land after or alongside `seethroughlab/familiar-apple` #118, since the matrix references that Apple-client PR as the implementation that closes the playlist-editing gap.