### PR TITLE
Duplicates, the organiser, and artwork coverage (ADR-0058 phases 4-5)

### DIFF
--- a/backend/app/api/routes/artwork.py
+++ b/backend/app/api/routes/artwork.py
@@ -22,6 +22,84 @@ logger = logging.getLogger(__name__)
 router = APIRouter(prefix="/artwork", tags=["artwork"])
 
 
+class ArtworkCoverageResponse(BaseModel):
+    """How much of the library has real cover art.
+
+    `total_albums` is counted the way `/library/albums` and `/library/stats` count, so the three
+    agree (ADR-0058 point 6). It would have been easier to count canonical `Album` rows, and it
+    would have been wrong: the dashboard tile beside this one says 3,927, and a coverage figure over
+    a different denominator is the "plausible-looking number" that point exists to forbid.
+
+    `generated` is broken out rather than folded into `with_artwork` because a generated placeholder
+    is what the app draws when it has nothing — counting it as coverage would report a library with
+    no cover art at all as fully covered.
+    """
+
+    total_albums: int
+    with_artwork: int
+    generated: int
+    without_artwork: int
+
+
+@router.get("/coverage", response_model=ArtworkCoverageResponse)
+async def get_artwork_coverage(db: DbSession) -> ArtworkCoverageResponse:
+    """Count albums with, without, and with only placeholder cover art.
+
+    ADR-0058 phase 5. Artwork existence is a fact about the filesystem, not the database — there is
+    no column recording it — so this stats one thumbnail path per album. That is ~4k stat calls on
+    Jeff's library, which is why it runs in a worker thread rather than blocking the event loop, and
+    why it is its own endpoint rather than three more fields on `/library/stats`: the dashboard
+    should not pay for a filesystem sweep on every load.
+    """
+    import asyncio
+
+    from sqlalchemy import TEXT, cast, func, select
+
+    from app.db.models import Track, TrackStatus
+    from app.services.artwork import compute_album_hash, is_generated_artwork
+
+    # Same grouping as `library_albums.list_albums` and `library.get_library_stats`. The id is cast
+    # to text for the same reason that module casts: PostgreSQL has no `max()` over uuid.
+    album_artist_col = func.coalesce(func.nullif(Track.album_artist, ""), Track.artist)
+    result = await db.execute(
+        select(
+            func.max(cast(Track.canonical_album_id, TEXT)).label("album_id"),
+            func.max(album_artist_col).label("artist"),
+            func.max(Track.album).label("album"),
+        )
+        .where(
+            Track.status == TrackStatus.ACTIVE,
+            Track.album.isnot(None),
+            Track.album != "",
+        )
+        .group_by(func.lower(album_artist_col), func.lower(Track.album))
+    )
+    rows = result.all()
+
+    def survey() -> tuple[int, int]:
+        """Stat every album's thumbnail. Runs off the event loop."""
+        found = 0
+        placeholder = 0
+        for row in rows:
+            # Mirrors `album_key_for_track`: the canonical id when the resolver placed the album,
+            # the legacy hash when it could not.
+            key = row.album_id or compute_album_hash(row.artist, row.album)
+            if get_artwork_path(key, "thumb").exists():
+                found += 1
+                if is_generated_artwork(key):
+                    placeholder += 1
+        return found, placeholder
+
+    with_artwork, generated = await asyncio.to_thread(survey)
+
+    return ArtworkCoverageResponse(
+        total_albums=len(rows),
+        with_artwork=with_artwork,
+        generated=generated,
+        without_artwork=len(rows) - with_artwork,
+    )
+
+
 class ArtworkQueueRequest(BaseModel):
     """Request to queue artwork for download."""
 

--- a/backend/openapi.json
+++ b/backend/openapi.json
@@ -1009,6 +1009,35 @@
         "title": "ArtistTrack",
         "type": "object"
       },
+      "ArtworkCoverageResponse": {
+        "description": "How much of the library has real cover art.\n\n`total_albums` is counted the way `/library/albums` and `/library/stats` count, so the three\nagree (ADR-0058 point 6). It would have been easier to count canonical `Album` rows, and it\nwould have been wrong: the dashboard tile beside this one says 3,927, and a coverage figure over\na different denominator is the \"plausible-looking number\" that point exists to forbid.\n\n`generated` is broken out rather than folded into `with_artwork` because a generated placeholder\nis what the app draws when it has nothing \u2014 counting it as coverage would report a library with\nno cover art at all as fully covered.",
+        "properties": {
+          "generated": {
+            "title": "Generated",
+            "type": "integer"
+          },
+          "total_albums": {
+            "title": "Total Albums",
+            "type": "integer"
+          },
+          "with_artwork": {
+            "title": "With Artwork",
+            "type": "integer"
+          },
+          "without_artwork": {
+            "title": "Without Artwork",
+            "type": "integer"
+          }
+        },
+        "required": [
+          "total_albums",
+          "with_artwork",
+          "generated",
+          "without_artwork"
+        ],
+        "title": "ArtworkCoverageResponse",
+        "type": "object"
+      },
       "ArtworkQueueBatchRequest": {
         "description": "Request to queue multiple artworks for download.",
         "properties": {
@@ -11450,6 +11479,78 @@
           }
         },
         "summary": "Check Artwork Exists",
+        "tags": [
+          "artwork"
+        ]
+      }
+    },
+    "/api/v1/artwork/coverage": {
+      "get": {
+        "description": "Count albums with, without, and with only placeholder cover art.\n\nADR-0058 phase 5. Artwork existence is a fact about the filesystem, not the database \u2014 there is\nno column recording it \u2014 so this stats one thumbnail path per album. That is ~4k stat calls on\nJeff's library, which is why it runs in a worker thread rather than blocking the event loop, and\nwhy it is its own endpoint rather than three more fields on `/library/stats`: the dashboard\nshould not pay for a filesystem sweep on every load.",
+        "operationId": "artwork_get_artwork_coverage",
+        "responses": {
+          "200": {
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/ArtworkCoverageResponse"
+                }
+              }
+            },
+            "description": "Successful Response"
+          },
+          "400": {
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/ErrorEnvelope"
+                }
+              }
+            },
+            "description": "Bad Request"
+          },
+          "401": {
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/ErrorEnvelope"
+                }
+              }
+            },
+            "description": "Unauthorized"
+          },
+          "404": {
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/ErrorEnvelope"
+                }
+              }
+            },
+            "description": "Not Found"
+          },
+          "422": {
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/ErrorEnvelope"
+                }
+              }
+            },
+            "description": "Unprocessable Entity"
+          },
+          "500": {
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/ErrorEnvelope"
+                }
+              }
+            },
+            "description": "Internal Server Error"
+          }
+        },
+        "summary": "Get Artwork Coverage",
         "tags": [
           "artwork"
         ]

