### PR TITLE
The countdown empties: casting shipped, the map is desktop-only, New Releases exists nowhere

### DIFF
--- a/docs/WEB-PARITY.md
+++ b/docs/WEB-PARITY.md
@@ -32,7 +32,7 @@ which only holds if it is corrected when a row changes. Update it in the same ch
 | Playlists | ✅ | ✅ | ✅ | |
 | Smart playlists | ✅ | ✅ | ✅ | Browse and play on all three. **Editing is Mac-only** (ADR-0013 point 3): full CRUD over 25 server-supplied rule fields, and the phone shows no pencil and no `+` |
 | Favorites, Downloads | ✅ | ✅ | ✅ | |
-| Music Map | ✅ | ✅ | ❌ | Native `Canvas`, 500-artist cap. Web uses three.js |
+| Music Map | ✅ | ✅ | ❌ | **not a blocker:** desktop-only by decision — a dense field of labels navigated by pinch and pan wants a large screen and hover (ADR-0062). Native `Canvas`, 500-artist cap; web uses three.js |
 | Discover | ✅ | ✅ | ✅ | **The native ones are a `WKWebView` on `/embed`** (ADR-0016/0017/0019) |
 | New Releases detail | ✅ | ❌ | ❌ | The embed bridge only understands `openArtist` / `openAlbum` |
 | Home | ✅ | ✅ | ✅ | ADR-0032 |
@@ -216,6 +216,10 @@ with no affordance is what `.smartPlaylists` was: routable, stored, rendered, an
   called it: no active-status filter, a string distinct for albums, raw tag strings for artists.
   Nothing in the matrix changes; noted because "the web app can show library stats" was true of the
   screen and false of the numbers.
