### PR TITLE
Search Bandcamp's JSON endpoint, and say so when it breaks

### DIFF
--- a/backend/app/services/bandcamp.py
+++ b/backend/app/services/bandcamp.py
@@ -1,10 +1,24 @@
-"""Bandcamp search service for finding albums to purchase."""
+"""Bandcamp search service for finding albums to purchase.
 
+**Search uses Bandcamp's own JSON endpoint, not the search page.** That page became a JavaScript
+shell: a request for `/search?q=ambient+drone` returns **HTTP 200 and about 3 KB containing no
+results at all**. The scraper that read it therefore matched nothing and returned an empty list —
+not once with an error, because a 200 with unfamiliar markup is not an exception. Both
+`search_bandcamp` and `recommend_bandcamp_purchases` had been answering "no results" for every
+query, indistinguishable from a genuinely empty search.
+
+`autocomplete_elastic` is what bandcamp.com's own front end calls. Album detail below still parses
+HTML, which still works — a release page is server-rendered where search no longer is.
+"""
+
+import logging
 from dataclasses import dataclass
 from typing import Any
 
 import httpx
-from bs4 import BeautifulSoup, Tag
+from bs4 import BeautifulSoup
+
+logger = logging.getLogger(__name__)
 
 
 @dataclass
@@ -24,7 +38,9 @@ class BandcampService:
     """Service for searching Bandcamp."""
 
     BASE_URL = "https://bandcamp.com"
