### PR TITLE
Open the web app on a library dashboard (ADR-0058 phase 1)

### DIFF
--- a/backend/app/api/routes/library.py
+++ b/backend/app/api/routes/library.py
@@ -17,7 +17,7 @@ from app.api.routes.library_import import router as import_router
 from app.api.routes.library_maps import router as maps_router
 from app.api.routes.library_missing import router as missing_router
 from app.api.routes.library_sync import router as sync_router
-from app.db.models import AlbumType, Track, TrackAnalysis
+from app.db.models import Track, TrackAnalysis
 
 logger = logging.getLogger(__name__)
 
@@ -25,11 +25,20 @@ router = APIRouter(prefix="/library", tags=["library"])
 
 
 class LibraryStats(BaseModel):
-    """Library statistics."""
+    """Library statistics.
+
+    The three totals agree with the list endpoints that show the same things, and are counted the
+    same way — see ``get_library_stats``. They did not until 2026-08-16.
+    """
 
     total_tracks: int
     total_albums: int
     total_artists: int
+    # Deprecated, and structurally meaningless: nothing in the codebase ever writes
+    # ``Track.album_type``. Every row keeps the ``default=AlbumType.ALBUM`` set on the column, so
+    # ``albums`` is a track count and the other two are always 0 — on a library ADR-0052 found 297
+    # compilations in. Kept only because `library` is a generated tag (ADR-0007) and dropping
+    # required fields is a cross-repo break; do not display them. See ADR-0058's follow-up.
     albums: int
     compilations: int
     soundtracks: int
@@ -42,33 +51,70 @@ class LibraryStats(BaseModel):
 
 @router.get("/stats", response_model=LibraryStats)
 async def get_library_stats(db: DbSession) -> LibraryStats:
-    """Get library statistics in a single query using conditional aggregation."""
-    from sqlalchemy import and_, case
+    """Get library statistics.
+
+    **These are the same counts the list endpoints return, counted the same way**, because a
+    dashboard figure that disagrees with the screen it links to is worse than no figure
+    (ADR-0058 point 6). Verified against the 26k-track library on 2026-08-16, when all three
+    disagreed:
+
+    - ``total_tracks`` counted every row regardless of status, so 66 missing/deleted tracks were
+      reported as library size (26,488 against ``/tracks``' 26,422).
+    - ``total_albums`` was ``count(distinct Track.album)`` — a *string* distinct, which merges
+      same-titled albums by different artists. ``library_albums`` groups by
+      ``(album_artist, album)`` case-insensitively, and said 3,927 against this query's 3,873.
+    - ``total_artists`` was ``count(distinct Track.artist)`` over raw tag strings, so "The
+      Beatles" and "Beatles, The" counted twice and features counted separately.
+      ``library_artists`` reads the canonical ``Artist`` table (ADR-0052) and said 3,477 against
+      this query's 3,664.
+
+    ``tests/test_library_stats.py`` asserts the agreement rather than the arithmetic, so a future
+    change to either side has to move both.
+    """
+    from sqlalchemy import and_, literal_column
 
     from app.config import FEATURES_VERSION, MELODIC_VERSION, MOOD_TAGS_VERSION
+    from app.db.models import Artist, TrackStatus
 
