### PR TITLE
Visualizers declare affinity, and the server ranks them (ADR-0064)

### DIFF
--- a/backend/app/api/routes/tracks/__init__.py
+++ b/backend/app/api/routes/tracks/__init__.py
@@ -145,6 +145,7 @@ from app.api.routes.tracks.listing import router as listing_router  # noqa: E402
 from app.api.routes.tracks.metadata import router as metadata_router  # noqa: E402
 from app.api.routes.tracks.playback import router as playback_router  # noqa: E402
 from app.api.routes.tracks.streaming import router as streaming_router  # noqa: E402
+from app.api.routes.tracks.visualizers import router as visualizers_router  # noqa: E402
 
 router = APIRouter(prefix="/tracks", tags=["tracks"])
 # Register list_tracks directly on the parent router so its path is ""
@@ -157,4 +158,5 @@ router.include_router(discovery_router)
 router.include_router(playback_router)
 router.include_router(metadata_router)
 router.include_router(identification_router)
+router.include_router(visualizers_router)
 

--- a/backend/app/api/routes/tracks/visualizers.py
+++ b/backend/app/api/routes/tracks/visualizers.py
@@ -1,0 +1,160 @@
+"""Rank a client's visualizers against a track (ADR-0064).
+
+**The client sends its candidates and the server ranks them.** That shape is forced rather than
+preferred: ADR-0029 point 5 keeps device identity uninvented, so the server has no key to file
+"which visualizers does this device have" under — and ADR-0034 point 4 puts local bundles in a
+directory on the device that the server is never told about. A ranking over visualizers the
+listener does not have is not a ranking.
+
+**Nothing is stored** (ADR-0064 point 6). The chosen visualizer and whether auto-select is on at
+all are listener preferences and stay on the device under ADR-0029 point 4; this endpoint is a pure
+function of the posted candidates and the track's analysis.
+"""
+
+from uuid import UUID
+
+from fastapi import APIRouter
+from pydantic import BaseModel, Field
+from sqlalchemy import select
+
+from app.api.deps import CurrentProfile, DbSession
+from app.api.exceptions import TrackNotFoundError
+from app.db.models import Track, TrackAnalysis
+from app.services.visualizer_affinity import (
+    Affinity,
+    Candidate,
+    FeatureRange,
+    rank_candidates,
+)
+
+router = APIRouter()
+
+
+class VisualizerFeatureRange(BaseModel):
+    """A bound a visualizer declares over one numeric analysis column.
+
+    Either end may be omitted for an open range. A feature this server does not know, one that
+    holds a string, and one this track was never analysed for are all inert — see
+    `services/visualizer_affinity`.
+    """
+
+    feature: str
+    minimum: float | None = None
+    maximum: float | None = None
+
+
+class VisualizerAffinity(BaseModel):
+    """What a visualizer says it suits, as declared in its manifest."""
+
+    tags: list[str] = Field(default_factory=list)
+    ranges: list[VisualizerFeatureRange] = Field(default_factory=list)
+
+
+class VisualizerCandidate(BaseModel):
+    """One visualizer the client reports having loaded."""
+
+    id: str
+    affinity: VisualizerAffinity | None = None
+
+
+class VisualizerRankingRequest(BaseModel):
+    """The visualizers this client actually has, in the order it would otherwise use."""
+
+    candidates: list[VisualizerCandidate] = Field(default_factory=list)
+
+
+class RankedVisualizer(BaseModel):
+    """One visualizer's placing, with enough detail to explain it.
+
+    `ignored` is per-candidate rather than global because a declaration belongs to the visualizer
+    that made it — it is what the picker shows an author whose tag did not land.
+    """
+
+    id: str
+    score: float
+    matched_tags: list[str] = Field(default_factory=list)
+    matched_ranges: list[str] = Field(default_factory=list)
+    unmatched_ranges: list[str] = Field(default_factory=list)
+    ignored: list[str] = Field(default_factory=list)
+
+
+class VisualizerRankingResponse(BaseModel):
+    """Candidates best-first, or unranked when there was nothing to rank against."""
+
+    visualizers: list[RankedVisualizer]
+    # False when the track has no analysis row, or none of its features are populated. The client
+    # must keep whatever it is showing rather than pick — a library mid-sync has a meaningful
+    # fraction of such tracks, and switching to an arbitrary visualizer on each is worse than not
+    # switching at all (ADR-0064).
+    ranked: bool
+
+
+def _to_domain(candidate: VisualizerCandidate) -> Candidate:
+    affinity = candidate.affinity
+    if affinity is None:
+        return Candidate(id=candidate.id)
+    return Candidate(
+        id=candidate.id,
+        affinity=Affinity(
+            tags=tuple(affinity.tags),
+            ranges=tuple(
+                FeatureRange(feature=r.feature, minimum=r.minimum, maximum=r.maximum)
+                for r in affinity.ranges
+            ),
+        ),
+    )
+
+
+@router.post("/{track_id}/visualizer-ranking", response_model=VisualizerRankingResponse)
+async def rank_visualizers(
+    track_id: UUID,
+    request: VisualizerRankingRequest,
+    db: DbSession,
+    profile: CurrentProfile,
+) -> VisualizerRankingResponse:
+    """Rank the client's visualizers by how well each suits this track.
+
+    A track that does not exist is a 404. A track that exists but has never been analysed is **not**
+    — it returns the candidates in the order they were submitted with `ranked: false`, because
+    "nothing to rank against" is an ordinary state on a library that is still being analysed, and
+    an error would push the client into treating it as a failure.
+    """
+    track_exists = (
+        await db.execute(select(Track.id).where(Track.id == track_id))
+    ).scalar_one_or_none()
+    if track_exists is None:
+        raise TrackNotFoundError()
+
+    analysis = (
+        await db.execute(select(TrackAnalysis).where(TrackAnalysis.track_id == track_id))
+    ).scalar_one_or_none()
+
+    features = analysis.to_features_dict() if analysis else {}
+    mood_tags = (analysis.mood_tags if analysis else None) or []
+
+    if not features and not mood_tags:
+        return VisualizerRankingResponse(
+            visualizers=[
+                RankedVisualizer(id=c.id, score=0.0) for c in request.candidates
+            ],
+            ranked=False,
+        )
+
+    ranked = rank_candidates(
+        [_to_domain(c) for c in request.candidates], features, list(mood_tags)
+    )
+
+    return VisualizerRankingResponse(
+        visualizers=[
+            RankedVisualizer(
+                id=r.id,
+                score=round(r.score, 4),
+                matched_tags=list(r.matched_tags),
+                matched_ranges=list(r.matched_ranges),
+                unmatched_ranges=list(r.unmatched_ranges),
+                ignored=list(r.ignored),
+            )
+            for r in ranked
+        ],
+        ranked=True,
+    )

--- a/backend/app/services/mood_tags.py
+++ b/backend/app/services/mood_tags.py
@@ -71,6 +71,12 @@ DESCRIPTORS: list[dict[str, str]] = [
     {"tag": "freeform", "category": "energy", "description": "freeform improvised experimental music"},
 ]
 
+# The vocabulary as a membership test. Added for ADR-0064, where a visualizer declares the tags it
+# suits and the server has to decide whether it recognises one — several of these are not
+# identifiers (`acoustic guitar`, `brass/sax`, `hip-hop`, `mid-tempo`, `bass-heavy`, `vocal/choir`),
+# so anything matching against them has to use these strings verbatim rather than a normalised form.
+KNOWN_TAGS: frozenset[str] = frozenset(d["tag"] for d in DESCRIPTORS)
+
 # Cache for descriptor text embeddings (computed once, kept in memory)
 _descriptor_embeddings: np.ndarray | None = None
 _descriptor_embeddings_failed = False

--- a/backend/app/services/visualizer_affinity.py
+++ b/backend/app/services/visualizer_affinity.py
@@ -1,0 +1,254 @@
+"""Score a visualizer's declared affinity against one track's analysis (ADR-0064).
+
+A visualizer declares, in its `familiar-plugin.json`, the tags it suits and ranges over the
+numeric analysis columns. This module decides how well one such declaration fits one track.
+
+**Pure by design.** Everything arrives as plain values — a features dict, a mood-tag list, the
+candidates' declarations — and nothing here touches the database or the ORM. That is the same rule
+`ambient.score_candidate` states for itself ("taste and listening history arrive as numbers rather
+than being queried here"), and it is what lets the whole scorer be tested without a database.
+
+**Unrecognised means inert, never rejected** (ADR-0064 point 3). A tag outside the 48-descriptor
+vocabulary, a range over a column that does not exist, a range over one of the seven columns that
+holds a string, and a range over a feature this particular track was never analysed for all
+contribute nothing *and are excluded from the denominator* — they neither help nor harm. They are
+reported back so the picker can show an author what did not land, rather than being dropped
+silently. Refusing a working visualizer over a typo in an optional field would be the worst trade
+available here.
+
+**Nothing to judge scores neutral, not zero.** A visualizer that declares no affinity, and a track
+with no mood tags, both land on `NEUTRAL`. Zero would mean "definitely wrong for this track", which
+is a much stronger claim than "nobody said". `ambient.py` uses the same 0.5 for an unparseable key.
+"""
+
+from dataclasses import dataclass, field
+
+import sqlalchemy as sa
+
+from app.db.models.tracks import ANALYSIS_FEATURE_COLUMNS, TrackAnalysis
+from app.services.mood_tags import KNOWN_TAGS
+
+# What an unjudgeable term scores. See the module docstring.
+NEUTRAL = 0.5
+
+# Weight keys, explicit so a typo is a KeyError at import rather than a silently dropped term —
+# the convention `ranking_profiles.WEIGHT_KEYS` establishes.
+WEIGHT_KEYS = ("tags", "ranges")
+
+# A starting guess, as ADR-0064 says the weights must be: tags carry more because they describe
+# what a track *is* and are what an author reaches for first, while ranges are a refinement.
+# There is no listening data to tune against — that is the ADR's own follow-up.
+WEIGHTS: dict[str, float] = {
+    "tags": 0.6,
+    "ranges": 0.4,
+}
+
+
+def _numeric_feature_columns() -> frozenset[str]:
+    """The analysis columns a numeric range can meaningfully be declared over.
+
+    Derived from the mapped column types rather than listed by hand, so a column added to
+    `ANALYSIS_FEATURE_COLUMNS` later is classified correctly without anyone remembering to edit a
+    second list here. Seven of the twenty-eight hold strings (`key`, `key_stability`,
+    `modal_character`, `tempo_character`, `energy_shape`, `form_string`, `interval_character`) and
+    a range over one of those is inert.
+    """
+    table = TrackAnalysis.__table__
+    numeric = set()
+    for name in ANALYSIS_FEATURE_COLUMNS:
+        column = table.columns.get(name)
+        if column is not None and isinstance(column.type, (sa.Float, sa.Integer, sa.Numeric)):
+            numeric.add(name)
+    return frozenset(numeric)
+
+
+NUMERIC_FEATURE_COLUMNS: frozenset[str] = _numeric_feature_columns()
+
+
+@dataclass(frozen=True)
+class FeatureRange:
+    """One declared bound on a numeric analysis column. Either end may be open."""
+
+    feature: str
+    minimum: float | None = None
+    maximum: float | None = None
+
+    def contains(self, value: float) -> bool:
+        if self.minimum is not None and value < self.minimum:
+            return False
+        if self.maximum is not None and value > self.maximum:
+            return False
+        return True
+
+    @property
+    def is_bounded(self) -> bool:
+        """A range with neither end set constrains nothing and is treated as unrecognised."""
+        return self.minimum is not None or self.maximum is not None
+
+
+@dataclass(frozen=True)
+class Affinity:
+    """What a visualizer says it suits. Every field optional — the whole block is optional."""
+
+    tags: tuple[str, ...] = ()
+    ranges: tuple[FeatureRange, ...] = ()
+
+    @property
+    def is_empty(self) -> bool:
+        return not self.tags and not self.ranges
+
+
+@dataclass(frozen=True)
+class Candidate:
+    """One visualizer offered for ranking, as the client reports having it loaded."""
+
+    id: str
+    affinity: Affinity = field(default_factory=Affinity)
+
+
+@dataclass(frozen=True)
+class ScoredCandidate:
+    """One visualizer's score, with enough detail to explain the ordering.
+
+    `ignored` is the ADR-0064 point 3 report: declarations this server did not understand. It is
+    per-candidate rather than global because it belongs to the visualizer that made them.
+    """
+
+    id: str
+    score: float
+    matched_tags: tuple[str, ...] = ()
+    matched_ranges: tuple[str, ...] = ()
+    unmatched_ranges: tuple[str, ...] = ()
+    ignored: tuple[str, ...] = ()
+
+
+def _tag_term(
+    declared: tuple[str, ...],
+    track_tags: list[dict],
+) -> tuple[float, tuple[str, ...], tuple[str, ...]]:
+    """How much of this track's character the visualizer claims.
+
+    Scored as the share of the track's total tag confidence that the visualizer declared, so a
+    visualizer naming the track's strongest tags scores near 1 and one naming only a weak tag
+    scores low. Counting matched tags instead would rate "matched one incidental tag" the same as
+    "matched the defining one".
+    """
+    ignored = tuple(t for t in declared if t not in KNOWN_TAGS)
+    recognised = {t for t in declared if t in KNOWN_TAGS}
+
+    usable = [
+        t for t in track_tags
+        if isinstance(t, dict) and isinstance(t.get("tag"), str)
+    ]
+    total = sum(float(t.get("confidence") or 0.0) for t in usable)
+
+    # Nothing declared that we understand, or a track nothing was tagged on: no opinion.
+    if not recognised or total <= 0.0:
+        return NEUTRAL, (), ignored
+
+    matched = tuple(t["tag"] for t in usable if t["tag"] in recognised)
+    claimed = sum(
+        float(t.get("confidence") or 0.0) for t in usable if t["tag"] in recognised
+    )
+    return min(1.0, claimed / total), matched, ignored
+
+
+def _range_term(
+    declared: tuple[FeatureRange, ...],
+    features: dict,
+) -> tuple[float, tuple[str, ...], tuple[str, ...], tuple[str, ...]]:
+    """The share of judgeable declared ranges this track falls inside.
+
+    A range is judgeable only when the column exists, is numeric, the range actually bounds
+    something, and this track has a value for it. `to_features_dict()` omits nulls entirely, so a
+    missing key means "not analysed for that feature" — which must be inert rather than a miss,
+    or a partly-analysed track would rank every declaring visualizer down.
+    """
+    ignored: list[str] = []
+    inside: list[str] = []
+    outside: list[str] = []
+
+    for declared_range in declared:
+        if declared_range.feature not in NUMERIC_FEATURE_COLUMNS or not declared_range.is_bounded:
+            ignored.append(declared_range.feature)
+            continue
+
+        value = features.get(declared_range.feature)
+        if not isinstance(value, (int, float)) or isinstance(value, bool):
+            # Present-but-unusable and absent are the same thing here: nothing to judge.
+            continue
+
+        (inside if declared_range.contains(float(value)) else outside).append(
+            declared_range.feature
+        )
+
+    judged = len(inside) + len(outside)
+    if judged == 0:
+        return NEUTRAL, (), (), tuple(ignored)
+    return len(inside) / judged, tuple(inside), tuple(outside), tuple(ignored)
+
+
+def score_candidate(
+    candidate: Candidate,
+    features: dict,
+    track_tags: list[dict],
+) -> ScoredCandidate:
+    """Score one visualizer against one track. Always in [0, 1]."""
+    if candidate.affinity.is_empty:
+        # Declared nothing. Neutral rather than last, so a visualizer that has not been described
+        # is not effectively removed from a library — ADR-0064 point 4's concern, from the other end.
+        return ScoredCandidate(id=candidate.id, score=NEUTRAL)
+
+    tag_score, matched_tags, ignored_tags = _tag_term(candidate.affinity.tags, track_tags)
+    range_score, inside, outside, ignored_ranges = _range_term(
+        candidate.affinity.ranges, features
+    )
+
+    total = WEIGHTS["tags"] * tag_score + WEIGHTS["ranges"] * range_score
+
+    return ScoredCandidate(
+        id=candidate.id,
+        score=max(0.0, min(1.0, total)),
+        matched_tags=matched_tags,
+        matched_ranges=inside,
+        unmatched_ranges=outside,
+        ignored=ignored_tags + ignored_ranges,
+    )
+
+
+def rank_candidates(
+    candidates: list[Candidate],
+    features: dict,
+    track_tags: list[dict],
+) -> list[ScoredCandidate]:
+    """Score every candidate, best first.
+
+    Ties break on the order the client submitted, because that is the order it would have used
+    anyway and a stable result is worth more than an arbitrary one — a visualizer that flickered
+    between two equal matches on every track would read as a bug.
+    """
+    scored = [score_candidate(c, features, track_tags) for c in candidates]
+    return sorted(
+        scored,
+        key=lambda s: (-s.score, [c.id for c in candidates].index(s.id)),
+    )
+
+
+def _validate() -> None:
+    """Fail at import if the weights are malformed, rather than scoring silently wrong."""
+    missing = set(WEIGHT_KEYS) - set(WEIGHTS)
+    if missing:
+        raise ValueError(f"visualizer affinity: missing weights {sorted(missing)}")
+    unknown = set(WEIGHTS) - set(WEIGHT_KEYS)
+    if unknown:
+        raise ValueError(f"visualizer affinity: unknown weight keys {sorted(unknown)}")
+    total = sum(WEIGHTS[k] for k in WEIGHT_KEYS)
+    if abs(total - 1.0) > 1e-9:
+        raise ValueError(f"visualizer affinity: weights must sum to 1.0, got {total}")
+    if not NUMERIC_FEATURE_COLUMNS:
+        # Would mean the model changed shape underneath this and every range became inert —
+        # a silent "nothing matches anything", which is exactly the failure worth failing loudly.
+        raise ValueError("visualizer affinity: no numeric analysis columns found")
+
+
+_validate()

--- a/backend/app/services/visualizer_affinity.py
+++ b/backend/app/services/visualizer_affinity.py
@@ -126,12 +126,21 @@ def _tag_term(
     declared: tuple[str, ...],
     track_tags: list[dict],
 ) -> tuple[float, tuple[str, ...], tuple[str, ...]]:
-    """How much of this track's character the visualizer claims.
+    """How well the visualizer's claim matches this track, against the best claim of that size.
 
