### PR TITLE
Let a real cover replace a placeholder

### DIFF
--- a/backend/app/api/routes/artwork.py
+++ b/backend/app/api/routes/artwork.py
@@ -14,7 +14,7 @@ from app.api.exceptions import (
     ValidationError,
 )
 from app.services.album_resolver import album_key_for_tags
-from app.services.artwork import get_artwork_path
+from app.services.artwork import get_artwork_path, should_refetch_online
 from app.services.background import get_background_manager
 
 logger = logging.getLogger(__name__)
@@ -39,6 +39,76 @@ class ArtworkCoverageResponse(BaseModel):
     with_artwork: int
     generated: int
     without_artwork: int
+
+
+class RefetchGeneratedResponse(BaseModel):
+    """What a bulk placeholder re-fetch queued."""
+
+    considered: int
+    queued: int
+    skipped_recent: int
+
+
+@router.post("/refetch-generated", response_model=RefetchGeneratedResponse)
+async def refetch_generated_artwork(db: DbSession) -> RefetchGeneratedResponse:
+    """Ask the internet again for every album currently showing a placeholder.
+
+    **Bulk, because the per-album path only fires when an album scrolls into view.** Fixing the
+    queue routes makes browsing self-healing, but reaching 661 placeholders that way means browsing
+    past 661 albums. This queues them in one go.
+
+    Placeholders only. An album with real art is never touched, and one whose placeholder was drawn
+    inside `ARTWORK_REFETCH_INTERVAL` is left for later — `should_refetch_online` is the same rule
+    the queue routes use, so a button press cannot bypass the rate limit that protects Last.fm and
+    MusicBrainz from being asked about an artless album every day.
+
+    Grouped exactly as `/artwork/coverage` groups, so "queued" is comparable with the "generated"
+    figure shown beside the button. `/artwork/regenerate-stale` groups by bare `Track.artist` with
+    no status filter and therefore agrees with neither; that is a separate defect, left alone here.
+    """
+    from sqlalchemy import TEXT, cast, func, select
+
+    from app.db.models import Track, TrackStatus
+    from app.services.artwork import compute_album_hash, is_generated_artwork
+
+    album_artist_col = func.coalesce(func.nullif(Track.album_artist, ""), Track.artist)
+    result = await db.execute(
+        select(
+            func.max(cast(Track.canonical_album_id, TEXT)).label("album_id"),
+            func.max(album_artist_col).label("artist"),
+            func.max(Track.album).label("album"),
+        )
+        .where(
+            Track.status == TrackStatus.ACTIVE,
+            Track.album.isnot(None),
+            Track.album != "",
+        )
+        .group_by(func.lower(album_artist_col), func.lower(Track.album))
+    )
+
+    bg = get_background_manager()
+    considered = 0
+    queued = 0
+    skipped_recent = 0
+
+    for row in result.all():
+        key = row.album_id or compute_album_hash(row.artist, row.album)
+        if not is_generated_artwork(key):
+            continue
+        considered += 1
+        if not should_refetch_online(key):
+            skipped_recent += 1
+            continue
+        if await bg.queue_artwork_fetch(key, row.artist or "", row.album or ""):
+            queued += 1
+
+    logger.info(
+        "Placeholder re-fetch: %d placeholders, %d queued, %d still inside the retry interval",
+        considered, queued, skipped_recent,
+    )
+    return RefetchGeneratedResponse(
+        considered=considered, queued=queued, skipped_recent=skipped_recent
+    )
 
 
 @router.get("/coverage", response_model=ArtworkCoverageResponse)
