### PR TITLE
Say whether a cover was fetched or drawn

### DIFF
--- a/backend/app/api/routes/artwork.py
+++ b/backend/app/api/routes/artwork.py
@@ -1,6 +1,7 @@
 """Artwork endpoints for proactive artwork downloading."""
 
 import logging
+from datetime import UTC, datetime
 from typing import Any
 
 from fastapi import APIRouter
@@ -191,6 +192,21 @@ class ArtworkStatusResponse(BaseModel):
     exists: bool
     queued: bool = False
 
+    #: True when the cover on disk is one Familiar drew, not one it fetched.
+    #:
+    #: **`exists` alone cannot answer "does this album have artwork".** A placeholder is a real file,
+    #: so it says yes — which is how 661 albums sat on drawn covers without anything noticing, and
+    #: why the queue routes could report "exists" for art nobody had ever found. The batch endpoint
+    #: below has always distinguished the two; this one did not, so a caller's answer depended on
+    #: which of the two it happened to ask.
+    generated: bool = False
+
+    #: When the placeholder was drawn, which is also when the internet was last asked.
+    #:
+    #: Present so a caller can tell "we tried yesterday and found nothing" from "we tried a year
+    #: ago" without knowing `ARTWORK_REFETCH_INTERVAL`. Null for real art.
+    generated_at: datetime | None = None
+
 
 @router.post("/queue", status_code=202)
 async def queue_artwork_download(
@@ -317,13 +333,33 @@ async def queue_artwork_batch(
 
 @router.get("/status/{album_hash}")
 async def get_artwork_status(album_hash: str) -> ArtworkStatusResponse:
-    """Check if artwork exists for an album hash."""
+    """Check whether artwork exists for an album hash, and whether it is real.
+
+    Reports the same provenance the batch endpoint reports. It did not, and the asymmetry is what
+    let a placeholder pass for artwork everywhere a caller used this one.
+    """
+    from app.services.artwork import _generated_marker_path, is_generated_artwork
+
     full_path = get_artwork_path(album_hash, "full")
     thumb_path = get_artwork_path(album_hash, "thumb")
+    generated = is_generated_artwork(album_hash)
+
+    generated_at: datetime | None = None
+    if generated:
+        try:
+            generated_at = datetime.fromtimestamp(
+                _generated_marker_path(album_hash).stat().st_mtime, tz=UTC
+            )
+        except OSError:
+            # Raced with a real cover landing and clearing the marker. Not an error: the album
+            # simply has real art now, which the next call will report.
+            generated = False
 
     return ArtworkStatusResponse(
         album_hash=album_hash,
         exists=full_path.exists() and thumb_path.exists(),
+        generated=generated,
+        generated_at=generated_at,
     )
 
 

--- a/backend/openapi.json
+++ b/backend/openapi.json
@@ -1161,6 +1161,19 @@
             "title": "Exists",
             "type": "boolean"
           },
+          "generated": {
+            "default": false,
+            "title": "Generated",
+            "type": "boolean"
+          },
+          "generated_at": {
+            "format": "date-time",
+            "title": "Generated At",
+            "type": [
+              "string",
+              "null"
+            ]
+          },
           "queued": {
             "default": false,
             "title": "Queued",
@@ -12062,7 +12075,7 @@
     },
     "/api/v1/artwork/status/{album_hash}": {
       "get": {
-        "description": "Check if artwork exists for an album hash.",
+        "description": "Check whether artwork exists for an album hash, and whether it is real.\n\nReports the same provenance the batch endpoint reports. It did not, and the asymmetry is what\nlet a placeholder pass for artwork everywhere a caller used this one.",
         "operationId": "artwork_get_artwork_status",
         "parameters": [
           {

--- a/backend/tests/test_artwork_refetch.py
+++ b/backend/tests/test_artwork_refetch.py
@@ -128,3 +128,46 @@ def _fixed_key(key: str):
         return key
 
     return _resolve
+
+
+class TestProvenanceIsReportable:
+    """`exists` alone cannot answer "does this album have artwork"."""
+
+    def test_status_reports_a_placeholder_as_generated(self, client, art_dir):
+        _write_art("drawn", generated=True, age_days=3)
+
+        body = client.get("/api/v1/artwork/status/drawn").json()
+
+        assert body["exists"] is True, "a placeholder is a real file, which is the whole problem"
+        assert body["generated"] is True
+        assert body["generated_at"] is not None
+
+    def test_status_reports_real_art_as_not_generated(self, client, art_dir):
+        _write_art("fetched", generated=False)
+
+        body = client.get("/api/v1/artwork/status/fetched").json()
+
+        assert body["exists"] is True
+        assert body["generated"] is False
+        assert body["generated_at"] is None
+
+    def test_the_two_status_endpoints_agree(self, client, art_dir):
+        """They disagreed, and that is why a placeholder passed for artwork.
+
+        The batch endpoint has always separated `generated`; the single one reported only
+        `exists`. Which answer a caller got depended on which endpoint it happened to ask.
+        """
+        _write_art("drawn", generated=True, age_days=3)
+        _write_art("fetched", generated=False)
+
+        single = {
+            key: client.get(f"/api/v1/artwork/status/{key}").json()["generated"]
+            for key in ("drawn", "fetched")
+        }
+        batch = client.post(
+            "/api/v1/artwork/status/batch", json={"hashes": ["drawn", "fetched"]}
+        ).json()
+
+        assert single == {"drawn": True, "fetched": False}
+        assert set(batch["generated"]) == {"drawn"}
+

--- a/packages/frontend/src/api/metadata.ts
+++ b/packages/frontend/src/api/metadata.ts
@@ -84,8 +84,18 @@ export interface ArtworkQueueBatchResponse {
 }
 
 export interface ArtworkStatusBatchResponse {
+  /** hash → whether *a file* exists, which a placeholder satisfies. See `generated`. */
   status: Record<string, boolean>;
+  /** Hashes whose fetch failed outright — stop polling these. */
   failed: string[];
+  /**
+   * Hashes whose cover Familiar drew rather than fetched.
+   *
+   * **The server has always sent this and the type omitted it**, so no caller could act on it —
+   * which is a large part of why 661 albums sat on placeholders unnoticed. Present now so a
+   * surface that wants to distinguish real art from a stand-in can.
+   */
+  generated: string[];
 }
 
 export interface ArtworkUploadResponse {


### PR DESCRIPTION
The follow-up to #180, and **the reason that bug hid for so long**: nothing outside the server could tell real artwork from a stand-in.

## The asymmetry

`GET /artwork/status/{hash}` reported only `exists` — which a placeholder satisfies, because it *is* a real file. So "does this album have artwork" had a misleading answer at the one endpoint built to answer it.

Meanwhile `POST /artwork/status/batch` has separated `generated` all along. The answer a caller got depended on **which of the two it happened to ask**.

## What changed

The single endpoint now reports `generated`, plus `generated_at` from the marker's mtime — so a caller can distinguish *"we tried yesterday and found nothing"* from *"we tried a year ago"* without knowing `ARTWORK_REFETCH_INTERVAL`. Null for real art.

If the marker vanishes mid-read (a real cover landing clears it), that's reported as not-generated rather than raising — it means the album now has real art.

## The same defect on the client

`ArtworkStatusBatchResponse` omitted `generated` from its TypeScript type. The server had always sent it; **no caller could see it.**

That's the third stale type in this stretch of work, after `LibraryStats`' three missing pending queues and `PlayableTrack`'s missing duration. Each one a capability that existed on the wire and could not be reached from the app — and in this case, a large part of why 661 albums sat on drawn covers without anyone noticing.

## Tests

They assert **the two endpoints agree**, rather than asserting either one's shape. Their disagreement was the actual defect, and a test of one alone would have passed throughout.

## Verification

- `pytest tests/test_artwork_refetch.py tests/test_library_stats.py` — 17 passed
- ruff clean, mypy 0 errors, OpenAPI regenerated and lint clean (260 operations)
- `tsc --noEmit` 14 errors (baseline), `pnpm test` 63 files / 955 tests, web build clean

🤖 Generated with [Claude Code](https://claude.com/claude-code)