-    result = await db.execute(
-        select(
-            func.count(Track.id).label("total_tracks"),
-            func.count(func.distinct(Track.album)).label("total_albums"),
-            func.count(func.distinct(Track.artist)).label("total_artists"),
-            func.sum(case((Track.album_type == AlbumType.ALBUM, 1), else_=0)).label("albums"),
-            func.sum(case((Track.album_type == AlbumType.COMPILATION, 1), else_=0)).label("compilations"),
-            func.sum(case((Track.album_type == AlbumType.SOUNDTRACK, 1), else_=0)).label("soundtracks"),
-        )
+    active = Track.status == TrackStatus.ACTIVE
+
+    total_tracks = await db.scalar(select(func.count(Track.id)).where(active)) or 0
+
+    # Mirrors ``library_albums.list_albums``' base query: coalesce album_artist to artist, group
+    # case-insensitively on both halves. Counting the grouped subquery is what makes it agree.
+    album_artist_col = func.coalesce(func.nullif(Track.album_artist, ""), Track.artist)
+    album_groups = (
+        select(literal_column("1"))
+        .where(active, Track.album.isnot(None), Track.album != "")
+        .group_by(func.lower(album_artist_col), func.lower(Track.album))
     )
-    row = result.one()
+    total_albums = await db.scalar(select(func.count()).select_from(album_groups.subquery())) or 0
 
-    total_tracks = row.total_tracks or 0
+    # Mirrors ``library_artists.list_artists``: canonical artists that have at least one active
+    # track. Tracks with no ``canonical_artist_id`` are scanner-failed and excluded there too.
+    total_artists = await db.scalar(
+        select(func.count(func.distinct(Artist.id)))
+        .select_from(Artist)
+        .join(Track, Track.canonical_artist_id == Artist.id)
+        .where(active)
+    ) or 0
+    # Every analysis count joins ``Track`` and filters to active, for the same reason the totals
+    # do — and here it is load-bearing rather than cosmetic. ``pending_analysis`` below is
+    # ``total_tracks - analyzed_tracks``, so counting analyses of tracks that are no longer in the
+    # library against an active-only total produces a *negative* backlog. On the 26k library that
+    # was -41 the moment the total was corrected.
+    def analysis_count(*conditions):
+        return select(func.count(TrackAnalysis.id)).join(
+            Track, Track.id == TrackAnalysis.track_id
+        ).where(active, *conditions)
+
     analyzed_tracks = await db.scalar(
-        select(func.count(TrackAnalysis.id)).where(
-            TrackAnalysis.features_version >= FEATURES_VERSION
-        )
+        analysis_count(TrackAnalysis.features_version >= FEATURES_VERSION)
     ) or 0
 
     # Per-phase pending counts
     pending_backfill = await db.scalar(
-        select(func.count(TrackAnalysis.id)).where(
+        analysis_count(
             and_(
                 TrackAnalysis.features_version >= FEATURES_VERSION,
                 TrackAnalysis.analysis_detail.is_(None),
@@ -77,7 +123,7 @@ async def get_library_stats(db: DbSession) -> LibraryStats:
     ) or 0
 
     pending_melodic = await db.scalar(
-        select(func.count(TrackAnalysis.id)).where(
+        analysis_count(
             and_(
                 TrackAnalysis.features_version >= FEATURES_VERSION,
                 TrackAnalysis.analysis_detail.is_not(None),
@@ -87,7 +133,7 @@ async def get_library_stats(db: DbSession) -> LibraryStats:
     ) or 0
 
     pending_mood_tags = await db.scalar(
-        select(func.count(TrackAnalysis.id)).where(
+        analysis_count(
             and_(
                 TrackAnalysis.embedding.isnot(None),
                 TrackAnalysis.mood_tags_version < MOOD_TAGS_VERSION,
@@ -97,13 +143,15 @@ async def get_library_stats(db: DbSession) -> LibraryStats:
 
     return LibraryStats(
         total_tracks=total_tracks,
-        total_albums=row.total_albums or 0,
-        total_artists=row.total_artists or 0,
-        albums=row.albums or 0,
-        compilations=row.compilations or 0,
-        soundtracks=row.soundtracks or 0,
+        total_albums=total_albums,
+        total_artists=total_artists,
+        # See the deprecation note on the model. These are wrong by construction, not by query.
+        albums=total_tracks,
+        compilations=0,
+        soundtracks=0,
         analyzed_tracks=analyzed_tracks,
-        pending_analysis=total_tracks - analyzed_tracks,
+        # Clamped: a backlog is a count of work, and there is no such thing as -41 of it.
+        pending_analysis=max(0, total_tracks - analyzed_tracks),
         pending_backfill=pending_backfill,
         pending_melodic=pending_melodic,
         pending_mood_tags=pending_mood_tags,

--- a/backend/tests/test_library_stats.py
+++ b/backend/tests/test_library_stats.py
@@ -1,0 +1,152 @@
+"""`/library/stats` must agree with the endpoints that show the same things.
+
+Written after the dashboard for ADR-0058 was pointed at the real 26k library and every total on
+this endpoint turned out to be wrong — not by a rounding error, but by counting a different thing
+than the screen each figure links to:
+
+| field | stats said | the list endpoint said |
+|---|---|---|
+| `total_tracks` | 26,488 | 26,422 (`status == ACTIVE`) |
+| `total_albums` | 3,873 (`count(distinct album)`) | 3,927 (grouped by album_artist + album) |
+| `total_artists` | 3,664 (`count(distinct artist)`) | 3,477 (canonical `Artist`) |
+
+**These assert agreement, not arithmetic.** A test that hard-coded "3 albums" would pass just as
+happily with either counting method, which is exactly how the endpoint drifted for as long as it
+did. Comparing the two sides means a change to either one has to move both.
+"""
+
+from __future__ import annotations
+
+from uuid import uuid4
+
+import pytest
+
+from app.api.routes.library import get_library_stats
+from app.api.routes.library_albums import list_albums
+from app.api.routes.library_artists import list_artists
+from app.db.models import Track, TrackAnalysis, TrackStatus
+from app.services import artist_resolver as ar
+
+
+def _track(
+    *,
+    file: str,
+    artist_id,
+    artist: str = "Artist",
+    album: str = "Album",
+    album_artist: str | None = None,
+    status: TrackStatus = TrackStatus.ACTIVE,
+) -> Track:
+    return Track(
+        id=uuid4(),
+        file_path=f"/music/{file}.mp3",
+        file_hash=f"hash-{file}",
+        title=file,
+        artist=artist,
+        album=album,
+        album_artist=album_artist,
+        canonical_artist_id=artist_id,
+        status=status,
+    )
+
+
+@pytest.mark.asyncio
+async def test_album_total_agrees_with_the_album_list(async_db):
+    """Two artists with an identically-titled album are two albums, not one.
+
+    `count(distinct Track.album)` said one. The album list, which groups by
+    (album_artist, album), said two — and it is the one a person can click through and count.
+    """
+    a = await ar.resolve_canonical_artist(async_db, "Alpha", do_mb_lookup=False)
+    b = await ar.resolve_canonical_artist(async_db, "Beta", do_mb_lookup=False)
+    async_db.add(_track(file="t1", artist_id=a.id, artist="Alpha", album="Greatest Hits"))
+    async_db.add(_track(file="t2", artist_id=b.id, artist="Beta", album="Greatest Hits"))
+    await async_db.commit()
+
+    stats = await get_library_stats(db=async_db)
+    albums = await list_albums(db=async_db)
+
+    assert stats.total_albums == albums.total == 2
+
+
+@pytest.mark.asyncio
+async def test_album_total_is_case_insensitive_like_the_album_list(async_db):
+    """"Alice In Ultraland" and "Alice in Ultraland" are one album on both sides."""
+    a = await ar.resolve_canonical_artist(async_db, "Alpha", do_mb_lookup=False)
+    async_db.add(_track(file="t1", artist_id=a.id, artist="Alpha", album="Alice In Ultraland"))
+    async_db.add(_track(file="t2", artist_id=a.id, artist="Alpha", album="Alice in Ultraland"))
+    await async_db.commit()
+
+    stats = await get_library_stats(db=async_db)
+    albums = await list_albums(db=async_db)
+
+    assert stats.total_albums == albums.total == 1
+
+
+@pytest.mark.asyncio
+async def test_artist_total_agrees_with_the_artist_list(async_db):
+    """Tag variants of one canonical artist count once, as they do on the artist screen."""
+    canonical = await ar.resolve_canonical_artist(async_db, "The Beatles", do_mb_lookup=False)
+    async_db.add(_track(file="t1", artist_id=canonical.id, artist="Beatles"))
+    async_db.add(_track(file="t2", artist_id=canonical.id, artist="The Beatles"))
+    async_db.add(_track(file="t3", artist_id=canonical.id, artist="Beatles, The"))
+    await async_db.commit()
+
+    stats = await get_library_stats(db=async_db)
+    artists = await list_artists(db=async_db)
+
+    assert stats.total_artists == artists.total == 1
+
+
+@pytest.mark.asyncio
+async def test_non_active_tracks_are_not_library_size(async_db):
+    """A deleted file is not in the library, on any of the three totals.
+
+    The real library reported 66 missing/deleted tracks as part of its size.
+    """
+    a = await ar.resolve_canonical_artist(async_db, "Alpha", do_mb_lookup=False)
+    b = await ar.resolve_canonical_artist(async_db, "Ghost", do_mb_lookup=False)
+    async_db.add(_track(file="live", artist_id=a.id, artist="Alpha", album="Real"))
+    async_db.add(
+        _track(
+            file="gone",
+            artist_id=b.id,
+            artist="Ghost",
+            album="Vanished",
+            status=TrackStatus.MISSING,
+        )
+    )
+    await async_db.commit()
+
+    stats = await get_library_stats(db=async_db)
+
+    assert stats.total_tracks == 1
+    assert stats.total_albums == 1
+    assert stats.total_artists == 1
+
+
+@pytest.mark.asyncio
+async def test_pending_analysis_is_never_negative(async_db):
+    """An analysis belonging to a track that left the library is not credit against the backlog.
+
+    This is the failure the active-filter fix would otherwise have *introduced*: scoping
+    `total_tracks` to active while leaving the analysis counts unscoped rendered -41 pending on
+    the real library.
+    """
+    from app.config import FEATURES_VERSION
+
+    a = await ar.resolve_canonical_artist(async_db, "Alpha", do_mb_lookup=False)
+    live = _track(file="live", artist_id=a.id, artist="Alpha")
+    gone = _track(file="gone", artist_id=a.id, artist="Alpha", status=TrackStatus.MISSING)
+    async_db.add_all([live, gone])
+    await async_db.flush()
+    # Both analysed; only one is still in the library.
+    async_db.add(TrackAnalysis(track_id=live.id, features_version=FEATURES_VERSION))
+    async_db.add(TrackAnalysis(track_id=gone.id, features_version=FEATURES_VERSION))
+    await async_db.commit()
+
+    stats = await get_library_stats(db=async_db)
+
+    assert stats.total_tracks == 1
+    assert stats.analyzed_tracks == 1
+    assert stats.pending_analysis == 0

--- a/docs/REST-API.md
+++ b/docs/REST-API.md
@@ -374,13 +374,25 @@ curl "http://localhost:4400/api/v1/library/stats"
   "total_tracks": 1295,
   "total_albums": 156,
   "total_artists": 89,
-  "albums": 1100,
-  "compilations": 150,
-  "soundtracks": 45,
+  "albums": 1295,
+  "compilations": 0,
+  "soundtracks": 0,
   "analyzed_tracks": 1250,
-  "pending_analysis": 45
+  "pending_analysis": 45,
+  "pending_backfill": 0,
+  "pending_melodic": 0,
+  "pending_mood_tags": 0
 }
 ```
+
+The three totals count active tracks only, and agree with `/library/albums` and `/library/artists`
+— same grouping, same canonical tables. `tests/test_library_stats.py` asserts that agreement.
+
+**`albums`, `compilations` and `soundtracks` are deprecated and should not be displayed.** Nothing
+writes `Track.album_type`, so every row keeps the column default: `albums` always equals
+`total_tracks` and the other two are always `0`. This example previously showed `150` compilations
+and `45` soundtracks, which no instance has ever returned. They remain on the wire only because
+`library` is a generated tag (ADR-0007) and removing required fields breaks the Swift client.
 
 ### Start Library Sync
 

--- a/docs/decisions/ADR-0058-the-web-app-is-an-administration-tool.md
+++ b/docs/decisions/ADR-0058-the-web-app-is-an-administration-tool.md
@@ -1,0 +1,141 @@
+# ADR-0058: The Web App Is an Administration Tool
+
+Status: proposed
+
+Date: 2026-08-16
+
+Extends [ADR-0050](ADR-0050-the-web-app-is-a-management-surface.md) and
+[ADR-0057](ADR-0057-the-web-app-keeps-only-what-has-no-native-answer.md). Those said what the
+browser is *not* and what it keeps. This says what it is, and schedules the last thing it kept.
+
+## Context
+
+`0050` made the browser a management surface. `0057` gave that a rule and removed the detail routes.
+What remains is Settings, `/library/tracks`, `/library/artist-cleanup` and `/listen/:code` — a
+management surface still arranged as a music player: it opens on a settings page, and that page is
+one scroll of nine sections, five of which are listener preferences.
+
+**The tools mostly exist already.** Four capabilities are built server-side with no web interface,
+and two of them already have a client wrapper that nothing calls:
+
+| Endpoint | Gives | State |
+|---|---|---|
+| `GET /library/stats` | totals, **four separate** pending-analysis queues | `libraryApi.getStats` wraps it, uncalled |
+| `GET /tracks/stats/plays` | total plays, seconds listened, unique tracks, top tracks | `profilesApi.getStats` wraps it, uncalled |
+| `POST /library/deduplicate/preview` | duplicate candidates | no UI |
+| `organizer` — `/templates`, `/preview`, `/track/{id}/preview` | file organisation against a naming template | no UI |
+
+So "library stats" is an unbuilt front end rather than a new feature — the same generated-and-uncalled
+shape this codebase keeps finding, this time in the browser.
+
+**One number that does not exist.** There is no artwork-coverage endpoint. `artwork.py` has per-album
+status and a batch status POST, but nothing counts albums without art. Recorded because a mock-up
+during discussion showed such a tile, and it would otherwise be planned as free.
+
+**And the numbers that did exist were wrong — every one of them.** The first draft of the dashboard
+was pointed at the 26k library, and each total disagreed with the screen it links to, because the
+stats endpoint counted a different thing:
+
+| field | stats said | the list endpoint said | why |
+|---|---|---|---|
+| `total_tracks` | 26,488 | 26,422 | no `status == ACTIVE` filter — 66 missing/deleted files counted as library size |
+| `total_albums` | 3,873 | 3,927 | `count(distinct Track.album)`, a *string* distinct; the album list groups by `(album_artist, album)` |
+| `total_artists` | 3,664 | 3,477 | raw tag strings, so "The Beatles" and "Beatles, The" counted twice; the artist list reads canonical `Artist` (ADR-0052) |
+
+Worse, `albums` / `compilations` / `soundtracks` are not fixable: **nothing in the codebase writes
+`Track.album_type`.** Every row keeps the column default, so `albums` is a track count equal to
+`total_tracks`, and compilations reads `0` on a library ADR-0052 identified 297 compilations in. It
+is a *consumer with no producer* — the mirror of the generated-and-uncalled shape this codebase keeps
+finding, and the reason point 6 is written the way it is. A number can be wrong while looking
+completely reasonable, and nobody checks a plausible figure.
+
+**And the player is on borrowed time.** Jeff's words: a stop-gap until he is happy with the native
+apps. That is a decision this ADR has to carry rather than leave in a message, because everything
+below depends on not investing in it.
+
+## Decision
+
+1. **The web app is an administration tool, and opens on a library dashboard.** Not on Settings.
+   The first thing an administrator wants is the state of the thing they administer.
+
+2. **Three destinations.** *Library* — dashboard, scan and sync, analysis, pending review, artist
+   cleanup. *Tools* — duplicates, organiser, backup and restore, community cache. *Server* — health,
+   diagnostics, profiles, Last.fm, API keys, update channel.
+
+3. **The fallback player is temporary and gets no investment.** It stays exactly as `0057` left it —
+   a flat searchable track list — appears as a tool rather than a destination, and receives no
+   redesign, no new controls and no place on the dashboard. Effort spent on it is spent on something
+   scheduled for deletion.
+
+4. **Its removal has a condition that can be checked by reading a file, because prose conditions
+   have already failed here.** `0050` point 3 kept `/playlists/:id` "until the Apple clients can edit
+   a playlist"; that became true and nothing happened. "Until Jeff is happy with the native apps" is
+   worse — subjective as well as unwatched. So: **when `docs/WEB-PARITY.md` shows no ❌ in the Mac and
+   iPhone columns of its Listening table, the player is removed.** That file is already obliged to be
+   current by `0050` point 6 and is already the removal trigger under `0057` point 7.
+
+5. **Listener preferences leave in two waves.** Now: shuffle weights, radio, audio effects and queue
+   sync, which the native clients own per-device (ADR-0029). With the player: offline cache and
+   playback, which configure nothing else. Theme outlives both, because it applies to the
+   administration interface itself.
+
+6. **A dashboard tile must be backed by a real query, and must agree with the screen it links to.**
+   No tile ships whose number is estimated, derived from a sample, or plausible-looking. Where the
+   count does not exist, the endpoint comes first — which is why artwork coverage is last rather
+   than first, and why no albums/compilations breakdown ships at all.
+
+   The agreement half is the part that was missing, and it is testable: a total on the dashboard
+   and the total on the list endpoint behind it are the same number counted the same way, asserted
+   against each other rather than against a hard-coded constant. A test that says "expect 3 albums"
+   passes under either counting method, which is how this drifted unnoticed for as long as it did.
+
+7. **The four pending-analysis queues are shown separately.** `analysis`, `backfill`, `melodic` and
+   `mood_tags` are distinct backlogs with distinct versions, and a single "pending" number hides
+   which one is stuck. This is the whole reason to have a dashboard rather than a progress bar.
+
+## Alternatives Considered
+
+- **Tidy the settings page and add a stats panel at the top.** Much the cheapest, and it keeps the
+  mental model anyone already has. Rejected because the arrangement is the problem: an
+  administration tool that opens on a form, with playback controls above library health, is telling
+  the operator that its own subject is secondary.
+
+- **A task list rather than a dashboard** — open on what you can *do*, with numbers inside each
+  task. Genuinely close, and better for a first-run install where every number is zero. Rejected
+  because the recurring question on a live library is "is anything wrong", which a list of actions
+  answers only by making you visit each one.
+
+- **Keep the listener preferences until the player is removed**, so settings change once rather than
+  twice. Rejected for shuffle weights, radio and audio effects specifically: they do not configure
+  the fallback player in any useful sense — they configure a listening experience the browser no
+  longer provides — so they are not waiting on anything.
+
+- **Remove the player now and skip the intermediate state.** Tempting, and it is where this ends.
+  Rejected because it is Jeff's call on his own listening, the native apps still have ❌ rows in the
+  Listening table, and a guest machine is a real case until they do not.
+
+## Consequences
+
+- **Positive:** four built capabilities become reachable, two of them by calling a wrapper that
+  already exists.
+- **Positive:** the operator sees which of the four analysis backlogs is stuck, which today requires
+  reading the database.
+- **Positive:** the player's removal has a trigger someone will actually notice, which is the defect
+  `0050` point 3 shipped.
+- **Tradeoff:** a browser-only listener loses shuffle weights, radio and audio effects. They exist on
+  the native clients and not here, and this makes that division explicit rather than gradual.
+- **Tradeoff:** settings move twice — once now, once when the player goes. Accepted rather than
+  delaying the first move to avoid the second.
+- **Positive:** `/library/stats` now agrees with `/library/albums` and `/library/artists`, with
+  `tests/test_library_stats.py` asserting the agreement rather than the arithmetic. The endpoint had
+  been wrong on all three totals for as long as nothing called it — which is the actual cost of a
+  generated-and-uncalled capability: it is not merely unused, it is unverified.
+- **Follow-up:** `Track.album_type` has no writer. Either the scanner sets it — MusicBrainz release
+  types are already fetched in `metadata/musicbrainz.py`, which penalises compilations, so the data
+  is at hand — or the column and the three response fields go. Until then `albums`, `compilations`
+  and `soundtracks` stay on the wire, deprecated in the model and in `types/index.ts`, displayed
+  nowhere. Removing them is a cross-repo break: `library` is a generated tag under ADR-0007.
+- **Follow-up:** artwork coverage needs a count endpoint before its tile can exist.
+- **Follow-up:** when the player is removed, `0050`'s reasoning that it keeps `WebAudioEngine` and
+  the effects chain "exercised rather than rotting untested" needs re-examining rather than assuming
+  it evaporates — `/embed` and `/visualizer` pin much of `player/` regardless.

--- a/packages/frontend/src/App.tsx
+++ b/packages/frontend/src/App.tsx
@@ -21,6 +21,7 @@ import { AppShell } from './components/AppShell';
 import { LibraryBrowser } from './components/Library/LibraryBrowser';
 
 // Lazy-loaded route components
+const Dashboard = lazy(() => import('./components/Admin/Dashboard').then(m => ({ default: m.Dashboard })));
 const SettingsPanel = lazy(() => import('./components/Settings').then(m => ({ default: m.SettingsPanel })));
 // The guest listener (ADR-0036). Lazy like every other route component, and worth it here: a guest
 // loads this page and nothing else, and everyone else never loads it at all.
@@ -243,8 +244,14 @@ function App() {
             {/* Mix Tapes */}
 
             {/* Default redirect */}
-            <Route index element={<Navigate to="/settings" replace />} />
-            <Route path="*" element={<Navigate to="/settings" replace />} />
+            {/* ADR-0058 point 1: the administrator lands on the thing being administered, not on a
+                form. This was `Navigate to="/settings"`. */}
+            <Route index element={
+              <Suspense fallback={<LazyLoadSpinner />}>
+                <Dashboard />
+              </Suspense>
+            } />
+            <Route path="*" element={<Navigate to="/" replace />} />
           </Route>
         </Routes>
       </QueryClientProvider>

--- a/packages/frontend/src/api/queryKeys.ts
+++ b/packages/frontend/src/api/queryKeys.ts
@@ -25,6 +25,12 @@ export const queryKeys = {
     detail: (trackId: string) => ['track-discover', trackId] as const,
   },
 
+  // ── Library ───────────────────────────────────────────────────────────
+  library: {
+    stats: () => ['library', 'stats'] as const,
+    playStats: (limit: number) => ['library', 'play-stats', limit] as const,
+  },
+
   // ── Albums ────────────────────────────────────────────────────────────
   albums: {
     all: ['library-albums'] as const,

--- a/packages/frontend/src/components/Admin/Dashboard.tsx
+++ b/packages/frontend/src/components/Admin/Dashboard.tsx
@@ -1,0 +1,171 @@
+import { useQuery } from '@tanstack/react-query';
+import { Disc3, Users, Music, Activity, Clock, AlertTriangle } from 'lucide-react';
+
+import { libraryApi } from '../../api/library';
+import { playTrackingApi, type PlayStatsResponse } from '../../api/profiles';
+import { queryKeys } from '../../api/queryKeys';
+import { offlineAwareRetry } from '../../api/queryDefaults';
+import { useOfflineStatus } from '../../hooks/useOfflineStatus';
+
+/**
+ * What the administrator is administering (ADR-0058 point 1).
+ *
+ * The app used to open on Settings — a form, with playback controls above library health, which
+ * told the operator its own subject was secondary. This opens on the state of the library instead.
+ *
+ * **Every number here comes from a real query** (point 6). Both endpoints already existed and both
+ * already had a client wrapper that nothing called: `libraryApi.getStats` over `/library/stats` and
+ * `playTrackingApi.getStats` over `/tracks/stats/plays`. Nothing on this screen is derived from a
+ * sample or rounded into a nicer shape, and a count that does not exist does not get a tile —
+ * artwork coverage is absent for exactly that reason and needs an endpoint first.
+ */
+export function Dashboard() {
+  const { isOffline } = useOfflineStatus();
+
+  const { data: library, isLoading: libraryLoading } = useQuery({
+    queryKey: queryKeys.library.stats(),
+    queryFn: () => libraryApi.getStats(),
+    retry: offlineAwareRetry(isOffline),
+  });
+
+  const { data: plays } = useQuery({
+    queryKey: queryKeys.library.playStats(5),
+    queryFn: () => playTrackingApi.getStats(5),
+    retry: offlineAwareRetry(isOffline),
+  });
+
+  const analysed = library ? library.analyzed_tracks : 0;
+  const total = library ? library.total_tracks : 0;
+  const coverage = total > 0 ? Math.round((analysed / total) * 100) : 0;
+
+  /**
+   * The four backlogs, named separately (point 7).
+   *
+   * `analysis`, `backfill`, `melodic` and `mood_tags` have their own version constants and their
+   * own reasons to stall — a single "pending" number hides which one is stuck, which is most of the
+   * reason to have this screen rather than a progress bar.
+   */
+  const queues = library
+    ? [
+        { label: 'Analysis', value: library.pending_analysis },
+        { label: 'Backfill', value: library.pending_backfill },
+        { label: 'Melodic', value: library.pending_melodic },
+        { label: 'Mood tags', value: library.pending_mood_tags },
+      ].filter((q) => q.value > 0)
+    : [];
+
+  return (
+    <div className="p-4 sm:p-6 max-w-4xl mx-auto space-y-6">
+      <h2 className="text-xl font-bold text-white dark:text-white light:text-zinc-900">Library</h2>
+
+      <div className="grid grid-cols-1 sm:grid-cols-3 gap-3">
+        <Stat icon={<Music className="w-5 h-5 text-cyan-400" />} label="Tracks"
+              value={library?.total_tracks} loading={libraryLoading} />
+        {/*
+          * No albums/compilations/soundtracks breakdown, though `/library/stats` returns one.
+          * Nothing writes `Track.album_type`, so every row keeps the column default: the
+          * breakdown reads "26,488 albums · 0 compilations" on a library ADR-0052 found 297
+          * compilations in. Point 6 forbids exactly this — a figure that looks like data.
+          */}
+        <Stat icon={<Disc3 className="w-5 h-5 text-cyan-400" />} label="Albums"
+              value={library?.total_albums} loading={libraryLoading} />
+        <Stat icon={<Users className="w-5 h-5 text-cyan-400" />} label="Artists"
+              value={library?.total_artists} loading={libraryLoading} />
+      </div>
+
+      <section className="bg-zinc-800/50 dark:bg-zinc-800/50 light:bg-zinc-100 rounded-lg p-4 space-y-3">
+        <div className="flex items-center gap-3">
+          <Activity className="w-5 h-5 text-cyan-400" />
+          <h3 className="font-medium text-white dark:text-white light:text-zinc-900">Analysis</h3>
+          <span className="ml-auto text-sm text-zinc-400 dark:text-zinc-400 light:text-zinc-600 tabular-nums">
+            {libraryLoading ? '—' : `${analysed.toLocaleString()} of ${total.toLocaleString()}`}
+          </span>
+        </div>
+
+        <div className="h-2 rounded bg-zinc-700/50 overflow-hidden">
+          <div className="h-full bg-cyan-500 transition-[width] duration-500"
+               style={{ width: `${coverage}%` }} />
+        </div>
+        <p className="text-sm text-zinc-400 dark:text-zinc-400 light:text-zinc-600">
+          {libraryLoading ? 'Loading…' : `${coverage}% analysed`}
+        </p>
+
+        {queues.length > 0 && (
+          <div className="pt-1 space-y-1">
+            <div className="flex items-center gap-2 text-sm text-zinc-300 dark:text-zinc-300 light:text-zinc-700">
+              <AlertTriangle className="w-4 h-4 text-amber-400" />
+              <span>Waiting</span>
+            </div>
+            {queues.map((q) => (
+              <div key={q.label} className="flex items-center justify-between bg-zinc-900/50 rounded p-2">
+                <span className="text-sm text-zinc-300 dark:text-zinc-300 light:text-zinc-700">{q.label}</span>
+                <span className="text-sm tabular-nums text-zinc-400 dark:text-zinc-400 light:text-zinc-600">
+                  {q.value.toLocaleString()}
+                </span>
+              </div>
+            ))}
+          </div>
+        )}
+      </section>
+
+      {plays && plays.total_plays > 0 && (
+        <section className="bg-zinc-800/50 dark:bg-zinc-800/50 light:bg-zinc-100 rounded-lg p-4 space-y-3">
+          <div className="flex items-center gap-3">
+            <Clock className="w-5 h-5 text-cyan-400" />
+            <h3 className="font-medium text-white dark:text-white light:text-zinc-900">Listening</h3>
+          </div>
+          <p className="text-sm text-zinc-400 dark:text-zinc-400 light:text-zinc-600">
+            {plays.total_plays.toLocaleString()} plays across{' '}
+            {plays.unique_tracks.toLocaleString()} tracks · {formatHours(plays.total_play_seconds)}
+          </p>
+          {plays.top_tracks.length > 0 && (
+            <ol className="space-y-1">
+              {plays.top_tracks.map((t: PlayStatsResponse['top_tracks'][number]) => (
+                <li key={t.id} className="flex items-center justify-between bg-zinc-900/50 rounded p-2">
+                  <span className="text-sm truncate text-zinc-300 dark:text-zinc-300 light:text-zinc-700">
+                    {t.title ?? 'Untitled'}
+                    {t.artist ? <span className="text-zinc-500"> — {t.artist}</span> : null}
+                  </span>
+                  <span className="text-sm tabular-nums text-zinc-400 dark:text-zinc-400 light:text-zinc-600 pl-3">
+                    {t.play_count}
+                  </span>
+                </li>
+              ))}
+            </ol>
+          )}
+        </section>
+      )}
+    </div>
+  );
+}
+
+function Stat({ icon, label, value, detail, loading }: {
+  icon: React.ReactNode;
+  label: string;
+  value: number | undefined;
+  detail?: string;
+  loading: boolean;
+}) {
+  return (
+    <div className="bg-zinc-800/50 dark:bg-zinc-800/50 light:bg-zinc-100 rounded-lg p-4">
+      <div className="flex items-center gap-2 mb-1">
+        {icon}
+        <span className="text-sm text-zinc-400 dark:text-zinc-400 light:text-zinc-600">{label}</span>
+      </div>
+      <div className="text-2xl font-semibold tabular-nums text-white dark:text-white light:text-zinc-900">
+        {loading || value === undefined ? '—' : value.toLocaleString()}
+      </div>
+      {detail && (
+        <p className="text-xs text-zinc-500 mt-1">{detail}</p>
+      )}
+    </div>
+  );
+}
+
+/** Seconds are what the endpoint returns; hours are what a person reads. */
+function formatHours(seconds: number): string {
+  const hours = seconds / 3600;
+  if (hours < 1) return `${Math.round(seconds / 60)} minutes`;
+  if (hours < 100) return `${hours.toFixed(1)} hours`;
+  return `${Math.round(hours).toLocaleString()} hours`;
+}

--- a/packages/frontend/src/routes.ts
+++ b/packages/frontend/src/routes.ts
@@ -39,9 +39,11 @@ export const PARKED_BROWSERS: Record<string, string> = {
 };
 
 /** Where the app opens. Settings, because that is what the browser is for now. */
+/// Where the app opens. The library, since ADR-0058 point 1 — it was `/settings`, which opened an
+/// administration tool on a form rather than on the thing being administered.
 export const HOME_ROUTE = {
-  path: '/settings',
-  label: 'Settings',
+  path: '/',
+  label: 'Library',
 } as const;
 
 /** Sidebar library navigation items. */

--- a/packages/frontend/src/types/index.ts
+++ b/packages/frontend/src/types/index.ts
@@ -61,11 +61,29 @@ export interface LibraryStats {
   total_tracks: number;
   total_albums: number;
   total_artists: number;
+  /**
+   * @deprecated Do not display. Nothing writes `Track.album_type`, so every row keeps the column
+   * default `ALBUM`: `albums` is a track count and the other two are always 0, on a library
+   * ADR-0052 found 297 compilations in. Still on the wire because `library` is a generated tag
+   * (ADR-0007) and dropping required fields breaks the Swift client.
+   */
   albums: number;
+  /** @deprecated Always 0 — see `albums`. */
   compilations: number;
+  /** @deprecated Always 0 — see `albums`. */
   soundtracks: number;
   analyzed_tracks: number;
+  /**
+   * Four separate backlogs, not one (ADR-0058 point 7).
+   *
+   * Each has its own version constant in `config.py` and its own reason to stall, so a single
+   * "pending" number hides which one is stuck. The last three were missing from this type entirely
+   * while the server had been sending them — visible on the wire, invisible to the app.
+   */
   pending_analysis: number;
+  pending_backfill: number;
+  pending_melodic: number;
+  pending_mood_tags: number;
 }
 
 export interface QueueItem {


### PR DESCRIPTION
**Stacks on #167** — base is `strip/web-detail-routes`, not `main`. Merge that first.

Proposes **ADR-0058: The Web App Is an Administration Tool** and ships its phase 1.

## The dashboard

The web app opened on Settings — a form, with playback controls above library health, telling the operator its own subject was secondary. It now opens on the state of the library.

Almost none of this is new capability. Both endpoints existed and both already had a client wrapper that nothing called: `libraryApi.getStats` over `/library/stats`, `playTrackingApi.getStats` over `/tracks/stats/plays`. The four pending-analysis queues are shown **separately** (point 7) — they are distinct backlogs with distinct version constants, and one number hides which is stuck.

No artwork-coverage tile: there is no endpoint that counts albums without art. Point 6 says the count comes first.

## Pointing it at the real library turned it into a backend change

Every total on `/library/stats` disagreed with the screen it links to:

| field | stats said | list endpoint said | why |
|---|---|---|---|
| `total_tracks` | 26,488 | 26,422 | no `status == ACTIVE` filter — 66 missing/deleted files counted as library size |
| `total_albums` | 3,873 | 3,927 | `count(distinct Track.album)` is a **string** distinct, merging same-titled albums by different artists |
| `total_artists` | 3,664 | 3,477 | raw tag strings — "The Beatles" and "Beatles, The" counted twice |

Each now counts the way the list endpoint counts.

**A trap on the way in:** scoping the totals to active tracks while leaving the analysis counts unscoped renders a *negative* backlog — −41 pending on the real library, since 41 analyses belong to tracks that have left it. The analysis counts join `Track` too, and `pending_analysis` is clamped.

After deploying, `analyzed_tracks` fell 26,463 → 26,422 and `pending_analysis` 25 → **0**. The library is fully analysed; that "25 pending" was 66 non-active tracks netted against 41 stale analyses.

## What could not be fixed

`albums` / `compilations` / `soundtracks` are meaningless: **nothing writes `Track.album_type`**, so every row keeps the column default. The breakdown reads "26,488 albums · 0 compilations" on a library ADR-0052 found **297** compilations in — a consumer with no producer, the mirror of the generated-and-uncalled shape this codebase keeps finding.

They stay on the wire (`library` is a generated tag under ADR-0007, so dropping required fields breaks the Swift client), deprecated in the model and in `types/index.ts`, displayed nowhere. `docs/REST-API.md` had been documenting `150` compilations and `45` soundtracks — values no instance has ever returned. Recorded as an ADR follow-up: either the scanner sets `album_type` (MusicBrainz release types are already fetched) or the column and the fields go.

## Tests

`backend/tests/test_library_stats.py` asserts stats **against the list endpoints**, not against constants — "expect 3 albums" passes under either counting method, which is how this drifted unnoticed. All five fail against the previous implementation; verified by stashing the fix.

## Verification

- `pytest tests/test_library_stats.py tests/test_api_library.py tests/test_library_artists_canonical.py` — 42 passed
- `tsc --noEmit` — 14 errors (unchanged baseline)
- `pnpm test` — 63 files / 952 tests passed
- `pnpm run build` — clean
- Deployed to the NAS: all three totals now equal the list endpoints exactly (26,422 / 3,927 / 3,477), and the deployed `Dashboard` chunk contains no `compilations` reference

ADR-0058 is `proposed` — points 1–7 need your say-so before phase 2 (navigation).

🤖 Generated with [Claude Code](https://claude.com/claude-code)