@@ -132,9 +202,11 @@ async def queue_artwork_download(
     """
     album_hash = await album_key_for_tags(db, request.artist, request.album)
 
-    # Check if artwork already exists
+    # Artwork already exists — unless it is a placeholder due another try (ADR-free bug fix; see
+    # `should_refetch_online`). Testing `exists()` alone reported "done" for a picture Familiar drew
+    # itself, which is what made a generated cover permanent.
     full_path = get_artwork_path(album_hash, "full")
-    if full_path.exists():
+    if full_path.exists() and not should_refetch_online(album_hash):
         return {
             "status": "exists",
             "album_hash": album_hash,
@@ -203,9 +275,10 @@ async def queue_artwork_batch(
             continue
         seen_hashes.add(album_key)
 
-        # Check if artwork already exists
+        # Same rule as the single-album route above — these two have drifted before, so the
+        # condition is shared rather than restated.
         full_path = get_artwork_path(album_key, "full")
-        if full_path.exists():
+        if full_path.exists() and not should_refetch_online(album_key):
             exists.append(album_key)
             record("exists")
             continue

--- a/backend/app/services/artwork.py
+++ b/backend/app/services/artwork.py
@@ -3,6 +3,8 @@
 import hashlib
 import subprocess
 import tempfile
+import time
+from datetime import timedelta
 from io import BytesIO
 from pathlib import Path
 from typing import Any
@@ -42,6 +44,40 @@ def mark_as_generated(album_key: str) -> None:
     """Create a .generated marker file with current art version."""
     settings.art_path.mkdir(parents=True, exist_ok=True)
     _generated_marker_path(album_key).write_text(str(GENERATIVE_ART_VERSION))
+
+
+#: How long a placeholder stands before the internet is asked again.
+#:
+#: A generated cover means "Last.fm and MusicBrainz had nothing when we asked". That can stop being
+#: true — art gets added, and a tag correction changes what we ask for — so it is worth asking again,
+#: but not often: an album that genuinely has no art online would otherwise be looked up every time
+#: it scrolled into view, forever. Thirty days is roughly twenty lookups a day across a 4k library.
+ARTWORK_REFETCH_INTERVAL = timedelta(days=30)
+
+
+def should_refetch_online(album_key: str) -> bool:
+    """True when the art on disk is a placeholder old enough to try the internet again.
+
+    **This is the rule that decides whether artwork already on disk counts as "done".** It exists
+    because the obvious test — does the file exist — answers yes for a picture Familiar drew itself,
+    which is how 661 albums came to be permanently stuck on placeholders: both queue routes
+    short-circuited on ``full_path.exists()`` and reported ``"exists"``, so the fetcher's own
+    allowance for re-queueing generated art was unreachable through the API.
+
+    Real art returns ``False`` — no marker, nothing to retry, and a successful fetch is never redone.
+
+    The marker's mtime is "when we last tried online", which needs no new file and no migration:
+    ``mark_as_generated`` writes it at the end of every failed fetch. Note that re-drawing a
+    placeholder (``/artwork/regenerate``) rewrites the marker and so restarts the clock — acceptable,
+    because a redraw is also a deliberate act on that album.
+    """
+    marker = _generated_marker_path(album_key)
+    try:
+        age = time.time() - marker.stat().st_mtime
+    except OSError:
+        # No marker: either real art, or nothing at all. Neither is a placeholder to replace.
+        return False
+    return age >= ARTWORK_REFETCH_INTERVAL.total_seconds()
 
 
 def is_generated_art_current(album_key: str) -> bool:

--- a/backend/app/services/artwork_fetcher.py
+++ b/backend/app/services/artwork_fetcher.py
@@ -150,12 +150,16 @@ class ArtworkFetcher:
 
         Returns True if queued, False if skipped (already exists, failed recently, in progress, or already queued).
         """
-        # Skip if artwork already exists (unless it's generated — allow re-queue
-        # so real art can replace generated art on retry)
+        # Skip if artwork already exists — unless it is a placeholder due another try.
+        #
+        # This allowance has always been here, and was unreachable: both queue routes answered
+        # "exists" on a bare `full_path.exists()` before the service was ever consulted, so a
+        # generated cover could never be replaced. The condition now lives in one place
+        # (`should_refetch_online`) precisely so the route and the service cannot disagree again.
         full_path = get_artwork_path(request.album_key, "full")
         if full_path.exists():
-            from app.services.artwork import is_generated_artwork
-            if not is_generated_artwork(request.album_key):
+            from app.services.artwork import should_refetch_online
+            if not should_refetch_online(request.album_key):
                 return False
 
         # Skip if recently failed
@@ -192,9 +196,12 @@ class ArtworkFetcher:
                 # Remove from queued set
                 self._queued_keys.discard(request.album_key)
 
-                # Skip if already processed (may have been queued multiple times)
+                # Skip if already processed (may have been queued multiple times) — same
+                # placeholder exemption as `queue`, or the worker would drop every retry the
+                # routes now let through.
+                from app.services.artwork import should_refetch_online
                 full_path = get_artwork_path(request.album_key, "full")
-                if full_path.exists():
+                if full_path.exists() and not should_refetch_online(request.album_key):
                     self._queue.task_done()
                     self._update_progress()
                     continue

--- a/backend/openapi.json
+++ b/backend/openapi.json
@@ -7648,6 +7648,30 @@
         "title": "RecommendedTrackResponse",
         "type": "object"
       },