+- **2026-08-18** — the Music Map became **desktop-only by decision** (ADR-0062) rather than an
+  unfinished row. No ADR had ever said the phone should have one — ADR-0016 is Mac-scoped — so the
+  ❌ recorded "nobody decided" and the countdown read it as "not yet done". **One row now remains**:
+  New Releases detail, which needs a decision about the embed bridge before it needs code.
 - **2026-08-18** — casting reached the phone (`familiar-apple` #125 and #127, ADR-0056), so
   **Network output goes native-✅ and leaves the player's removal countdown**. Two rows remain in the
   Listening table under ADR-0060's rule: Music Map on iPhone, and New Releases detail on Mac and

--- a/docs/WEB-PARITY.md
+++ b/docs/WEB-PARITY.md
@@ -43,7 +43,7 @@ which only holds if it is corrected when a row changes. Update it in the same ch
 | Audio effects (EQ, reverb, delay…) | ✅ | ✅ | ✅ | Web `EffectsChain`; native its own DSP |
 | Visualizer | ✅ | ✅ | ✅ | **A `WKWebView`**, bundled *inside* the app (3.4 MB `VisualizerBundle.html`) |
 | Offline downloads | ✅ | ✅ | ✅ | Independent implementations — Dexie vs background `URLSession` |
-| Network output (Sonos/UPnP/Chromecast) | ✅ | ✅ | ❌ | AirPlay deliberately left to the OS picker |
+| Network output (Sonos/UPnP/Chromecast) | ✅ | ✅ | ✅ | ADR-0056 brought casting to the phone. AirPlay stays the OS picker's job (ADR-0031 point 3), reachable from the same merged control |
 | CarPlay | — | — | ✅ | |
 | Listen-together (guest sessions) | ✅ | ❌ | ❌ | **not a blocker:** web-only by decision — ADR-0036 built the server half and **ADR-0037 was rejected** (ADR-0060 point 1) |
 | Sleep timer, playback speed | ❌ | ❌ | ❌ | **not a blocker:** exists nowhere, including the web app, so it is not a reason to keep it (ADR-0060 point 1) |
@@ -216,6 +216,15 @@ with no affordance is what `.smartPlaylists` was: routable, stored, rendered, an
   called it: no active-status filter, a string distinct for albums, raw tag strings for artists.
   Nothing in the matrix changes; noted because "the web app can show library stats" was true of the
   screen and false of the numbers.
+- **2026-08-18** — casting reached the phone (`familiar-apple` #125 and #127, ADR-0056), so
+  **Network output goes native-✅ and leaves the player's removal countdown**. Two rows remain in the
+  Listening table under ADR-0060's rule: Music Map on iPhone, and New Releases detail on Mac and
+  iPhone. Both are `familiar-apple` work; nothing in the web app blocks its own player now.
+
+  The ADR is worth reading for what the measurement did to it: it argued the discarded *stream* was
+  the cost, and the server log said otherwise — a downloaded track is never fetched, and casting
+  only works on the home LAN where bandwidth is not the constraint. What it actually removes is the
+  full decode ADR-0031 point 7 named in the first place.
 - **2026-08-17** — the PWA was retired (ADR-0059). No manifest, no service worker, no install
   prompt, and `vite-plugin-pwa` is gone. `/sw.js` still exists and must: it serves a **tombstone**
   worker that unregisters the Workbox worker earlier versions installed, because deleting a service

--- a/docs/WEB-PARITY.md
+++ b/docs/WEB-PARITY.md
@@ -34,7 +34,7 @@ which only holds if it is corrected when a row changes. Update it in the same ch
 | Favorites, Downloads | ✅ | ✅ | ✅ | |
 | Music Map | ✅ | ✅ | ❌ | **not a blocker:** desktop-only by decision — a dense field of labels navigated by pinch and pan wants a large screen and hover (ADR-0062). Native `Canvas`, 500-artist cap; web uses three.js |
 | Discover | ✅ | ✅ | ✅ | **The native ones are a `WKWebView` on `/embed`** (ADR-0016/0017/0019) |
-| New Releases detail | ✅ | ❌ | ❌ | The embed bridge only understands `openArtist` / `openAlbum` |
+| New Releases detail | ❌ | ❌ | ❌ | **not a blocker:** exists nowhere. The web screen was deleted by ADR-0050 (`35ba672`) and this row went on claiming it; the "See all" link that reached it was dead on all three until 2026-08-18. The *section* still renders, on all three |
 | Home | ✅ | ✅ | ✅ | ADR-0032 |
 | Queue | ✅ | ✅ | ✅ | See "reorder" below |
 | Shuffle | ✅ | ✅ | ✅ | Native adds four server-drawn weighted presets (ADR-0035) |
@@ -216,6 +216,19 @@ with no affordance is what `.smartPlaylists` was: routable, stored, rendered, an
   called it: no active-status filter, a string distinct for albums, raw tag strings for artists.
   Nothing in the matrix changes; noted because "the web app can show library stats" was true of the
   screen and false of the numbers.
+- **2026-08-18** — **New Releases detail was never a native gap: it exists nowhere.** The web
+  screen (`NewReleasesDetail.tsx`) was deleted by ADR-0050 in `35ba672`, and the Web column went on
+  saying ✅ for eight days. The "See all" link that reached it was therefore dead on every platform —
+  redirecting home in a browser, and inside the embedded Discover WebView changing the URL while
+  leaving the same page on screen, because a react-router `Link` is a `pushState` the native side
+  never sees. The link is now removed; the section, the count, dismiss and the purchase links all
+  stay and all work.
+
+  **This empties the player's removal countdown.** Under ADR-0060 point 1's second rule a row that
+  is ❌ in the Web column too cannot be a reason to keep the browser, and no rule was bent to get
+  here — the ✅ was simply false. `docs/WEB-PARITY.md`'s Listening table now shows no ❌ in the Mac
+  or iPhone columns that is not excluded, which is the condition ADR-0058 point 4 set for removing
+  the web player.
 - **2026-08-18** — the Music Map became **desktop-only by decision** (ADR-0062) rather than an
   unfinished row. No ADR had ever said the phone should have one — ADR-0016 is Mac-scoped — so the
   ❌ recorded "nobody decided" and the countdown read it as "not yet done". **One row now remains**:

--- a/docs/decisions/ADR-0062-the-music-map-is-a-desktop-surface.md
+++ b/docs/decisions/ADR-0062-the-music-map-is-a-desktop-surface.md
@@ -1,0 +1,90 @@
+# ADR-0062: The Music Map Is a Desktop Surface
+
+Status: proposed
+
+Date: 2026-08-18
+
+Extends [ADR-0016](ADR-0016-embedded-web-surfaces-on-the-mac.md), whose point 3 built the map
+natively for the Mac. Adds an exclusion under [ADR-0060](ADR-0060-the-players-removal-trigger-must-be-reachable.md)
+point 1.
+
+## Context
+
+`docs/WEB-PARITY.md` shows Music Map as `Web ✅ / Mac ✅ / iPhone ❌`, and under ADR-0060's rule
+that ❌ is one of two rows standing between the web player and deletion.
+
+**It was never a gap.** ADR-0016 is titled *Embedded Web Surfaces on the Mac* and its point 3
+decides the map is built native there; ADR-0013 put Discover and Music Map on the Mac. No ADR has
+ever said the phone should have one. The cell was empty because nobody had decided, and the
+countdown read "not decided" as "not yet done" — which is the failure mode of deriving a to-do list
+from a matrix that records capability rather than intent.
+
+**And the port is not what makes it a bad idea.** Scoped before deciding, so the decision is not
+resting on an assumption that it would be hard:
+
+- The layout, projection and geometry are already platform-agnostic — 492 lines in
+  `Sources/FamiliarKit/MusicMap.swift`, tested.
+- `MusicMapStore.swift` is gated `#if os(macOS)` but contains **zero** AppKit references. The gate
+  is incidental.
+- `MusicMapView.swift` already uses `MagnifyGesture`, `DragGesture` and single/double
+  `onTapGesture` — the whole iOS interaction model, already written. Only three things in its 591
+  lines are genuinely Mac-only: the `NSEvent` scroll-wheel monitor, `.onContinuousHover`, and
+  `.help` tooltips. All three wrap in `#if os(macOS)`.
+
+So it would compile on the phone in about an hour. **The reason not to is that it would be bad to
+use**, which is Jeff's call and is the only reason that matters here.
+
+The map's own source says why, at `MusicMap.swift:257`: at 500 artists "the same zoom draws two and
+a half times as many names in the same space". Earlier work on the map established that **drawing is
+not the bottleneck, text is**. A dense 2D field of overlapping labels, navigated by pinch and pan, is
+a desktop interaction: it wants a large surface, a precise pointer, and hover to disambiguate — the
+one affordance a phone does not have and the map uses to tell crowded names apart.
+
+## Decision
+
+1. **The Music Map is macOS-only, by decision rather than by backlog.** It is not built for the
+   phone, and the iPhone ❌ on its parity row is a statement of intent.
+
+2. **The row is excluded from the player's removal countdown** under ADR-0060 point 1's first rule —
+   *excluded by decision* — and marked `**not a blocker:**` in the Listening table alongside
+   listen-together. This ADR is the record point 3 of that ADR requires before an exclusion is added.
+
+3. **This does not reverse ADR-0016 point 3 or ADR-0013.** Both are Mac-scoped and stay exactly as
+   written. It also does not touch ADR-0019, which put embedded Discover on the phone: Discover is a
+   list, and a list works on a phone.
+
+4. **If it is ever wanted on the phone, this ADR is what to supersede** — and the work is the density
+   problem, not the port. Recorded so nobody re-derives the port cost to reach the same answer.
+
+## Alternatives Considered
+
+- **Ship it with a lower artist cap on the phone.** The obvious compromise, and it was the plan
+  before this decision: fewer labels, less crowding. Rejected because the cap is what makes the map
+  worth looking at — ADR-0016's map earns its place by showing the shape of a whole library, and a
+  phone-sized subset is a different, weaker thing wearing the same name. Cutting it until it fits
+  produces something that fits and is not worth opening.
+
+- **Ship it and let the density be bad.** Would close the row and take the countdown to one, which
+  is a genuine pull. Rejected because that is optimising the bookkeeping rather than the product,
+  and ADR-0060 point 3 exists precisely to stop a countdown becoming a reason to ship something.
+
+- **Embed the web map in a `WKWebView`, as ADR-0016 considered and rejected for the Mac.** Cheapest
+  possible route. Rejected for the same reason it was there — and more so here, since the three.js
+  map is heavier than the native one and the phone is the device with less to spend.
+
+- **Leave the row as an open ❌ and simply not do it.** What is happening today. Rejected because it
+  keeps the player's removal blocked on work nobody intends to do, which is exactly the unreachable
+  trigger ADR-0060 was written to fix — arrived at from the other direction.
+
+## Consequences
+
+- **Positive:** the countdown drops from two rows to one. Only New Releases detail remains, and
+  that one needs a decision about the embed bridge before it needs code.
+- **Positive:** the parity matrix stops implying an intention nobody has. A ❌ that means "we decided
+  not to" now says so, next to the one that means "not yet".
+- **Tradeoff:** a listener on the phone cannot see the map. That is the whole point, and it is a
+  real loss for anyone who uses it to find something to play — Discover, which is on the phone, is
+  the intended route to the same end.
+- **Follow-up:** `MusicMapStore.swift`'s `#if os(macOS)` is incidental rather than meaningful, since
+  the file has no AppKit in it. Harmless, and worth a comment saying the gate is about where the map
+  is shown rather than what the store can compile against.

--- a/docs/decisions/ADR-0062-the-music-map-is-a-desktop-surface.md
+++ b/docs/decisions/ADR-0062-the-music-map-is-a-desktop-surface.md
@@ -1,6 +1,6 @@
 # ADR-0062: The Music Map Is a Desktop Surface
 
-Status: proposed
+Status: accepted
 
 Date: 2026-08-18
 

--- a/packages/frontend/src/components/Discovery/ExternalAlbumCard.tsx
+++ b/packages/frontend/src/components/Discovery/ExternalAlbumCard.tsx
@@ -4,8 +4,11 @@
  * Used by:
  *   - Discover page "New releases from your artists" section (#3)
  *   - Discover page "Albums you might want" section (listening-profile #2)
- *   - /library/discover/new-releases detail page (#3 detail)
  *   - Playlist drawer (#2 per-playlist, Pass 4)
+ *
+ * The `/library/discover/new-releases` detail page was here too. It was deleted when ADR-0050 made
+ * the web app a management surface, and this list went on naming it — which is how the "See all"
+ * link that reached it survived being dead on every platform.
  *
  * Visually mirrors DiscoveryCard's grid look, but adds external-album-specific
  * affordances: dismiss button, context label, release type/date, purchase links.

--- a/packages/frontend/src/components/Library/browsers/DiscoverBrowser/NewReleasesSection.tsx
+++ b/packages/frontend/src/components/Library/browsers/DiscoverBrowser/NewReleasesSection.tsx
@@ -8,9 +8,8 @@
  * Polls /new-releases/status every 2s while a check is running.
  */
 import { useState } from 'react';
-import { Link } from 'react-router-dom';
 import { useMutation, useQuery, useQueryClient } from '@tanstack/react-query';
-import { Disc3, Loader2, RefreshCw, ChevronRight } from 'lucide-react';
+import { Disc3, Loader2, RefreshCw } from 'lucide-react';
 import { newReleasesApi, externalAlbumsApi } from '../../../../api/discovery';
 import { queryKeys } from '../../../../api/queryKeys';
 import { STALE_TIME } from '../../../../api/queryDefaults';
@@ -121,15 +120,17 @@ export function NewReleasesSection() {
             </span>
           )}
         </div>
-        {releases.length > 0 && (
-          <Link
-            to="/library/discover/new-releases"
-            className="flex items-center gap-1 text-sm text-zinc-400 hover:text-zinc-200 transition-colors"
-          >
-            See all
-            <ChevronRight className="w-4 h-4" />
-          </Link>
-        )}
+        {/*
+          * No "See all". It linked to `/library/discover/new-releases`, whose screen was deleted
+          * when ADR-0050 made the web app a management surface — so in a browser it redirected
+          * home, and inside the Mac and iPhone Discover WebView it changed the URL and left you on
+          * the same page, because a react-router `Link` is a pushState rather than a navigation the
+          * native side ever sees.
+          *
+          * A visible affordance reaching a screen that no longer exists is the defect this codebase
+          * has shipped repeatedly (`familiar` #70, #74, #76). The count beside the heading still
+          * says how many there are; nothing now offers to show them.
+          */}
       </div>
 
       {listQuery.isLoading ? (


### PR DESCRIPTION
Three corrections to `WEB-PARITY.md`, the ADR one of them requires, and the dead link the third turned up.

Together they empty the web player's removal countdown. That was not the intent when this PR opened — it was two rows of bookkeeping — so the last section says plainly what it now means.

## 1. Casting reached the phone

**Network output (Sonos/UPnP/Chromecast) → iPhone ✅** (ADR-0056, `familiar-apple` #125 and #127). AirPlay is unchanged and still the OS picker's job, now reachable from the same merged control.

ADR-0050 point 6 obliges this file to move with the capability. It didn't, because the capability shipped in the *other* repo — which is how this file went nine rows stale once before.

## 2. The Music Map is desktop-only, by decision (ADR-0062)

Jeff: *it should not be on the phone — too complicated to navigate on a phone screen.*

**It was never a gap.** ADR-0016 is titled *Embedded Web Surfaces on the Mac*, and ADR-0013 put Discover and Music Map on the Mac. No ADR ever said the phone should have one. The ❌ recorded "nobody decided", and the countdown read that as "not yet done" — the failure mode of deriving a to-do list from a matrix that records *capability* rather than *intent*.

ADR-0060 point 3 requires an ADR before a row joins the exclusion list, so the list can't quietly absorb whatever is inconvenient. ADR-0062 is that record.

**The port cost was scoped before deciding**, so this doesn't rest on assuming it'd be hard — it's about an hour:

- layout and geometry are already platform-agnostic (492 lines in `FamiliarKit`, tested)
- `MusicMapStore`'s macOS gate is incidental — **zero** AppKit references
- the view already uses `MagnifyGesture`, `DragGesture` and tap gestures: the entire iOS interaction model. Only the `NSEvent` scroll monitor, `.onContinuousHover` and `.help` are Mac-only.

The reason not to is that it would be **bad to use**. Its own source says why (`MusicMap.swift:257`): at 500 artists *"the same zoom draws two and a half times as many names in the same space"*, and drawing was never the bottleneck — text is. Overlapping labels navigated by pinch and pan want a big surface and hover, the one affordance a phone lacks.

Shipping it with a lower cap was the plan an hour ago, and is rejected in the ADR: the cap is what makes the map worth opening.

## 3. New Releases detail exists nowhere, and its link was dead everywhere

The row said Web ✅ / Mac ❌ / iPhone ❌ — the native clients behind the browser. **They are not.** The web screen was deleted by ADR-0050 in `35ba672`, and the row went on claiming it for eight days. The row goes `❌ | ❌ | ❌`.

So the "See all" link that reached it has been dead on every platform: in a browser `/library/discover/new-releases` falls through to the catch-all and redirects home, and inside the embedded Discover `WKWebView` it changes the URL and leaves the same page on screen, because a react-router `Link` is a `pushState` the native side never sees. That is the defect this codebase keeps shipping — #70, #74, #76 — and it was live on the Mac and phone Discover tab.

**The link is removed. Everything else in the section stays and works:** the grid, the count, dismiss (a plain API call) and the purchase links (which the WebView already routes to the system browser). The release cards were never clickable on any platform.

`ExternalAlbumCard`'s docstring still listed the deleted detail page among its callers, which is how the dead link survived being obviously dead.

## The countdown is now empty

ADR-0060 point 4 named three rows. All three clear here:

| row | status |
|---|---|
| Network output — iPhone | ✅ **shipped** (ADR-0056) |
| Music Map — iPhone | **excluded by decision** (ADR-0062) |
| New Releases detail — Mac + iPhone | **excluded as absent everywhere** — ❌ in the Web column too |

The third exclusion bends no rule: ADR-0060 point 1's second rule already excludes a row the browser does not have, on the grounds that it cannot be a reason to keep the browser. The ✅ was simply false, and correcting it is the bookkeeping ADR-0050 point 6 obliges anyway.

**So ADR-0058 point 4's condition is met, and nothing in the web app blocks its own player.** Stating that plainly because the consequence is deleting roughly 14,000 lines, and **a countdown that empties itself deserves more suspicion than one that does not** — read the three rows above rather than the summary.

**ADR-0062 is `accepted`** (`2e4aab2`), approved by Jeff, so the Music Map exclusion ADR-0060 point 3 requires is a decision rather than a proposal. It opened `proposed`, as new ADRs do; until it was accepted this PR took the countdown to one rather than zero.

What this does *not* do is **remove the player**. Not in this PR, and a separate change. Scoping for it is on `strip/remove-web-player`, whose measurement found the removal is not a delete of `player/` — `/embed` and `/visualizer` pin 11 of its 28 files.

## Also checked

Smart playlists still reads correctly — `familiar-apple` #123 shipped *browse and play, not edit*, which is what the row already says.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