-    Scored as the share of the track's total tag confidence that the visualizer declared, so a
-    visualizer naming the track's strongest tags scores near 1 and one naming only a weak tag
-    scores low. Counting matched tags instead would rate "matched one incidental tag" the same as
-    "matched the defining one".
+    **Measured against the track's strongest *n* tags, where n is how many the visualizer declared**
+    — not against the track's total confidence. That distinction was got wrong once and the
+    correction is the reason this docstring is long.
+
+    `compute_mood_tags` returns up to five tags with near-equal confidences (a real example: 0.511,
+    0.500, 0.489, 0.485, 0.465). Dividing by their sum meant a visualizer that named the track's two
+    strongest tags scored 0.41 — **below the 0.5 a visualizer that declared nothing gets** — and the
+    only way to score well was to claim nearly every tag. That is precisely the over-claiming the
+    design says must carry no advantage, so the arithmetic was rewarding what the rule forbids.
+
+    Comparing against the best *n* tags asks the right question: given that you named two things,
+    how close did you come to naming the two that fit best? Naming the top two scores 1.0; naming
+    five to catch one scores low, because the denominator grows with every guess.
     """
     ignored = tuple(t for t in declared if t not in KNOWN_TAGS)
     recognised = {t for t in declared if t in KNOWN_TAGS}
@@ -140,17 +149,23 @@ def _tag_term(
         t for t in track_tags
         if isinstance(t, dict) and isinstance(t.get("tag"), str)
     ]
-    total = sum(float(t.get("confidence") or 0.0) for t in usable)
 
     # Nothing declared that we understand, or a track nothing was tagged on: no opinion.
-    if not recognised or total <= 0.0:
+    if not recognised or not usable:
+        return NEUTRAL, (), ignored
+
+    confidences = sorted(
+        (float(t.get("confidence") or 0.0) for t in usable), reverse=True
+    )
+    best_possible = sum(confidences[: len(recognised)])
+    if best_possible <= 0.0:
         return NEUTRAL, (), ignored
 
     matched = tuple(t["tag"] for t in usable if t["tag"] in recognised)
     claimed = sum(
         float(t.get("confidence") or 0.0) for t in usable if t["tag"] in recognised
     )
-    return min(1.0, claimed / total), matched, ignored
+    return min(1.0, claimed / best_possible), matched, ignored
 
 
 def _range_term(

--- a/backend/openapi.json
+++ b/backend/openapi.json
@@ -7518,6 +7518,53 @@
         "title": "QueueStats",
         "type": "object"
       },
+      "RankedVisualizer": {
+        "description": "One visualizer's placing, with enough detail to explain it.\n\n`ignored` is per-candidate rather than global because a declaration belongs to the visualizer\nthat made it \u2014 it is what the picker shows an author whose tag did not land.",
+        "properties": {
+          "id": {
+            "title": "Id",
+            "type": "string"
+          },
+          "ignored": {
+            "items": {
+              "type": "string"
+            },
+            "title": "Ignored",
+            "type": "array"
+          },
+          "matched_ranges": {
+            "items": {
+              "type": "string"
+            },
+            "title": "Matched Ranges",
+            "type": "array"
+          },
+          "matched_tags": {
+            "items": {
+              "type": "string"
+            },
+            "title": "Matched Tags",
+            "type": "array"
+          },
+          "score": {
+            "title": "Score",
+            "type": "number"
+          },
+          "unmatched_ranges": {
+            "items": {
+              "type": "string"
+            },
+            "title": "Unmatched Ranges",
+            "type": "array"
+          }
+        },
+        "required": [
+          "id",
+          "score"
+        ],
+        "title": "RankedVisualizer",
+        "type": "object"
+      },
       "RecommendationsResponse": {
         "description": "Recommendations response.",
         "properties": {
@@ -10577,6 +10624,108 @@
           "has_video"
         ],
         "title": "VideoStatusResponse",
+        "type": "object"
+      },
+      "VisualizerAffinity": {
+        "description": "What a visualizer says it suits, as declared in its manifest.",
+        "properties": {
+          "ranges": {
+            "items": {
+              "$ref": "#/components/schemas/VisualizerFeatureRange"
+            },
+            "title": "Ranges",
+            "type": "array"
+          },
+          "tags": {
+            "items": {
+              "type": "string"
+            },
+            "title": "Tags",
+            "type": "array"
+          }
+        },
+        "title": "VisualizerAffinity",
+        "type": "object"
+      },
+      "VisualizerCandidate": {
+        "description": "One visualizer the client reports having loaded.",
+        "properties": {
+          "affinity": {
+            "$ref": "#/components/schemas/VisualizerAffinity"
+          },
+          "id": {
+            "title": "Id",
+            "type": "string"
+          }
+        },
+        "required": [
+          "id"
+        ],
+        "title": "VisualizerCandidate",
+        "type": "object"
+      },
+      "VisualizerFeatureRange": {
+        "description": "A bound a visualizer declares over one numeric analysis column.\n\nEither end may be omitted for an open range. A feature this server does not know, one that\nholds a string, and one this track was never analysed for are all inert \u2014 see\n`services/visualizer_affinity`.",
+        "properties": {
+          "feature": {
+            "title": "Feature",
+            "type": "string"
+          },
+          "maximum": {
+            "title": "Maximum",
+            "type": [
+              "number",
+              "null"
+            ]
+          },
+          "minimum": {
+            "title": "Minimum",
+            "type": [
+              "number",
+              "null"
+            ]
+          }
+        },
+        "required": [
+          "feature"
+        ],
+        "title": "VisualizerFeatureRange",
+        "type": "object"
+      },
+      "VisualizerRankingRequest": {
+        "description": "The visualizers this client actually has, in the order it would otherwise use.",
+        "properties": {
+          "candidates": {
+            "items": {
+              "$ref": "#/components/schemas/VisualizerCandidate"
+            },
+            "title": "Candidates",
+            "type": "array"
+          }
+        },
+        "title": "VisualizerRankingRequest",
+        "type": "object"
+      },
+      "VisualizerRankingResponse": {
+        "description": "Candidates best-first, or unranked when there was nothing to rank against.",
+        "properties": {
+          "ranked": {
+            "title": "Ranked",
+            "type": "boolean"
+          },
+          "visualizers": {
+            "items": {
+              "$ref": "#/components/schemas/RankedVisualizer"
+            },
+            "title": "Visualizers",
+            "type": "array"
+          }
+        },
+        "required": [
+          "visualizers",
+          "ranked"
+        ],
+        "title": "VisualizerRankingResponse",
         "type": "object"
       },
       "VolumeRequest": {
@@ -33407,6 +33556,105 @@
           }
         },
         "summary": "Stream Track",
+        "tags": [
+          "tracks"
+        ]
+      }
+    },
+    "/api/v1/tracks/{track_id}/visualizer-ranking": {
+      "post": {
+        "description": "Rank the client's visualizers by how well each suits this track.\n\nA track that does not exist is a 404. A track that exists but has never been analysed is **not**\n\u2014 it returns the candidates in the order they were submitted with `ranked: false`, because\n\"nothing to rank against\" is an ordinary state on a library that is still being analysed, and\nan error would push the client into treating it as a failure.",
+        "operationId": "tracks_rank_visualizers",
+        "parameters": [
+          {
+            "in": "path",
+            "name": "track_id",
+            "required": true,
+            "schema": {
+              "format": "uuid",
+              "title": "Track Id",
+              "type": "string"
+            }
+          }
+        ],
+        "requestBody": {
+          "content": {
+            "application/json": {
+              "schema": {
+                "$ref": "#/components/schemas/VisualizerRankingRequest"
+              }
+            }
+          },
+          "required": true
+        },
+        "responses": {
+          "200": {
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/VisualizerRankingResponse"
+                }
+              }
+            },
+            "description": "Successful Response"
+          },
+          "400": {
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/ErrorEnvelope"
+                }
+              }
+            },
+            "description": "Bad Request"
+          },
+          "401": {
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/ErrorEnvelope"
+                }
+              }
+            },
+            "description": "Unauthorized"
+          },
+          "404": {
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/ErrorEnvelope"
+                }
+              }
+            },
+            "description": "Not Found"
+          },
+          "422": {
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/ErrorEnvelope"
+                }
+              }
+            },
+            "description": "Unprocessable Entity"
+          },
+          "500": {
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/ErrorEnvelope"
+                }
+              }
+            },
+            "description": "Internal Server Error"
+          }
+        },
+        "security": [
+          {
+            "ProfileHeader": []
+          }
+        ],
+        "summary": "Rank Visualizers",
         "tags": [
           "tracks"
         ]

--- a/backend/tests/test_api_visualizer_ranking.py
+++ b/backend/tests/test_api_visualizer_ranking.py
@@ -1,0 +1,208 @@
+"""Tests for `POST /tracks/{id}/visualizer-ranking` (ADR-0064).
+
+The scoring itself is covered without a database in `test_visualizer_affinity.py`. What needs the
+database is the wiring: that a real `TrackAnalysis` reaches the scorer, and — the assertion that
+matters most here — that **an unanalysed track is a 200 with `ranked: false`, not a 404**.
+
+That distinction is the whole no-analysis contract. A library part-way through a sync has a
+meaningful fraction of unanalysed tracks, and if this endpoint errored on them the client would
+treat an ordinary state as a failure. A track that does not exist is still a genuine 404.
+"""
+
+from uuid import uuid4
+
+import pytest
+from sqlalchemy.ext.asyncio import AsyncSession
+
+from tests.conftest import make_profile_headers
+from tests.factories import insert_test_analysis, insert_test_track
+
+pytestmark = pytest.mark.asyncio
+
+
+def url(track_id) -> str:
+    return f"/api/v1/tracks/{track_id}/visualizer-ranking"
+
+
+AMBIENT_VIS = {
+    "id": "reactive-terrain",
+    "affinity": {"tags": ["ambient", "dreamy"], "ranges": [{"feature": "energy", "maximum": 0.4}]},
+}
+LOUD_VIS = {
+    "id": "beat-tiles",
+    "affinity": {"tags": ["metal"], "ranges": [{"feature": "energy", "minimum": 0.7}]},
+}
+
+
+class TestRanking:
+    async def test_ranks_a_calm_track_toward_the_calm_visualizer(
+        self, client, test_profile, async_db: AsyncSession
+    ):
+        track = await insert_test_track(async_db, title="Slow One")
+        await insert_test_analysis(
+            async_db,
+            track.id,
+            {
+                "energy": 0.15,
+                "bpm": 72.0,
+                "mood_tags": [{"tag": "ambient", "category": "mood", "confidence": 0.9}],
+            },
+        )
+        await async_db.commit()
+
+        r = client.post(
+            url(track.id),
+            json={"candidates": [LOUD_VIS, AMBIENT_VIS]},
+            headers=make_profile_headers(test_profile),
+        )
+
+        assert r.status_code == 200, r.text
+        body = r.json()
+        assert body["ranked"] is True
+        assert [v["id"] for v in body["visualizers"]] == ["reactive-terrain", "beat-tiles"]
+        assert "ambient" in body["visualizers"][0]["matched_tags"]
+        assert "energy" in body["visualizers"][0]["matched_ranges"]
+
+    async def test_the_response_is_typed_rather_than_a_bare_dict(
+        self, client, test_profile, async_db: AsyncSession
+    ):
+        """Shape assertion — this is what the generated Swift client models (ADR-0007)."""
+        track = await insert_test_track(async_db)
+        await insert_test_analysis(async_db, track.id, {"energy": 0.5})
+        await async_db.commit()
+
+        r = client.post(
+            url(track.id),
+            json={"candidates": [{"id": "lyrics"}]},
+            headers=make_profile_headers(test_profile),
+        )
+
+        assert r.status_code == 200, r.text
+        assert set(r.json()) == {"visualizers", "ranked"}
+        assert set(r.json()["visualizers"][0]) == {
+            "id",
+            "score",
+            "matched_tags",
+            "matched_ranges",
+            "unmatched_ranges",
+            "ignored",
+        }
+
+    async def test_a_candidate_with_no_affinity_is_accepted(
+        self, client, test_profile, async_db: AsyncSession
+    ):
+        track = await insert_test_track(async_db)
+        await insert_test_analysis(async_db, track.id, {"energy": 0.5})
+        await async_db.commit()
+
+        r = client.post(
+            url(track.id),
+            json={"candidates": [{"id": "music-video"}]},
+            headers=make_profile_headers(test_profile),
+        )
+        assert r.status_code == 200, r.text
+        assert r.json()["visualizers"][0]["id"] == "music-video"
+
+    async def test_unrecognised_declarations_are_reported_not_refused(
+        self, client, test_profile, async_db: AsyncSession
+    ):
+        track = await insert_test_track(async_db)
+        await insert_test_analysis(
+            async_db,
+            track.id,
+            {"energy": 0.5, "mood_tags": [{"tag": "calm", "category": "mood", "confidence": 0.8}]},
+        )
+        await async_db.commit()
+
+        r = client.post(
+            url(track.id),
+            json={
+                "candidates": [
+                    {
+                        "id": "odd",
+                        "affinity": {
+                            "tags": ["calm", "not-a-real-tag"],
+                            # `form_string` holds a string; `vibes` does not exist.
+                            "ranges": [
+                                {"feature": "form_string", "minimum": 0},
+                                {"feature": "vibes", "maximum": 1},
+                            ],
+                        },
+                    }
+                ]
+            },
+            headers=make_profile_headers(test_profile),
+        )
+
+        assert r.status_code == 200, r.text
+        ignored = r.json()["visualizers"][0]["ignored"]
+        assert set(ignored) == {"not-a-real-tag", "form_string", "vibes"}
+        # Still ranked, and still matched on the part that was understood.
+        assert r.json()["visualizers"][0]["matched_tags"] == ["calm"]
+
+
+class TestNoAnalysis:
+    async def test_an_unanalysed_track_is_200_and_unranked(
+        self, client, test_profile, async_db: AsyncSession
+    ):
+        """The load-bearing case: ordinary on a syncing library, so it must not be an error."""
+        track = await insert_test_track(async_db, title="Not Analysed Yet")
+        await async_db.commit()
+
+        r = client.post(
+            url(track.id),
+            json={"candidates": [LOUD_VIS, AMBIENT_VIS]},
+            headers=make_profile_headers(test_profile),
+        )
+
+        assert r.status_code == 200, r.text
+        body = r.json()
+        assert body["ranked"] is False
+        # Submitted order preserved, so the client can keep showing what it already had.
+        assert [v["id"] for v in body["visualizers"]] == ["beat-tiles", "reactive-terrain"]
+
+    async def test_an_analysis_row_with_no_features_is_also_unranked(
+        self, client, test_profile, async_db: AsyncSession
+    ):
+        track = await insert_test_track(async_db)
+        await insert_test_analysis(async_db, track.id, None)
+        await async_db.commit()
+
+        r = client.post(
+            url(track.id),
+            json={"candidates": [AMBIENT_VIS]},
+            headers=make_profile_headers(test_profile),
+        )
+        assert r.status_code == 200, r.text
+        assert r.json()["ranked"] is False
+
+
+class TestErrors:
+    async def test_an_unknown_track_is_404(self, client, test_profile):
+        r = client.post(
+            url(uuid4()),
+            json={"candidates": [AMBIENT_VIS]},
+            headers=make_profile_headers(test_profile),
+        )
+        assert r.status_code == 404, r.text
+
+    async def test_a_malformed_track_id_is_422(self, client, test_profile):
+        r = client.post(
+            url("not-a-uuid"),
+            json={"candidates": []},
+            headers=make_profile_headers(test_profile),
+        )
+        assert r.status_code == 422, r.text
+
+    async def test_no_candidates_ranks_to_an_empty_list(
+        self, client, test_profile, async_db: AsyncSession
+    ):
+        track = await insert_test_track(async_db)
+        await insert_test_analysis(async_db, track.id, {"energy": 0.5})
+        await async_db.commit()
+
+        r = client.post(
+            url(track.id), json={"candidates": []}, headers=make_profile_headers(test_profile)
+        )
+        assert r.status_code == 200, r.text
+        assert r.json()["visualizers"] == []

--- a/backend/tests/test_visualizer_affinity.py
+++ b/backend/tests/test_visualizer_affinity.py
@@ -210,3 +210,53 @@ class TestRanking:
             tags(("ambient", 0.95)),
         )
         assert ranked[0].id == "silent"
+
+
+class TestTagNormalisation:
+    """The scale the tag term is measured on. Got wrong once; these pin the correction.
+
+    `compute_mood_tags` returns up to five tags with near-equal confidences, so dividing by their
+    *total* meant a good claim could never score well — a visualizer naming the track's two
+    strongest tags landed below one that declared nothing, and only over-claiming scored highly.
+    These use a real tag set from the library rather than invented numbers.
+    """
+
+    REAL = tags(
+        ("rebellious", 0.511),
+        ("rock", 0.500),
+        ("hip-hop", 0.489),
+        ("blues", 0.485),
+        ("country", 0.465),
+    )
+
+    def test_naming_the_two_strongest_tags_scores_at_the_top(self):
+        result = score_candidate(candidate("c", tags_=["rebellious", "rock"]), {}, self.REAL)
+        assert result.matched_tags == ("rebellious", "rock")
+        assert result.score == pytest.approx(WEIGHTS["tags"] * 1.0 + WEIGHTS["ranges"] * NEUTRAL)
+
+    def test_a_good_match_beats_declaring_nothing(self):
+        """The regression. A perfect claim scoring below silence made the feature pointless."""
+        good = score_candidate(candidate("good", tags_=["rebellious", "rock"]), {}, self.REAL)
+        silent = score_candidate(candidate("silent"), {}, self.REAL)
+        assert good.score > silent.score
+
+    def test_naming_one_tag_well_is_not_punished_for_being_selective(self):
+        """A visualizer that suits rock should not have to also claim blues and country."""
+        selective = score_candidate(candidate("one", tags_=["rock"]), {}, self.REAL)
+        silent = score_candidate(candidate("silent"), {}, self.REAL)
+        assert selective.score > silent.score
+
+    def test_over_claiming_scores_below_a_selective_match(self):
+        """Every extra guess widens the denominator, so shotgunning the vocabulary costs."""
+        selective = score_candidate(candidate("one", tags_=["rebellious"]), {}, self.REAL)
+        shotgun = score_candidate(
+            candidate("many", tags_=["rebellious", "classical", "jazz", "metal", "reggae"]),
+            {},
+            self.REAL,
+        )
+        assert selective.score > shotgun.score
+
+    def test_matching_nothing_still_scores_worst(self):
+        miss = score_candidate(candidate("miss", tags_=["classical", "serene"]), {}, self.REAL)
+        silent = score_candidate(candidate("silent"), {}, self.REAL)
+        assert miss.score < silent.score

--- a/backend/tests/test_visualizer_affinity.py
+++ b/backend/tests/test_visualizer_affinity.py
@@ -1,0 +1,212 @@
+"""Tests for the visualizer affinity scorer (ADR-0064).
+
+No database: the scorer is pure, and that is the point of it being pure. Following
+`test_ranking_profiles.py`'s doctrine, these assert **relationships and invariants** rather than
+exact scores — the weights are a starting guess the ADR says cannot be tuned without listening
+data, so pinning "0.73" here would make retuning fail a test for no reason.
+"""
+
+import pytest
+
+from app.services.mood_tags import KNOWN_TAGS
+from app.services.visualizer_affinity import (
+    NEUTRAL,
+    NUMERIC_FEATURE_COLUMNS,
+    WEIGHT_KEYS,
+    WEIGHTS,
+    Affinity,
+    Candidate,
+    FeatureRange,
+    rank_candidates,
+    score_candidate,
+)
+
+
+def tags(*pairs: tuple[str, float]) -> list[dict]:
+    """Track mood tags in their stored shape: {"tag", "category", "confidence"}."""
+    return [{"tag": t, "category": "mood", "confidence": c} for t, c in pairs]
+
+
+def candidate(id_: str, *, tags_=(), ranges=()) -> Candidate:
+    return Candidate(id=id_, affinity=Affinity(tags=tuple(tags_), ranges=tuple(ranges)))
+
+
+class TestWeights:
+    def test_weights_cover_exactly_the_declared_keys(self):
+        assert set(WEIGHTS) == set(WEIGHT_KEYS)
+
+    def test_weights_sum_to_one(self):
+        assert sum(WEIGHTS[k] for k in WEIGHT_KEYS) == pytest.approx(1.0)
+
+    def test_numeric_columns_exclude_the_string_ones(self):
+        # Seven of the twenty-eight analysis columns hold strings; a numeric range over one of
+        # them is meaningless and must not be offered as judgeable.
+        for string_column in (
+            "key",
+            "key_stability",
+            "modal_character",
+            "tempo_character",
+            "energy_shape",
+            "form_string",
+            "interval_character",
+        ):
+            assert string_column not in NUMERIC_FEATURE_COLUMNS
+
+    def test_numeric_columns_include_the_obvious_ones(self):
+        for numeric_column in ("energy", "valence", "bpm", "danceability", "brightness"):
+            assert numeric_column in NUMERIC_FEATURE_COLUMNS
+
+
+class TestNothingToJudge:
+    def test_no_affinity_scores_neutral(self):
+        result = score_candidate(candidate("plain"), {"energy": 0.9}, tags(("calm", 0.8)))
+        assert result.score == NEUTRAL
+
+    def test_track_with_no_tags_is_neutral_on_the_tag_term(self):
+        # Neutral, not zero: an untagged track is not evidence the visualizer is wrong for it.
+        result = score_candidate(candidate("c", tags_=["calm"]), {}, [])
+        assert result.score == NEUTRAL
+
+    def test_range_over_a_feature_the_track_lacks_is_inert(self):
+        # `to_features_dict()` omits nulls, so a missing key means "not analysed for this".
+        # Treating that as a miss would rank every declaring visualizer down on a partly
+        # analysed library.
+        result = score_candidate(
+            candidate("c", ranges=[FeatureRange("bpm", 60, 100)]), {"energy": 0.5}, []
+        )
+        assert result.score == NEUTRAL
+        assert result.unmatched_ranges == ()
+
+
+class TestTags:
+    def test_claiming_the_dominant_tag_beats_claiming_a_weak_one(self):
+        track_tags = tags(("ambient", 0.9), ("playful", 0.1))
+        strong = score_candidate(candidate("s", tags_=["ambient"]), {}, track_tags)
+        weak = score_candidate(candidate("w", tags_=["playful"]), {}, track_tags)
+        assert strong.score > weak.score
+
+    def test_claiming_every_tag_scores_at_least_as_high_as_claiming_one(self):
+        track_tags = tags(("ambient", 0.6), ("dreamy", 0.4))
+        both = score_candidate(candidate("b", tags_=["ambient", "dreamy"]), {}, track_tags)
+        one = score_candidate(candidate("o", tags_=["ambient"]), {}, track_tags)
+        assert both.score >= one.score
+
+    def test_matched_tags_are_reported(self):
+        result = score_candidate(
+            candidate("c", tags_=["ambient", "dreamy"]), {}, tags(("ambient", 0.7))
+        )
+        assert result.matched_tags == ("ambient",)
+
+    def test_a_mismatched_tag_scores_below_neutral(self):
+        # Declared something we understand, and none of it applies. That is a real signal.
+        result = score_candidate(candidate("c", tags_=["metal"]), {}, tags(("ambient", 0.9)))
+        assert result.score < NEUTRAL
+
+
+class TestRanges:
+    def test_a_track_inside_the_range_beats_one_outside(self):
+        vis = candidate("c", ranges=[FeatureRange("energy", 0.0, 0.4)])
+        inside = score_candidate(vis, {"energy": 0.2}, [])
+        outside = score_candidate(vis, {"energy": 0.9}, [])
+        assert inside.score > outside.score
+
+    def test_open_ended_ranges_work(self):
+        vis = candidate("c", ranges=[FeatureRange("bpm", minimum=120)])
+        assert score_candidate(vis, {"bpm": 140}, []).matched_ranges == ("bpm",)
+        assert score_candidate(vis, {"bpm": 90}, []).unmatched_ranges == ("bpm",)
+
+    def test_bounds_are_inclusive(self):
+        vis = candidate("c", ranges=[FeatureRange("energy", 0.2, 0.8)])
+        assert score_candidate(vis, {"energy": 0.2}, []).matched_ranges == ("energy",)
+        assert score_candidate(vis, {"energy": 0.8}, []).matched_ranges == ("energy",)
+
+    def test_an_integer_column_is_judgeable(self):
+        vis = candidate("c", ranges=[FeatureRange("section_count", 4, 12)])
+        assert score_candidate(vis, {"section_count": 8}, []).matched_ranges == ("section_count",)
+
+
+class TestIgnoredRatherThanRefused:
+    def test_an_unknown_tag_is_ignored_and_reported(self):
+        result = score_candidate(candidate("c", tags_=["definitely-not-a-tag"]), {}, tags(("calm", 0.9)))
+        assert "definitely-not-a-tag" in result.ignored
+        # Ignored means inert: with nothing else declared, the verdict is "no opinion".
+        assert result.score == NEUTRAL
+
+    def test_a_range_over_a_string_column_is_ignored(self):
+        result = score_candidate(
+            candidate("c", ranges=[FeatureRange("form_string", 0, 1)]), {"form_string": "ABAB"}, []
+        )
+        assert "form_string" in result.ignored
+        assert result.score == NEUTRAL
+
+    def test_a_range_over_an_unknown_column_is_ignored(self):
+        result = score_candidate(
+            candidate("c", ranges=[FeatureRange("vibes", 0, 1)]), {"energy": 0.5}, []
+        )
+        assert "vibes" in result.ignored
+
+    def test_an_unbounded_range_is_ignored(self):
+        result = score_candidate(candidate("c", ranges=[FeatureRange("energy")]), {"energy": 0.5}, [])
+        assert "energy" in result.ignored
+
+    def test_an_unknown_tag_does_not_dilute_a_recognised_one(self):
+        # The whole point of "inert": adding a typo must not change the score.
+        track_tags = tags(("ambient", 0.9))
+        clean = score_candidate(candidate("a", tags_=["ambient"]), {}, track_tags)
+        typo = score_candidate(candidate("b", tags_=["ambient", "ambiant"]), {}, track_tags)
+        assert typo.score == clean.score
+
+    def test_every_known_tag_is_accepted(self):
+        for tag in KNOWN_TAGS:
+            result = score_candidate(candidate("c", tags_=[tag]), {}, tags((tag, 0.5)))
+            assert result.ignored == (), f"{tag!r} should be recognised"
+
+
+class TestRanking:
+    def test_best_match_comes_first(self):
+        track_tags = tags(("ambient", 0.9))
+        ranked = rank_candidates(
+            [candidate("wrong", tags_=["metal"]), candidate("right", tags_=["ambient"])],
+            {},
+            track_tags,
+        )
+        assert [r.id for r in ranked] == ["right", "wrong"]
+
+    def test_ties_keep_the_submitted_order(self):
+        # Stability matters: a visualizer that flickered between two equal matches on every
+        # track would read as a bug rather than a choice.
+        ranked = rank_candidates([candidate("a"), candidate("b"), candidate("c")], {}, [])
+        assert [r.id for r in ranked] == ["a", "b", "c"]
+
+    def test_scores_stay_within_bounds(self):
+        ranked = rank_candidates(
+            [
+                candidate("a", tags_=["ambient"], ranges=[FeatureRange("energy", 0, 0.1)]),
+                candidate("b", tags_=["metal"], ranges=[FeatureRange("energy", 0.9, 1.0)]),
+            ],
+            {"energy": 0.05},
+            tags(("ambient", 1.0)),
+        )
+        for result in ranked:
+            assert 0.0 <= result.score <= 1.0
+
+    def test_empty_candidate_list_ranks_to_nothing(self):
+        assert rank_candidates([], {"energy": 0.5}, tags(("calm", 0.5))) == []
+
+    def test_a_declaring_visualizer_that_fits_beats_one_that_declared_nothing(self):
+        ranked = rank_candidates(
+            [candidate("silent"), candidate("fitting", tags_=["ambient"])],
+            {},
+            tags(("ambient", 0.95)),
+        )
+        assert ranked[0].id == "fitting"
+
+    def test_a_declaring_visualizer_that_does_not_fit_loses_to_one_that_declared_nothing(self):
+        # ADR-0064 point 4's concern from the other end: declaring must be able to hurt, or
+        # declaring is free and every author over-claims.
+        ranked = rank_candidates(
+            [candidate("wrong", tags_=["metal"]), candidate("silent")],
+            {},
+            tags(("ambient", 0.95)),
+        )
+        assert ranked[0].id == "silent"

--- a/docs/VISUALIZER_API.md
+++ b/docs/VISUALIZER_API.md
@@ -111,7 +111,8 @@ interface Track {
 
 ### TrackFeatures
 
-Audio analysis data (available when track has been analyzed):
+Audio analysis, present once the track has been analysed. A track that has not been — or one part
+way through a re-analysis — arrives as `null`, so read every field defensively.
 
 ```typescript
 interface TrackFeatures {
@@ -123,8 +124,19 @@ interface TrackFeatures {
   acousticness: number | null;     // 0-1, acoustic vs electronic
   instrumentalness: number | null; // 0-1, vocals vs instrumental
   speechiness: number | null;      // 0-1, spoken word presence
+  brightness: number | null;       // Spectral centroid
+  harmonic_complexity: number | null;
+  swing_ratio: number | null;
+  syncopation: number | null;
+  loudness_lufs: number | null;    // Integrated loudness
+  track_peak: number | null;
+  replaygain_track_gain: number | null;
 }
 ```
+
+**`instrumentalness` and `speechiness` are not reliable for "does this have singing on it".** The
+detector finds *speech*, not singing, so an instrumental track and a sung one are not dependably
+separated. The `vocal/choir` mood tag is the better signal; see the affinity vocabulary below.
 
 ### LyricLine
 
@@ -153,11 +165,24 @@ import {
 
 ### useAudioAnalyser
 
-Real-time audio frequency data from Web Audio API.
+Real-time audio data for the frame being drawn.
 
 ```typescript
 const audioData = useAudioAnalyser(enabled: boolean = true);
 ```
+
+**There are three sources behind this, and a visualizer is written against none of them in
+particular.** In the browser it reads a Web Audio `AnalyserNode` off the playing engine. Embedded in
+the Mac or iPhone app it reads frames the native side pushes across the bridge, because that page
+runs a null audio engine and constructs no `AudioContext` at all
+([ADR-0033](decisions/ADR-0033-the-embed-bridge-gains-a-return-channel.md),
+[ADR-0017](decisions/ADR-0017-the-embedded-surface-gets-a-null-audio-engine.md)). And when nothing
+is playing it reads zeroes. All three fill the same buffers, which is what lets one visualizer run
+unmodified on every client.
+
+The practical consequence: **the native channel runs at about 10 Hz**, a platform floor rather than
+a tuning choice, while the browser's runs per animation frame. Anything that looks jerky when
+embedded and smooth in a browser is this — interpolate between values rather than stepping to them.
 
 **Returns:**
 
@@ -550,15 +575,23 @@ registerVisualizer(
 
 ## Existing Visualizers
 
-| Visualizer | Description | Key Features |
-|------------|-------------|--------------|
-| `CosmicOrb` | Glowing orb with particle field | GPU particles, custom shaders, waveform ring |
-| `FrequencyBars` | Spectrum analyzer | 128 bars, gradient colors, reflective floor |
-| `AlbumKaleidoscope` | Kaleidoscope from artwork | Shader-based mirroring, twist effects, sparkles |
-| `ColorFlow` | Flowing color particles | Palette extraction, flow field, glowing rings |
-| `LyricStorm` | 3D floating lyrics | drei Text, depth sorting, current line highlight |
-| `LyricPulse` | Pulsing current lyric | BPM sync, glow effects, progress bar |
-| `TypographyWave` | Animated text waves | Canvas 2D, per-character animation |
+These are the five compiled into the app, registered in
+`components/Visualizer/visualizers/index.ts`. **Their ids are reserved**: a plugin claiming one is
+refused rather than allowed to shadow it, because the registry has no removal and the built-in would
+be unrecoverable short of deleting the file.
+
+| id | Component | What it draws |
+|----|-----------|---------------|
+| `reactive-terrain` | `ReactiveTerrain` | Neon wireframe landscape driven by the spectrum, flashing on every beat |
+| `beat-tiles` | `BeatTiles` | Album cover split into tiles that pop to the beat |
+| `lyrics` | `ScrollingLyrics` | Scrolling synced lyrics over a drifting field of the song's words |
+| `music-video` | `MusicVideo` | Searches and plays a synced music video from YouTube |
+| `lyric-storm` | `LyricStorm` | The song's own words drifting through a dark 3D space |
+
+*Corrected 2026-08-18. This table previously listed seven components — `CosmicOrb`, `FrequencyBars`,
+`AlbumKaleidoscope`, `ColorFlow`, `LyricPulse` and `TypographyWave` — of which only `LyricStorm` was
+real. Recorded rather than quietly replaced, because anyone who read the old table went looking for
+six things that do not exist, and may still have notes that say so.*
 
 ---
 
@@ -626,18 +659,62 @@ my-visualizer/
   "description": "Surreal 3D models drifting through fog",
   "main": "dist/index.js",
   "familiar": { "apiVersion": 1 },
-  "icon": "Building2"
+  "icon": "Building2",
+  "affinity": {
+    "tags": ["ambient", "dreamy", "electronic"],
+    "ranges": [{ "feature": "energy", "maximum": 0.5 }]
+  }
 }
 ```
 
 | Field | Required | Notes |
 |---|---|---|
-| `id` | yes | Lowercase letters, digits and hyphens. Must match the id your bundle registers, and must not be one of the built-ins (`reactive-terrain`, `beat-tiles`, `lyrics`, `music-video`). |
+| `id` | yes | Lowercase letters, digits and hyphens. Must match the id your bundle registers, and must not be one of the five built-ins (`reactive-terrain`, `beat-tiles`, `lyrics`, `music-video`, `lyric-storm`). |
 | `name` | yes | Shown in the picker. |
 | `type` | yes | Must be `visualizer`. Library browsers are out of scope. |
 | `main` | yes | Path to the bundle, relative to this folder. It may not point outside it. |
 | `familiar.apiVersion` | yes | Must equal the version the app implements — currently **1**. A missing or mismatched value is refused before the bundle is run. |
 | `version`, `description`, `icon`, `author` | no | `icon` is a [lucide](https://lucide.dev) name, used by the web picker only. |
+| `affinity` | no | What kind of music your visualizer suits. See below. |
+
+### Affinity — what your visualizer suits
+
+Optional, and nothing is lost by omitting it. It is read when the listener turns on **Match to the
+music**, which asks the server to pick a visualizer for each track from what that device actually
+has installed.
+
+```json
+"affinity": {
+  "tags": ["ambient", "dreamy"],
+  "ranges": [
+    { "feature": "energy", "maximum": 0.4 },
+    { "feature": "bpm", "minimum": 60, "maximum": 100 }
+  ]
+}
+```
+
+- **`tags`** are matched against the tags the analysis assigned the track. They come from a fixed
+  vocabulary of 48 — sixteen moods (`happy`, `sad`, `angry`, `calm`, `dark`, `bright`, `dreamy`,
+  `energetic`, `romantic`, `mysterious`, `nostalgic`, `triumphant`, `playful`, `anxious`, `serene`,
+  `rebellious`), sixteen genres (`jazz`, `electronic`, `rock`, `classical`, `hip-hop`, `folk`,
+  `metal`, `ambient`, `blues`, `funk`, `reggae`, `soul`, `country`, `punk`, `world`, `pop`), eight
+  instrumentation (`piano`, `acoustic guitar`, `bass-heavy`, `strings`, `brass/sax`, `synthesizer`,
+  `drums`, `vocal/choir`) and eight energy (`slow`, `mid-tempo`, `fast`, `building`, `sparse`,
+  `dense`, `danceable`, `freeform`). **Spell them exactly** — several are not identifiers.
+- **`ranges`** bound any numeric field of `TrackFeatures`. Either end may be omitted for an open
+  range, and both ends are inclusive. A range over `key` or another text field means nothing and is
+  ignored.
+
+**Anything not understood is ignored, never a refusal.** A misspelled tag, a field that does not
+exist, a range over a text field, a range with no numeric bound: each contributes nothing, is left
+out of the scoring entirely so it cannot drag your score down, and is listed under *Ignored in
+manifest* in the picker so you can find it. A bad affinity block never costs you a working
+visualizer.
+
+Scoring is charitable in both directions. Declaring nothing scores neutral rather than last, so an
+undescribed visualizer is not effectively removed — but declaring something that does not fit *can*
+lose to declaring nothing, so there is no advantage in claiming everything. A track with no analysis
+yet is not ranked at all, and whatever is on stays on.
 
 ### Building the bundle
 

--- a/docs/WEB-PARITY.md
+++ b/docs/WEB-PARITY.md
@@ -42,6 +42,7 @@ which only holds if it is corrected when a row changes. Update it in the same ch
 | Radio | ✅ | ✅ | ✅ | ADR-0040 |
 | Audio effects (EQ, reverb, delay…) | ✅ | ✅ | ✅ | Web `EffectsChain`; native its own DSP |
 | Visualizer | ✅ | ✅ | ✅ | **A `WKWebView`**, bundled *inside* the app (3.4 MB `VisualizerBundle.html`) |
+| Visualizer auto-select | ✅ | ❌ | ❌ | **not a blocker:** ADR-0064's ranking endpoint and page half are built; the native menu has still to send its catalog as candidates, which is the ADR's own follow-up on `VisualizerCatalog.swift`. Shipping the web half first must not extend the player's countdown (ADR-0060 point 1) |
 | Offline downloads | ✅ | ✅ | ✅ | Independent implementations — Dexie vs background `URLSession` |
 | Network output (Sonos/UPnP/Chromecast) | ✅ | ✅ | ❌ | AirPlay deliberately left to the OS picker |
 | CarPlay | — | — | ✅ | |

--- a/docs/decisions/ADR-0062-the-site-adopts-a-static-site-generator.md
+++ b/docs/decisions/ADR-0062-the-site-adopts-a-static-site-generator.md
@@ -1,0 +1,149 @@
+# ADR-0062: The Site Adopts a Static Site Generator
+
+Status: proposed
+
+Date: 2026-08-17
+
+Supersedes [ADR-0039](ADR-0039-the-website-is-rebuilt-in-place.md) points 1 and 6. The rest of
+`0039` stands: the site lives in `site/`, deploys to Cloudflare Pages, leads with the install
+command, and still has no blog. Point 6 named the condition under which point 1 should be decided
+again; this is that condition arriving, so the decision is made again rather than worked around.
+
+## Context
+
+`0039` point 1 reads in full: *"The site stays static, in `site/`, deployed to Cloudflare Pages. No
+generator, no build step, no new dependency, no `packages/` workspace. Two HTML files and a
+stylesheet do not justify a toolchain, and the deployment path already works."*
+
+That was correct, and the reasoning is worth preserving rather than dismissed: the site is three
+hand-written pages — `site/index.html` (15,890 bytes), `site/faq.html`, `site/privacy.html` — plus
+`assets/`, a `screenshots` symlink into the repository root, and two Python scripts. There is no
+generator anywhere in this repository: no mkdocs, no Docusaurus, no Astro, no Eleventy, no
+`_config.yml`.
+
+**Point 6 is the part that matters here, and it is unusually specific about its own reversal:**
+
+> Release notes, a blog and rendered docs are out of scope, and that is what would reverse point 1.
+> Fork has all three and they are why Fork would need a generator. Familiar has `CHANGELOG.md` and a
+> `docs/` directory of unbuilt Markdown; the moment either wants to be a section of the site with an
+> index and permalinks, this decision should be made again rather than worked around with
+> hand-written pages.
+
+[ADR-0063](ADR-0063-the-visualizer-api-is-published-for-outside-authors.md) wants exactly that: the
+719-line `docs/VISUALIZER_API.md` as a section of the site, plus a gallery with an index and a
+permalink per listed visualizer. It is the case point 6 reserved, arriving for the reason point 6
+predicted.
+
+**[ADR-0055](ADR-0055-the-site-is-restructured-around-five-things.md) already rejected a generator,
+and that rejection has expired rather than been overruled.** Its alternative reads: *"Move to a
+static site generator so docs, changelog and FAQ become real sections… Rejected because it reverses
+`0039` point 1 and point 6 for a page of five sections, and `0039` was explicit that this is the
+decision to make again only when a blog or rendered docs are actually wanted."* The rejection was
+conditional on its own terms. Rendered docs are now actually wanted, so the condition it named is
+met — this ADR is not disagreeing with `0055`, it is the branch `0055` left open.
+
+**The boundary that does not move.** [ADR-0038](ADR-0038-the-demo-server-is-always-on.md) point 7
+holds the demo server to *"not hosted Familiar… no growth into a service"*, and `0039` separately
+rejected serving the site from the Familiar server because *"the marketing site must be up when
+nobody's server is — it is what someone reads before they have one"*. A generator changes how the
+site is built. It must not change where it is served from, and this ADR does not.
+
+## Decision
+
+1. **The site is built by Eleventy, from sources in `site/`, and still deploys to Cloudflare
+   Pages.** The generator is chosen for the two properties this specific job needs and not for
+   capability in general: it passes HTML through untouched, so the three existing pages move
+   without being rewritten, and it accepts arbitrary input globs, so Markdown that lives elsewhere
+   in the repository can be rendered from where it already is. It emits static HTML with no client
+   runtime, which is the part of `0039` point 1 that was actually load-bearing.
+
+2. **Markdown in the repository stays the single source of truth, and is rendered in place.**
+   `docs/VISUALIZER_API.md` is not copied into `site/`. A second copy of a contract is precisely
+   the drift `ADR-0055` point 2 exists to prevent, and a documentation page that disagrees with the
+   document it was made from is worse than no page. The `screenshots` symlink is the existing
+   precedent for reaching out of `site/` rather than duplicating into it.
+
+3. **Only developer documentation becomes a rendered section. The blog is still refused, and
+   `CHANGELOG.md` is not published by this ADR.** `0039` point 6 named three things; this reverses
+   it for one of them. A changelog section is defensible and is deliberately left undecided, because
+   the argument for it is about release communication and has nothing to do with why a generator is
+   being adopted. Adding it later is a paragraph in a new ADR, not a re-migration.
+
+4. **The generator is a dev dependency of `site/`, not a member of the pnpm workspace.** `0039`
+   point 1's "no `packages/` workspace" clause survives intact: `site/` gets its own `package.json`
+   and the frontend build is untouched. The site must remain buildable and deployable by someone
+   who has never run the app.
+
+5. **`site/scripts/check-claims.py` runs against the build output, and the build fails if it
+   fails.** The script currently reads `site/index.html` directly and hardcodes
+   `PAGES = ["index.html", "faq.html", "privacy.html"]`; under a generator those become artefacts of
+   a build, so the script has to be pointed at the output directory. This is called out as a
+   decision point rather than left to implementation because `ADR-0055` point 2's ledger is the only
+   mechanism standing between this site and lying by attrition, and a migration that quietly stops
+   running it would remove that mechanism while appearing to succeed.
+
+6. **`ADR-0055` lands before this migration, or is withdrawn first.** `0055` is still `proposed` and
+   unimplemented: it deletes the screenshot grid, collapses fourteen features into five illustrated
+   sections, moves the FAQ to its own page and caps `<main>` at six claims and 700 words. Migrating
+   the current eleven-section page into a generator and then restructuring it means doing the work
+   twice, and the second pass is the one that would be rushed.
+
+7. **The pages the site already has must render byte-identically at first, and the deploy is
+   verified before anything new is added.** A migration and a new section in the same change makes a
+   broken page ambiguous. `0039` point 8 set the precedent when the demo link was held back for
+   hours: **the condition is not "the build succeeded" but "the thing a visitor will do works"**.
+
+## Alternatives Considered
+
+- **Astro.** More capable than Eleventy in every direction — components, islands, content
+  collections, first-class Markdown. Genuinely the better tool if the site ever becomes an
+  application. Rejected because every one of those capabilities is one this site has no use for,
+  and its content-collection model expects Markdown to live inside the project, which fights point
+  2's requirement that `docs/` stays where it is. The larger dependency surface buys nothing here.
+
+- **One narrow render step: a script that turns `docs/VISUALIZER_API.md` into a styled HTML page at
+  deploy time, and nothing else.** Reverses only "no build step" and leaves the rest of `0039`
+  point 1 standing, which makes it the smallest honest change. Rejected because `ADR-0063` also
+  wants a gallery index with a permalink per entry, and a bespoke script that grows a routing and
+  templating layer is a static site generator being written by hand, badly.
+
+- **Hand-write the documentation as HTML pages.** No new dependency at all, and the site keeps
+  working exactly as it does. Rejected because it is the workaround `0039` point 6 forbids by name,
+  and because it creates the second copy of the contract that point 2 rules out. A 719-line document
+  transcribed by hand is stale the first time the source changes.
+
+- **Link out to GitHub, which renders Markdown already, and add nothing to the site.** Costs
+  nothing, reverses nothing, and is genuinely how most small projects handle this. Rejected because
+  it does not answer the ask: an invitation to outside authors that bounces them to a repository
+  file browser is not a documented API that lives on the website, and the gallery has nowhere to go
+  at all.
+
+- **Serve the documentation from the Familiar server, alongside `/embed` and `/visualizer`.** The
+  bundle already builds three documents and the machinery is there. Rejected on `0039`'s original
+  grounds — the site is what someone reads *before* they have a server — and on
+  [ADR-0058](ADR-0058-the-web-app-is-an-administration-tool.md) point 2, which holds the web app to
+  three destinations.
+
+## Consequences
+
+- **Positive:** `docs/` becomes publishable without being copied, which makes `ADR-0063` possible
+  and makes any future document cheap to publish.
+- **Positive:** The decision `0039` point 6 deferred is now made explicitly, with its trigger
+  recorded, rather than eroded by a series of hand-written pages that each seemed reasonable.
+- **Tradeoff:** The site gains a toolchain, and `0039`'s objection to that was correct at the time
+  and is not wrong now — it is outweighed. A contributor who wants to fix a typo on the marketing
+  page now needs Node and an install where previously they needed a text editor.
+- **Tradeoff:** The deploy path gains a way to fail that it did not have. Cloudflare Pages currently
+  publishes files that are already correct on disk; a build step can succeed and emit something
+  wrong, which is what point 7 exists to catch and point 5 exists to keep catching.
+- **Tradeoff:** Point 6 puts this behind `ADR-0055`, which has been `proposed` since 2026-08-13. If
+  `0055` stalls, this stalls, and `ADR-0063` stalls behind it. The alternative — migrating first —
+  was rejected, but the dependency is real and is the most likely reason this does not happen.
+- **Follow-up:** `site/README.md` describes the current no-build deployment and will be wrong the
+  moment this lands. `0039` point 7 corrected that file once already, after it spent months
+  describing GitHub Pages and a CNAME the repository does not contain.
+- **Follow-up:** Whether `CHANGELOG.md` becomes a rendered section, per point 3. The machinery will
+  exist and the decision will not have been made.
+- **Follow-up:** The `.github/workflows/cloudflare-pages.yml` job is still named `Pages`, a name
+  inherited from the GitHub Pages era. `0039` left renaming it as the only thing keeping that
+  confusion from recurring, and this change touches the same workflow.

--- a/docs/decisions/ADR-0063-the-visualizer-api-is-published-for-outside-authors.md
+++ b/docs/decisions/ADR-0063-the-visualizer-api-is-published-for-outside-authors.md
@@ -1,0 +1,176 @@
+# ADR-0063: The Visualizer API Is Published for Outside Authors
+
+Status: proposed
+
+Date: 2026-08-17
+
+Extends [ADR-0034](ADR-0034-visualizers-are-drop-in-bundles.md), which decided what a visualizer
+*is* and how a client loads one. That format, its two sources and its refusal rules all stand. This
+decides who the contract is written for and where it is read, which `0034` did not address.
+Depends on [ADR-0062](ADR-0062-the-site-adopts-a-static-site-generator.md) for the rendering.
+
+## Context
+
+[ADR-0033](ADR-0033-the-embed-bridge-gains-a-return-channel.md) stated the ambition plainly: the
+visualizer is *"the one place in Familiar where someone outside this repository can add
+something"*, and its argument for embedding rather than rebuilding natively was that otherwise
+*"the reward for writing one is that it runs in the place nobody listens"*. `ADR-0034` then built
+the loader, and it shipped in both repositories.
+
+**So the machinery exists and the invitation does not.** `0034` verified the fact that makes this
+worth doing rather than assumed it: *"No third party has written one, and there is no ecosystem to
+strand."* The three sample plugins on disk — `familiar-plugin-lyric-pulse`,
+`familiar-plugin-non-places`, `familiar-plugin-timeline` — are this project's own, all declaring an
+`author.url` pointing at an unrelated account. Two years of plugin machinery has zero outside
+authors, and the reason is not that the API is bad. It is that nobody outside this repository has
+been told it exists.
+
+**The contract is already written, is already shared, and is already wrong in three checkable
+ways.** `docs/VISUALIZER_API.md` is 719 lines, and `0034` point 6 made it the contract for every
+client rather than a web-app document. Audited against the repository on 2026-08-17:
+
+- Its "Existing Visualizers" table lists seven components, of which **six do not exist**:
+  `CosmicOrb`, `FrequencyBars`, `AlbumKaleidoscope`, `ColorFlow`, `LyricPulse` and
+  `TypographyWave`. Only `LyricStorm` is real. The registry actually holds five ids —
+  `reactive-terrain`, `beat-tiles`, `lyrics`, `music-video` and `lyric-storm`, registered in
+  `components/Visualizer/visualizers/index.ts`.
+- It describes `useAudioAnalyser` as reading a Web Audio `AnalyserNode`. Under `ADR-0033` that is
+  one of three sources, the other two being native frames and nothing at all. `0034` recorded this
+  as a follow-up and it is still open.
+- All three sample plugins' READMEs instruct the reader to *"Go to Settings > Plugins"*, a screen
+  deleted in `dbdef05` on 2026-03-06. `0034` flagged this as an unresolved tradeoff and predicted
+  it would otherwise become another instance of an affordance pointing at a destination that is not
+  mounted. It has been one for eleven days.
+
+The first of these is the dangerous one. A stale table inside a repository is a nuisance; the same
+table published as the invitation to write a visualizer sends every new author looking for six
+components that were deleted, and the API's first impression is that nobody maintains it.
+
+**Distribution is where this could go wrong, and `0034` already drew the lines.** Point 5 deferred
+install-from-URL — *"a `plugins` table, a server route, a download path and a trust question about
+arbitrary JavaScript from a URL"* — and its Alternatives separately rejected serving bundles from
+the Familiar server, on the grounds that it is install-from-URL with the URL fixed. `ADR-0038`
+point 7 refuses growth into a service. A gallery that *hosts bundles* would walk into all three at
+once. A gallery that *lists and links* walks into none of them, and that is the difference this ADR
+turns on.
+
+## Decision
+
+1. **`docs/VISUALIZER_API.md` becomes a published, versioned contract, rendered as a section of the
+   site under `ADR-0062`.** It is already the shared contract for every client per `0034` point 6.
+   Publishing changes who it is addressed to, not what it says, and the document stays in `docs/`
+   as its single source — `0062` point 2 renders it in place rather than copying it.
+
+2. **It is corrected before it is published, and the correction is part of this work rather than a
+   follow-up.** All three defects in the Context: the six absent components, `useAudioAnalyser`'s
+   three sources, and the sample READMEs' dead install instructions. This is `ADR-0055` point 2's
+   rule applied one directory over — a claim nobody re-reads becomes a lie by attrition, and the
+   moment a document is published, the number of people who cannot check it goes up sharply.
+
+3. **A gallery page lists submitted visualizers and links to their repositories. The site hosts no
+   bundles.** Discovery is the problem being solved; installation is unchanged and remains the
+   `Visualizers/` directory of `0034` point 4. This is what keeps a gallery clear of `0034` point
+   5's deferred trust question, clear of its rejected server-served-bundles alternative, and clear
+   of `ADR-0038` point 7. **Familiar links to third-party code; it does not distribute it.**
+
+4. **Submission is a pull request against a data file in `site/`, and curation is review of that
+   pull request.** No accounts, no upload endpoint, no submission form, no moderation queue — each
+   of those is the service `ADR-0038` point 7 refuses, and a project with zero third-party
+   visualizers does not need a workflow. A pull request also means every listing arrives with an
+   author who has a GitHub identity, which is the whole of the trust model and is stated as such.
+
+5. **A listing states what can be checked, and is checked.** An entry carries an author, a
+   repository URL, a licence and a declared `familiar.apiVersion`; an entry whose repository has no
+   `familiar-plugin.json` with `"type": "visualizer"` is not listed. This is mechanical on purpose.
+   `ADR-0055` point 2 found that a comparison table audited only against its own author's
+   repository drifts toward flattering its author, and a curated gallery has the same failure mode
+   with someone else's work.
+
+6. **`familiar.apiVersion` is the compatibility promise, and publishing creates an obligation
+   `0034` did not have.** The host implements version 1 (`VISUALIZER_API_VERSION` in
+   `services/visualizerPlugins.ts`), and `0034` point 7 refuses any manifest declaring a version the
+   host does not implement — including, as implemented, a manifest declaring none. Until now that
+   only ever refused first-party samples. Once outside authors exist, a bump breaks strangers'
+   work, so a bump requires the host to keep accepting the previous version for a stated period, and
+   the gallery to record which entries are affected.
+
+7. **The published starting point is a template repository an author clones, not a directory inside
+   this one.** `visualizers/_template/` holds a 166-line `ExampleVisualizer.tsx` and a 271-line
+   README, and it is good; but it lives inside the frontend package, cannot be cloned, and builds
+   nothing. An author needs a manifest, a rollup config producing an IIFE, and a `dist/` — which is
+   what the three sample plugins have and what `_template/` does not. `familiar-plugin-lyric-pulse`
+   is the working reference for that shape.
+
+8. **Install-from-URL stays deferred.** Restated here so that a gallery is not read as having
+   settled it. `0034` point 5's reasoning is untouched by anything in this ADR: a list of links is
+   not a download path, and the trust question it names still deserves its own argument.
+
+9. **Library-browser plugins stay out of scope**, per `0034` point 9. `familiar-plugin-timeline`
+   declares `"type": "browser"` and is refused by the loader; the gallery lists visualizers, so it
+   is not listed either. Publishing an invitation is exactly the moment this boundary would blur.
+
+## Alternatives Considered
+
+- **Revive install-from-URL alongside the gallery, so a listed visualizer installs in one click.**
+  It is what all three sample READMEs already tell people to do, and the shelved implementation is
+  the starting point — `backend/app/services/plugins.py` (480 lines), `api/plugins.ts` (100) and
+  `PluginsSettings.tsx` (378), all removed in `dbdef05`. Rejected for the reason `0034` point 5
+  gave and did not retract: downloading and executing JavaScript from a URL the user supplied is a
+  trust decision, and it should be argued on its own rather than arriving as the convenience half
+  of a documentation change.
+
+- **Host the bundles on the site so installation is a single download.** Removes the worst friction
+  in the whole feature, and the files are small. Rejected because it makes Familiar the distributor
+  of third-party code — the point at which a listing stops being a link and starts being an
+  endorsement backed by nothing, and the point `ADR-0038` point 7 draws.
+
+- **Publish the docs and skip the gallery; let GitHub topics and search do discovery.** Cheaper,
+  self-maintaining, and it is how most projects this size handle it. Rejected because discovery by
+  search requires something to find: with zero third-party visualizers, a topic tag returns the
+  three first-party samples and nothing else. A curated list is the invitation, and it can be
+  retired once it is no longer the only way to find anything.
+
+- **Put the documentation in the web app as a `/docs` route.** The bundle already serves three
+  documents and the routing exists. Rejected against `ADR-0058` point 2's three destinations, and
+  because documentation that requires a running Familiar server is unreachable by exactly the
+  person who has not installed one yet.
+
+- **Write a new authoring guide rather than publishing the existing document.** The existing one is
+  719 lines aimed at someone reading the repository. Rejected because two documents describing one
+  contract is the drift `0062` point 2 refuses, and because the existing document's problem is that
+  three specific things in it are wrong, not that it is the wrong document.
+
+## Consequences
+
+- **Positive:** The plugin surface that `ADR-0033` called the one place outsiders can contribute
+  becomes reachable by an outsider, which is the first time that has been true since the loader
+  shipped.
+- **Positive:** Three known-stale artefacts get corrected under point 2, including one — the sample
+  READMEs — that `0034` predicted would rot and which has.
+- **Positive:** The gallery is a data file and a page. If nobody submits anything, the cost is a
+  page that lists the first-party samples, which is still better than today.
+- **Tradeoff:** Point 6 turns `apiVersion` from an internal check into a promise to strangers.
+  Version 1 is now expensive to leave, and it was designed without anyone outside this repository
+  in mind.
+- **Tradeoff:** Curation is a person, and that person is one person. A submission queue with no
+  reviewer is worse than no queue, and this ADR creates the queue without creating a second
+  reviewer.
+- **Tradeoff:** The site gains two audiences. `ADR-0055` point 1 says it exists *"to get one kind of
+  person to run one command"*, and an author looking for a plugin API is a second kind. The
+  documentation and gallery are their own pages, so `0055` point 4's budget of six claims and 700
+  words in `<main>` is untouched — but the nav is where the two audiences meet, and a developer link
+  there is the first thing on that page that is not aimed at the installer.
+- **Tradeoff:** Point 3 means installation stays manual — find a repository, download a build, drop
+  a folder in a directory a Settings button reveals. That is real friction on the exact path this
+  ADR is trying to open, and point 8 declines to fix it.
+- **Tradeoff:** A published contract makes `ADR-0034` point 3's unenforceable rule — that a bundle
+  must not carry its own React or three.js — a support burden rather than a note. Nothing checks
+  it, and now the people breaking it will not be in this repository.
+- **Follow-up:** Install-from-URL, per point 8 and `0034` point 5. This ADR raises its value
+  without changing its argument.
+- **Follow-up:** `visualizers/_template/` is superseded as the published starting point by point 7,
+  but still exists and still documents the component API accurately. Decide whether it stays as an
+  in-repo reference or is folded into the template repository.
+- **Follow-up:** The gallery's per-entry checks in point 5 are described but not automated. Until
+  they are, they are a reviewer's checklist — which `ADR-0055` point 2 observed is the form of audit
+  that has already expired.

--- a/docs/decisions/ADR-0064-visualizers-declare-affinity-and-the-server-ranks-them.md
+++ b/docs/decisions/ADR-0064-visualizers-declare-affinity-and-the-server-ranks-them.md
@@ -11,6 +11,48 @@ two sources, the refusal rules — stands unchanged. Independent of
 [ADR-0063](ADR-0063-the-visualizer-api-is-published-for-outside-authors.md), and should ship before
 them so the manifest is settled before it is published.
 
+## Implementation
+
+Points 1–10 shipped on `adr/open-visualizer-platform`, in four commits. The `familiar-apple` half —
+the catalog carrying `affinity` so the native host can send candidates — is the remaining follow-up,
+and `docs/WEB-PARITY.md` carries the row marked **not a blocker** until it lands, so shipping the
+web half first does not extend the web player's countdown under
+[ADR-0060](ADR-0060-the-players-removal-trigger-must-be-reachable.md) point 1.
+
+**Point 9 needed no backend work**, which this ADR did not know. `GET /tracks/{id}` already
+populates all fifteen `TrackFeatures` fields and `tracksApi.get` already wraps it. The trap was the
+obvious fix: `playerStore.currentTrack` comes from `tracksApi.list`, which fills `features` only
+when the caller passes `include_features`, and the only caller that does is the track-list browser.
+Passing `currentTrack.features` would have worked on exactly one screen.
+
+**Point 10's endpoint went under the existing `tracks` tag**, not a new `visualizers` one. That
+avoids editing `VENDORED_TAGS` and the Swift generator config, and since `tracks` is already in the
+generated surface the operation reaches the Apple clients on the next regeneration with no
+cross-repo change.
+
+Four things were decided here that the ADR left open:
+
+1. **Unrecognised means excluded from the denominator, not scored zero.** Point 3 said "inert" and
+   the arithmetic had to make it true: a typo in an optional field must not change a score at all.
+   Nothing declared, and a track with no mood tags, both score neutral rather than last — but
+   declaring something that does *not* fit can lose to declaring nothing, so there is no advantage
+   in claiming everything.
+2. **`music-video` declares no affinity, deliberately.** Point 4 says the built-ins declare too, and
+   this one has nothing honest to say: it plays a video rather than drawing the audio, so no
+   property of the analysis makes it more apt.
+3. **`instrumentalness` and `speechiness` are not used as signals**, though they are the obvious
+   choice for the two lyric visualizers. The detector finds speech rather than singing, so it does
+   not separate an instrumental track from a sung one; the CLAP-derived `vocal/choir` tag is the
+   better proxy. This is now recorded in `VISUALIZER_API.md` so a plugin author does not repeat it.
+4. **A manual pick switches auto-select off.** Point 7 forbids silently overriding a chosen
+   visualizer, and leaving the toggle on would have let the *next* track do exactly that.
+
+**One defect this created and the ADR did not anticipate.** Auto-select introduces a second answer
+to "which visualizer is on", and `FullPlayer` gates its whole layout on whether Music Video is
+playing — read from the stored id, so an auto-selected Music Video would have drawn album art over
+a playing video. Resolved with one shared `useActiveVisualizerId`; the lesson is the general one,
+that adding a second source for an existing answer means auditing every reader of the first.
+
 ## Context
 
 **A visualizer is currently a setting somebody picks once.** The whole of the state is one id, and
@@ -188,10 +230,12 @@ server therefore cannot know which visualizers a given device has installed**, b
   on a large library mid-sync that will be a meaningful fraction of tracks.
 - **Follow-up:** The catalog published as `window.__familiarVisualizers` must carry the affinity
   block for the native host to forward it, which extends `VisualizerCatalog.swift` and the
-  `evaluateJavaScript` probe `0034` added rather than adding a message handler.
-- **Follow-up:** `docs/VISUALIZER_API.md` documents the manifest and will need the `affinity` block
-  before `ADR-0063` publishes it. That ADR's point 2 already requires the document to be correct
-  first; this adds to what "correct" means.
+  `evaluateJavaScript` probe `0034` added rather than adding a message handler. *The page half is
+  done — the catalog carries `affinity`; the Swift half is what remains.*
+- **Follow-up:** ~~`docs/VISUALIZER_API.md` documents the manifest and will need the `affinity`
+  block before `ADR-0063` publishes it.~~ — done, along with the three defects that ADR names: the
+  six absent components, `useAudioAnalyser`'s three sources, and the fifth reserved id. The 48-tag
+  vocabulary is listed there and was verified against `mood_tags.DESCRIPTORS` at write time.
 - **Follow-up:** The `"visualizer"` entry in `KNOWN_CAPABILITIES` remains declared and unused after
   this ADR, per point 10. It should either acquire a producer or be removed, and this is the second
   time it has been looked at and left.

--- a/docs/decisions/ADR-0064-visualizers-declare-affinity-and-the-server-ranks-them.md
+++ b/docs/decisions/ADR-0064-visualizers-declare-affinity-and-the-server-ranks-them.md
@@ -1,0 +1,197 @@
+# ADR-0064: Visualizers Declare Affinity, and the Server Ranks Them
+
+Status: proposed
+
+Date: 2026-08-17
+
+Extends [ADR-0034](ADR-0034-visualizers-are-drop-in-bundles.md), whose manifest this adds one
+optional block to. Everything `0034` decided — the IIFE format, evaluation only inside the web view,
+two sources, the refusal rules — stands unchanged. Independent of
+[ADR-0062](ADR-0062-the-site-adopts-a-static-site-generator.md) and
+[ADR-0063](ADR-0063-the-visualizer-api-is-published-for-outside-authors.md), and should ship before
+them so the manifest is settled before it is published.
+
+## Context
+
+**A visualizer is currently a setting somebody picks once.** The whole of the state is one id, and
+the two clients disagree about its default: the web app persists `visualizerId` and `glowLevel`
+under the zustand key `familiar-visualizer` in `stores/visualizerStore.ts`, defaulting to
+`reactive-terrain` per `components/Visualizer/constants.ts`; the Apple clients keep a per-profile
+`visualizerID` in `UserDefaults` with `VisualizerChoice` in `ServerConfiguration.swift` defaulting
+to `beat-tiles`. **There is no per-track association of any kind, on any client.** Nothing in
+Familiar has ever asked which visualizer suits a song.
+
+**The analysis half of the visualizer contract is already built and connected to nothing.**
+`VisualizerProps` declares `features: TrackFeatures | null`; `AudioVisualizer` defaults it to
+`null` and forwards it to the chosen visualizer. **Neither call site passes it.** `FullPlayer.tsx`
+supplies `track`, `artworkUrl`, `lyrics`, `isPlaying`, `currentTime` and `duration`;
+`EmbedVisualizer.tsx` supplies `track`, `artworkUrl`, `isPlaying` and `currentTime` — and no
+`lyrics` either. `ReactiveTerrain` is the only visualizer that reads `features`, for `valence` and
+`energy`, and therefore always takes its `?? 0.4` and `?? 0.5` fallbacks. The documented,
+first-class, analysis-driven half of the API has never run.
+
+`EmbedVisualizer` is worse than the summary suggests: it constructs a partial `Track` with an
+`as Track` cast from `{id, title, artist, album}`, so on the surface the Apple clients actually
+use, **no analysis reaches a visualizer at all**. This is the "consumer with no producer" shape,
+and it means a feature that matches visualizers to songs must first make the song's analysis
+present on the surface where the matching would be visible.
+
+**The vocabulary to match against already exists and is already computed.**
+`backend/app/services/mood_tags.py` holds **48 CLAP descriptors — 16 mood, 16 genre, 8
+instrumentation, 8 energy** — scored by cosine similarity between a track's CLAP audio embedding
+and pre-computed text embeddings of each descriptor, and stored on `TrackAnalysis.mood_tags` as
+JSONB with a GIN index (`ix_track_analysis_mood_tags`). Beside it, `ANALYSIS_FEATURE_COLUMNS` lists
+28 typed columns including `energy`, `valence`, `bpm`, `danceability`, `brightness` and
+`instrumentalness`, several separately B-tree indexed. Nothing new has to be extracted or analysed
+for this feature; the numbers are on disk for every analysed track.
+
+Two pieces of prior art are worth naming so they are not re-derived.
+`services/smart_playlists.py` already implements tag matching against this exact column, through a
+`mood_tag` pseudo-field that compiles to a JSONB containment test. And `services/generative_art.py`
+already maps aggregated `TrackAnalysis` features onto visual output, deterministically, to render
+album art — features-to-visuals is not a new idea in this codebase.
+
+**There is a seam for this with nothing on either end.**
+`backend/app/services/playback_commands.py` declares `"visualizer"` in `KNOWN_CAPABILITIES`, the
+command-channel vocabulary of [ADR-0044](ADR-0044-mcp-clients-actuate-playback-through-a-command-channel.md)
+and [ADR-0053](ADR-0053-the-command-channel-drives-and-observes-the-interface.md). Nothing in the
+backend emits a visualizer command and nothing handles one; the string appears once in the entire
+repository. It was declared in anticipation and never used.
+
+**[ADR-0029](ADR-0029-the-server-stores-no-listener-preferences.md) constrains the shape of any
+server-side answer, and it is the reason this ADR looks the way it does.** Point 4: the server
+stores no listener preferences, and the chosen visualizer is one. Point 5 is the harder
+constraint — device identity stays uninvented, `Profile.device_id` has no readers, and *"anything
+device-scoped is local by construction, because the server has no key to file it under."* **The
+server therefore cannot know which visualizers a given device has installed**, because `0034` point
+4 puts local bundles in a directory on that device and tells the server nothing about them.
+
+## Decision
+
+1. **`familiar-plugin.json` gains an optional `affinity` block, declared by the author.** It carries
+   tags the visualizer suits and ranges over the numeric feature columns — the shape a picker would
+   need to explain its choice. Author-declared rather than derived, because the author is the only
+   party that knows a visualizer needs lyrics, or looks wrong below 90 bpm.
+
+2. **The block is optional, and `apiVersion` stays 1.** Stated explicitly because `0034` point 7
+   refuses any manifest declaring a version the host does not implement — and, as implemented,
+   refuses one declaring no version at all. Bumping to 2 for an additive field would refuse every
+   bundle that exists, including both working samples, to add a feature none of them uses.
+
+3. **The matcher scores what it recognises and ignores the rest.** A tag outside the 48-descriptor
+   vocabulary, or a range over a column that does not exist, is inert — it contributes nothing and
+   refuses nothing. `0034`'s refusal taxonomy is for bundles that *cannot run*; a tag the server
+   does not understand is not that, and refusing a working visualizer over a typo in an optional
+   field would be the worst trade in the feature. The ignored entries are surfaced in the picker,
+   reusing the refusal display `0034` already built, so an author can see what did not land.
+
+4. **The five built-in visualizers declare affinity too.** Otherwise the ranker holds five
+   unlabelled candidates and one labelled plugin, and the plugin wins every track by default — a
+   scoring artefact that would be indistinguishable from favouritism, and one that gets worse the
+   better the built-ins are.
+
+5. **The client sends its candidates and the server ranks them.** The client posts the visualizer
+   ids and affinity blocks it actually has loaded, together with a track id; the server scores them
+   against that track's `TrackAnalysis` and returns an ordering with a reason per entry. **This is
+   forced by `ADR-0029` point 5 rather than preferred**: the server has no device identity, so it
+   cannot know what is installed, and a ranking over visualizers the listener does not have is not
+   a ranking. The catalog the page already publishes as `window.__familiarVisualizers` is the
+   source of that list.
+
+6. **The server stores nothing.** The endpoint is a pure function of the posted candidates and the
+   track's analysis. The chosen id, and whether auto-select is on at all, stay on the device as
+   listener preferences under `ADR-0029` point 4. A server that ranked *and remembered* would
+   reopen `0029` for a screensaver.
+
+7. **Auto-select is a mode, off by default, beside the existing manual choice.** A listener who has
+   picked a visualizer has expressed a preference, and silently overriding it is not a feature. The
+   manual picker keeps working exactly as it does now.
+
+8. **The choice is made when a track starts and holds for that track.** No mid-song switching: a
+   three.js scene tearing down and rebuilding halfway through a song is more disruptive than an
+   imperfect match is dull, and `TrackAnalysis.section_count` would make it tempting. A hysteresis
+   rule keeps the current visualizer through a run of similar tracks unless another scores
+   meaningfully higher, so a playlist of near-ties does not alternate between two of them.
+
+9. **`VisualizerProps.features` is wired at both call sites as part of this work**, and
+   `EmbedVisualizer` stops constructing a partial `Track` by cast. This is a decision point rather
+   than an implementation detail because it is the prerequisite for everything above, because it is
+   currently invisible, and because it is worth doing on its own: it makes the documented API real
+   for hand-picked visualizers whether or not anything ever auto-selects.
+
+10. **The endpoint is typed and joins the generated surface**, per
+    [ADR-0007](ADR-0007-clients-are-generated-from-openapi.md) points 2 and 4 — a real Pydantic
+    response model, no bare `dict`, a tag, and no addition to the lint's burn-down list. The
+    `"visualizer"` capability already declared in `playback_commands.py` is **left alone**: this is
+    a client asking a question and getting an answer, not the server actuating a client, which is
+    what the command channel is for.
+
+## Alternatives Considered
+
+- **Enforce a closed vocabulary, refusing any manifest whose affinity tags are not among the 48
+  descriptors.** Every declaration would then be checkable, matchable and consistent, and authors
+  would get an error at install time rather than silence. Rejected because it refuses a working
+  visualizer for a soft reason: `0034`'s refusals are reserved for bundles that cannot run, and a
+  misspelled optional tag is not that. Point 3 gets the same guidance from the picker without the
+  refusal.
+
+- **Embed each visualizer's description with CLAP's text encoder and rank by cosine similarity
+  against the track's own embedding.** Genuinely elegant, needs no new manifest field at all, and
+  costs almost nothing to build — `mood_tags.py` already computes exactly this shape of similarity
+  against pre-computed text embeddings. Rejected because an author can neither predict nor control
+  the result, and has no way to say "never use me for solo piano". A declared block is a contract
+  the author can reason about; an embedding of their marketing copy is a guess they cannot correct.
+
+- **Learn the match from what listeners actually keep on, per
+  [ADR-0004](ADR-0004-listening-feedback-is-event-sourced.md)'s shape.** Needs no declarations,
+  cannot be gamed by an author's optimism, and would get better over time. Rejected because it is
+  cold at launch and there is no event stream for visualizer choice to make it warm — and `0004`'s
+  own history is the measure of that cost, since `play_events` only became trustworthy on
+  2026-08-01, months after the events started accumulating. Worth naming as the eventual refinement
+  over declared tags rather than as a rejected idea.
+
+- **Match on the client, from features the server already serves.** Works offline, needs no new
+  endpoint, and the client is the only party that already knows what it has installed — which is
+  the real objection to point 5. Rejected because the scoring rule would then exist in TypeScript
+  and in Swift, and `0034` states the consequence from experience: *"Two copies of that rule in two
+  languages is how the picker comes to disagree with what actually loaded."*
+
+- **Derive affinity by inspecting the bundle.** No author burden at all. Rejected because an IIFE
+  evaluated with `new Function` offers nothing meaningful to inspect, and a heuristic over minified
+  source would be wrong in ways nobody could debug.
+
+- **Let the LLM pick, through the MCP server of
+  [ADR-0043](ADR-0043-the-llm-surface-is-an-mcp-server.md).** It already has the analysis tools and
+  would give better-than-mechanical answers. Rejected because it makes a screensaver depend on a
+  configured model and a network round trip per track, for a decision that has to be right within
+  the first second of playback.
+
+## Consequences
+
+- **Positive:** Point 9 makes the documented `features` half of the visualizer API real for the
+  first time, on both surfaces, whether or not auto-selection is ever switched on.
+- **Positive:** Nothing new is analysed, extracted or migrated. Every input already exists on
+  `TrackAnalysis` for every analysed track, and `FEATURES_VERSION` is untouched.
+- **Positive:** A visualizer becomes a thing that can be *right for a song*, which is the argument
+  for writing one — and it lands before `ADR-0063` publishes an invitation to write them.
+- **Tradeoff:** Self-reported affinity will over-claim, and nothing can check it. This is the same
+  shape as `0034` point 3's unenforceable contract about bundled React, and the only defence is the
+  same one: documentation, plus the fact that an over-claiming visualizer is mostly punished by
+  looking wrong.
+- **Tradeoff:** A new endpoint is a new client-facing contract under `ADR-0007`, and casual changes
+  to it get more expensive from the day it is generated.
+- **Tradeoff:** The two disagreeing defaults — `reactive-terrain` in the browser, `beat-tiles` on
+  the Apple clients — become visible the moment anything reasons about which visualizer is *right*.
+  This ADR surfaces that disagreement without resolving it.
+- **Tradeoff:** A track with no analysis, or one still awaiting a features re-run, has nothing to
+  rank against. The behaviour has to be "keep the current visualizer", not "pick arbitrarily", and
+  on a large library mid-sync that will be a meaningful fraction of tracks.
+- **Follow-up:** The catalog published as `window.__familiarVisualizers` must carry the affinity
+  block for the native host to forward it, which extends `VisualizerCatalog.swift` and the
+  `evaluateJavaScript` probe `0034` added rather than adding a message handler.
+- **Follow-up:** `docs/VISUALIZER_API.md` documents the manifest and will need the `affinity` block
+  before `ADR-0063` publishes it. That ADR's point 2 already requires the document to be correct
+  first; this adds to what "correct" means.
+- **Follow-up:** The `"visualizer"` entry in `KNOWN_CAPABILITIES` remains declared and unused after
+  this ADR, per point 10. It should either acquire a producer or be removed, and this is the second
+  time it has been looked at and left.

--- a/docs/decisions/ADR-0064-visualizers-declare-affinity-and-the-server-ranks-them.md
+++ b/docs/decisions/ADR-0064-visualizers-declare-affinity-and-the-server-ranks-them.md
@@ -1,6 +1,6 @@
 # ADR-0064: Visualizers Declare Affinity, and the Server Ranks Them
 
-Status: proposed
+Status: accepted
 
 Date: 2026-08-17
 

--- a/packages/frontend/src/api/tracks.ts
+++ b/packages/frontend/src/api/tracks.ts
@@ -8,6 +8,35 @@ export interface TrackIdsResponse {
   total: number;
 }
 
+/** One visualizer offered for ranking, with whatever affinity it declared (ADR-0064). */
+export interface VisualizerRankingCandidate {
+  id: string;
+  affinity?: {
+    tags: string[];
+    ranges: { feature: string; minimum?: number; maximum?: number }[];
+  };
+}
+
+/** One visualizer's placing, and why. `ignored` is what the server did not recognise. */
+export interface RankedVisualizer {
+  id: string;
+  score: number;
+  matched_tags: string[];
+  matched_ranges: string[];
+  unmatched_ranges: string[];
+  ignored: string[];
+}
+
+export interface VisualizerRankingResponse {
+  visualizers: RankedVisualizer[];
+  /**
+   * False when the track has no analysis to rank against — an ordinary state on a library still
+   * being analysed, **not** an error. The client must keep whatever it is showing rather than
+   * pick, so `visualizers` comes back in the order it was submitted.
+   */
+  ranked: boolean;
+}
+
 export const tracksApi = {
   list: async (params?: {
     page?: number;
@@ -79,6 +108,21 @@ export const tracksApi = {
 
   get: async (id: string): Promise<Track> => {
     const { data } = await api.get(`/tracks/${id}`);
+    return data;
+  },
+
+  /**
+   * Ask the server which of *these* visualizers suits this track (ADR-0064).
+   *
+   * The candidates travel from the client because the server cannot know what is installed on a
+   * device — ADR-0029 point 5 leaves device identity uninvented, and drop-in bundles live in a
+   * directory on the device the server is never told about.
+   */
+  rankVisualizers: async (
+    trackId: string,
+    candidates: VisualizerRankingCandidate[]
+  ): Promise<VisualizerRankingResponse> => {
+    const { data } = await api.post(`/tracks/${trackId}/visualizer-ranking`, { candidates });
     return data;
   },
 

--- a/packages/frontend/src/components/Embed/EmbedVisualizer.tsx
+++ b/packages/frontend/src/components/Embed/EmbedVisualizer.tsx
@@ -1,6 +1,7 @@
 import { useSyncExternalStore } from 'react';
 import { AudioVisualizer } from '../Visualizer/AudioVisualizer';
 import { getVisualizerState, subscribeToVisualizerState } from '../../services/visualizerSink';
+import { useTrackDetail } from '../../hooks/useTrackDetail';
 import { tracksApi } from '../../api/tracks';
 import type { Track } from '../../types';
 
@@ -19,7 +20,14 @@ import type { Track } from '../../types';
 export function EmbedVisualizer() {
   const state = useSyncExternalStore(subscribeToVisualizerState, getVisualizerState);
 
-  const track: Track | null = state.track
+  // The frame carries four identity fields and no analysis — deliberately, since a channel that
+  // carries everything has no shape (ADR-0033). Artwork and lyrics are already fetched by the page
+  // rather than pushed, so the analysis is fetched the same way (ADR-0064 point 9).
+  const detail = useTrackDetail(state.track?.id ?? null);
+
+  // Until that resolves — and if it never does, because the page is offline — fall back to the
+  // frame's own fields. Partial, and cast as such; it is what this surface has always drawn with.
+  const fallback: Track | null = state.track
     ? ({
         id: state.track.id,
         title: state.track.title ?? 'Unknown',
@@ -28,9 +36,12 @@ export function EmbedVisualizer() {
       } as Track)
     : null;
 
+  const track = detail ?? fallback;
+
   return (
     <AudioVisualizer
       track={track}
+      features={detail?.features ?? null}
       artworkUrl={state.track ? tracksApi.getArtworkUrl(state.track.id) : null}
       isPlaying={state.playing}
       currentTime={state.position}

--- a/packages/frontend/src/components/Embed/__tests__/EmbedVisualizer.test.tsx
+++ b/packages/frontend/src/components/Embed/__tests__/EmbedVisualizer.test.tsx
@@ -1,0 +1,120 @@
+/* @vitest-environment jsdom */
+import { act, cleanup, render, waitFor } from '@testing-library/react';
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
+import { EmbedVisualizer } from '../EmbedVisualizer';
+import { registerVisualizer, type VisualizerProps } from '../../Visualizer/types';
+import { useVisualizerStore } from '../../../stores/visualizerStore';
+import {
+  installVisualizerSink,
+  resetVisualizerSinkForTesting,
+  type AnalysisFrame,
+} from '../../../services/visualizerSink';
+import { tracksApi } from '../../../api/tracks';
+import type { Track } from '../../../types';
+
+vi.mock('../../../api/tracks', () => ({
+  tracksApi: { get: vi.fn(), getArtworkUrl: (id: string) => `/artwork/${id}` },
+}));
+
+const get = tracksApi.get as ReturnType<typeof vi.fn>;
+
+// Same capture harness as AudioVisualizer.test.tsx: a stub visualizer that records its props, so
+// the assertion is on what actually reached a visualizer rather than on an intermediate component.
+let lastProps: VisualizerProps | null = null;
+const CAPTURE_ID = 'embed-capture';
+
+registerVisualizer(
+  { id: CAPTURE_ID, name: 'Capture', description: 'test', usesMetadata: true },
+  (props: VisualizerProps) => {
+    lastProps = props;
+    return <div data-testid="capture" />;
+  }
+);
+
+/** A frame as the native host sends it. Empty base64 decodes to a zero-length buffer, which is all
+ *  this test needs — the spectrum never passes through React. */
+function frame(track: AnalysisFrame['track']): AnalysisFrame {
+  return {
+    frequency: '',
+    timeDomain: '',
+    flux: [],
+    fluxInterval: 0.1,
+    cadenceHz: 10,
+    playing: true,
+    position: 0,
+    track,
+  };
+}
+
+function send(f: AnalysisFrame): void {
+  (window as unknown as Record<string, (frame: AnalysisFrame) => void>).__familiarAnalysis(f);
+}
+
+beforeEach(() => {
+  get.mockReset();
+  resetVisualizerSinkForTesting();
+  installVisualizerSink();
+  useVisualizerStore.getState().setVisualizerId(CAPTURE_ID);
+});
+
+afterEach(() => {
+  cleanup();
+  lastProps = null;
+  resetVisualizerSinkForTesting();
+});
+
+describe('EmbedVisualizer', () => {
+  // ADR-0064 point 9. This surface is the one the Apple clients actually use, and it passed no
+  // features at all — it built a partial Track by cast from the frame's four identity fields, so no
+  // analysis reached a visualizer here. The frame still carries no analysis (ADR-0033 keeps the
+  // channel narrow); the page fetches it, the way it already fetches artwork and lyrics.
+  it('fetches the track detail and passes its features to the visualizer', async () => {
+    get.mockResolvedValueOnce({
+      id: 'T1',
+      title: 'Real Title',
+      features: { energy: 0.77, valence: 0.22 },
+    } as Track);
+
+    render(<EmbedVisualizer />);
+    act(() => send(frame({ id: 'T1', title: 'From Frame' })));
+
+    await waitFor(() => expect(lastProps?.features?.energy).toBe(0.77));
+    expect(get).toHaveBeenCalledWith('T1');
+    // Once the real track arrives it replaces the frame-derived partial.
+    expect(lastProps?.track?.title).toBe('Real Title');
+  });
+
+  it('falls back to the frame fields while the fetch is pending', async () => {
+    let resolve!: (t: Track) => void;
+    get.mockReturnValueOnce(new Promise<Track>((r) => { resolve = r; }));
+
+    render(<EmbedVisualizer />);
+    act(() => send(frame({ id: 'T1', title: 'From Frame', artist: 'A' })));
+
+    // The visualizer draws immediately rather than waiting on the network.
+    await waitFor(() => expect(lastProps?.track?.title).toBe('From Frame'));
+    expect(lastProps?.features).toBeNull();
+
+    await act(async () => { resolve({ id: 'T1', title: 'Real Title' } as Track); });
+    await waitFor(() => expect(lastProps?.track?.title).toBe('Real Title'));
+  });
+
+  it('still draws when the detail fetch fails', async () => {
+    get.mockRejectedValueOnce(new Error('offline'));
+
+    render(<EmbedVisualizer />);
+    act(() => send(frame({ id: 'T1', title: 'From Frame' })));
+
+    await waitFor(() => expect(get).toHaveBeenCalled());
+    expect(lastProps?.track?.title).toBe('From Frame');
+    expect(lastProps?.features).toBeNull();
+  });
+
+  it('renders with no track before any frame arrives', () => {
+    render(<EmbedVisualizer />);
+
+    expect(lastProps?.track).toBeNull();
+    expect(lastProps?.features).toBeNull();
+    expect(get).not.toHaveBeenCalled();
+  });
+});

--- a/packages/frontend/src/components/FullPlayer/FullPlayer.tsx
+++ b/packages/frontend/src/components/FullPlayer/FullPlayer.tsx
@@ -23,6 +23,7 @@ import { useVisualizerStore } from '../../stores/visualizerStore';
 import { useAudioControls } from '../../hooks/useAudioControls';
 import { useAppNavigation } from '../../hooks/useAppNavigation';
 import { useSyncedLyrics } from '../../hooks/useSyncedLyrics';
+import { useTrackDetail } from '../../hooks/useTrackDetail';
 import { tracksApi } from '../../api';
 import { useUIStore } from '../../stores/uiStore';
 import { AudioVisualizer, VisualizerPicker } from '../Visualizer';
@@ -131,6 +132,9 @@ export function FullPlayer({ isOpen, onClose }: FullPlayerProps) {
 
   // Fetch lyrics for the visualizer (race-safe across track skips).
   const lyrics = useSyncedLyrics(currentTrack?.id ?? null);
+
+  // And the analysis, which `currentTrack` does not reliably carry — see `useTrackDetail`.
+  const trackDetail = useTrackDetail(currentTrack?.id ?? null);
 
   // Reset image error when track changes
   useEffect(() => {
@@ -275,6 +279,7 @@ export function FullPlayer({ isOpen, onClose }: FullPlayerProps) {
         ) : (
           <AudioVisualizer
             track={currentTrack}
+            features={trackDetail?.features ?? null}
             artworkUrl={artworkUrl}
             lyrics={lyrics}
             isPlaying={isPlaying}

--- a/packages/frontend/src/components/FullPlayer/FullPlayer.tsx
+++ b/packages/frontend/src/components/FullPlayer/FullPlayer.tsx
@@ -19,11 +19,11 @@ import {
 import { useShallow } from 'zustand/react/shallow';
 import { usePlayerStore } from '../../stores/playerStore';
 import { useSelectionStore } from '../../stores/selectionStore';
-import { useVisualizerStore } from '../../stores/visualizerStore';
 import { useAudioControls } from '../../hooks/useAudioControls';
 import { useAppNavigation } from '../../hooks/useAppNavigation';
 import { useSyncedLyrics } from '../../hooks/useSyncedLyrics';
 import { useTrackDetail } from '../../hooks/useTrackDetail';
+import { useActiveVisualizerId } from '../../hooks/useAutoSelectedVisualizer';
 import { tracksApi } from '../../api';
 import { useUIStore } from '../../stores/uiStore';
 import { AudioVisualizer, VisualizerPicker } from '../Visualizer';
@@ -80,8 +80,9 @@ export function FullPlayer({ isOpen, onClose }: FullPlayerProps) {
 
   const { seek, togglePlayPause } = useAudioControls();
   const { isFavorite, toggle: toggleFavorite } = useFavorites();
-  const { visualizerId } = useVisualizerStore();
-  const isMusicVideo = visualizerId === VISUALIZER_IDS.MUSIC_VIDEO;
+  // The *active* id, not the stored one: with auto-select on these differ, and this gates the
+  // whole layout — album art laid over a playing video is what reading the stored id would give.
+  const isMusicVideo = useActiveVisualizerId() === VISUALIZER_IDS.MUSIC_VIDEO;
 
   // Shuffle weight popover (long-press / right-click)
   const shuffleButtonRef = useRef<HTMLButtonElement>(null);

--- a/packages/frontend/src/components/Visualizer/AudioVisualizer.tsx
+++ b/packages/frontend/src/components/Visualizer/AudioVisualizer.tsx
@@ -12,7 +12,7 @@ import { getVisualizer } from './types';
 import { DEFAULT_VISUALIZER_ID } from './constants';
 import { useVisualizerStore } from '../../stores/visualizerStore';
 import { useVisualizerPluginStore } from '../../stores/visualizerPluginStore';
-import { useAutoSelectedVisualizer } from '../../hooks/useAutoSelectedVisualizer';
+import { useAutoSelectedVisualizer, useActiveVisualizerId } from '../../hooks/useAutoSelectedVisualizer';
 import { ErrorBoundary } from '../ErrorBoundary';
 
 // Import all visualizers to register them
@@ -89,14 +89,19 @@ export function AudioVisualizer({
   const { visualizerId } = useVisualizerStore();
   const markPluginFailed = useVisualizerPluginStore((s) => s.markFailed);
 
-  // ADR-0064 point 7. Null whenever auto-select is off, or on but with no opinion yet — so the
-  // listener's own choice is what shows unless something actively decided otherwise. Wired here
-  // rather than at each call site because both surfaces render through this component.
-  const autoSelectedId = useAutoSelectedVisualizer(track?.id);
+  // ADR-0064 point 7. **This is the only caller**, so the ranking is asked for once per track no
+  // matter how many things want to know the answer — wired here rather than at each call site
+  // because both surfaces render through this component. The value is read back through
+  // `useActiveVisualizerId` so the "which visualizer is on" rule has exactly one definition.
+  useAutoSelectedVisualizer(track?.id);
+  // The id we are *asking* for, which is not necessarily the one that resolves — see `activeId`
+  // below, which is what actually rendered after the fallbacks.
+  const requestedId = useActiveVisualizerId();
 
-  // Get the current visualizer component
+  // Falls back to the listener's own choice before the built-in default, so an auto-chosen plugin
+  // that has since been removed lands on what they picked rather than on Reactive Terrain.
   const visualizer =
-    getVisualizer(autoSelectedId ?? visualizerId) ||
+    getVisualizer(requestedId) ||
     getVisualizer(visualizerId) ||
     getVisualizer(DEFAULT_VISUALIZER_ID);
   const activeId = visualizer?.metadata.id;

--- a/packages/frontend/src/components/Visualizer/AudioVisualizer.tsx
+++ b/packages/frontend/src/components/Visualizer/AudioVisualizer.tsx
@@ -12,6 +12,7 @@ import { getVisualizer } from './types';
 import { DEFAULT_VISUALIZER_ID } from './constants';
 import { useVisualizerStore } from '../../stores/visualizerStore';
 import { useVisualizerPluginStore } from '../../stores/visualizerPluginStore';
+import { useAutoSelectedVisualizer } from '../../hooks/useAutoSelectedVisualizer';
 import { ErrorBoundary } from '../ErrorBoundary';
 
 // Import all visualizers to register them
@@ -88,8 +89,16 @@ export function AudioVisualizer({
   const { visualizerId } = useVisualizerStore();
   const markPluginFailed = useVisualizerPluginStore((s) => s.markFailed);
 
+  // ADR-0064 point 7. Null whenever auto-select is off, or on but with no opinion yet — so the
+  // listener's own choice is what shows unless something actively decided otherwise. Wired here
+  // rather than at each call site because both surfaces render through this component.
+  const autoSelectedId = useAutoSelectedVisualizer(track?.id);
+
   // Get the current visualizer component
-  const visualizer = getVisualizer(visualizerId) || getVisualizer(DEFAULT_VISUALIZER_ID);
+  const visualizer =
+    getVisualizer(autoSelectedId ?? visualizerId) ||
+    getVisualizer(visualizerId) ||
+    getVisualizer(DEFAULT_VISUALIZER_ID);
   const activeId = visualizer?.metadata.id;
 
   // ADR-0034 point 8: the picker marks the plugin as failed. A built-in id is not in the plugin

--- a/packages/frontend/src/components/Visualizer/VisualizerPicker.tsx
+++ b/packages/frontend/src/components/Visualizer/VisualizerPicker.tsx
@@ -9,6 +9,7 @@ import { getVisualizers } from './types';
 import { useVisualizerStore } from '../../stores/visualizerStore';
 import { useVisualizerPluginStore } from '../../stores/visualizerPluginStore';
 import { useVisualizerAutoSelectStore } from '../../stores/visualizerAutoSelectStore';
+import { useActiveVisualizerId } from '../../hooks/useAutoSelectedVisualizer';
 
 // Icon mapping for visualizers
 const visualizerIcons: Record<string, typeof Sparkles> = {
@@ -43,14 +44,14 @@ function ProblemRow({ title, detail }: { title: string; detail: string }) {
 export function VisualizerPicker() {
   const [isOpen, setIsOpen] = useState(false);
   const containerRef = useRef<HTMLDivElement>(null);
-  const { visualizerId, setVisualizerId, glowLevel, setGlowLevel, autoSelect, setAutoSelect } =
+  const { setVisualizerId, glowLevel, setGlowLevel, autoSelect, setAutoSelect } =
     useVisualizerStore();
   const { chosenId, unranked, ignoredByVisualizer } = useVisualizerAutoSelectStore();
 
   const visualizers = getVisualizers();
 
-  // What is actually drawing: auto-select's choice when it has one, the listener's otherwise.
-  const activeId = (autoSelect && chosenId) || visualizerId;
+  // What is actually drawing — shared with `FullPlayer`, which gates its layout on the same answer.
+  const activeId = useActiveVisualizerId();
   const currentVisualizer = visualizers.find(v => v.metadata.id === activeId);
 
   const records = useVisualizerPluginStore((s) => s.records);

--- a/packages/frontend/src/components/Visualizer/VisualizerPicker.tsx
+++ b/packages/frontend/src/components/Visualizer/VisualizerPicker.tsx
@@ -8,6 +8,7 @@ import { ChevronDown, Sparkles, Image, Type, Video, AlertTriangle, CloudLightnin
 import { getVisualizers } from './types';
 import { useVisualizerStore } from '../../stores/visualizerStore';
 import { useVisualizerPluginStore } from '../../stores/visualizerPluginStore';
+import { useVisualizerAutoSelectStore } from '../../stores/visualizerAutoSelectStore';
 
 // Icon mapping for visualizers
 const visualizerIcons: Record<string, typeof Sparkles> = {
@@ -18,17 +19,56 @@ const visualizerIcons: Record<string, typeof Sparkles> = {
   'lyric-storm': CloudLightning,
 };
 
+/**
+ * A row that cannot be selected, because there is nothing to select — it exists so a problem has
+ * somewhere to be said. Shared by the two such sections rather than written twice: a refused plugin
+ * (ADR-0034 point 7) and a loaded plugin whose affinity was partly unreadable (ADR-0064 point 3)
+ * look the same and mean different things, and filtering one list two ways would have conflated
+ * them, since ignored declarations belong to plugins that *did* load.
+ */
+function ProblemRow({ title, detail }: { title: string; detail: string }) {
+  return (
+    <div className="flex items-start gap-3 p-3 text-left">
+      <div className="p-2 rounded-lg bg-zinc-800">
+        <AlertTriangle className="w-4 h-4 text-amber-500" />
+      </div>
+      <div className="flex-1 min-w-0">
+        <div className="font-medium text-zinc-400">{title}</div>
+        <div className="text-xs text-zinc-500 mt-0.5">{detail}</div>
+      </div>
+    </div>
+  );
+}
+
 export function VisualizerPicker() {
   const [isOpen, setIsOpen] = useState(false);
   const containerRef = useRef<HTMLDivElement>(null);
-  const { visualizerId, setVisualizerId, glowLevel, setGlowLevel } = useVisualizerStore();
+  const { visualizerId, setVisualizerId, glowLevel, setGlowLevel, autoSelect, setAutoSelect } =
+    useVisualizerStore();
+  const { chosenId, unranked, ignoredByVisualizer } = useVisualizerAutoSelectStore();
 
   const visualizers = getVisualizers();
-  const currentVisualizer = visualizers.find(v => v.metadata.id === visualizerId);
+
+  // What is actually drawing: auto-select's choice when it has one, the listener's otherwise.
+  const activeId = (autoSelect && chosenId) || visualizerId;
+  const currentVisualizer = visualizers.find(v => v.metadata.id === activeId);
+
+  const records = useVisualizerPluginStore((s) => s.records);
 
   // ADR-0034 points 7 and 8: a plugin that was refused, or that crashed, says so here. Anything
   // that loaded is already in `visualizers` above and needs no separate row.
-  const troubled = useVisualizerPluginStore((s) => s.records).filter((r) => r.status !== 'loaded');
+  const troubled = records.filter((r) => r.status !== 'loaded');
+
+  // ADR-0064 point 3: declarations that were not understood, from both halves — the client checks
+  // structure while parsing the manifest, the server checks the tag vocabulary it owns. Neither is
+  // a refusal; these plugins are loaded and in the list above.
+  const ignoredEntries = visualizers
+    .map(({ metadata }) => {
+      const fromManifest = records.find((r) => r.id === metadata.id)?.ignored ?? [];
+      const fromServer = ignoredByVisualizer[metadata.id] ?? [];
+      return { id: metadata.id, name: metadata.name, ignored: [...fromManifest, ...fromServer] };
+    })
+    .filter((entry) => entry.ignored.length > 0);
 
   // Close on click outside
   useEffect(() => {
@@ -58,6 +98,10 @@ export function VisualizerPicker() {
 
   const handleSelect = (id: string) => {
     setVisualizerId(id);
+    // **Choosing one turns auto-select off.** Leaving it on would let the next track overrule the
+    // choice that was just made, which is the silent override ADR-0064 point 7 rules out — and
+    // picking from this list is about as explicit as a preference gets.
+    setAutoSelect(false);
     setIsOpen(false);
   };
 
@@ -95,6 +139,25 @@ export function VisualizerPicker() {
           </div>
 
           <div className="px-3 py-2.5 border-b border-zinc-700">
+            <label className="flex items-center justify-between gap-3 cursor-pointer">
+              <span className="min-w-0">
+                <span className="text-xs text-zinc-400 block">Match to the music</span>
+                <span className="text-[11px] text-zinc-500 block mt-0.5">
+                  {unranked
+                    ? 'This track has not been analysed yet'
+                    : 'Pick a visualizer to suit each track'}
+                </span>
+              </span>
+              <input
+                type="checkbox"
+                checked={autoSelect}
+                onChange={(e) => setAutoSelect(e.target.checked)}
+                className="w-4 h-4 shrink-0 rounded accent-purple-500 cursor-pointer"
+              />
+            </label>
+          </div>
+
+          <div className="px-3 py-2.5 border-b border-zinc-700">
             <div className="flex items-center justify-between mb-1.5">
               <span className="text-xs text-zinc-400">Glow</span>
               <span className="text-xs text-zinc-500 tabular-nums">{glowLevel}%</span>
@@ -112,7 +175,8 @@ export function VisualizerPicker() {
           <div className="max-h-80 overflow-y-auto">
             {visualizers.map(({ metadata }) => {
               const Icon = visualizerIcons[metadata.id] || Sparkles;
-              const isSelected = metadata.id === visualizerId;
+              const isSelected = metadata.id === activeId;
+              const isAutoChoice = autoSelect && chosenId === metadata.id;
 
               return (
                 <button
@@ -134,6 +198,11 @@ export function VisualizerPicker() {
                   <div className="flex-1 min-w-0">
                     <div className="font-medium flex items-center gap-2">
                       {metadata.name}
+                      {isAutoChoice && (
+                        <span className="text-[10px] px-1.5 py-0.5 bg-emerald-500/30 text-emerald-300 rounded">
+                          AUTO
+                        </span>
+                      )}
                       {metadata.usesMetadata && (
                         <span className="text-[10px] px-1.5 py-0.5 bg-purple-500/30 text-purple-300 rounded">
                           METADATA
@@ -162,22 +231,28 @@ export function VisualizerPicker() {
                   </span>
                 </div>
                 {troubled.map((record, index) => (
-                  <div
+                  <ProblemRow
                     key={`${record.id ?? 'unnamed'}-${index}`}
-                    className="flex items-start gap-3 p-3 text-left"
-                  >
-                    <div className="p-2 rounded-lg bg-zinc-800">
-                      <AlertTriangle className="w-4 h-4 text-amber-500" />
-                    </div>
-                    <div className="flex-1 min-w-0">
-                      <div className="font-medium text-zinc-400">
-                        {record.name ?? record.id ?? 'Unnamed plugin'}
-                      </div>
-                      <div className="text-xs text-zinc-500 mt-0.5">
-                        {record.detail}
-                      </div>
-                    </div>
-                  </div>
+                    title={record.name ?? record.id ?? 'Unnamed plugin'}
+                    detail={record.detail ?? ''}
+                  />
+                ))}
+              </div>
+            )}
+
+            {/* ADR-0064 point 3. These plugins work and are in the list above — this is only the
+                part of what they declared that nothing understood. An author whose typo vanished
+                silently has no way to find it, and refusing the visualizer over it would be a far
+                worse trade. */}
+            {ignoredEntries.length > 0 && (
+              <div className="border-t border-zinc-700">
+                <div className="px-3 pt-3 pb-1">
+                  <span className="text-xs text-zinc-500 uppercase tracking-wide">
+                    Ignored in manifest
+                  </span>
+                </div>
+                {ignoredEntries.map((entry) => (
+                  <ProblemRow key={entry.id} title={entry.name} detail={entry.ignored.join(', ')} />
                 ))}
               </div>
             )}

--- a/packages/frontend/src/components/Visualizer/__tests__/AudioVisualizer.test.tsx
+++ b/packages/frontend/src/components/Visualizer/__tests__/AudioVisualizer.test.tsx
@@ -46,4 +46,27 @@ describe('AudioVisualizer prop wiring', () => {
     expect(lastProps!.currentTime).toBe(0);
     expect(lastProps!.duration).toBe(0);
   });
+
+  // ADR-0064 point 9. `features` was declared on VisualizerProps, defaulted to null here and
+  // forwarded — and passed by neither call site, so ReactiveTerrain (its only reader) always took
+  // its `?? 0.4` / `?? 0.5` fallbacks. Nothing asserted the prop arrived, which is why it could be
+  // dead for that long.
+  it('forwards features to the visualizer', () => {
+    useVisualizerStore.getState().setVisualizerId(CAPTURE_ID);
+    const features = { energy: 0.82, valence: 0.19 } as VisualizerProps['features'];
+
+    render(<AudioVisualizer features={features} />);
+
+    expect(lastProps).not.toBeNull();
+    expect(lastProps!.features).toBe(features);
+  });
+
+  it('defaults features to null when not provided', () => {
+    useVisualizerStore.getState().setVisualizerId(CAPTURE_ID);
+
+    render(<AudioVisualizer />);
+
+    expect(lastProps).not.toBeNull();
+    expect(lastProps!.features).toBeNull();
+  });
 });

--- a/packages/frontend/src/components/Visualizer/__tests__/VisualizerPicker.test.tsx
+++ b/packages/frontend/src/components/Visualizer/__tests__/VisualizerPicker.test.tsx
@@ -1,0 +1,173 @@
+/* @vitest-environment jsdom */
+/**
+ * ADR-0064 point 3 and point 7, at the surface where they are visible.
+ *
+ * The picker had no test at all. What it needs one for is the two things that are easy to get
+ * quietly wrong: an auto-select toggle that overrules a listener who has just chosen, and an
+ * ignored declaration with nowhere to be said — the same "no destination" shape this surface keeps
+ * producing.
+ *
+ * Plain DOM assertions rather than `toBeInTheDocument`: this package installs no jest-dom matchers.
+ */
+import { cleanup, fireEvent, render, screen } from '@testing-library/react';
+import { afterEach, beforeEach, describe, expect, it } from 'vitest';
+import { VisualizerPicker } from '../VisualizerPicker';
+import { registerVisualizer, visualizerRegistry } from '../types';
+import { useVisualizerStore } from '../../../stores/visualizerStore';
+import { useVisualizerPluginStore } from '../../../stores/visualizerPluginStore';
+import { useVisualizerAutoSelectStore } from '../../../stores/visualizerAutoSelectStore';
+
+beforeEach(() => {
+  visualizerRegistry.clear();
+  registerVisualizer(
+    { id: 'alpha', name: 'Alpha', description: 'the alpha scene', usesMetadata: false },
+    () => null
+  );
+  registerVisualizer(
+    { id: 'beta', name: 'Beta', description: 'the beta scene', usesMetadata: false },
+    () => null
+  );
+  useVisualizerStore.setState({ visualizerId: 'alpha', autoSelect: false });
+  useVisualizerPluginStore.setState({ records: [], scanned: true });
+  useVisualizerAutoSelectStore.getState().reset();
+});
+
+afterEach(cleanup);
+
+/** The list only exists once the dropdown is open. */
+function open() {
+  render(<VisualizerPicker />);
+  fireEvent.click(screen.getAllByRole('button')[0]);
+}
+
+/** A row is identified by its description, which the trigger button does not repeat. */
+function row(description: string): HTMLElement {
+  const node = screen.getByText(description).closest('button');
+  if (!node) throw new Error(`no row for ${description}`);
+  return node;
+}
+
+const checkbox = () => screen.getByRole('checkbox') as HTMLInputElement;
+const text = (pattern: RegExp | string) => screen.queryByText(pattern);
+
+describe('auto-select', () => {
+  it('is off by default', () => {
+    open();
+    expect(checkbox().checked).toBe(false);
+  });
+
+  it('can be switched on', () => {
+    open();
+    fireEvent.click(checkbox());
+    expect(useVisualizerStore.getState().autoSelect).toBe(true);
+  });
+
+  it('marks the auto-chosen visualizer rather than the stored one', () => {
+    useVisualizerStore.setState({ autoSelect: true, visualizerId: 'alpha' });
+    useVisualizerAutoSelectStore.getState().recordChoice({
+      trackId: 'T1',
+      chosenId: 'beta',
+      unranked: false,
+      ignoredByVisualizer: {},
+    });
+    open();
+
+    expect(text('AUTO')).not.toBeNull();
+    // The badge sits on Beta's row, not Alpha's — the stored id is still 'alpha'.
+    expect(row('the beta scene').textContent).toContain('AUTO');
+    expect(row('the alpha scene').textContent).not.toContain('AUTO');
+  });
+
+  // ADR-0064 point 7: auto-select must never overrule a choice the listener just made. Leaving it
+  // on would let the next track do exactly that.
+  it('turns itself off when a visualizer is chosen by hand', () => {
+    useVisualizerStore.setState({ autoSelect: true });
+    open();
+    fireEvent.click(row('the beta scene'));
+
+    expect(useVisualizerStore.getState().visualizerId).toBe('beta');
+    expect(useVisualizerStore.getState().autoSelect).toBe(false);
+  });
+
+  it('says so when the track has no analysis to rank against', () => {
+    useVisualizerStore.setState({ autoSelect: true });
+    useVisualizerAutoSelectStore.getState().recordChoice({
+      trackId: 'T1',
+      chosenId: null,
+      unranked: true,
+      ignoredByVisualizer: {},
+    });
+    open();
+    expect(text(/has not been analysed/i)).not.toBeNull();
+  });
+});
+
+describe('ignored declarations', () => {
+  it('shows nothing when everything was understood', () => {
+    open();
+    expect(text(/Ignored in manifest/i)).toBeNull();
+  });
+
+  it('reports what the manifest parser dropped', () => {
+    useVisualizerPluginStore.setState({
+      records: [
+        {
+          id: 'alpha',
+          name: 'Alpha',
+          source: 'local',
+          status: 'loaded',
+          ignored: ['affinity.tags entry 42'],
+        },
+      ],
+      scanned: true,
+    });
+    open();
+    expect(text(/Ignored in manifest/i)).not.toBeNull();
+    expect(text(/affinity\.tags entry 42/)).not.toBeNull();
+  });
+
+  // The vocabulary is the server's, so an unknown *tag* can only be reported from the ranking.
+  it('reports what the server did not recognise', () => {
+    useVisualizerAutoSelectStore.getState().recordChoice({
+      trackId: 'T1',
+      chosenId: 'alpha',
+      unranked: false,
+      ignoredByVisualizer: { beta: ['not-a-real-tag'] },
+    });
+    open();
+    expect(text(/not-a-real-tag/)).not.toBeNull();
+  });
+
+  // A loaded plugin stays selectable; an unusable optional field is not a reason to withhold it.
+  it('leaves a plugin with ignored declarations in the selectable list', () => {
+    useVisualizerPluginStore.setState({
+      records: [{ id: 'beta', name: 'Beta', source: 'local', status: 'loaded', ignored: ['x'] }],
+      scanned: true,
+    });
+    open();
+    fireEvent.click(row('the beta scene'));
+    expect(useVisualizerStore.getState().visualizerId).toBe('beta');
+  });
+});
+
+describe('refused plugins', () => {
+  it('lists a refused plugin separately from an ignored declaration', () => {
+    useVisualizerPluginStore.setState({
+      records: [
+        {
+          id: 'gamma',
+          name: 'Gamma',
+          source: 'local',
+          status: 'refused',
+          detail: 'Bad api version.',
+        },
+      ],
+      scanned: true,
+    });
+    open();
+    expect(text(/Not loaded/i)).not.toBeNull();
+    expect(text('Bad api version.')).not.toBeNull();
+    // A refusal is not an ignored declaration; the two sections mean different things.
+    expect(text(/Ignored in manifest/i)).toBeNull();
+  });
+});

--- a/packages/frontend/src/components/Visualizer/constants.ts
+++ b/packages/frontend/src/components/Visualizer/constants.ts
@@ -1,12 +1,19 @@
 /** Default visualizer shown on first load. */
 export const DEFAULT_VISUALIZER_ID = 'reactive-terrain';
 
-/** Well-known visualizer IDs to avoid magic strings. */
+/**
+ * Well-known visualizer IDs to avoid magic strings.
+ *
+ * All five built-ins, and it must stay that way: a plugin claiming one of these ids is refused, so
+ * a missing entry here is a reserved id nothing in this file records. `lyric-storm` was absent from
+ * this list for as long as it has existed.
+ */
 export const VISUALIZER_IDS = {
   REACTIVE_TERRAIN: 'reactive-terrain',
   BEAT_TILES: 'beat-tiles',
   LYRICS: 'lyrics',
   MUSIC_VIDEO: 'music-video',
+  LYRIC_STORM: 'lyric-storm',
 } as const;
 
 /** localStorage key for persisted visualizer preference. */

--- a/packages/frontend/src/components/Visualizer/types.ts
+++ b/packages/frontend/src/components/Visualizer/types.ts
@@ -8,6 +8,7 @@
 import type { ComponentType } from 'react';
 import type { Track, TrackFeatures } from '../../types';
 import type { LyricLine } from '../../api';
+import type { VisualizerAffinity } from '../../services/visualizerPlugins';
 
 /**
  * Metadata about a visualizer for the picker UI.
@@ -21,6 +22,15 @@ export interface VisualizerMetadata {
   author?: string;
   /** Optional: preview image URL */
   previewUrl?: string;
+  /**
+   * What this visualizer suits, for auto-selection (ADR-0064).
+   *
+   * **The built-ins declare this too**, per point 4: a ranker holding five unlabelled candidates
+   * and one labelled plugin would hand the plugin every track, which is indistinguishable from
+   * favouritism. A plugin's block arrives on its *manifest* rather than here — the bundle registers
+   * its own metadata and knows nothing about its manifest — so the loader merges the two.
+   */
+  affinity?: VisualizerAffinity;
 }
 
 /**

--- a/packages/frontend/src/components/Visualizer/visualizers/index.ts
+++ b/packages/frontend/src/components/Visualizer/visualizers/index.ts
@@ -7,25 +7,84 @@
 import { lazy } from 'react';
 import { registerVisualizer } from '../types';
 
+/**
+ * The built-ins declare affinity as well as plugins do (ADR-0064 point 4) — otherwise the ranker
+ * holds five unlabelled candidates and any labelled plugin wins every track.
+ *
+ * These are a starting guess, as the ADR says the weights are: they describe what each scene was
+ * built to do, and there is no listening data to tune them against yet.
+ *
+ * **`instrumentalness` and `speechiness` are deliberately not used.** They would be the obvious
+ * signal for the two lyric visualizers, and they are not trustworthy: the detector finds *speech*,
+ * not singing, so an instrumental track and a sung one are not reliably separated. The `vocal/choir`
+ * tag comes from CLAP and is the better proxy for "has someone singing on it".
+ */
+
 registerVisualizer(
-  { id: 'reactive-terrain', name: 'Reactive Terrain', description: 'Neon wireframe landscape driven by the spectrum, flashing on every beat', usesMetadata: true },
+  {
+    id: 'reactive-terrain',
+    name: 'Reactive Terrain',
+    description: 'Neon wireframe landscape driven by the spectrum, flashing on every beat',
+    usesMetadata: true,
+    // Spectrum-driven and beat-flashing: it has the most to work with on dense, energetic music.
+    affinity: {
+      tags: ['electronic', 'energetic', 'synthesizer', 'dense'],
+      ranges: [{ feature: 'energy', minimum: 0.4 }],
+    },
+  },
   lazy(() => import('./ReactiveTerrain'))
 );
 registerVisualizer(
-  { id: 'beat-tiles', name: 'Beat Tiles', description: 'Album cover split into tiles that pop to the beat', usesMetadata: true },
+  {
+    id: 'beat-tiles',
+    name: 'Beat Tiles',
+    description: 'Album cover split into tiles that pop to the beat',
+    usesMetadata: true,
+    // Every tile moves on a beat, so a track without a clear one leaves the artwork sitting still.
+    affinity: {
+      tags: ['danceable', 'drums', 'funk', 'hip-hop'],
+      ranges: [{ feature: 'danceability', minimum: 0.5 }],
+    },
+  },
   lazy(() => import('./BeatTiles'))
 );
 registerVisualizer(
-  { id: 'lyrics', name: 'Lyrics', description: 'Scrolling synced lyrics over a drifting field of the song\'s words', usesMetadata: true },
+  {
+    id: 'lyrics',
+    name: 'Lyrics',
+    description: 'Scrolling synced lyrics over a drifting field of the song\'s words',
+    usesMetadata: true,
+    // Nothing to scroll without words. Whether synced lyrics exist is not in the analysis, so the
+    // tag is the closest available signal.
+    affinity: { tags: ['vocal/choir'], ranges: [] },
+  },
   lazy(() => import('./ScrollingLyrics'))
 );
 registerVisualizer(
-  { id: 'music-video', name: 'Music Video', description: 'Search and play synced music videos from YouTube', usesMetadata: false },
+  {
+    id: 'music-video',
+    name: 'Music Video',
+    description: 'Search and play synced music videos from YouTube',
+    usesMetadata: false,
+    // **Deliberately undeclared.** This one plays a video instead of drawing the audio, so no
+    // property of the analysis makes it more or less apt — it is a different way of watching, not a
+    // scene that suits some music. Declaring nothing scores neutral, which is the honest answer,
+    // and is why "no affinity" is neutral rather than last.
+  },
   lazy(() => import('./MusicVideo'))
 );
 // The word field on its own, without the lyric column and vignette `ScrollingLyrics` layers over
 // it. Same `LyricWordField` scene, so the two cannot drift apart.
 registerVisualizer(
-  { id: 'lyric-storm', name: 'Lyric Storm', description: 'The song\'s own words drifting through a dark 3D space, reacting to the music', usesMetadata: true },
+  {
+    id: 'lyric-storm',
+    name: 'Lyric Storm',
+    description: 'The song\'s own words drifting through a dark 3D space, reacting to the music',
+    usesMetadata: true,
+    affinity: {
+      tags: ['vocal/choir', 'dreamy', 'dark', 'ambient'],
+      ranges: [{ feature: 'energy', maximum: 0.7 }],
+    },
+  },
   lazy(() => import('./LyricStorm'))
 );

--- a/packages/frontend/src/hooks/__tests__/useAutoSelectedVisualizer.test.ts
+++ b/packages/frontend/src/hooks/__tests__/useAutoSelectedVisualizer.test.ts
@@ -8,7 +8,11 @@
  */
 import { act, cleanup, renderHook, waitFor } from '@testing-library/react';
 import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
-import { useAutoSelectedVisualizer, SWITCH_MARGIN } from '../useAutoSelectedVisualizer';
+import {
+  useAutoSelectedVisualizer,
+  useActiveVisualizerId,
+  SWITCH_MARGIN,
+} from '../useAutoSelectedVisualizer';
 import { tracksApi } from '../../api';
 import { useVisualizerStore } from '../../stores/visualizerStore';
 import { useVisualizerAutoSelectStore } from '../../stores/visualizerAutoSelectStore';
@@ -211,5 +215,58 @@ describe('what the picker is told', () => {
         alpha: ['not-a-tag'],
       })
     );
+  });
+});
+
+/**
+ * The active id is what anything outside the visualizer itself must read. `FullPlayer` gates its
+ * entire layout on whether Music Video is playing, and reading the *stored* id would lay album art
+ * over a playing video the moment auto-select chose it.
+ */
+describe('useActiveVisualizerId', () => {
+  beforeEach(() => {
+    useVisualizerStore.setState({ visualizerId: 'alpha', autoSelect: false });
+    useVisualizerAutoSelectStore.getState().reset();
+  });
+
+  it('is the stored id while auto-select is off', () => {
+    const { result } = renderHook(() => useActiveVisualizerId());
+    expect(result.current).toBe('alpha');
+  });
+
+  it('is still the stored id when auto-select is on but has not chosen', () => {
+    useVisualizerStore.setState({ autoSelect: true });
+    const { result } = renderHook(() => useActiveVisualizerId());
+    expect(result.current).toBe('alpha');
+  });
+
+  it('is the auto-chosen id once there is one', () => {
+    useVisualizerStore.setState({ autoSelect: true });
+    useVisualizerAutoSelectStore.getState().recordChoice({
+      trackId: 'T1',
+      chosenId: 'beta',
+      unranked: false,
+      ignoredByVisualizer: {},
+    });
+    const { result } = renderHook(() => useActiveVisualizerId());
+    expect(result.current).toBe('beta');
+  });
+
+  it('reverts to the stored id when auto-select is switched off', () => {
+    useVisualizerAutoSelectStore.getState().recordChoice({
+      trackId: 'T1',
+      chosenId: 'beta',
+      unranked: false,
+      ignoredByVisualizer: {},
+    });
+    useVisualizerStore.setState({ autoSelect: false });
+    const { result } = renderHook(() => useActiveVisualizerId());
+    expect(result.current).toBe('alpha');
+  });
+
+  it('asks for no ranking of its own', () => {
+    useVisualizerStore.setState({ autoSelect: true });
+    renderHook(() => useActiveVisualizerId());
+    expect(rank).not.toHaveBeenCalled();
   });
 });

--- a/packages/frontend/src/hooks/__tests__/useAutoSelectedVisualizer.test.ts
+++ b/packages/frontend/src/hooks/__tests__/useAutoSelectedVisualizer.test.ts
@@ -1,0 +1,215 @@
+/* @vitest-environment jsdom */
+/**
+ * ADR-0064 points 7 and 8: when auto-select changes the visualizer, and — mostly — when it does not.
+ *
+ * Nearly every case here is a *don't switch* case, which is the point. Picking arbitrarily is worse
+ * than not picking, so the failure modes worth testing are the ones where something changed that
+ * should not have.
+ */
+import { act, cleanup, renderHook, waitFor } from '@testing-library/react';
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
+import { useAutoSelectedVisualizer, SWITCH_MARGIN } from '../useAutoSelectedVisualizer';
+import { tracksApi } from '../../api';
+import { useVisualizerStore } from '../../stores/visualizerStore';
+import { useVisualizerAutoSelectStore } from '../../stores/visualizerAutoSelectStore';
+import { registerVisualizer, visualizerRegistry } from '../../components/Visualizer/types';
+import type { VisualizerRankingResponse } from '../../api/tracks';
+
+vi.mock('../../api', () => ({ tracksApi: { rankVisualizers: vi.fn() } }));
+
+const rank = tracksApi.rankVisualizers as ReturnType<typeof vi.fn>;
+
+function ranking(...pairs: [string, number][]): VisualizerRankingResponse {
+  return {
+    ranked: true,
+    visualizers: pairs.map(([id, score]) => ({
+      id,
+      score,
+      matched_tags: [],
+      matched_ranges: [],
+      unmatched_ranges: [],
+      ignored: [],
+    })),
+  };
+}
+
+beforeEach(() => {
+  rank.mockReset();
+  visualizerRegistry.clear();
+  for (const id of ['alpha', 'beta']) {
+    registerVisualizer({ id, name: id, description: '', usesMetadata: false }, () => null);
+  }
+  useVisualizerStore.setState({ autoSelect: true });
+  useVisualizerAutoSelectStore.getState().reset();
+});
+
+afterEach(() => {
+  // **Explicit, because this package has no RTL auto-cleanup** — `AudioVisualizer.test.tsx` calls
+  // it by hand for the same reason. Without it a hook from a finished test stays mounted, and the
+  // next `beforeEach` flipping `autoSelect` back on re-fires *its* effect, which consumes the next
+  // test's mocked response and makes the failure look like a bug in the hook.
+  cleanup();
+  useVisualizerStore.setState({ autoSelect: false });
+  vi.clearAllMocks();
+});
+
+describe('useAutoSelectedVisualizer', () => {
+  it('returns null and asks nothing while switched off', async () => {
+    useVisualizerStore.setState({ autoSelect: false });
+    const { result } = renderHook(({ id }) => useAutoSelectedVisualizer(id), {
+      initialProps: { id: 'T1' },
+    });
+    expect(result.current).toBeNull();
+    expect(rank).not.toHaveBeenCalled();
+  });
+
+  it('chooses the best-scoring visualizer for a track', async () => {
+    rank.mockResolvedValueOnce(ranking(['beta', 0.9], ['alpha', 0.2]));
+    const { result } = renderHook(({ id }) => useAutoSelectedVisualizer(id), {
+      initialProps: { id: 'T1' },
+    });
+    await waitFor(() => expect(result.current).toBe('beta'));
+  });
+
+  it('sends the registered visualizers as candidates', async () => {
+    rank.mockResolvedValueOnce(ranking(['alpha', 0.5]));
+    renderHook(({ id }) => useAutoSelectedVisualizer(id), { initialProps: { id: 'T1' } });
+    await waitFor(() => expect(rank).toHaveBeenCalled());
+    const [trackId, candidates] = rank.mock.calls[0];
+    expect(trackId).toBe('T1');
+    expect(candidates.map((c: { id: string }) => c.id).sort()).toEqual(['alpha', 'beta']);
+  });
+
+  it('holds the choice for the length of a track', async () => {
+    rank.mockResolvedValueOnce(ranking(['alpha', 0.9]));
+    const { result, rerender } = renderHook(({ id }) => useAutoSelectedVisualizer(id), {
+      initialProps: { id: 'T1' },
+    });
+    await waitFor(() => expect(result.current).toBe('alpha'));
+
+    // A re-render that is not a track change must not re-ask — the choice is made at the boundary.
+    rerender({ id: 'T1' });
+    expect(rank).toHaveBeenCalledTimes(1);
+  });
+});
+
+describe('hysteresis', () => {
+  it('keeps the current visualizer when a rival wins by less than the margin', async () => {
+    rank.mockResolvedValueOnce(ranking(['alpha', 0.6]));
+    const { result, rerender } = renderHook(({ id }) => useAutoSelectedVisualizer(id), {
+      initialProps: { id: 'T1' },
+    });
+    await waitFor(() => expect(result.current).toBe('alpha'));
+
+    // beta edges ahead, but not by enough. Two near-ties alternating track by track across an
+    // album that suits both reads as a bug rather than a choice.
+    rank.mockResolvedValueOnce(ranking(['beta', 0.6 + SWITCH_MARGIN / 2], ['alpha', 0.6]));
+    rerender({ id: 'T2' });
+    await waitFor(() => expect(rank).toHaveBeenCalledTimes(2));
+    expect(result.current).toBe('alpha');
+  });
+
+  it('switches when a rival clears the margin', async () => {
+    rank.mockResolvedValueOnce(ranking(['alpha', 0.5]));
+    const { result, rerender } = renderHook(({ id }) => useAutoSelectedVisualizer(id), {
+      initialProps: { id: 'T1' },
+    });
+    await waitFor(() => expect(result.current).toBe('alpha'));
+
+    rank.mockResolvedValueOnce(ranking(['beta', 0.5 + SWITCH_MARGIN * 2], ['alpha', 0.5]));
+    rerender({ id: 'T2' });
+    await waitFor(() => expect(result.current).toBe('beta'));
+  });
+
+  it('takes the best when the incumbent is no longer offered', async () => {
+    rank.mockResolvedValueOnce(ranking(['alpha', 0.9]));
+    const { result, rerender } = renderHook(({ id }) => useAutoSelectedVisualizer(id), {
+      initialProps: { id: 'T1' },
+    });
+    await waitFor(() => expect(result.current).toBe('alpha'));
+
+    // A plugin removed between tracks: holding a visualizer that is gone would show nothing.
+    rank.mockResolvedValueOnce(ranking(['beta', 0.3]));
+    rerender({ id: 'T2' });
+    await waitFor(() => expect(result.current).toBe('beta'));
+  });
+});
+
+describe('keeping what is showing', () => {
+  it('does not change anything for an unanalysed track', async () => {
+    rank.mockResolvedValueOnce(ranking(['alpha', 0.9]));
+    const { result, rerender } = renderHook(({ id }) => useAutoSelectedVisualizer(id), {
+      initialProps: { id: 'T1' },
+    });
+    await waitFor(() => expect(result.current).toBe('alpha'));
+
+    rank.mockResolvedValueOnce({ ranked: false, visualizers: [] });
+    rerender({ id: 'T2' });
+    await waitFor(() => expect(useVisualizerAutoSelectStore.getState().unranked).toBe(true));
+    expect(result.current).toBe('alpha');
+  });
+
+  it('does not change anything when the request fails', async () => {
+    rank.mockResolvedValueOnce(ranking(['alpha', 0.9]));
+    const { result, rerender } = renderHook(({ id }) => useAutoSelectedVisualizer(id), {
+      initialProps: { id: 'T1' },
+    });
+    await waitFor(() => expect(result.current).toBe('alpha'));
+
+    rank.mockRejectedValueOnce(new Error('offline'));
+    rerender({ id: 'T2' });
+    await waitFor(() => expect(rank).toHaveBeenCalledTimes(2));
+    expect(result.current).toBe('alpha');
+  });
+
+  it('picks nothing at all before the first ranking arrives', () => {
+    rank.mockReturnValueOnce(new Promise(() => {}));
+    const { result } = renderHook(({ id }) => useAutoSelectedVisualizer(id), {
+      initialProps: { id: 'T1' },
+    });
+    // Null means "no opinion", and the caller keeps the listener's manual choice.
+    expect(result.current).toBeNull();
+  });
+
+  it('ignores a late response from a previous track', async () => {
+    let resolveFirst!: (r: VisualizerRankingResponse) => void;
+    rank.mockReturnValueOnce(new Promise((r) => { resolveFirst = r; }));
+    rank.mockResolvedValueOnce(ranking(['beta', 0.9]));
+
+    const { result, rerender } = renderHook(({ id }) => useAutoSelectedVisualizer(id), {
+      initialProps: { id: 'T1' },
+    });
+    rerender({ id: 'T2' });
+    await waitFor(() => expect(result.current).toBe('beta'));
+
+    await act(async () => { resolveFirst(ranking(['alpha', 1.0])); });
+    // T1's answer, however emphatic, must not land on T2.
+    expect(result.current).toBe('beta');
+  });
+});
+
+describe('what the picker is told', () => {
+  it('records the server-reported ignored declarations', async () => {
+    rank.mockResolvedValueOnce({
+      ranked: true,
+      visualizers: [
+        {
+          id: 'alpha',
+          score: 0.9,
+          matched_tags: [],
+          matched_ranges: [],
+          unmatched_ranges: [],
+          ignored: ['not-a-tag'],
+        },
+      ],
+    });
+
+    renderHook(({ id }) => useAutoSelectedVisualizer(id), { initialProps: { id: 'T1' } });
+
+    await waitFor(() =>
+      expect(useVisualizerAutoSelectStore.getState().ignoredByVisualizer).toEqual({
+        alpha: ['not-a-tag'],
+      })
+    );
+  });
+});

--- a/packages/frontend/src/hooks/__tests__/useTrackDetail.test.ts
+++ b/packages/frontend/src/hooks/__tests__/useTrackDetail.test.ts
@@ -1,0 +1,97 @@
+/* @vitest-environment jsdom */
+import { act, renderHook, waitFor } from '@testing-library/react';
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
+import { useTrackDetail } from '../useTrackDetail';
+import { tracksApi } from '../../api';
+import type { Track, TrackFeatures } from '../../types';
+
+vi.mock('../../api', () => ({ tracksApi: { get: vi.fn() } }));
+
+const get = tracksApi.get as ReturnType<typeof vi.fn>;
+
+function track(id: string, features?: Partial<TrackFeatures>): Track {
+  return {
+    id,
+    title: id,
+    features: features as TrackFeatures | undefined,
+  } as Track;
+}
+
+function deferred<T>() {
+  let resolve!: (v: T) => void;
+  let reject!: (e: unknown) => void;
+  const promise = new Promise<T>((res, rej) => { resolve = res; reject = rej; });
+  return { promise, resolve, reject };
+}
+
+beforeEach(() => get.mockReset());
+afterEach(() => vi.clearAllMocks());
+
+describe('useTrackDetail', () => {
+  it('loads the track detail, carrying features', async () => {
+    get.mockResolvedValueOnce(track('A', { energy: 0.8, valence: 0.3 }));
+    const { result } = renderHook(({ id }) => useTrackDetail(id), { initialProps: { id: 'A' } });
+    await waitFor(() => expect(result.current?.features?.energy).toBe(0.8));
+  });
+
+  it('does not fetch without a track id', () => {
+    const { result } = renderHook(({ id }) => useTrackDetail(id), {
+      initialProps: { id: null as string | null },
+    });
+    expect(get).not.toHaveBeenCalled();
+    expect(result.current).toBeNull();
+  });
+
+  // An unanalysed track resolves fine, just without features. That is not an error, and the
+  // visualizer falls back to its own defaults (ADR-0064: no analysis must not mean no track).
+  it('accepts a track with no features', async () => {
+    get.mockResolvedValueOnce(track('A'));
+    const { result } = renderHook(({ id }) => useTrackDetail(id), { initialProps: { id: 'A' } });
+    await waitFor(() => expect(result.current?.id).toBe('A'));
+    expect(result.current?.features).toBeUndefined();
+  });
+
+  it('yields null when the fetch fails, rather than throwing', async () => {
+    get.mockRejectedValueOnce(new Error('offline'));
+    const { result } = renderHook(({ id }) => useTrackDetail(id), { initialProps: { id: 'A' } });
+    await waitFor(() => expect(get).toHaveBeenCalled());
+    expect(result.current).toBeNull();
+  });
+
+  it('clears the previous track detail immediately on skip', async () => {
+    get.mockResolvedValueOnce(track('A', { energy: 0.1 }));
+    const slow = deferred<Track>();
+    get.mockReturnValueOnce(slow.promise);
+
+    const { result, rerender } = renderHook(({ id }) => useTrackDetail(id), {
+      initialProps: { id: 'A' },
+    });
+    await waitFor(() => expect(result.current?.id).toBe('A'));
+
+    rerender({ id: 'B' }); // skip before B resolves
+    // A's analysis must not be read against B — that would drive the visualizer from the wrong song.
+    expect(result.current).toBeNull();
+
+    await act(async () => { slow.resolve(track('B', { energy: 0.9 })); });
+    await waitFor(() => expect(result.current?.features?.energy).toBe(0.9));
+  });
+
+  it('ignores a stale out-of-order response from a previous track', async () => {
+    const a = deferred<Track>();
+    const b = deferred<Track>();
+    get.mockReturnValueOnce(a.promise).mockReturnValueOnce(b.promise);
+
+    const { result, rerender } = renderHook(({ id }) => useTrackDetail(id), {
+      initialProps: { id: 'A' },
+    });
+    rerender({ id: 'B' });
+
+    await act(async () => { b.resolve(track('B', { energy: 0.9 })); });
+    await waitFor(() => expect(result.current?.id).toBe('B'));
+
+    await act(async () => { a.resolve(track('A', { energy: 0.1 })); });
+    // The late A response must not replace B's detail.
+    expect(result.current?.id).toBe('B');
+    expect(result.current?.features?.energy).toBe(0.9);
+  });
+});

--- a/packages/frontend/src/hooks/useAutoSelectedVisualizer.ts
+++ b/packages/frontend/src/hooks/useAutoSelectedVisualizer.ts
@@ -1,0 +1,96 @@
+/**
+ * Choose a visualizer to suit the playing track (ADR-0064 points 5, 7 and 8).
+ *
+ * Returns the id auto-select settled on, or `null` when it has no opinion — the caller keeps the
+ * listener's manual choice in that case, which is every case where this is switched off.
+ *
+ * **The choice is made when a track starts and holds for that track.** The request is keyed on the
+ * track id, so nothing can switch mid-song: a three.js scene tearing down halfway through is more
+ * disruptive than an imperfect match is dull. `section_count` and `form_string` would make
+ * within-track switching tempting and it is deliberately not done.
+ *
+ * **Hysteresis, so a run of similar tracks does not flicker.** Once something is chosen it stays
+ * unless another candidate beats it by `SWITCH_MARGIN`. Without that, two visualizers scoring 0.61
+ * and 0.60 would alternate track by track on an album that suits both, which reads as a bug rather
+ * than a choice.
+ *
+ * **Every failure keeps what is showing.** An unanalysed track, an offline server, an empty
+ * ranking: all leave the current visualizer alone. Picking arbitrarily would be worse than not
+ * picking, and on a library mid-sync unanalysed tracks are a meaningful fraction.
+ */
+import { useEffect, useRef, useState } from 'react';
+import { tracksApi } from '../api';
+import { getVisualizers } from '../components/Visualizer/types';
+import { useVisualizerStore } from '../stores/visualizerStore';
+import { useVisualizerAutoSelectStore } from '../stores/visualizerAutoSelectStore';
+
+/** How much better a rival must be before the visualizer changes. */
+export const SWITCH_MARGIN = 0.1;
+
+export function useAutoSelectedVisualizer(trackId: string | null | undefined): string | null {
+  const autoSelect = useVisualizerStore((s) => s.autoSelect);
+
+  const [chosenId, setChosenId] = useState<string | null>(null);
+  // Read inside the effect without making it a dependency — depending on the chosen id would
+  // re-run the request each time it changed and could settle into a loop.
+  const chosenRef = useRef<string | null>(null);
+
+  useEffect(() => {
+    if (!autoSelect || !trackId) return;
+
+    let ignore = false;
+    // Read the action off the store rather than subscribing to it. A store action in the
+    // dependency array is one identity change away from re-requesting on every render — and
+    // this effect's whole contract is that it fires once per track.
+    const { recordChoice } = useVisualizerAutoSelectStore.getState();
+
+    const candidates = getVisualizers().map(({ metadata }) => ({
+      id: metadata.id,
+      affinity: metadata.affinity,
+    }));
+    if (candidates.length === 0) return;
+
+    tracksApi
+      .rankVisualizers(trackId, candidates)
+      .then((response) => {
+        if (ignore) return;
+
+        const ignoredByVisualizer: Record<string, string[]> = {};
+        for (const entry of response.visualizers) {
+          if (entry.ignored.length > 0) ignoredByVisualizer[entry.id] = entry.ignored;
+        }
+
+        if (!response.ranked || response.visualizers.length === 0) {
+          // Nothing to rank against. Report it — the picker says so rather than leaving
+          // auto-select looking inert — but do not disturb the visualizer in force.
+          recordChoice({ trackId, chosenId: null, unranked: true, ignoredByVisualizer });
+          return;
+        }
+
+        const best = response.visualizers[0];
+        const current = chosenRef.current;
+        const currentScore = current
+          ? response.visualizers.find((v) => v.id === current)?.score
+          : undefined;
+
+        // Nothing chosen yet, or the incumbent is no longer offered (a plugin removed between
+        // tracks): take the best. Otherwise it has to clear the margin.
+        const shouldSwitch =
+          current === null || currentScore === undefined || best.score > currentScore + SWITCH_MARGIN;
+
+        const settled = shouldSwitch ? best.id : current;
+        chosenRef.current = settled;
+        setChosenId(settled);
+        recordChoice({ trackId, chosenId: settled, unranked: false, ignoredByVisualizer });
+      })
+      .catch(() => {
+        // Offline, or the server does not know this track. Keep what is showing.
+      });
+
+    return () => {
+      ignore = true;
+    };
+  }, [trackId, autoSelect]);
+
+  return autoSelect ? chosenId : null;
+}

--- a/packages/frontend/src/hooks/useAutoSelectedVisualizer.ts
+++ b/packages/frontend/src/hooks/useAutoSelectedVisualizer.ts
@@ -27,6 +27,25 @@ import { useVisualizerAutoSelectStore } from '../stores/visualizerAutoSelectStor
 /** How much better a rival must be before the visualizer changes. */
 export const SWITCH_MARGIN = 0.1;
 
+/**
+ * The visualizer actually drawing — auto-select's choice when it has one, the listener's otherwise.
+ *
+ * **One definition, because there is more than one consumer.** Auto-select introduces a second
+ * possible answer to "which visualizer is on", and anything still reading `visualizerId` directly
+ * gets the wrong one: `FullPlayer` gates its whole layout on whether Music Video is playing, and
+ * would have laid album art over a video the moment auto-select chose it. Re-deriving this at each
+ * call site is how those two answers come apart.
+ *
+ * Reads state only — it never triggers a ranking. `useAutoSelectedVisualizer` is what asks, and it
+ * is called once, by `AudioVisualizer`.
+ */
+export function useActiveVisualizerId(): string {
+  const visualizerId = useVisualizerStore((s) => s.visualizerId);
+  const autoSelect = useVisualizerStore((s) => s.autoSelect);
+  const chosenId = useVisualizerAutoSelectStore((s) => s.chosenId);
+  return (autoSelect && chosenId) || visualizerId;
+}
+
 export function useAutoSelectedVisualizer(trackId: string | null | undefined): string | null {
   const autoSelect = useVisualizerStore((s) => s.autoSelect);
 

--- a/packages/frontend/src/hooks/useTrackDetail.ts
+++ b/packages/frontend/src/hooks/useTrackDetail.ts
@@ -1,0 +1,51 @@
+/**
+ * Fetch a track's full detail — the shape that carries `features`.
+ *
+ * `VisualizerProps.features` is part of the documented visualizer contract (ADR-0034 point 6) and
+ * until now nothing supplied it: `AudioVisualizer` defaults it to null and both call sites omitted
+ * it, so `ReactiveTerrain` — the only visualizer that reads it — always took its fallbacks. This
+ * hook is what makes that half of the API real (ADR-0064 point 9).
+ *
+ * **Why a fetch rather than the track already in hand.** `playerStore.currentTrack` comes from
+ * `tracksApi.list`, which only populates `features` when the caller passes `include_features` —
+ * and the only caller that does is the track-list browser, for its feature columns. So
+ * `currentTrack.features` is usually undefined, and passing it would appear to work on exactly one
+ * screen. `GET /tracks/{id}` always populates all fifteen fields when the track has been analysed.
+ *
+ * Race-safe across track changes, in the same shape as `useSyncedLyrics`: the previous track's
+ * detail is cleared immediately so it cannot be read against a new track, and an in-flight response
+ * from a prior track is ignored rather than applied late.
+ *
+ * A track that has never been analysed resolves with `features` absent, which is not an error —
+ * callers get `null` features and visualizers use their own defaults.
+ */
+import { useEffect, useState } from 'react';
+import { tracksApi } from '../api';
+import type { Track } from '../types';
+
+export function useTrackDetail(trackId: string | null | undefined): Track | null {
+  const [track, setTrack] = useState<Track | null>(null);
+
+  useEffect(() => {
+    // Clear first so a previous track's analysis is never read against a new track.
+    setTrack(null);
+    if (!trackId) return;
+
+    let ignore = false;
+    tracksApi
+      .get(trackId)
+      .then((detail) => {
+        if (!ignore) setTrack(detail);
+      })
+      .catch(() => {
+        // Offline, or a track the server does not know. The visualizer falls back to what it has.
+        if (!ignore) setTrack(null);
+      });
+
+    return () => {
+      ignore = true;
+    };
+  }, [trackId]);
+
+  return track;
+}

--- a/packages/frontend/src/services/__tests__/visualizerPluginHost.test.ts
+++ b/packages/frontend/src/services/__tests__/visualizerPluginHost.test.ts
@@ -196,3 +196,75 @@ describe('markFailed', () => {
     });
   });
 });
+
+/**
+ * ADR-0064: affinity has to survive the trip from a plugin's manifest to the catalog the native
+ * host reads. Nothing tested `publishCatalog` at all before this.
+ */
+describe('publishCatalog', () => {
+  beforeEach(() => {
+    visualizerRegistry.clear();
+    useVisualizerPluginStore.setState({ records: [], scanned: false });
+    delete window.Familiar;
+    delete (window as unknown as Record<string, unknown>).__familiarVisualizers;
+  });
+
+  afterEach(() => {
+    vi.unstubAllGlobals();
+  });
+
+  function catalog() {
+    const read = (window as unknown as Record<string, () => string>).__familiarVisualizers;
+    expect(read).toBeInstanceOf(Function);
+    return JSON.parse(read());
+  }
+
+  const AFFINITY = { tags: ['ambient'], ranges: [{ feature: 'energy', maximum: 0.4 }] };
+
+  it('carries a plugin affinity declared in its manifest', async () => {
+    vi.stubGlobal(
+      'fetch',
+      server([{ source: 'local', manifest: manifest({ affinity: AFFINITY }) }], {
+        demo: bundleFor('demo'),
+      })
+    );
+
+    await loadVisualizerPlugins([]);
+
+    const entry = catalog().visualizers.find((v: { id: string }) => v.id === 'demo');
+    // **The asymmetry this covers:** the bundle calls `registerVisualizer` with its own metadata
+    // and cannot see its manifest, so without an explicit merge the affinity would be parsed,
+    // stored, and never reach the catalog — every plugin ranking neutral for ever.
+    expect(entry.affinity).toEqual(AFFINITY);
+  });
+
+  it('leaves affinity absent for a plugin that declares none', async () => {
+    vi.stubGlobal(
+      'fetch',
+      server([{ source: 'local', manifest: manifest() }], { demo: bundleFor('demo') })
+    );
+
+    await loadVisualizerPlugins([]);
+
+    const entry = catalog().visualizers.find((v: { id: string }) => v.id === 'demo');
+    expect(entry.affinity).toBeUndefined();
+    expect(entry.source).toBe('local');
+  });
+
+  it('records an unusable affinity block as ignored, and still loads the plugin', async () => {
+    vi.stubGlobal(
+      'fetch',
+      server([{ source: 'local', manifest: manifest({ affinity: { tags: [7] } }) }], {
+        demo: bundleFor('demo'),
+      })
+    );
+
+    await loadVisualizerPlugins([]);
+
+    const record = useVisualizerPluginStore
+      .getState()
+      .records.find((r) => r.id === 'demo');
+    expect(record?.status).toBe('loaded');
+    expect(record?.ignored?.length).toBeGreaterThan(0);
+  });
+});

--- a/packages/frontend/src/services/__tests__/visualizerPlugins.test.ts
+++ b/packages/frontend/src/services/__tests__/visualizerPlugins.test.ts
@@ -54,6 +54,9 @@ describe('parseManifest', () => {
         familiar: { apiVersion: 1 },
         icon: 'Building2',
       }),
+      // A real sample manifest predates `affinity` and declares none — which is not a problem,
+      // so nothing is ignored (ADR-0064 point 2: the block is optional and its absence is silent).
+      ignored: [],
     });
   });
 
@@ -140,5 +143,89 @@ describe('reviewPlugins', () => {
     const [verdict] = reviewPlugins([local({ name: 'Broken' })]);
     expect(verdict).toMatchObject({ ok: false, refusal: 'malformed', id: null });
     expect((verdict as { detail: string }).detail).toBeTruthy();
+  });
+});
+
+/**
+ * ADR-0064: the optional `affinity` block.
+ *
+ * The vocabulary check is deliberately **not** here. Whether `"dreamy"` is a tag the server knows
+ * is decided where the analysis lives; duplicating the 48 descriptors into TypeScript is the
+ * "two copies of that rule in two languages" ADR-0034 warns about. These cover structure only.
+ */
+describe('parseAffinity', () => {
+  function affinityOf(block: unknown) {
+    const result = parseManifest({ ...nonPlaces, affinity: block });
+    if ('error' in result) throw new Error(`unexpected refusal: ${result.error}`);
+    return result;
+  }
+
+  it('reads tags and ranges', () => {
+    const { manifest, ignored } = affinityOf({
+      tags: ['ambient', 'dreamy'],
+      ranges: [{ feature: 'energy', minimum: 0.1, maximum: 0.4 }],
+    });
+    expect(manifest.affinity).toEqual({
+      tags: ['ambient', 'dreamy'],
+      ranges: [{ feature: 'energy', minimum: 0.1, maximum: 0.4 }],
+    });
+    expect(ignored).toEqual([]);
+  });
+
+  it('keeps an open-ended range', () => {
+    const { manifest } = affinityOf({ ranges: [{ feature: 'bpm', minimum: 120 }] });
+    expect(manifest.affinity?.ranges).toEqual([{ feature: 'bpm', minimum: 120 }]);
+  });
+
+  // The reason this had to be parsed rather than copied: `parseManifest` rebuilds the object field
+  // by field, so a block it does not name never reaches anyone.
+  it('survives parseManifest, which drops anything it does not name', () => {
+    const { manifest } = affinityOf({ tags: ['calm'] });
+    expect(manifest.affinity).toBeDefined();
+  });
+
+  it('is absent, and silent, when not declared', () => {
+    const result = parseManifest(nonPlaces);
+    if ('error' in result) throw new Error('unexpected refusal');
+    expect(result.manifest.affinity).toBeUndefined();
+    expect(result.ignored).toEqual([]);
+  });
+
+  it.each([
+    ['not an object', 'nope'],
+    ['an array', ['ambient']],
+    ['a number', 7],
+  ])('reports a block that is %s', (_label, block) => {
+    const { manifest, ignored } = affinityOf(block);
+    expect(manifest.affinity).toBeUndefined();
+    expect(ignored.length).toBeGreaterThan(0);
+  });
+
+  it('drops a non-string tag and says so', () => {
+    const { manifest, ignored } = affinityOf({ tags: ['ambient', 42] });
+    expect(manifest.affinity?.tags).toEqual(['ambient']);
+    expect(ignored.join(' ')).toContain('42');
+  });
+
+  it('drops a range with no feature', () => {
+    const { manifest, ignored } = affinityOf({ ranges: [{ minimum: 1 }] });
+    expect(manifest.affinity).toBeUndefined();
+    expect(ignored.join(' ')).toContain('feature');
+  });
+
+  it('drops a range bounded by nothing numeric', () => {
+    const { manifest, ignored } = affinityOf({
+      ranges: [{ feature: 'energy', minimum: 'loud' }],
+    });
+    expect(manifest.affinity).toBeUndefined();
+    expect(ignored.join(' ')).toContain('energy');
+  });
+
+  // The point of ADR-0064 point 3, at the parse layer: a bad optional field must never cost the
+  // author a working visualizer.
+  it('never refuses the plugin over an unusable affinity block', () => {
+    const [verdict] = reviewPlugins([local({ ...nonPlaces, affinity: 'rubbish' })]);
+    expect(verdict.ok).toBe(true);
+    expect((verdict as { ignored: string[] }).ignored.length).toBeGreaterThan(0);
   });
 });

--- a/packages/frontend/src/services/visualizerPluginHost.ts
+++ b/packages/frontend/src/services/visualizerPluginHost.ts
@@ -26,7 +26,12 @@ import * as ReactThreeFiber from '@react-three/fiber';
 import * as Drei from '@react-three/drei';
 
 import { createLogger } from '../utils/logger';
-import { registerVisualizer, getVisualizer, getVisualizers } from '../components/Visualizer/types';
+import {
+  registerVisualizer,
+  getVisualizer,
+  getVisualizers,
+  visualizerRegistry,
+} from '../components/Visualizer/types';
 import { useAudioAnalyser, getAudioData } from '../hooks/useAudioAnalyser';
 import { useArtworkPalette } from '../components/Visualizer/hooks/useArtworkPalette';
 import { useBeatSync, getBeatPhase, getBeatSine } from '../components/Visualizer/hooks/useBeatSync';
@@ -205,13 +210,26 @@ async function evaluate(
   // cleanly, the picker shows no new entry, and there is no error anywhere to explain it — which is
   // the exact failure shape this codebase keeps producing. The usual cause is a manifest whose `id`
   // does not match the id the bundle passes to `registerVisualizer`.
-  if (!getVisualizer(manifest.id)) {
+  const registered = getVisualizer(manifest.id);
+  if (!registered) {
     return {
       ...base,
       status: 'refused',
       refusal: 'registered-nothing',
       detail: `The bundle loaded but registered no visualizer with the id "${manifest.id}".`,
     };
+  }
+
+  // **The manifest declares affinity; the bundle registers metadata; neither knows the other**
+  // (ADR-0064 point 1). A plugin's `registerVisualizer` call is written against the same API a
+  // built-in uses and has no access to its own manifest, so the two halves are joined here — after
+  // the bundle has run, which is the first moment both exist. Without this the catalog would carry
+  // affinity for the built-ins only, and every plugin would rank neutral for ever.
+  if (manifest.affinity) {
+    visualizerRegistry.set(manifest.id, {
+      ...registered,
+      metadata: { ...registered.metadata, affinity: manifest.affinity },
+    });
   }
 
   return { ...base, status: 'loaded' };
@@ -242,7 +260,10 @@ export async function loadVisualizerPlugins(builtInIds: Iterable<string>): Promi
   // other order and the picker would describe the one that lost.
   for (const verdict of verdicts) {
     if (verdict.ok) {
-      records.push(await evaluate(verdict.manifest, verdict.source));
+      const record = await evaluate(verdict.manifest, verdict.source);
+      // Carried whatever the outcome: a plugin refused for an unrelated reason still had its
+      // affinity read, and an author fixing one problem should see the other already listed.
+      records.push(verdict.ignored.length > 0 ? { ...record, ignored: verdict.ignored } : record);
     } else {
       records.push({
         id: verdict.id,
@@ -300,6 +321,10 @@ export function publishCatalog(): void {
       // Absent for the compile-time visualizers, which is how the host tells them apart without
       // being given the list twice.
       source: bySource.get(metadata.id)?.source,
+      // What each visualizer suits (ADR-0064). The native host cannot ask the server to rank
+      // without this: the server has no way to know what is installed on a device, so the
+      // candidates and their declarations travel from here.
+      affinity: metadata.affinity,
     })),
     problems: records
       .filter((r) => r.status !== 'loaded')

--- a/packages/frontend/src/services/visualizerPlugins.ts
+++ b/packages/frontend/src/services/visualizerPlugins.ts
@@ -44,6 +44,26 @@ export interface VisualizerPluginManifest {
   icon?: string;
   author?: { name?: string; url?: string };
   familiar?: { apiVersion?: number };
+  /**
+   * What this visualizer suits (ADR-0064). **Optional, and its absence is not a refusal** — which
+   * is why adding it did not bump `VISUALIZER_API_VERSION`: a bump refuses every manifest declaring
+   * the old version, so raising it for an additive field would have refused both working samples to
+   * add a feature neither uses.
+   */
+  affinity?: VisualizerAffinity;
+}
+
+/** One bound a visualizer declares over a numeric analysis column. Either end may be open. */
+export interface VisualizerFeatureRange {
+  feature: string;
+  minimum?: number;
+  maximum?: number;
+}
+
+/** What a visualizer says it suits — matched against a track's analysis by the server. */
+export interface VisualizerAffinity {
+  tags: string[];
+  ranges: VisualizerFeatureRange[];
 }
 
 /** One entry as the native host lists it, before anything has been checked. */
@@ -76,7 +96,18 @@ export type PluginRefusal =
   | 'registered-nothing';
 
 export type PluginVerdict =
-  | { ok: true; source: VisualizerPluginSource; manifest: VisualizerPluginManifest }
+  | {
+      ok: true;
+      source: VisualizerPluginSource;
+      manifest: VisualizerPluginManifest;
+      /**
+       * Declarations dropped while parsing, for a plugin that loaded anyway (ADR-0064 point 3).
+       * Not a refusal and deliberately not one: an unusable optional field is not a reason to
+       * withhold a working visualizer. It rides on the *ok* verdict because that is the case it
+       * describes — a refused plugin has a `detail` instead.
+       */
+      ignored: string[];
+    }
   | {
       ok: false;
       source: VisualizerPluginSource;
@@ -95,11 +126,78 @@ function nonEmptyString(value: unknown): string | null {
   return typeof value === 'string' && value.trim() !== '' ? value : null;
 }
 
+function finiteNumber(value: unknown): number | null {
+  return typeof value === 'number' && Number.isFinite(value) ? value : null;
+}
+
+/**
+ * Parse the optional `affinity` block (ADR-0064 point 1).
+ *
+ * **Structure only.** Whether `"dreamy"` is a tag this server knows, or `energy` a column it can
+ * range over, is decided where the analysis lives — the server, which reports back what it ignored.
+ * Checking it here as well would put the 48-descriptor vocabulary in TypeScript and in Python, and
+ * ADR-0034 already names the consequence: "two copies of that rule in two languages is how the
+ * picker comes to disagree with what actually loaded."
+ *
+ * So this drops only what cannot be sent at all, and says which, because an author whose typo
+ * vanished silently has no way to find it.
+ */
+export function parseAffinity(raw: unknown): { affinity?: VisualizerAffinity; ignored: string[] } {
+  if (raw === undefined) return { ignored: [] };
+  if (!isRecord(raw)) return { ignored: ['affinity (not an object)'] };
+
+  const ignored: string[] = [];
+  const tags: string[] = [];
+  const ranges: VisualizerFeatureRange[] = [];
+
+  const rawTags = Array.isArray(raw.tags) ? raw.tags : [];
+  if (raw.tags !== undefined && !Array.isArray(raw.tags)) ignored.push('affinity.tags (not an array)');
+  for (const tag of rawTags) {
+    const value = nonEmptyString(tag);
+    if (value) tags.push(value);
+    else ignored.push(`affinity.tags entry ${JSON.stringify(tag)}`);
+  }
+
+  const rawRanges = Array.isArray(raw.ranges) ? raw.ranges : [];
+  if (raw.ranges !== undefined && !Array.isArray(raw.ranges)) {
+    ignored.push('affinity.ranges (not an array)');
+  }
+  for (const entry of rawRanges) {
+    if (!isRecord(entry)) {
+      ignored.push(`affinity.ranges entry ${JSON.stringify(entry)}`);
+      continue;
+    }
+    const feature = nonEmptyString(entry.feature);
+    if (!feature) {
+      ignored.push('affinity.ranges entry with no "feature"');
+      continue;
+    }
+    const minimum = finiteNumber(entry.minimum);
+    const maximum = finiteNumber(entry.maximum);
+    if (minimum === null && maximum === null) {
+      // Bounds neither of which is a number constrains nothing; sending it would only produce a
+      // server-side "ignored" a step further from the author.
+      ignored.push(`affinity.ranges "${feature}" (no numeric minimum or maximum)`);
+      continue;
+    }
+    ranges.push({
+      feature,
+      ...(minimum === null ? {} : { minimum }),
+      ...(maximum === null ? {} : { maximum }),
+    });
+  }
+
+  if (tags.length === 0 && ranges.length === 0) return { ignored };
+  return { affinity: { tags, ranges }, ignored };
+}
+
 /**
  * Parse and validate one manifest. Returns the reason as a string rather than throwing, because
  * every caller wants to show it rather than handle it.
  */
-export function parseManifest(raw: unknown): { manifest: VisualizerPluginManifest } | { error: string } {
+export function parseManifest(
+  raw: unknown
+): { manifest: VisualizerPluginManifest; ignored: string[] } | { error: string } {
   if (!isRecord(raw)) return { error: 'The manifest is not a JSON object.' };
 
   const id = nonEmptyString(raw.id);
@@ -131,6 +229,10 @@ export function parseManifest(raw: unknown): { manifest: VisualizerPluginManifes
     ? { name: nonEmptyString(raw.author.name) ?? undefined, url: nonEmptyString(raw.author.url) ?? undefined }
     : undefined;
 
+  // Parsed rather than copied: this function rebuilds the manifest field by field, so anything it
+  // does not name is dropped. An `affinity` block that was never parsed here would reach nothing.
+  const { affinity, ignored } = parseAffinity(raw.affinity);
+
   return {
     manifest: {
       id,
@@ -142,7 +244,9 @@ export function parseManifest(raw: unknown): { manifest: VisualizerPluginManifes
       icon: nonEmptyString(raw.icon) ?? undefined,
       author,
       familiar: apiVersion === undefined ? undefined : { apiVersion },
+      affinity,
     },
+    ignored,
   };
 }
 
@@ -256,7 +360,7 @@ export function reviewPlugins(
     }
 
     claimed.add(manifest.id);
-    verdicts.push({ ok: true, source: entry.source, manifest });
+    verdicts.push({ ok: true, source: entry.source, manifest, ignored: parsed.ignored });
   }
 
   return verdicts;

--- a/packages/frontend/src/stores/visualizerAutoSelectStore.ts
+++ b/packages/frontend/src/stores/visualizerAutoSelectStore.ts
@@ -1,0 +1,59 @@
+/**
+ * What auto-select decided, for this run (ADR-0064 points 3 and 7).
+ *
+ * **Deliberately not persisted**, for the reason its sibling `visualizerPluginStore` gives: every
+ * fact here is about the track playing now and the plugins present now. A choice restored from last
+ * launch would be attributed to whatever happens to be playing this time, and the server-reported
+ * `ignored` list would still name a tag the author has since fixed.
+ *
+ * The persisted half — whether auto-select is on at all — is a listener preference and lives in
+ * `visualizerStore` under ADR-0029 point 4.
+ */
+import { create } from 'zustand';
+
+interface VisualizerAutoSelectState {
+  /** The visualizer auto-select settled on, or null when it has not chosen (yet, or at all). */
+  chosenId: string | null;
+  /** The track `chosenId` was chosen for, so a stale choice can be told from a current one. */
+  trackId: string | null;
+  /**
+   * True when the last ranking had nothing to rank against — an unanalysed track. Distinct from
+   * "not asked yet", because the picker says so rather than leaving auto-select looking broken.
+   */
+  unranked: boolean;
+  /**
+   * Declarations the *server* did not recognise, by visualizer id. The client checks structure and
+   * the server checks vocabulary (it owns the descriptor list), so an author's unknown tag can only
+   * be reported from here.
+   */
+  ignoredByVisualizer: Record<string, string[]>;
+
+  recordChoice: (args: {
+    trackId: string;
+    chosenId: string | null;
+    unranked: boolean;
+    ignoredByVisualizer: Record<string, string[]>;
+  }) => void;
+  reset: () => void;
+}
+
+export const useVisualizerAutoSelectStore = create<VisualizerAutoSelectState>()((set) => ({
+  chosenId: null,
+  trackId: null,
+  unranked: false,
+  ignoredByVisualizer: {},
+
+  recordChoice: ({ trackId, chosenId, unranked, ignoredByVisualizer }) =>
+    set((state) => ({
+      trackId,
+      // A ranking that produced no choice must not clear the one in force — that is what "keep the
+      // current visualizer" means when a track has no analysis.
+      chosenId: chosenId ?? state.chosenId,
+      unranked,
+      // Merged rather than replaced: only the candidates in this request are described, and
+      // forgetting the rest would make the picker's list flicker between tracks.
+      ignoredByVisualizer: { ...state.ignoredByVisualizer, ...ignoredByVisualizer },
+    })),
+
+  reset: () => set({ chosenId: null, trackId: null, unranked: false, ignoredByVisualizer: {} }),
+}));

--- a/packages/frontend/src/stores/visualizerPluginStore.ts
+++ b/packages/frontend/src/stores/visualizerPluginStore.ts
@@ -16,6 +16,14 @@ export interface VisualizerPluginRecord {
   /** Present for `refused` and `failed`. What a person reads in the picker. */
   detail?: string;
   refusal?: PluginRefusal;
+  /**
+   * Affinity declarations dropped while parsing the manifest (ADR-0064 point 3).
+   *
+   * **Belongs to a `loaded` plugin**, which is why it sits apart from `detail` and `refusal`: the
+   * plugin works and is in the picker, and this is only the part of its manifest that did not. An
+   * author whose typo vanished silently has no way to find it.
+   */
+  ignored?: string[];
 }
 
 interface VisualizerPluginState {

--- a/packages/frontend/src/stores/visualizerStore.ts
+++ b/packages/frontend/src/stores/visualizerStore.ts
@@ -10,10 +10,20 @@ interface VisualizerState {
   visualizerId: string;
   // Glow (bloom) level: 0 = off, 100 = full intensity
   glowLevel: number;
+  /**
+   * Let the server choose a visualizer to suit each track (ADR-0064 point 7).
+   *
+   * **Off by default, and beside the manual choice rather than replacing it.** Someone who picked a
+   * visualizer expressed a preference, and silently overriding it is not a feature. Only the toggle
+   * is persisted — which visualizer was chosen for which track is a fact about this run and lives in
+   * `visualizerAutoSelectStore`, unpersisted for the reason its sibling gives.
+   */
+  autoSelect: boolean;
 
   // Actions
   setVisualizerId: (id: string) => void;
   setGlowLevel: (level: number) => void;
+  setAutoSelect: (enabled: boolean) => void;
 }
 
 export const useVisualizerStore = create<VisualizerState>()(
@@ -21,11 +31,15 @@ export const useVisualizerStore = create<VisualizerState>()(
     (set) => ({
       visualizerId: DEFAULT_VISUALIZER_ID,
       glowLevel: 50,
+      autoSelect: false,
 
       setVisualizerId: (id: string) => set({ visualizerId: id }),
       setGlowLevel: (level: number) => set({ glowLevel: Math.max(0, Math.min(100, level)) }),
+      setAutoSelect: (enabled: boolean) => set({ autoSelect: enabled }),
     }),
     {
+      // No `version`/`migrate`: zustand shallow-merges over the initial state, so a blob persisted
+      // before `autoSelect` existed simply takes its default.
       name: VISUALIZER_STORAGE_KEY,
     }
   )


### PR DESCRIPTION
Three ADRs for an open visualizer platform, and the full implementation of one of them.

## The ADRs

| ADR | Status | |
|---|---|---|
| **0062** — The Site Adopts a Static Site Generator | `proposed` | Supersedes ADR-0039 points 1 and 6, which named rendered docs as the trigger to decide this again |
| **0063** — The Visualizer API Is Published for Outside Authors | `proposed` | Publishes the contract; a gallery that **links but hosts no bundles**, keeping clear of ADR-0034 point 5 and ADR-0038 point 7 |
| **0064** — Visualizers Declare Affinity, and the Server Ranks Them | `accepted` | Implemented here |

`0062` and `0063` stay proposed: both are blocked behind ADR-0055, itself still proposed, and `0062` point 6 deliberately puts the site migration behind it so the work is not done twice.

## What ADR-0064 ships

A visualizer declares in its manifest what music it suits — tags from the 48-descriptor vocabulary, and ranges over the numeric analysis columns. The client posts what it actually has installed; the server scores it against the track and returns a ranking. Turn on **Match to the music** in the picker and the visualizer follows the album.

**The client sends its candidates because it has to.** ADR-0029 point 5 leaves device identity uninvented and ADR-0034 point 4 puts drop-in bundles in a directory on the device, so the server cannot know what is installed. Nothing is stored: the endpoint is a pure function of the request and the track's analysis, and the chosen id stays on the device.

`POST /tracks/{id}/visualizer-ranking` goes under the existing `tracks` tag, so `VENDORED_TAGS` and the Swift generator config are untouched — and since `tracks` is already generated, the operation reaches the Apple clients on the next regeneration with no cross-repo edit.

## The defect it started from

`VisualizerProps.features` was declared, defaulted to null, forwarded to the chosen visualizer — and passed by **neither call site**. `ReactiveTerrain` is its only reader, so it always took its `?? 0.4` / `?? 0.5` fallbacks. On the embedded surface the Apple clients use it was worse: a `Track` fabricated by cast from four fields, so no analysis reached a visualizer anywhere in production.

The obvious fix would have been wrong. `currentTrack.features` is populated only when a caller passes `include_features`, and the only one that does is the track-list browser — it would have worked on exactly one screen.

## Decisions worth review

- **Unrecognised means inert, never a refusal.** A misspelled tag, a range over a text column, a feature this track lacks: each is excluded from the denominator so it cannot change a score, and is surfaced under *Ignored in manifest*. A bad optional field must never cost an author a working visualizer.
- **`instrumentalness` and `speechiness` are rejected as signals**, though obvious for the lyric visualizers — the detector finds speech, not singing. `vocal/choir` is used instead. Now documented so a plugin author does not repeat it.
- **`music-video` declares nothing on purpose.** It plays a video rather than drawing audio, so no property of the analysis makes it more apt.
- **A manual pick switches auto-select off**, or the next track would overrule the choice just made.
- **Hysteresis at 0.1**, so two near-ties do not alternate across an album that suits both.

## A defect this created, found and fixed

Auto-select introduced a second answer to "which visualizer is on", and `FullPlayer` still read the stored id to gate its entire layout — auto-selecting Music Video would have drawn album art over a playing video. Now one shared `useActiveVisualizerId`. The ADR records the general lesson.

## Documentation

`docs/VISUALIZER_API.md` corrected before ADR-0063 publishes it: its "Existing Visualizers" table listed seven components of which **six do not exist**; `useAudioAnalyser` claimed one source where there are three; `TrackFeatures` documented 8 of 15 fields; a fifth reserved id was missing from both the doc and `VISUALIZER_IDS`. The affinity vocabulary is listed in full and was verified programmatically against `mood_tags.DESCRIPTORS`.

## Verification

- Frontend **1008 tests / 67 files**; web build green
- Backend **36 new tests** — 27 of them DB-free, in 0.03s, because the scorer is pure
- OpenAPI lint OK (260 operations, Swift cross-check green), profile-contract lint OK, `openapi.json` regenerated
- Lint, tsc and dependency-boundary warnings **identical to baseline** — no new ones

## Not done here

The `familiar-apple` half — `VisualizerCatalog.swift` carrying `affinity`, and a rebuilt `VisualizerBundle.html`. `docs/WEB-PARITY.md` carries the row marked **not a blocker** until it lands, so shipping the web half first does not extend the web player's countdown under ADR-0060 point 1.

Nobody has yet watched this against real music. The built-ins' affinity values, `SWITCH_MARGIN`, and the 60/40 tag-vs-range weighting are all starting guesses with no listening data to tune against.

🤖 Generated with [Claude Code](https://claude.com/claude-code)