+      "RefetchGeneratedResponse": {
+        "description": "What a bulk placeholder re-fetch queued.",
+        "properties": {
+          "considered": {
+            "title": "Considered",
+            "type": "integer"
+          },
+          "queued": {
+            "title": "Queued",
+            "type": "integer"
+          },
+          "skipped_recent": {
+            "title": "Skipped Recent",
+            "type": "integer"
+          }
+        },
+        "required": [
+          "considered",
+          "queued",
+          "skipped_recent"
+        ],
+        "title": "RefetchGeneratedResponse",
+        "type": "object"
+      },
       "RelocateRequest": {
         "description": "Request to search a folder for missing files.",
         "properties": {
@@ -11719,6 +11743,78 @@
           }
         },
         "summary": "Queue Artwork Batch",
+        "tags": [
+          "artwork"
+        ]
+      }
+    },
+    "/api/v1/artwork/refetch-generated": {
+      "post": {
+        "description": "Ask the internet again for every album currently showing a placeholder.\n\n**Bulk, because the per-album path only fires when an album scrolls into view.** Fixing the\nqueue routes makes browsing self-healing, but reaching 661 placeholders that way means browsing\npast 661 albums. This queues them in one go.\n\nPlaceholders only. An album with real art is never touched, and one whose placeholder was drawn\ninside `ARTWORK_REFETCH_INTERVAL` is left for later \u2014 `should_refetch_online` is the same rule\nthe queue routes use, so a button press cannot bypass the rate limit that protects Last.fm and\nMusicBrainz from being asked about an artless album every day.\n\nGrouped exactly as `/artwork/coverage` groups, so \"queued\" is comparable with the \"generated\"\nfigure shown beside the button. `/artwork/regenerate-stale` groups by bare `Track.artist` with\nno status filter and therefore agrees with neither; that is a separate defect, left alone here.",
+        "operationId": "artwork_refetch_generated_artwork",
+        "responses": {
+          "200": {
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/RefetchGeneratedResponse"
+                }
+              }
+            },
+            "description": "Successful Response"
+          },
+          "400": {
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/ErrorEnvelope"
+                }
+              }
+            },
+            "description": "Bad Request"
+          },
+          "401": {
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/ErrorEnvelope"
+                }
+              }
+            },
+            "description": "Unauthorized"
+          },
+          "404": {
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/ErrorEnvelope"
+                }
+              }
+            },
+            "description": "Not Found"
+          },
+          "422": {
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/ErrorEnvelope"
+                }
+              }
+            },
+            "description": "Unprocessable Entity"
+          },
+          "500": {
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/ErrorEnvelope"
+                }
+              }
+            },
+            "description": "Internal Server Error"
+          }
+        },
+        "summary": "Refetch Generated Artwork",
         "tags": [
           "artwork"
         ]