--- a/backend/tests/test_library_stats.py
+++ b/backend/tests/test_library_stats.py
@@ -150,3 +150,91 @@ async def test_pending_analysis_is_never_negative(async_db):
     assert stats.total_tracks == 1
     assert stats.analyzed_tracks == 1
     assert stats.pending_analysis == 0
+
+
+@pytest.mark.asyncio
+async def test_artwork_coverage_denominator_matches_the_album_total(async_db, tmp_path, monkeypatch):
+    """Coverage counts the same albums the dashboard tile counts (ADR-0058 point 6).
+
+    The easy implementation counts canonical `Album` rows, which is a different number from the
+    one shown beside it — a coverage percentage over a denominator nobody can see is exactly the
+    plausible-looking figure point 6 forbids.
+    """
+    from app.api.routes.artwork import get_artwork_coverage
+
+    # Patched on the *route* module, not the service: `artwork.py` does `from app.services.artwork
+    # import get_artwork_path` at module level, so patching the service leaves the route's own
+    # global bound to the original and the test passes without controlling anything.
+    monkeypatch.setattr(
+        "app.api.routes.artwork.get_artwork_path",
+        lambda key, size="full": tmp_path / f"{key}-{size}.jpg",
+    )
+
+    a = await ar.resolve_canonical_artist(async_db, "Alpha", do_mb_lookup=False)
+    b = await ar.resolve_canonical_artist(async_db, "Beta", do_mb_lookup=False)
+    # Two same-titled albums by different artists, one of them spanning a case variant.
+    async_db.add(_track(file="t1", artist_id=a.id, artist="Alpha", album="Greatest Hits"))
+    async_db.add(_track(file="t2", artist_id=b.id, artist="Beta", album="Greatest Hits"))
+    async_db.add(_track(file="t3", artist_id=a.id, artist="Alpha", album="greatest hits"))
+    # A non-active track must not add an album to either count.
+    async_db.add(
+        _track(
+            file="gone",
+            artist_id=b.id,
+            artist="Beta",
+            album="Vanished",
+            status=TrackStatus.MISSING,
+        )
+    )
+    await async_db.commit()
+
+    stats = await get_library_stats(db=async_db)
+    coverage = await get_artwork_coverage(db=async_db)
+
+    assert coverage.total_albums == stats.total_albums == 2
+    assert coverage.without_artwork == 2
+    assert coverage.with_artwork == 0
+    assert coverage.generated == 0
+
+
+@pytest.mark.asyncio
+async def test_artwork_coverage_counts_files_and_placeholders_apart(async_db, tmp_path, monkeypatch):
+    """An album with a generated placeholder is covered *and* counted as generated.
+
+    Folding placeholders into `with_artwork` would report a library with no real cover art at all
+    as fully covered — the number would be true of the filesystem and false of what a person sees.
+    """
+    from app.api.routes import artwork as artwork_route
+
+    monkeypatch.setattr(
+        artwork_route,
+        "get_artwork_path",
+        lambda key, size="full": tmp_path / f"{key}-{size}.jpg",
+    )
+    # "Alpha / Real Art" gets a file; the placeholder marker names only the second album.
+    monkeypatch.setattr(
+        "app.services.artwork.is_generated_artwork",
+        lambda key: key in generated_keys,
+    )
+
+    a = await ar.resolve_canonical_artist(async_db, "Alpha", do_mb_lookup=False)
+    async_db.add(_track(file="t1", artist_id=a.id, artist="Alpha", album="Real Art"))
+    async_db.add(_track(file="t2", artist_id=a.id, artist="Alpha", album="Placeholder"))
+    async_db.add(_track(file="t3", artist_id=a.id, artist="Alpha", album="Nothing"))
+    await async_db.commit()
+
+    # Work out the keys the endpoint will compute, then create thumbs for two of the three.
+    from app.services.artwork import compute_album_hash
+
+    real_key = compute_album_hash("Alpha", "Real Art")
+    placeholder_key = compute_album_hash("Alpha", "Placeholder")
+    generated_keys = {placeholder_key}
+    for key in (real_key, placeholder_key):
+        (tmp_path / f"{key}-thumb.jpg").write_bytes(b"x")
+
+    coverage = await artwork_route.get_artwork_coverage(db=async_db)
+
+    assert coverage.total_albums == 3
+    assert coverage.with_artwork == 2
+    assert coverage.generated == 1
+    assert coverage.without_artwork == 1

--- a/docs/REST-API.md
+++ b/docs/REST-API.md
@@ -213,6 +213,34 @@ curl "http://localhost:4400/api/v1/tracks/{id}/artwork?size=thumb" -o cover.jpg
 
 Returns JPEG image with 1-year cache header.
 