-    SEARCH_URL = "https://bandcamp.com/search"
+    #: What bandcamp.com's own front end calls. The human-facing `/search` page renders its results
+    #: client-side and is not scrapable.
+    SEARCH_URL = "https://bandcamp.com/api/bcsearch_public_api/1/autocomplete_elastic"
 
     def __init__(self) -> None:
         self.client = httpx.AsyncClient(
@@ -50,91 +66,76 @@ class BandcampService:
         Returns:
             List of BandcampResult objects
         """
-        params = {
-            "q": query,
-            "item_type": item_type,
+        body = {
+            "search_text": query,
+            # The endpoint's `search_filter` uses the same letters this method already took.
+            "search_filter": item_type,
+            "full_page": False,
         }
 
         try:
-            response = await self.client.get(self.SEARCH_URL, params=params)
+            response = await self.client.post(self.SEARCH_URL, json=body)
             response.raise_for_status()
-        except httpx.HTTPError:
+        except httpx.HTTPError as exc:
+            # Logged, not swallowed. Returning [] here is indistinguishable from "nothing matched",
+            # which is exactly how this integration stayed broken without anyone noticing.
+            logger.warning("Bandcamp search failed for %r: %r", query, exc)
             return []
 
-        soup = BeautifulSoup(response.text, "html.parser")
-        results = []
+        try:
+            payload = response.json()
+        except ValueError:
+            logger.warning(
+                "Bandcamp search returned %d bytes that are not JSON — the endpoint has probably "
+                "changed. Query was %r.",
+                len(response.text),
+                query,
+            )
+            return []
 
-        # Find search result items
-        result_items = soup.select(".searchresult.data-search")
+        raw = (payload.get("auto") or {}).get("results") or []
+        results = [r for r in (self._parse_result(item) for item in raw[:limit]) if r]
 
-        for item in result_items[:limit]:
-            result = self._parse_result_item(item, item_type)
-            if result:
-                results.append(result)
-
+        if raw and not results:
+            # A response full of items that none of which parsed means the shape moved under us.
+            # Distinct from an empty search, and the caller must not see them as the same thing.
+            logger.warning(
+                "Bandcamp returned %d results for %r and none could be parsed — the response "
+                "shape has changed.",
+                len(raw),
+                query,
+            )
         return results
 
-    def _parse_result_item(self, item: Tag, item_type: str) -> BandcampResult | None:  # type: ignore[return]
-        """Parse a single search result item."""
+    def _parse_result(self, item: dict[str, Any]) -> "BandcampResult | None":
+        """Map one `autocomplete_elastic` result onto `BandcampResult`."""
         try:
-            # Get result type
-            result_class_raw: str | list[str] | None = item.get("class")
-            result_class: list[str] = [result_class_raw] if isinstance(result_class_raw, str) else list(result_class_raw or [])
-            if "album" in result_class:
-                rtype = "album"
-            elif "track" in result_class:
-                rtype = "track"
-            elif "band" in result_class:
-                rtype = "artist"
-            else:
-                rtype = "album"  # Default
-
-            # Get name
-            heading = item.select_one(".heading a")
-            name = heading.get_text(strip=True) if heading else None
-            url_attr = heading.get("href") if heading else None
-            url = str(url_attr) if url_attr else None
-
+            kind = {"a": "album", "t": "track", "b": "artist"}.get(str(item.get("type")), "album")
+            name = item.get("name")
+            # A band has no `item_url_path`; its page *is* the root.
+            url = item.get("item_url_path") or item.get("item_url_root")
             if not name or not url:
                 return None
 
-            # Get artist (for albums/tracks)
-            subhead = item.select_one(".subhead")
-            artist = None
-            if subhead:
-                artist_text = subhead.get_text(strip=True)
-                # Format is typically "by Artist Name"
-                if artist_text.startswith("by "):
-                    artist = artist_text[3:]
-                else:
-                    artist = artist_text
-
-            # Get image
-            art = item.select_one(".art img")
-            image_url_attr = art.get("src") if art else None
-            image_url = str(image_url_attr) if image_url_attr else None
-
-            # Get genre from tags
-            genre = None
-            tags = item.select(".tags .tag")
-            if tags:
-                genre = tags[0].get_text(strip=True)
-
-            # Get release date if available
-            release = item.select_one(".released")
-            release_date = release.get_text(strip=True).replace("released ", "") if release else None
-
+            tags = item.get("tag_names") or []
             return BandcampResult(
-                result_type=rtype,
-                name=name,
-                artist=artist,
-                album=None if rtype != "track" else None,  # For tracks, album is separate
-                url=url,
-                image_url=image_url,
-                genre=genre,
-                release_date=release_date,
+                result_type=kind,
+                # A band result names the band in `name` and has no `band_name`.
+                name=str(name),
+                artist=str(item["band_name"]) if item.get("band_name") else None,
+                album=str(item["album_name"]) if item.get("album_name") else None,
+                url=str(url),
+                image_url=str(item["img"]) if item.get("img") else None,
+                genre=(
+                    str(item.get("genre_name"))
+                    if item.get("genre_name")
+                    else (str(tags[0]) if tags else None)
+                ),
+                # Not carried by this endpoint. `get_album_details` has it for a specific release.
+                release_date=None,
             )
-        except Exception:
+        except Exception:  # noqa: BLE001 - one malformed row must not lose the whole search
+            logger.warning("Could not parse a Bandcamp result: %r", item, exc_info=True)
             return None
 
     async def get_album_details(self, url: str) -> dict[str, Any] | None:  # type: ignore[return]

--- a/backend/pyproject.toml
+++ b/backend/pyproject.toml
@@ -39,7 +39,6 @@ dependencies = [
     # Utilities
     "python-multipart>=0.0.6",
     "spotipy>=2.25.2",
-    "bandcamp-api>=0.2.3",
     "beautifulsoup4>=4.14.3",
     "rapidfuzz>=3.0.0",
     "pyacoustid>=1.3.0",

--- a/backend/tests/test_bandcamp.py
+++ b/backend/tests/test_bandcamp.py
@@ -1,49 +1,172 @@
-"""Tests for Bandcamp service - search result parsing."""
+"""Tests for Bandcamp search.
 
-from unittest.mock import AsyncMock, MagicMock
+**These exist because of a failure that looked exactly like success.** Bandcamp's `/search` page
+became a JavaScript shell — HTTP 200, ~3 KB, no results in the HTML — so the scraper matched
+nothing and returned `[]`. A 200 with unfamiliar markup raises nothing, so `search_bandcamp` and
+`recommend_bandcamp_purchases` answered "no results" for every query, for however long it had been
+broken, and nothing anywhere said so.
 
+The tests therefore assert two different things:
+
+1. A real response parses (the ordinary case).
+2. **A broken integration is reported, not returned as an empty list.** "Nothing matched your
+   query" and "this no longer works" must not be the same answer.
+
+Recorded fixtures rather than the network, so CI does not depend on Bandcamp being up — which is
+also the condition these tests exist to detect.
+"""
+
+from __future__ import annotations
+
+import json
+import logging
+
+import httpx
 import pytest
 
-from app.services.bandcamp import BandcampResult, BandcampService
+from app.services.bandcamp import BandcampService
+
+# One real result of each type, as `autocomplete_elastic` returns them.
+ALBUM = {
+    "type": "a",
+    "id": 477965531,
+    "name": "Inferno",
+    "band_name": "Boards of Canada",
+    "item_url_root": "https://boardsofcanada.bandcamp.com",
+    "item_url_path": "https://boardsofcanada.bandcamp.com/album/inferno",
+    "img": "https://f4.bcbits.com/img/3190407865_3.jpg",
+    "tag_names": None,
+}
+TRACK = {
+    "type": "t",
+    "name": "SISTERS (Boards of Canada remix)",
+    "band_name": "Odd Nosdam",
+    "album_name": "SISTERS (Boards of Canada remix)",
+    "item_url_path": "https://nosdam.bandcamp.com/track/sisters-boards-of-canada-remix",
+    "img": "https://f4.bcbits.com/img/4202052153_3.jpg",
+}
+BAND = {
+    "type": "b",
+    "name": "Boards of Canada",
+    # A band result has no `item_url_path` — its page *is* the root.
+    "item_url_root": "https://boardsofcanada.bandcamp.com",
+    "tag_names": ["Alternative"],
+    "genre_name": "Alternative",
+    "img": "https://f4.bcbits.com/img/3190407865_23.jpg",
+}
 
 
-class TestBandcampSearch:
-    @pytest.fixture
-    def service(self):
-        return BandcampService()
+def service_returning(payload, *, status: int = 200, text: str | None = None) -> BandcampService:
+    """A service whose HTTP client answers with one canned response."""
+    def handler(request: httpx.Request) -> httpx.Response:
+        if text is not None:
+            return httpx.Response(status, text=text)
+        return httpx.Response(status, json=payload)
+
+    service = BandcampService()
+    service.client = httpx.AsyncClient(transport=httpx.MockTransport(handler))
+    return service
+
+
+def wrap(results: list[dict]) -> dict:
+    return {"auto": {"results": results}}
+
+
+class TestParsing:
+    @pytest.mark.asyncio
+    async def test_parses_an_album(self):
+        results = await service_returning(wrap([ALBUM])).search("boards of canada")
+        assert len(results) == 1
+        album = results[0]
+        assert album.result_type == "album"
+        assert album.name == "Inferno"
+        assert album.artist == "Boards of Canada"
+        assert album.url == "https://boardsofcanada.bandcamp.com/album/inferno"
 
     @pytest.mark.asyncio
-    async def test_returns_empty_on_http_error(self, service):
-        import httpx
-        service.client = AsyncMock()
-        service.client.get.side_effect = httpx.ConnectError("Connection error")
-        results = await service.search("test query")
-        assert results == []
+    async def test_parses_a_track_with_its_album(self):
+        results = await service_returning(wrap([TRACK])).search("sisters", item_type="t")
+        assert results[0].result_type == "track"
+        assert results[0].album == "SISTERS (Boards of Canada remix)"
 
     @pytest.mark.asyncio
-    async def test_returns_empty_for_no_results(self, service):
-        mock_response = MagicMock()
-        mock_response.text = "<html><body>No results</body></html>"
-        mock_response.raise_for_status = MagicMock()
-        service.client = AsyncMock()
-        service.client.get.return_value = mock_response
+    async def test_a_band_falls_back_to_its_root_url(self):
+        """A band result carries no `item_url_path`; without the fallback it would be dropped."""
+        results = await service_returning(wrap([BAND])).search("boards", item_type="b")
+        assert results[0].result_type == "artist"
+        assert results[0].url == "https://boardsofcanada.bandcamp.com"
+        assert results[0].genre == "Alternative"
 
-        results = await service.search("very obscure query")
+    @pytest.mark.asyncio
+    async def test_limit_is_honoured(self):
+        results = await service_returning(wrap([ALBUM] * 10)).search("x", limit=3)
+        assert len(results) == 3
+
+    @pytest.mark.asyncio
+    async def test_one_malformed_row_does_not_lose_the_others(self):
+        results = await service_returning(wrap([{"type": "a"}, ALBUM])).search("x")
+        assert len(results) == 1, "the good row should survive its neighbour"
+
+
+class TestBrokenIntegrationIsReported:
+    """The half that matters. An empty list must not be the answer to "this is broken"."""
+
+    @pytest.mark.asyncio
+    async def test_the_javascript_shell_is_reported(self, caplog):
+        """The exact failure that shipped: 200, a few KB, and nothing parseable.
+
+        Bandcamp answers the *old* search URL this way today. If the JSON endpoint ever goes the
+        same way, this is the line that says so instead of the search quietly going dark.
+        """
+        shell = "<!DOCTYPE html><html><body><div id='pgBd'></div></body></html>"
+        with caplog.at_level(logging.WARNING):
+            results = await service_returning(None, text=shell).search("ambient drone")
         assert results == []
+        assert any("not JSON" in r.getMessage() for r in caplog.records)
+
+    @pytest.mark.asyncio
+    async def test_a_changed_result_shape_is_reported(self, caplog):
+        """Fifty results, none parseable, means the shape moved — not that nothing matched."""
+        moved = [{"kind": "album", "title": "Inferno"} for _ in range(50)]
+        with caplog.at_level(logging.WARNING):
+            results = await service_returning(wrap(moved)).search("boards of canada")
+        assert results == []
+        assert any("shape has changed" in r.getMessage() for r in caplog.records)
+
+    @pytest.mark.asyncio
+    async def test_an_http_failure_is_reported(self, caplog):
+        with caplog.at_level(logging.WARNING):
+            results = await service_returning(wrap([]), status=503).search("x")
+        assert results == []
+        assert any("search failed" in r.getMessage() for r in caplog.records)
+
+    @pytest.mark.asyncio
+    async def test_a_genuinely_empty_search_is_silent(self, caplog):
+        """Guard the guard: a real "nothing matched" must not cry wolf.
+
+        Without this, the tests above would pass just as well against a service that warned on
+        every call, which would train whoever reads the log to ignore it.
+        """
+        with caplog.at_level(logging.WARNING):
+            results = await service_returning(wrap([])).search("asdfghjkl no such band")
+        assert results == []
+        assert not caplog.records, f"unexpected warnings: {[r.getMessage() for r in caplog.records]}"
 
 
-class TestBandcampResult:
-    def test_dataclass_creation(self):
-        result = BandcampResult(
-            result_type="album",
-            name="Test Album",
-            artist="Test Artist",
-            album=None,
-            url="https://artist.bandcamp.com/album/test",
-            image_url="https://example.com/art.jpg",
-            genre="electronic",
-            release_date="January 1, 2024",
-        )
-        assert result.result_type == "album"
-        assert result.name == "Test Album"
-        assert result.artist == "Test Artist"
+class TestRequestShape:
+    @pytest.mark.asyncio
+    async def test_posts_the_query_the_endpoint_expects(self):
+        seen: dict = {}
+
+        def handler(request: httpx.Request) -> httpx.Response:
+            seen.update(json.loads(request.content))
+            return httpx.Response(200, json=wrap([ALBUM]))
+
+        service = BandcampService()
+        service.client = httpx.AsyncClient(transport=httpx.MockTransport(handler))
+        await service.search("ambient drone", item_type="t")
+
+        assert seen["search_text"] == "ambient drone"
+        # The method's `item_type` and the endpoint's `search_filter` share a vocabulary; this
+        # pins that, since a silent mismatch would return albums for a track search.
+        assert seen["search_filter"] == "t"

--- a/backend/uv.lock
+++ b/backend/uv.lock
@@ -371,20 +371,6 @@ wheels = [
 ]
 
 [[package]]
-name = "bandcamp-api"
-version = "0.2.3"
-source = { registry = "https://pypi.org/simple" }
-dependencies = [
-    { name = "beautifulsoup4" },
-    { name = "demjson3" },
-    { name = "html5lib" },
-    { name = "lxml" },
-    { name = "requests" },
-    { name = "setuptools" },
-]
-sdist = { url = "https://files.pythonhosted.org/packages/1b/32/f04a5d01f3951644abbdec70ca4430af94946182ef201167003bf7350f54/bandcamp_api-0.2.3.tar.gz", hash = "sha256:eff597328edf083307013a7884407c6fb7cd2568ac52fd3a85b3fe3bcefc3e1b", size = 25772, upload-time = "2023-10-31T03:19:21.537Z" }
-
-[[package]]
 name = "basic-pitch"
 version = "0.4.0"
 source = { registry = "https://pypi.org/simple" }
@@ -999,12 +985,6 @@ wheels = [
 ]
 
 [[package]]
-name = "demjson3"
-version = "3.0.6"
-source = { registry = "https://pypi.org/simple" }
-sdist = { url = "https://files.pythonhosted.org/packages/f7/d2/6a81a9b5311d50542e11218b470dafd8adbaf1b3e51fc1fddd8a57eed691/demjson3-3.0.6.tar.gz", hash = "sha256:37c83b0c6eb08d25defc88df0a2a4875d58a7809a9650bd6eee7afd8053cdbac", size = 131477, upload-time = "2022-10-22T19:09:05.379Z" }
-
-[[package]]
 name = "deprecated"
 version = "1.3.1"
 source = { registry = "https://pypi.org/simple" }
@@ -1025,7 +1005,6 @@ dependencies = [
     { name = "apscheduler" },
     { name = "async-upnp-client" },
     { name = "asyncpg" },
-    { name = "bandcamp-api" },
     { name = "beautifulsoup4" },
     { name = "boto3" },
     { name = "curl-cffi" },
@@ -1088,7 +1067,6 @@ requires-dist = [
     { name = "apscheduler", specifier = ">=3.10.0" },
     { name = "async-upnp-client", specifier = ">=0.47.0" },
     { name = "asyncpg", specifier = ">=0.29.0" },
-    { name = "bandcamp-api", specifier = ">=0.2.3" },
     { name = "basic-pitch", extras = ["onnx"], marker = "extra == 'analysis'", specifier = ">=0.3.0" },
     { name = "beautifulsoup4", specifier = ">=4.14.3" },
     { name = "boto3", specifier = ">=1.34.0" },
@@ -1567,19 +1545,6 @@ wheels = [
     { url = "https://files.pythonhosted.org/packages/0b/dd/7ac658d54b9fb7999a0ccb07ad863b413cbaf5cf172f48ebcd9497ec7263/hf_xet-1.2.0-cp37-abi3-musllinux_1_2_aarch64.whl", hash = "sha256:4c1428c9ae73ec0939410ec73023c4f842927f39db09b063b9482dac5a3bb737", size = 3413812, upload-time = "2025-10-24T19:04:24.585Z" },
     { url = "https://files.pythonhosted.org/packages/92/68/89ac4e5b12a9ff6286a12174c8538a5930e2ed662091dd2572bbe0a18c8a/hf_xet-1.2.0-cp37-abi3-musllinux_1_2_x86_64.whl", hash = "sha256:a55558084c16b09b5ed32ab9ed38421e2d87cf3f1f89815764d1177081b99865", size = 3508920, upload-time = "2025-10-24T19:04:26.927Z" },
     { url = "https://files.pythonhosted.org/packages/cb/44/870d44b30e1dcfb6a65932e3e1506c103a8a5aea9103c337e7a53180322c/hf_xet-1.2.0-cp37-abi3-win_amd64.whl", hash = "sha256:e6584a52253f72c9f52f9e549d5895ca7a471608495c4ecaa6cc73dba2b24d69", size = 2905735, upload-time = "2025-10-24T19:04:35.928Z" },
-]
-
-[[package]]
-name = "html5lib"
-version = "1.1"
-source = { registry = "https://pypi.org/simple" }
-dependencies = [
-    { name = "six" },
-    { name = "webencodings" },
-]
-sdist = { url = "https://files.pythonhosted.org/packages/ac/b6/b55c3f49042f1df3dcd422b7f224f939892ee94f22abcf503a9b7339eaf2/html5lib-1.1.tar.gz", hash = "sha256:b2e5b40261e20f354d198eae92afc10d750afb487ed5e50f9c4eaf07c184146f", size = 272215, upload-time = "2020-06-22T23:32:38.834Z" }
-wheels = [
-    { url = "https://files.pythonhosted.org/packages/6c/dd/a834df6482147d48e225a49515aabc28974ad5a4ca3215c18a882565b028/html5lib-1.1-py2.py3-none-any.whl", hash = "sha256:0d78f8fde1c230e99fe37986a60526d7049ed4bf8a9fadbad5f00e22e58e041d", size = 112173, upload-time = "2020-06-22T23:32:36.781Z" },
 ]
 
 [[package]]
@@ -4958,15 +4923,6 @@ wheels = [
     { url = "https://files.pythonhosted.org/packages/bd/95/615e72cd27b85b61eec764a5ca51bd94d40b5adea5ff47567d9ebc4d275a/watchfiles-1.1.1-pp311-pypy311_pp73-macosx_11_0_arm64.whl", hash = "sha256:89eef07eee5e9d1fda06e38822ad167a044153457e6fd997f8a858ab7564a336", size = 396117, upload-time = "2025-10-14T15:06:11.28Z" },
     { url = "https://files.pythonhosted.org/packages/c9/81/e7fe958ce8a7fb5c73cc9fb07f5aeaf755e6aa72498c57d760af760c91f8/watchfiles-1.1.1-pp311-pypy311_pp73-manylinux_2_17_aarch64.manylinux2014_aarch64.whl", hash = "sha256:ce19e06cbda693e9e7686358af9cd6f5d61312ab8b00488bc36f5aabbaf77e24", size = 450493, upload-time = "2025-10-14T15:06:12.321Z" },
     { url = "https://files.pythonhosted.org/packages/6e/d4/ed38dd3b1767193de971e694aa544356e63353c33a85d948166b5ff58b9e/watchfiles-1.1.1-pp311-pypy311_pp73-manylinux_2_17_x86_64.manylinux2014_x86_64.whl", hash = "sha256:3e6f39af2eab0118338902798b5aa6664f46ff66bc0280de76fca67a7f262a49", size = 457546, upload-time = "2025-10-14T15:06:13.372Z" },
-]
-
-[[package]]
-name = "webencodings"
-version = "0.5.1"
-source = { registry = "https://pypi.org/simple" }
-sdist = { url = "https://files.pythonhosted.org/packages/0b/02/ae6ceac1baeda530866a85075641cec12989bd8d31af6d5ab4a3e8c92f47/webencodings-0.5.1.tar.gz", hash = "sha256:b36a1c245f2d304965eb4e0a82848379241dc04b865afcc4aab16748587e1923", size = 9721, upload-time = "2017-04-05T20:21:34.189Z" }
-wheels = [
-    { url = "https://files.pythonhosted.org/packages/f4/24/2a3e3df732393fed8b3ebf2ec078f05546de641fe1b667ee316ec1dcf3b7/webencodings-0.5.1-py2.py3-none-any.whl", hash = "sha256:a0af1213f3c2226497a97e2b3aa01a7e4bee4f403f95be16fc9acd2947514a78", size = 11774, upload-time = "2017-04-05T20:21:32.581Z" },
 ]
 
 [[package]]


### PR DESCRIPTION
**This is a live bug on main**, and the branch has been sitting unmerged with no PR — found during the branch cleanup, one commit away from being deleted.

## What was wrong

Bandcamp's search page became a JavaScript shell. A request for `/search?q=ambient+drone` returns **HTTP 200 and about 3 KB containing no results at all**, so the scraper matched nothing and returned an empty list — **never once with an error**, because a 200 with unfamiliar markup is not an exception.

Both `search_bandcamp` and `recommend_bandcamp_purchases` have therefore been answering "no results" for every query, indistinguishable from a genuinely empty search.

**Verified today, against the live site:**

```
GET https://bandcamp.com/search?q=ambient+drone
  bytes: 3038
  "searchresult" matches: 0
```

## The fix

Search now calls `autocomplete_elastic` — the endpoint bandcamp.com's own front end uses. Same query, right now:

```
POST /api/bcsearch_public_api/1/autocomplete_elastic
  results: 50
   - 8 Bit Weapon — Ambient Drone Music
   - ROMERIUM — DUST (Ambient / Drone)
   - DRONE AMBIENT BY DRONE AMBIENT — …
```

Album detail still parses HTML, which still works — a release page is server-rendered where search no longer is.

**And it now says so when it breaks.** The failure mode that hid this for so long was silence; an unexpected shape is reported rather than returned as an empty list.

## Also

Drops the `bandcamp-api` dependency, which the scraper path used. `beautifulsoup4` stays, since album detail still needs it. `uv.lock` regenerated on top of current main rather than carried from the old branch — that also removes `demjson3`, `html5lib` and `webencodings`.

## Verification

- `pytest tests/test_bandcamp.py` — 10 passed
- `ruff` clean, `mypy app` — 0 errors, committed OpenAPI schema current
- Both the broken and the fixed path exercised against the real site, above

🤖 Generated with [Claude Code](https://claude.com/claude-code)