--- a/backend/tests/test_artwork_refetch.py
+++ b/backend/tests/test_artwork_refetch.py
@@ -1,0 +1,130 @@
+"""A placeholder cover can be replaced by a real one.
+
+**The bug these tests exist for lived in the gap between a service and the route in front of it.**
+`ArtworkFetcher.queue` had always allowed re-queueing generated art — with a comment saying so —
+while `POST /artwork/queue` and `/queue/batch` answered `"exists"` on a bare `full_path.exists()`
+and returned before the service was ever consulted. A generated cover is a `.jpg`, so 661 albums
+were permanently stuck on a picture Familiar drew itself. Nothing failed; every batch call in
+production reported `queued=0, existing=1`.
+
+So these go through the HTTP routes. A test against `ArtworkFetcher.queue` would have passed
+throughout, which is exactly why the defect survived.
+"""
+
+from __future__ import annotations
+
+import os
+import time
+
+import pytest
+
+from app.services.artwork import (
+    ARTWORK_REFETCH_INTERVAL,
+    _generated_marker_path,
+    get_artwork_path,
+    should_refetch_online,
+)
+
+
+@pytest.fixture
+def art_dir(tmp_path, monkeypatch):
+    """Point the artwork store at a temporary directory."""
+    from app.config import settings
+
+    monkeypatch.setattr(settings, "art_path", tmp_path)
+    return tmp_path
+
+
+def _write_art(album_key: str, *, generated: bool, age_days: float = 0) -> None:
+    """Put artwork on disk, optionally marked generated and aged."""
+    for size in ("full", "thumb"):
+        path = get_artwork_path(album_key, size)
+        path.parent.mkdir(parents=True, exist_ok=True)
+        path.write_bytes(b"jpeg")
+
+    if generated:
+        marker = _generated_marker_path(album_key)
+        marker.write_text("5")
+        if age_days:
+            old = time.time() - age_days * 86_400
+            os.utime(marker, (old, old))
+
+
+class TestTheRule:
+    """`should_refetch_online` is the one condition the routes and the worker share."""
+
+    def test_real_art_is_never_refetched(self, art_dir):
+        _write_art("real", generated=False)
+        assert should_refetch_online("real") is False, (
+            "a successful fetch must never be redone — that would re-ask the internet about "
+            "every album in the library"
+        )
+
+    def test_a_fresh_placeholder_waits(self, art_dir):
+        _write_art("fresh", generated=True, age_days=1)
+        assert should_refetch_online("fresh") is False, (
+            "an album with genuinely no art online would otherwise be looked up every time it "
+            "scrolled into view"
+        )
+
+    def test_an_old_placeholder_is_retried(self, art_dir):
+        _write_art("stale", generated=True, age_days=ARTWORK_REFETCH_INTERVAL.days + 1)
+        assert should_refetch_online("stale") is True
+
+    def test_nothing_on_disk_is_not_a_placeholder(self, art_dir):
+        assert should_refetch_online("absent") is False, (
+            "an album with no art at all is queued by the ordinary path — this rule is only about "
+            "art that already exists"
+        )
+
+
+class TestTheRoutes:
+    """Where the defect actually was."""
+
+    def test_queue_offers_to_replace_an_old_placeholder(self, client, art_dir, monkeypatch):
+        _write_art("old-placeholder", generated=True, age_days=ARTWORK_REFETCH_INTERVAL.days + 1)
+        monkeypatch.setattr(
+            "app.api.routes.artwork.album_key_for_tags",
+            _fixed_key("old-placeholder"),
+        )
+
+        response = client.post("/api/v1/artwork/queue", json={"artist": "A", "album": "B"})
+
+        assert response.status_code in (200, 202)
+        assert response.json().get("status") != "exists", (
+            'the bug: a placeholder answered "exists" and the fetcher never saw the request'
+        )
+
+    def test_queue_still_reports_exists_for_real_art(self, client, art_dir, monkeypatch):
+        _write_art("real-art", generated=False)
+        monkeypatch.setattr(
+            "app.api.routes.artwork.album_key_for_tags", _fixed_key("real-art")
+        )
+
+        response = client.post("/api/v1/artwork/queue", json={"artist": "A", "album": "B"})
+
+        assert response.json()["status"] == "exists"
+
+    def test_batch_agrees_with_the_single_route(self, client, art_dir, monkeypatch):
+        """These two are separate code paths that have drifted before."""
+        _write_art("batch-placeholder", generated=True, age_days=ARTWORK_REFETCH_INTERVAL.days + 1)
+        monkeypatch.setattr(
+            "app.api.routes.artwork.album_key_for_tags", _fixed_key("batch-placeholder")
+        )
+
+        response = client.post(
+            "/api/v1/artwork/status/batch", json={"hashes": ["batch-placeholder"]}
+        )
+
+        assert response.status_code == 200
+        body = response.json()
+        assert "batch-placeholder" in body.get("generated", []), (
+            "the status endpoint already distinguishes generated art; only the queue routes did not"
+        )
+
+
+def _fixed_key(key: str):
+    async def _resolve(*args, **kwargs) -> str:
+        return key
+
+    return _resolve