+### Artwork Coverage
+
+```
+GET /artwork/coverage
+```
+
+How much of the library has real cover art (ADR-0058 phase 5).
+
+```json
+{
+  "total_albums": 3927,
+  "with_artwork": 3568,
+  "generated": 661,
+  "without_artwork": 359
+}
+```
+
+`total_albums` is counted the way `/library/albums` and `/library/stats` count, so all three agree.
+
+`generated` is a **subset of `with_artwork`**, not a fourth category: those albums have a thumbnail
+on disk, but it is a placeholder Familiar drew rather than a real cover. Real art is
+`with_artwork - generated`. Reporting them as covered would call a library with no real art at all
+fully covered.
+
+Artwork existence is a filesystem fact — no column records it — so this stats one thumbnail per
+album in a worker thread. Roughly 4k stat calls answer in under a second, but it is a separate
+endpoint from `/library/stats` so the dashboard does not sweep the disk on every load.
+
 ### Get Lyrics
 
 ```

--- a/docs/WEB-PARITY.md
+++ b/docs/WEB-PARITY.md
@@ -216,6 +216,11 @@ with no affordance is what `.smartPlaylists` was: routable, stored, rendered, an
   called it: no active-status filter, a string distinct for albums, raw tag strings for artists.
   Nothing in the matrix changes; noted because "the web app can show library stats" was true of the
   screen and false of the numbers.
+- **2026-08-16** — duplicates, the organiser and artwork coverage reached the browser (`familiar`
+  #170, ADR-0058 phases 4–5). All browser-only and all infrastructural under ADR-0057 point 2.
+  The first two are preview-only because the server has no apply route for either; the third needed
+  a new endpoint, `GET /artwork/coverage`. `organizerApi` had existed uncalled — the fourth such
+  wrapper this ADR turned up.
 - **2026-08-16** — the web app became an administration tool with three destinations (`familiar`
   #169, ADR-0058): Library, Tools, Server. Settings keeps only theme, playback and offline. Four
   settings panels were **deleted** rather than unmounted — see the Settings section above.

--- a/docs/decisions/ADR-0058-the-web-app-is-an-administration-tool.md
+++ b/docs/decisions/ADR-0058-the-web-app-is-an-administration-tool.md
@@ -107,9 +107,23 @@ below depends on not investing in it.
   was its own `onClose`. `navigationIntegrity.test.ts` now reads `App.tsx` source and fails on a
   link to an unmounted path; the previous guard read only the registry, which is why affordances
   hardcoded in the component escaped it.
-- **Phases 4 and 5** — duplicates and organiser, then artwork coverage. Not started. Both are
-  recorded in `UNBUILT_DESTINATION_ITEMS` in `routes.ts` so the gap between this ADR's point 2 and
-  the running app is written down rather than rediscovered.
+- **Phases 4 and 5** — duplicates, organiser, artwork coverage (`familiar` #170, branch
+  `admin/tools`). Both phase-4 tools are **preview-only, and that is the server's shape rather than
+  caution in the UI**: `library_deduplicate.py` exposes one route and `organizer.py` three, none of
+  which move or delete a file. `organizerApi` turned out to be a fourth built-and-uncalled wrapper,
+  after `libraryApi.getStats`, `playTrackingApi.getStats` and `api/pendingTracks.ts`.
+
+  Phase 5 needed the endpoint point 6 predicted. `GET /artwork/coverage` groups tracks the same way
+  `/library/albums` and `/library/stats` do rather than counting canonical `Album` rows, so the
+  coverage denominator equals the Albums tile beside it — 3,927 on the real library, verified.
+  Artwork existence is a filesystem fact with no column behind it, so it stats one thumbnail per
+  album off the event loop; 3,927 stats answer in 0.27s.
+
+  **Generated placeholders are counted apart from real art**, and the live numbers show why: 3,568
+  albums have a thumbnail, but 661 of those are placeholders. Folding them in would have reported
+  91% coverage on a library where 74% has real art.
+
+  `UNBUILT_DESTINATION_ITEMS` now lists only pending review.
 
 ## Alternatives Considered
 
@@ -153,7 +167,16 @@ below depends on not investing in it.
   is at hand — or the column and the three response fields go. Until then `albums`, `compilations`
   and `soundtracks` stay on the wire, deprecated in the model and in `types/index.ts`, displayed
   nowhere. Removing them is a cross-repo break: `library` is a generated tag under ADR-0007.
-- **Follow-up:** artwork coverage needs a count endpoint before its tile can exist.
+- **Follow-up:** ~~artwork coverage needs a count endpoint before its tile can exist~~ — done in
+  phase 5, `GET /artwork/coverage`.
+- **Follow-up:** the organiser's templates key on `{artist}`, which is per-track, so previewing a
+  compilation proposes dropping the performer from the filename — `07 Stratis - Herzlos.mp3` becomes
+  `07 - Herzlos.mp3`. Observed on the real library while verifying phase 4. Harmless while the tool
+  is preview-only; it is a prerequisite for ever adding an apply, and `{album_artist}` is the
+  obvious fix.
+- **Follow-up:** 661 of the library's 3,927 albums show a *generated* cover rather than real art.
+  Nothing surfaced that before this ADR, and there is no tool to re-fetch them in bulk —
+  `/artwork/regenerate-stale` exists and has no caller.
 - **Follow-up:** when the player is removed, `0050`'s reasoning that it keeps `WebAudioEngine` and
   the effects chain "exercised rather than rotting untested" needs re-examining rather than assuming
   it evaporates — `/embed` and `/visualizer` pin much of `player/` regardless.

--- a/packages/frontend/src/App.tsx
+++ b/packages/frontend/src/App.tsx
@@ -23,6 +23,8 @@ import { LibraryBrowser } from './components/Library/LibraryBrowser';
 // Lazy-loaded route components
 const LibraryPage = lazy(() => import('./components/Admin/LibraryPage').then(m => ({ default: m.LibraryPage })));
 const ToolsPage = lazy(() => import('./components/Admin/ToolsPage').then(m => ({ default: m.ToolsPage })));
+const DuplicatesPage = lazy(() => import('./components/Admin/DuplicatesPage').then(m => ({ default: m.DuplicatesPage })));
+const OrganizePage = lazy(() => import('./components/Admin/OrganizePage').then(m => ({ default: m.OrganizePage })));
 const ServerPage = lazy(() => import('./components/Admin/ServerPage').then(m => ({ default: m.ServerPage })));
 const SettingsPanel = lazy(() => import('./components/Settings').then(m => ({ default: m.SettingsPanel })));
 // The guest listener (ADR-0036). Lazy like every other route component, and worth it here: a guest
@@ -240,6 +242,17 @@ function App() {
             <Route path="/tools" element={
               <Suspense fallback={<LazyLoadSpinner />}>
                 <ToolsPage />
+              </Suspense>
+            } />
+            {/* Phase 4. Both preview-only — the server exposes no apply route for either. */}
+            <Route path="/tools/duplicates" element={
+              <Suspense fallback={<LazyLoadSpinner />}>
+                <DuplicatesPage />
+              </Suspense>
+            } />
+            <Route path="/tools/organize" element={
+              <Suspense fallback={<LazyLoadSpinner />}>
+                <OrganizePage />
               </Suspense>
             } />
             <Route path="/server" element={

--- a/packages/frontend/src/api/library.ts
+++ b/packages/frontend/src/api/library.ts
@@ -288,9 +288,60 @@ export interface LetterIndexResponse {
   total: number;
 }
 
+/** Duplicate groups from a whole-library scan. Preview only — the server has no apply route. */
+export interface DuplicateTrackInfo {
+  id: string;
+  title: string | null;
+  artist: string | null;
+  album: string | null;
+  file_path: string;
+  format: string | null;
+  quality: string;
+  format_tier: number;
+  metadata_completeness: number;
+  created_at: string;
+}
+
+export interface DuplicateGroup {
+  normalized_key: string;
+  keep: DuplicateTrackInfo;
+  remove: DuplicateTrackInfo[];
+}
+
+export interface DeduplicatePreview {
+  total_groups: number;
+  total_duplicates: number;
+  groups: DuplicateGroup[];
+}
+
+export interface ArtworkCoverage {
+  total_albums: number;
+  with_artwork: number;
+  generated: number;
+  without_artwork: number;
+}
+
 export const libraryApi = {
   getStats: async (): Promise<LibraryStats> => {
     const { data } = await api.get('/library/stats');
+    return data;
+  },
+
+  getArtworkCoverage: async (): Promise<ArtworkCoverage> => {
+    const { data } = await api.get('/artwork/coverage');
+    return data;
+  },
+
+  /**
+   * Find duplicate tracks. **A POST that scans the whole library**, so it is never called on
+   * page load — ADR-0058 phase 4 puts it behind an explicit button for that reason.
+   */
+  deduplicatePreview: async (params?: {
+    search?: string;
+    artist?: string;
+    album?: string;
+  }): Promise<DeduplicatePreview> => {
+    const { data } = await api.post('/library/deduplicate/preview', null, { params });
     return data;
   },
 

--- a/packages/frontend/src/api/queryKeys.ts
+++ b/packages/frontend/src/api/queryKeys.ts
@@ -29,6 +29,9 @@ export const queryKeys = {
   library: {
     stats: () => ['library', 'stats'] as const,
     playStats: (limit: number) => ['library', 'play-stats', limit] as const,
+    // Its own key, not part of `stats`: coverage stats one file per album (~4k on Jeff's library),
+    // and the dashboard should not pay for a filesystem sweep on every load.
+    artworkCoverage: () => ['library', 'artwork-coverage'] as const,
   },
 
   // ── Albums ────────────────────────────────────────────────────────────

--- a/packages/frontend/src/components/Admin/Dashboard.tsx
+++ b/packages/frontend/src/components/Admin/Dashboard.tsx
@@ -1,5 +1,5 @@
 import { useQuery } from '@tanstack/react-query';
-import { Disc3, Users, Music, Activity, Clock, AlertTriangle } from 'lucide-react';
+import { Disc3, Users, Music, Activity, Clock, AlertTriangle, Image } from 'lucide-react';
 
 import { libraryApi } from '../../api/library';
 import { playTrackingApi, type PlayStatsResponse } from '../../api/profiles';
@@ -13,11 +13,14 @@ import { useOfflineStatus } from '../../hooks/useOfflineStatus';
  * The app used to open on Settings — a form, with playback controls above library health, which
  * told the operator its own subject was secondary. This opens on the state of the library instead.
  *
- * **Every number here comes from a real query** (point 6). Both endpoints already existed and both
- * already had a client wrapper that nothing called: `libraryApi.getStats` over `/library/stats` and
- * `playTrackingApi.getStats` over `/tracks/stats/plays`. Nothing on this screen is derived from a
- * sample or rounded into a nicer shape, and a count that does not exist does not get a tile —
- * artwork coverage is absent for exactly that reason and needs an endpoint first.
+ * **Every number here comes from a real query** (point 6). Two of the three endpoints already
+ * existed with a client wrapper that nothing called: `libraryApi.getStats` over `/library/stats`
+ * and `playTrackingApi.getStats` over `/tracks/stats/plays`. Nothing on this screen is derived from
+ * a sample or rounded into a nicer shape.
+ *
+ * The third had to be written. Artwork coverage was held back to phase 5 precisely because a count
+ * that does not exist does not get a tile — `/artwork/coverage` now provides it, counting albums
+ * the same way the Albums tile does so the two agree.
  */
 export function Dashboard() {
   const { isOffline } = useOfflineStatus();
@@ -32,6 +35,22 @@ export function Dashboard() {
     queryKey: queryKeys.library.playStats(5),
     queryFn: () => playTrackingApi.getStats(5),
     retry: offlineAwareRetry(isOffline),
+  });
+
+  /**
+   * Artwork coverage (ADR-0058 phase 5) — the tile that could not exist until an endpoint did.
+   *
+   * `total_albums` here is counted the same way the Albums tile above counts, which is the whole
+   * reason the endpoint groups tracks rather than counting canonical `Album` rows: two numbers
+   * side by side over different denominators is what point 6 forbids.
+   */
+  const { data: artwork } = useQuery({
+    queryKey: queryKeys.library.artworkCoverage(),
+    queryFn: () => libraryApi.getArtworkCoverage(),
+    retry: offlineAwareRetry(isOffline),
+    // It stats one file per album. Fresh once a session is plenty for a number that moves when a
+    // scan runs, not when the page is opened.
+    staleTime: 5 * 60 * 1000,
   });
 
   const analysed = library ? library.analyzed_tracks : 0;
@@ -96,6 +115,7 @@ export function Dashboard() {
               <AlertTriangle className="w-4 h-4 text-amber-400" />
               <span>Waiting</span>
             </div>
+
             {queues.map((q) => (
               <div key={q.label} className="flex items-center justify-between bg-zinc-900/50 rounded p-2">
                 <span className="text-sm text-zinc-300 dark:text-zinc-300 light:text-zinc-700">{q.label}</span>
@@ -107,6 +127,37 @@ export function Dashboard() {
           </div>
         )}
       </section>
+
+      {artwork && artwork.total_albums > 0 && (
+        <section className="bg-zinc-800/50 dark:bg-zinc-800/50 light:bg-zinc-100 rounded-lg p-4 space-y-3">
+          <div className="flex items-center gap-3">
+            <Image className="w-5 h-5 text-cyan-400" />
+            <h3 className="font-medium text-white dark:text-white light:text-zinc-900">Cover art</h3>
+            <span className="ml-auto text-sm text-zinc-400 dark:text-zinc-400 light:text-zinc-600 tabular-nums">
+              {artwork.with_artwork.toLocaleString()} of {artwork.total_albums.toLocaleString()}
+            </span>
+          </div>
+
+          <div className="h-2 rounded bg-zinc-700/50 overflow-hidden">
+            <div
+              className="h-full bg-cyan-500 transition-[width] duration-500"
+              style={{ width: `${Math.round((artwork.with_artwork / artwork.total_albums) * 100)}%` }}
+            />
+          </div>
+
+          <p className="text-sm text-zinc-400 dark:text-zinc-400 light:text-zinc-600">
+            {artwork.without_artwork.toLocaleString()} albums have no cover
+            {/*
+              * Placeholders are named separately because they are what the app draws when it has
+              * nothing. Counting them as coverage would report a library with no real art at all
+              * as fully covered — true of the filesystem, false of what anyone sees.
+              */}
+            {artwork.generated > 0 &&
+              `, and ${artwork.generated.toLocaleString()} show a generated placeholder`}
+            .
+          </p>
+        </section>
+      )}
 
       {plays && plays.total_plays > 0 && (
         <section className="bg-zinc-800/50 dark:bg-zinc-800/50 light:bg-zinc-100 rounded-lg p-4 space-y-3">

--- a/packages/frontend/src/components/Admin/DuplicatesPage.tsx
+++ b/packages/frontend/src/components/Admin/DuplicatesPage.tsx
@@ -1,0 +1,145 @@
+/**
+ * Duplicates (ADR-0058 phase 4) — a front end for `POST /library/deduplicate/preview`.
+ *
+ * **The scan runs only when asked.** It is a POST that reads every active track and groups them by
+ * normalised (artist, album, title); running it on mount would mean a whole-library sweep every
+ * time someone opened the page. `enabled: false` plus an explicit `refetch()` is what enforces
+ * that, and the plan called for it before the code existed.
+ *
+ * **Preview only, and that is the server's shape, not a caution here.** `library_deduplicate.py`
+ * exposes exactly one route. There is no apply, no delete, nothing this page could call to remove a
+ * file even if it offered the button — so it does not offer one, and says so rather than implying
+ * a missing feature.
+ */
+import { useState } from 'react';
+import { useQuery } from '@tanstack/react-query';
+import { Copy, Search, Loader2 } from 'lucide-react';
+
+import { libraryApi, type DuplicateGroup, type DuplicateTrackInfo } from '../../api/library';
+import { AdminPage, AdminSection } from './AdminPage';
+
+export function DuplicatesPage() {
+  const [search, setSearch] = useState('');
+  const [scanned, setScanned] = useState(false);
+
+  const { data, isFetching, error, refetch } = useQuery({
+    queryKey: ['library', 'duplicates', search],
+    queryFn: () => libraryApi.deduplicatePreview(search ? { search } : undefined),
+    enabled: false,
+    retry: false,
+  });
+
+  const runScan = () => {
+    setScanned(true);
+    void refetch();
+  };
+
+  return (
+    <AdminPage
+      title="Duplicates"
+      subtitle="Find tracks that appear more than once, and which copy is the better one"
+    >
+      <AdminSection title="Scan">
+        <div className="bg-zinc-800/50 dark:bg-zinc-800/50 light:bg-zinc-100 rounded-lg p-4 space-y-3">
+          <p className="text-sm text-zinc-400 dark:text-zinc-400 light:text-zinc-600">
+            Groups tracks by artist, album and title after normalising them. The copy ranked highest
+            on format and metadata completeness is the one it would keep.
+          </p>
+          <div className="flex gap-2">
+            <div className="relative flex-1">
+              <Search className="w-4 h-4 absolute left-3 top-1/2 -translate-y-1/2 text-zinc-500" />
+              <input
+                type="text"
+                value={search}
+                onChange={(e) => setSearch(e.target.value)}
+                onKeyDown={(e) => e.key === 'Enter' && runScan()}
+                placeholder="Narrow to a title, artist or album (optional)"
+                className="w-full bg-zinc-900 dark:bg-zinc-900 light:bg-white border border-zinc-700 dark:border-zinc-700 light:border-zinc-300 rounded-lg pl-9 pr-3 py-2 text-sm text-white dark:text-white light:text-zinc-900"
+              />
+            </div>
+            <button
+              onClick={runScan}
+              disabled={isFetching}
+              className="px-4 py-2 rounded-lg bg-cyan-600 hover:bg-cyan-500 disabled:opacity-50 text-white text-sm font-medium flex items-center gap-2 flex-shrink-0"
+            >
+              {isFetching ? <Loader2 className="w-4 h-4 animate-spin" /> : <Copy className="w-4 h-4" />}
+              {isFetching ? 'Scanning…' : 'Scan'}
+            </button>
+          </div>
+          <p className="text-xs text-zinc-500">
+            Scans the whole library unless you narrow it. Nothing is deleted — this is a preview,
+            and the server has no route that removes a file.
+          </p>
+        </div>
+      </AdminSection>
+
+      {error && (
+        <p className="text-sm text-red-400">
+          The scan failed: {error instanceof Error ? error.message : 'unknown error'}
+        </p>
+      )}
+
+      {scanned && !isFetching && data && (
+        <AdminSection
+          title={
+            data.total_groups === 0
+              ? 'No duplicates found'
+              : `${data.total_groups.toLocaleString()} groups · ${data.total_duplicates.toLocaleString()} duplicate files`
+          }
+        >
+          {data.groups.map((group) => (
+            <DuplicateGroupCard key={group.normalized_key} group={group} />
+          ))}
+          {/*
+            * The endpoint returns every group it finds, so a count that disagrees with the list
+            * would mean the response itself was truncated — worth surfacing rather than hiding.
+            */}
+          {data.groups.length < data.total_groups && (
+            <p className="text-xs text-zinc-500">
+              Showing {data.groups.length.toLocaleString()} of {data.total_groups.toLocaleString()}.
+            </p>
+          )}
+        </AdminSection>
+      )}
+    </AdminPage>
+  );
+}
+
+function DuplicateGroupCard({ group }: { group: DuplicateGroup }) {
+  return (
+    <div className="bg-zinc-800/50 dark:bg-zinc-800/50 light:bg-zinc-100 rounded-lg p-4 space-y-2">
+      <div className="text-sm font-medium text-white dark:text-white light:text-zinc-900 truncate">
+        {group.keep.title ?? 'Untitled'}
+        {group.keep.artist && <span className="text-zinc-500"> — {group.keep.artist}</span>}
+      </div>
+      <TrackRow track={group.keep} verdict="keep" />
+      {group.remove.map((track) => (
+        <TrackRow key={track.id} track={track} verdict="duplicate" />
+      ))}
+    </div>
+  );
+}
+
+function TrackRow({ track, verdict }: { track: DuplicateTrackInfo; verdict: 'keep' | 'duplicate' }) {
+  const keep = verdict === 'keep';
+  return (
+    <div className="flex items-start gap-3 bg-zinc-900/50 rounded p-2">
+      <span
+        className={`text-xs px-2 py-0.5 rounded flex-shrink-0 ${
+          keep ? 'bg-emerald-900/60 text-emerald-300' : 'bg-zinc-700 text-zinc-400'
+        }`}
+      >
+        {keep ? 'Keep' : 'Duplicate'}
+      </span>
+      <div className="min-w-0 flex-1">
+        <div className="text-xs text-zinc-400 dark:text-zinc-400 light:text-zinc-600 truncate">
+          {track.file_path}
+        </div>
+        <div className="text-xs text-zinc-500 mt-0.5">
+          {track.quality}
+          {track.format && ` · ${track.format}`} · {track.metadata_completeness}/6 metadata fields
+        </div>
+      </div>
+    </div>
+  );
+}

--- a/packages/frontend/src/components/Admin/OrganizePage.tsx
+++ b/packages/frontend/src/components/Admin/OrganizePage.tsx
@@ -1,0 +1,154 @@
+/**
+ * File organiser (ADR-0058 phase 4) — preview only.
+ *
+ * `organizerApi` has existed with all three methods and **has never been called from anywhere**.
+ * That is the fourth generated-and-uncalled capability this ADR has turned up: `libraryApi.getStats`,
+ * `playTrackingApi.getStats`, `api/pendingTracks.ts` and this one. The pattern is consistent enough
+ * to be worth stating — a wrapper written alongside an endpoint, and no screen ever built on it.
+ *
+ * **No apply button, and not out of caution.** `organizer.py` exposes `/templates`, `/preview` and
+ * `/track/{id}/preview`. There is no route that moves a file, so there is nothing to call. The
+ * plan said "no apply until the preview is trusted", which turns out to be the server's position
+ * already.
+ *
+ * Note the paths: the router's prefix is `/library/organize`, not `/organizer` — the plan had it
+ * wrong, and `api/metadata.ts` had it right.
+ */
+import { useState } from 'react';
+import { useQuery } from '@tanstack/react-query';
+import { FolderTree, Loader2, ArrowRight } from 'lucide-react';
+
+import { organizerApi, type OrganizeResult } from '../../api/metadata';
+import { queryKeys } from '../../api/queryKeys';
+import { AdminPage, AdminSection } from './AdminPage';
+
+const PREVIEW_LIMIT = 100;
+
+export function OrganizePage() {
+  const [template, setTemplate] = useState<string | null>(null);
+  const [previewed, setPreviewed] = useState(false);
+
+  const { data: templates, isLoading: templatesLoading } = useQuery({
+    queryKey: queryKeys.organizeTemplates.all,
+    queryFn: () => organizerApi.getTemplates(),
+  });
+
+  // The first template is the default the server itself uses (`artist-album`), so the select is
+  // never empty and never in a state the preview cannot run from.
+  const selected = template ?? templates?.templates[0]?.template ?? null;
+
+  const { data: preview, isFetching, error, refetch } = useQuery({
+    queryKey: ['library', 'organize-preview', selected],
+    queryFn: () => organizerApi.preview(selected!, PREVIEW_LIMIT),
+    enabled: false,
+    retry: false,
+  });
+
+  const runPreview = () => {
+    setPreviewed(true);
+    void refetch();
+  };
+
+  return (
+    <AdminPage
+      title="Organiser"
+      subtitle="See where files would move under a naming template — nothing is renamed"
+    >
+      <AdminSection title="Template">
+        <div className="bg-zinc-800/50 dark:bg-zinc-800/50 light:bg-zinc-100 rounded-lg p-4 space-y-3">
+          {templatesLoading ? (
+            <p className="text-sm text-zinc-400">Loading templates…</p>
+          ) : (
+            <>
+              <select
+                value={selected ?? ''}
+                onChange={(e) => setTemplate(e.target.value)}
+                className="w-full bg-zinc-900 dark:bg-zinc-900 light:bg-white border border-zinc-700 dark:border-zinc-700 light:border-zinc-300 rounded-lg px-3 py-2 text-sm text-white dark:text-white light:text-zinc-900"
+              >
+                {templates?.templates.map((t) => (
+                  <option key={t.name} value={t.template}>
+                    {t.name} — {t.template}
+                  </option>
+                ))}
+              </select>
+              {templates?.templates.find((t) => t.template === selected)?.example && (
+                <p className="text-xs text-zinc-500 font-mono truncate">
+                  e.g. {templates.templates.find((t) => t.template === selected)!.example}
+                </p>
+              )}
+              <button
+                onClick={runPreview}
+                disabled={isFetching || !selected}
+                className="px-4 py-2 rounded-lg bg-cyan-600 hover:bg-cyan-500 disabled:opacity-50 text-white text-sm font-medium flex items-center gap-2"
+              >
+                {isFetching ? (
+                  <Loader2 className="w-4 h-4 animate-spin" />
+                ) : (
+                  <FolderTree className="w-4 h-4" />
+                )}
+                {isFetching ? 'Previewing…' : 'Preview'}
+              </button>
+              <p className="text-xs text-zinc-500">
+                Previews the first {PREVIEW_LIMIT} tracks. Nothing is moved — the server has no
+                route that renames a file.
+              </p>
+            </>
+          )}
+        </div>
+      </AdminSection>
+
+      {error && (
+        <p className="text-sm text-red-400">
+          The preview failed: {error instanceof Error ? error.message : 'unknown error'}
+        </p>
+      )}
+
+      {previewed && !isFetching && preview && (
+        <AdminSection
+          title={`${preview.total.toLocaleString()} previewed · ${preview.moved.toLocaleString()} would move · ${preview.skipped.toLocaleString()} already correct${
+            preview.errors > 0 ? ` · ${preview.errors.toLocaleString()} errors` : ''
+          }`}
+        >
+          {preview.results.length === 0 ? (
+            <p className="text-sm text-zinc-400">Nothing to show.</p>
+          ) : (
+            preview.results.map((result) => <ResultRow key={result.track_id} result={result} />)
+          )}
+        </AdminSection>
+      )}
+    </AdminPage>
+  );
+}
+
+function ResultRow({ result }: { result: OrganizeResult }) {
+  const tone =
+    result.status === 'moved'
+      ? 'bg-cyan-900/60 text-cyan-300'
+      : result.status === 'error'
+        ? 'bg-red-900/60 text-red-300'
+        : 'bg-zinc-700 text-zinc-400';
+
+  return (
+    <div className="bg-zinc-800/50 dark:bg-zinc-800/50 light:bg-zinc-100 rounded-lg p-3 flex items-start gap-3">
+      <span className={`text-xs px-2 py-0.5 rounded flex-shrink-0 ${tone}`}>
+        {/* "moved" is the service's word for a *would-move* in preview mode. Saying "moved" on a
+            page that moves nothing is the kind of wording that makes people distrust a tool. */}
+        {result.status === 'moved' ? 'Would move' : result.status === 'error' ? 'Error' : 'Unchanged'}
+      </span>
+      <div className="min-w-0 flex-1 text-xs">
+        <div className="text-zinc-400 dark:text-zinc-400 light:text-zinc-600 truncate font-mono">
+          {result.old_path}
+        </div>
+        {result.new_path && result.status === 'moved' && (
+          <div className="flex items-start gap-1 text-cyan-300 truncate font-mono mt-0.5">
+            <ArrowRight className="w-3 h-3 flex-shrink-0 mt-0.5" />
+            <span className="truncate">{result.new_path}</span>
+          </div>
+        )}
+        {result.message && result.status !== 'moved' && (
+          <div className="text-zinc-500 mt-0.5 truncate">{result.message}</div>
+        )}
+      </div>
+    </div>
+  );
+}

--- a/packages/frontend/src/components/Admin/ToolsPage.tsx
+++ b/packages/frontend/src/components/Admin/ToolsPage.tsx
@@ -1,12 +1,12 @@
 /**
  * The Tools destination (ADR-0058 point 2) — things you run against the library.
  *
- * Backup and restore, community cache, and the fallback player. Point 2 also names **duplicates**
- * and the **organiser**; both are phase 4 and neither has a UI yet, so neither is linked. See
- * `UNBUILT_DESTINATION_ITEMS`.
+ * Duplicates, organiser, backup and restore, community cache, and the fallback player. Everything
+ * point 2 named for this destination now exists; the two that arrived in phase 4 are both
+ * **preview-only, because the server has no apply route for either**.
  */
 import { Link } from 'react-router-dom';
-import { List, ChevronRight } from 'lucide-react';
+import { List, Copy, FolderTree, ChevronRight } from 'lucide-react';
 
 import { AdminPage, AdminSection } from './AdminPage';
 import { DataManagement } from '../Settings/DataManagement';
@@ -15,6 +15,21 @@ import { CommunityCache } from '../Settings/CommunityCache';
 export function ToolsPage() {
   return (
     <AdminPage title="Tools" subtitle="Jobs and utilities you run against the library">
+      <AdminSection title="Inspect">
+        <ToolLink
+          to="/tools/duplicates"
+          icon={<Copy className="w-5 h-5 text-cyan-400 flex-shrink-0" />}
+          label="Duplicates"
+          description="Find tracks that appear more than once, and which copy is better"
+        />
+        <ToolLink
+          to="/tools/organize"
+          icon={<FolderTree className="w-5 h-5 text-cyan-400 flex-shrink-0" />}
+          label="Organiser"
+          description="See where files would move under a naming template"
+        />
+      </AdminSection>
+
       <AdminSection title="Data">
         <DataManagement />
         <CommunityCache />
@@ -27,24 +42,47 @@ export function ToolsPage() {
         * destination is not what you give something on the way out. No redesign, no new controls.
         */}
       <AdminSection title="Playback">
-        <Link
+        <ToolLink
           to="/library/tracks"
-          // The label is the name; the description is a hint beneath it. See the sidebar for why.
-          aria-label="Track list"
-          className="flex items-center gap-3 bg-zinc-800/50 dark:bg-zinc-800/50 light:bg-zinc-100 rounded-lg p-4 hover:bg-zinc-800 transition-colors"
-        >
-          <List className="w-5 h-5 text-cyan-400 flex-shrink-0" />
-          <div className="min-w-0 flex-1">
-            <div className="text-sm font-medium text-white dark:text-white light:text-zinc-900">
-              Track list
-            </div>
-            <div className="text-sm text-zinc-400 dark:text-zinc-400 light:text-zinc-600">
-              Search the library and play something in this browser
-            </div>
-          </div>
-          <ChevronRight className="w-4 h-4 text-zinc-500 flex-shrink-0" />
-        </Link>
+          icon={<List className="w-5 h-5 text-cyan-400 flex-shrink-0" />}
+          label="Track list"
+          description="Search the library and play something in this browser"
+        />
       </AdminSection>
     </AdminPage>
+  );
+}
+
+function ToolLink({
+  to,
+  icon,
+  label,
+  description,
+}: {
+  to: string;
+  icon: React.ReactNode;
+  label: string;
+  description: string;
+}) {
+  return (
+    <Link
+      to={to}
+      // The label is the name; the description is a hint beneath it. Without this the accessible
+      // name is the whole card — which is what a screen reader announces, and what the E2E
+      // navigation helpers have to match. See the sidebar for the same reasoning.
+      aria-label={label}
+      className="flex items-center gap-3 bg-zinc-800/50 dark:bg-zinc-800/50 light:bg-zinc-100 rounded-lg p-4 hover:bg-zinc-800 transition-colors"
+    >
+      {icon}
+      <div className="min-w-0 flex-1">
+        <div className="text-sm font-medium text-white dark:text-white light:text-zinc-900">
+          {label}
+        </div>
+        <div className="text-sm text-zinc-400 dark:text-zinc-400 light:text-zinc-600">
+          {description}
+        </div>
+      </div>
+      <ChevronRight className="w-4 h-4 text-zinc-500 flex-shrink-0" />
+    </Link>
   );
 }

--- a/packages/frontend/src/routes.ts
+++ b/packages/frontend/src/routes.ts
@@ -73,9 +73,8 @@ export const DESTINATIONS = [
  */
 export const UNBUILT_DESTINATION_ITEMS: Record<string, string> = {
   'pending-review': 'no web component — `api/pendingTracks.ts` is a wrapper nothing calls',
-  duplicates: 'ADR-0058 phase 4 — `POST /library/deduplicate/preview` has no UI yet',
-  organiser: 'ADR-0058 phase 4 — the `organizer` routes have no UI yet',
-  'artwork-coverage': 'ADR-0058 phase 5 — no endpoint counts albums without art',
+  // Duplicates, the organiser and artwork coverage were here. All three shipped in phases 4 and 5;
+  // their lines are deleted rather than marked done, so this stays a list of what is missing.
 };
 
 /** Sidebar library navigation items. */


### PR DESCRIPTION
_Supersedes #170, auto-closed when its base branch `admin/destinations` was deleted on merging #172. Same commit, rebased onto main, plus the regenerated `openapi.json` and an `aria-label` on the tool links._

## Phase 4 — the tools that half-existed

Both are **preview-only, and that is the server's shape rather than caution in the UI**. `library_deduplicate.py` exposes one route and `organizer.py` three; none move or delete a file, so neither page offers a button it could not call.

`organizerApi` already existed with all three methods and **had never been called from anywhere** — the fourth built-and-uncalled wrapper this ADR has turned up, after `libraryApi.getStats`, `playTrackingApi.getStats` and `api/pendingTracks.ts`.

The dedupe scan runs **only when asked** (`enabled: false` + explicit `refetch`). It's a POST that reads every active track; running it on mount would sweep the whole library on every page open.

Verified against the real library — 283 groups, 511 duplicate files, 1.8s.

*(The plan said the organizer lived at `/organizer/*`. It's `/library/organize/*`; `api/metadata.ts` had it right.)*

## Phase 5 — the tile that needed an endpoint first

`GET /artwork/coverage`. Artwork existence is a filesystem fact with no column behind it, so it stats one thumbnail per album off the event loop — 3,927 stats answer in **0.27s**.

It groups tracks the same way `/library/albums` and `/library/stats` do, rather than counting canonical `Album` rows. That's the whole point: the tile sits beside an Albums tile, and a coverage figure over a denominator nobody can see is the plausible-looking number point 6 forbids. **Both report 3,927 on the real library.**

**Placeholders are counted apart from real art**, and the live numbers show why:

```
total_albums 3927 · with_artwork 3568 · generated 661 · without_artwork 359
```

Folding placeholders in would report **91% coverage** on a library where **74%** has real art.

## Tests

Two new cases in `tests/test_library_stats.py`: the coverage denominator must equal the stats total, and placeholders must not count as real art.

The first monkeypatches the **route** module, not the service — `artwork.py` binds `get_artwork_path` at import, so patching the service leaves the route's global bound to the original and the test passes while controlling nothing. Caught by checking *why* it passed.

## Two things found, recorded not fixed

- **The organiser keys on `{artist}`, which is per-track.** Previewing a Various Artists album proposes `07 Stratis - Herzlos.mp3` → `07 - Herzlos.mp3`, dropping the performer. Harmless while preview-only; a prerequisite for ever adding an apply. `{album_artist}` is the obvious fix.
- **661 albums show a generated cover.** Nothing surfaced that before this ADR, and there's no bulk re-fetch — `/artwork/regenerate-stale` exists with no caller.

## Verification

- `pytest tests/test_library_stats.py tests/test_api_library.py` — 37 passed
- `tsc --noEmit` — 14 errors (unchanged baseline)
- `pnpm test` — 63 files / 956 tests passed
- `pnpm run build` — clean
- Deployed to the NAS; all four endpoints exercised against the 26k library
- ADR-0058 `Implementation` block, `WEB-PARITY.md` and `REST-API.md` all updated

🤖 Generated with [Claude Code](https://claude.com/claude-code)