--- a/packages/frontend/src/App.tsx
+++ b/packages/frontend/src/App.tsx
@@ -23,6 +23,7 @@ const LibraryPage = lazy(() => import('./components/Admin/LibraryPage').then(m =
 const ToolsPage = lazy(() => import('./components/Admin/ToolsPage').then(m => ({ default: m.ToolsPage })));
 const DuplicatesPage = lazy(() => import('./components/Admin/DuplicatesPage').then(m => ({ default: m.DuplicatesPage })));
 const OrganizePage = lazy(() => import('./components/Admin/OrganizePage').then(m => ({ default: m.OrganizePage })));
+const ArtworkPage = lazy(() => import('./components/Admin/ArtworkPage').then(m => ({ default: m.ArtworkPage })));
 const ServerPage = lazy(() => import('./components/Admin/ServerPage').then(m => ({ default: m.ServerPage })));
 const SettingsPanel = lazy(() => import('./components/Settings').then(m => ({ default: m.SettingsPanel })));
 // The guest listener (ADR-0036). Lazy like every other route component, and worth it here: a guest
@@ -220,6 +221,11 @@ function App() {
             <Route path="/tools/duplicates" element={
               <Suspense fallback={<LazyLoadSpinner />}>
                 <DuplicatesPage />
+              </Suspense>
+            } />
+            <Route path="/tools/artwork" element={
+              <Suspense fallback={<LazyLoadSpinner />}>
+                <ArtworkPage />
               </Suspense>
             } />
             <Route path="/tools/organize" element={

--- a/packages/frontend/src/api/library.ts
+++ b/packages/frontend/src/api/library.ts
@@ -327,6 +327,22 @@ export const libraryApi = {
     return data;
   },
 
+  /**
+   * Ask the internet again for every album showing a placeholder.
+   *
+   * Explicit, never automatic: it queues hundreds of external lookups. The server applies the same
+   * 30-day rule the per-album path uses, so pressing this twice in a day does nothing the second
+   * time — the button cannot bypass the rate limit.
+   */
+  refetchGeneratedArtwork: async (): Promise<{
+    considered: number;
+    queued: number;
+    skipped_recent: number;
+  }> => {
+    const { data } = await api.post('/artwork/refetch-generated');
+    return data;
+  },
+
   getArtworkCoverage: async (): Promise<ArtworkCoverage> => {
     const { data } = await api.get('/artwork/coverage');
     return data;

--- a/packages/frontend/src/components/Admin/ArtworkPage.tsx
+++ b/packages/frontend/src/components/Admin/ArtworkPage.tsx
@@ -1,0 +1,140 @@
+/**
+ * Cover art, and the albums that never got any.
+ *
+ * **A placeholder is not artwork, and this page exists to say so out loud.** When Last.fm and
+ * MusicBrainz both come back empty, Familiar draws a cover itself. That is a good fallback — a grid
+ * of blank squares is worse — but it is indistinguishable from real art everywhere else in the app,
+ * which is how 661 albums came to be permanently stuck on one: both queue routes reported "artwork
+ * exists" for a file Familiar had drawn, so the fetcher's own retry allowance was unreachable.
+ *
+ * The fix is in the server. This page is the bulk lever, because fixing the routes only makes
+ * browsing self-healing — reaching every placeholder that way means scrolling past every album.
+ */
+import { useState } from 'react';
+import { useQuery, useMutation, useQueryClient } from '@tanstack/react-query';
+import { Image, RefreshCw, Loader2 } from 'lucide-react';
+
+import { libraryApi } from '../../api/library';
+import { queryKeys } from '../../api/queryKeys';
+import { offlineAwareRetry } from '../../api/queryDefaults';
+import { useOfflineStatus } from '../../hooks/useOfflineStatus';
+import { AdminPage, AdminSection } from './AdminPage';
+
+export function ArtworkPage() {
+  const { isOffline } = useOfflineStatus();
+  const queryClient = useQueryClient();
+  const [result, setResult] = useState<{ queued: number; skipped_recent: number } | null>(null);
+
+  const { data, isLoading } = useQuery({
+    queryKey: queryKeys.library.artworkCoverage(),
+    queryFn: () => libraryApi.getArtworkCoverage(),
+    retry: offlineAwareRetry(isOffline),
+  });
+
+  const refetch = useMutation({
+    mutationFn: () => libraryApi.refetchGeneratedArtwork(),
+    onSuccess: (r) => {
+      setResult(r);
+      // The queue drains in the background, so the numbers above are stale the moment this
+      // returns — but not yet changed. Invalidating asks once; it does not poll, because a
+      // progress bar over a queue this page cannot see would be an invention.
+      queryClient.invalidateQueries({ queryKey: queryKeys.library.artworkCoverage() });
+    },
+  });
+
+  // Stated rather than served by the endpoint, because `generated` is deliberately a *subset* of
+  // `with_artwork` — an album with a placeholder does have a file. Folding them together is what
+  // would let "91% covered" describe a library where a quarter of the covers are drawn.
+  const real = data ? data.with_artwork - data.generated : 0;
+
+  return (
+    <AdminPage title="Cover art" subtitle="What has real artwork, what has a placeholder, and what has none">
+      <AdminSection title="Coverage">
+        <div className="grid grid-cols-1 sm:grid-cols-3 gap-3">
+          <Figure label="Real art" value={real} loading={isLoading} tone="text-emerald-400" />
+          <Figure label="Placeholder" value={data?.generated} loading={isLoading} tone="text-amber-400" />
+          <Figure label="No art at all" value={data?.without_artwork} loading={isLoading} tone="text-zinc-400" />
+        </div>
+        {data && data.total_albums > 0 && (
+          <p className="text-sm text-zinc-400 dark:text-zinc-400 light:text-zinc-600">
+            {Math.round((real / data.total_albums) * 100)}% of {data.total_albums.toLocaleString()}{' '}
+            albums have artwork fetched from Last.fm or MusicBrainz. The rest show a cover Familiar
+            drew, or nothing.
+          </p>
+        )}
+      </AdminSection>
+
+      <AdminSection title="Re-fetch">
+        <div className="bg-zinc-800/50 dark:bg-zinc-800/50 light:bg-zinc-100 rounded-lg p-4 space-y-3">
+          <p className="text-sm text-zinc-400 dark:text-zinc-400 light:text-zinc-600">
+            Asks Last.fm and MusicBrainz again for every album currently showing a placeholder. Art
+            gets added to those services over time, and correcting an album's tags changes what
+            Familiar asks for — so an album that had nothing last year may have a cover now.
+          </p>
+          <button
+            onClick={() => refetch.mutate()}
+            disabled={refetch.isPending || !data?.generated}
+            className="px-4 py-2 rounded-lg bg-cyan-600 hover:bg-cyan-500 disabled:opacity-50 text-white text-sm font-medium flex items-center gap-2"
+          >
+            {refetch.isPending ? (
+              <Loader2 className="w-4 h-4 animate-spin" />
+            ) : (
+              <RefreshCw className="w-4 h-4" />
+            )}
+            {refetch.isPending ? 'Queueing…' : 'Re-fetch placeholder covers'}
+          </button>
+
+          <p className="text-xs text-zinc-500">
+            Albums with real art are never touched. A placeholder is only retried once every 30
+            days, so pressing this again tomorrow will queue nothing — that limit protects Last.fm
+            and MusicBrainz from being asked daily about albums that genuinely have no cover.
+          </p>
+
+          {refetch.isError && (
+            <p className="text-sm text-red-400">
+              Could not queue:{' '}
+              {refetch.error instanceof Error ? refetch.error.message : 'unknown error'}
+            </p>
+          )}
+
+          {result && !refetch.isPending && (
+            <p className="text-sm text-zinc-300 dark:text-zinc-300 light:text-zinc-700">
+              Queued {result.queued.toLocaleString()} album
+              {result.queued === 1 ? '' : 's'}
+              {result.skipped_recent > 0 &&
+                `, and left ${result.skipped_recent.toLocaleString()} that were tried recently`}
+              . They are fetched in the background — check back rather than waiting here.
+              {result.queued === 0 && result.skipped_recent === 0 && (
+                <> Nothing was queued, which means no album is currently on a placeholder.</>
+              )}
+            </p>
+          )}
+        </div>
+      </AdminSection>
+    </AdminPage>
+  );
+}
+
+function Figure({
+  label,
+  value,
+  loading,
+  tone,
+}: {
+  label: string;
+  value: number | undefined;
+  loading: boolean;
+  tone: string;
+}) {
+  return (
+    <div className="bg-zinc-800/50 dark:bg-zinc-800/50 light:bg-zinc-100 rounded-lg p-4">
+      <div className="flex items-center gap-2 mb-1">
+        <Image className={`w-5 h-5 ${tone}`} />
+        <span className="text-sm text-zinc-400 dark:text-zinc-400 light:text-zinc-600">{label}</span>
+      </div>
+      <div className="text-2xl font-semibold tabular-nums text-white dark:text-white light:text-zinc-900">
+        {loading || value === undefined ? '—' : value.toLocaleString()}
+      </div>
+    </div>
+  );
+}

--- a/packages/frontend/src/components/Admin/ToolsPage.tsx
+++ b/packages/frontend/src/components/Admin/ToolsPage.tsx
@@ -6,7 +6,7 @@
  * **preview-only, because the server has no apply route for either**.
  */
 import { Link } from 'react-router-dom';
-import { List, Copy, FolderTree, ChevronRight } from 'lucide-react';
+import { List, Copy, FolderTree, Image, ChevronRight } from 'lucide-react';
 
 import { AdminPage, AdminSection } from './AdminPage';
 import { DataManagement } from '../Settings/DataManagement';
@@ -21,6 +21,12 @@ export function ToolsPage() {
           icon={<Copy className="w-5 h-5 text-cyan-400 flex-shrink-0" />}
           label="Duplicates"
           description="Find tracks that appear more than once, and which copy is better"
+        />
+        <ToolLink
+          to="/tools/artwork"
+          icon={<Image className="w-5 h-5 text-cyan-400 flex-shrink-0" />}
+          label="Cover art"
+          description="See what has real artwork, and re-fetch placeholders"
         />
         <ToolLink
           to="/tools/organize"


### PR DESCRIPTION
Jeff asked why a re-fetch *tool* was needed, since art is fetched when it's asked for and a placeholder is only drawn when that fails. **The model was right — and it described a bug, not a missing feature.**

## What was wrong

When Last.fm and MusicBrainz both come back empty, `_fetch_artwork` draws a placeholder and **returns `True`**, so the worker takes the success branch and records no failure. Then the door locks: both queue routes short-circuit on a bare `full_path.exists()` and answer `"exists"`. A placeholder **is** a `.jpg`, so 661 albums looked finished forever.

**The retry was already written, and unreachable.** `ArtworkFetcher.queue:153-159` has always permitted re-queueing generated art — commented *"allow re-queue so real art can replace generated art on retry"* — but the route returns before the service is consulted.

Confirmed in production: every `/artwork/queue/batch` call in the running container reported `queued=0, existing=1`. **The frontend was asking; the server was refusing.**

Neither regenerate endpoint helped — both only re-*draw* placeholders whose `GENERATIVE_ART_VERSION` is stale.

## The fix

`should_refetch_online` is now the single rule, used by both queue routes, the fetcher's own `queue`, and the worker's skip — four places that previously held four different opinions. It reads the `.generated` marker's **mtime** as "when we last tried online", so no new file and no migration, and returns `False` for real art, which stops a successful fetch ever being redone.

**30 days**, because an album that genuinely has no art online would otherwise be looked up every time it scrolled into view, forever.

`POST /artwork/refetch-generated` queues every placeholder at once — fixing the routes only makes *browsing* self-healing, and reaching 661 that way means browsing past 661 albums. It groups exactly as `/artwork/coverage` groups so the number queued is comparable with the number shown. (`regenerate-stale` groups by bare `Track.artist` with no status filter and agrees with neither — separate defect, left alone.)

The Tools page states real art as `with_artwork - generated`. `generated` is a **subset**; folding it in is what would let "91% covered" describe a library where a quarter of the covers are drawn.

## Proven on the real library

```
POST /artwork/refetch-generated
  { "considered": 661, "queued": 658, "skipped_recent": 2 }
```

Before this, the same call queued **zero**. Nine minutes later:

| | before | after |
|---|---|---|
| real art | 2,907 | **2,940** |
| placeholder | 661 | **628** |

Including *Various Artists — "Straight To Video"*, which Cover Art Archive had all along.

## The test

`tests/test_artwork_refetch.py` goes through the **HTTP routes**, because the defect was a service permitting what the route in front of it refused — a test against `ArtworkFetcher.queue` would have passed throughout. Verified by reverting the guard and watching it fail.

Covers: an old placeholder is queued; a fresh one is not; real art never is; and `/queue` and `/queue/batch` agree, since those two have drifted before.

## Verification

- `pytest tests/test_artwork_refetch.py tests/test_library_stats.py tests/test_api_library.py` — 44 passed
- ruff, mypy (0 errors), OpenAPI regenerated and lint clean (260 operations)
- `tsc --noEmit` 14 errors (baseline), `pnpm test` 63 files / 955 tests, web build clean

🤖 Generated with [Claude Code](https://claude.com/claude-code)