### PR TITLE
Let the host switch on visualizer matching (ADR-0064 point 7)

### DIFF
--- a/docs/WEB-PARITY.md
+++ b/docs/WEB-PARITY.md
@@ -42,7 +42,7 @@ which only holds if it is corrected when a row changes. Update it in the same ch
 | Radio | ✅ | ✅ | ✅ | ADR-0040 |
 | Audio effects (EQ, reverb, delay…) | ✅ | ✅ | ✅ | Web `EffectsChain`; native its own DSP |
 | Visualizer | ✅ | ✅ | ✅ | **A `WKWebView`**, bundled *inside* the app (3.4 MB `VisualizerBundle.html`) |
-| Visualizer auto-select | ✅ | ❌ | ❌ | **not a blocker:** ADR-0064's ranking endpoint and page half are built; the native menu has still to send its catalog as candidates, which is the ADR's own follow-up on `VisualizerCatalog.swift`. Shipping the web half first must not extend the player's countdown (ADR-0060 point 1) |
+| Visualizer auto-select | ✅ | ✅ | ✅ | ADR-0064. **The page does the ranking on all three** — it knows the server, the profile and what it registered; the app supplies a menu toggle that travels on the URL |
 | Offline downloads | ✅ | ✅ | ✅ | Independent implementations — Dexie vs background `URLSession` |
 | Network output (Sonos/UPnP/Chromecast) | ✅ | ✅ | ❌ | AirPlay deliberately left to the OS picker |
 | CarPlay | — | — | ✅ | |

--- a/docs/decisions/ADR-0064-visualizers-declare-affinity-and-the-server-ranks-them.md
+++ b/docs/decisions/ADR-0064-visualizers-declare-affinity-and-the-server-ranks-them.md
@@ -228,10 +228,20 @@ server therefore cannot know which visualizers a given device has installed**, b
 - **Tradeoff:** A track with no analysis, or one still awaiting a features re-run, has nothing to
   rank against. The behaviour has to be "keep the current visualizer", not "pick arbitrarily", and
   on a large library mid-sync that will be a meaningful fraction of tracks.
-- **Follow-up:** The catalog published as `window.__familiarVisualizers` must carry the affinity
-  block for the native host to forward it, which extends `VisualizerCatalog.swift` and the
-  `evaluateJavaScript` probe `0034` added rather than adding a message handler. *The page half is
-  done — the catalog carries `affinity`; the Swift half is what remains.*
+- **Follow-up:** ~~The catalog published as `window.__familiarVisualizers` must carry the affinity
+  block for the native host to forward it, which extends `VisualizerCatalog.swift`.~~ — **this was
+  wrong, and the Apple clients needed no such thing.** It assumed the *host* would gather candidates
+  and call the endpoint. It does not need to: the embedded page already has the server's origin and
+  the profile, already renders `AudioVisualizer`, and already knows what it registered — including
+  drop-in plugins the app has only ever seen as folders. Ranking from Swift would have been the same
+  rule in a second language, which `0034` says is how the menu comes to disagree with what loaded.
+  What was actually missing was a *switch*: `autoSelect` is off by default and the embedded surface
+  has no picker. So the app gained a menu toggle that travels on the URL beside `visualizer`, and
+  `VisualizerCatalog` is unchanged. The catalog does carry `affinity` — harmless, and it is what the
+  page sends — but nothing on the native side reads it, which a test now pins.
+
+  The general shape worth keeping: **before building a second implementation for another client,
+  check whether the shared page already does the work.** Here it had done it for a week.
 - **Follow-up:** ~~`docs/VISUALIZER_API.md` documents the manifest and will need the `affinity`
   block before `ADR-0063` publishes it.~~ — done, along with the three defects that ADR names: the
   six absent components, `useAudioAnalyser`'s three sources, and the fifth reserved id. The 48-tag

--- a/packages/frontend/src/renderVisualizer.tsx
+++ b/packages/frontend/src/renderVisualizer.tsx
@@ -2,7 +2,7 @@ import { StrictMode } from 'react';
 import { createRoot } from 'react-dom/client';
 import { QueryClient, QueryClientProvider } from '@tanstack/react-query';
 import { initApiOrigin, registerProfileProvider, setApiOrigin } from './api/base';
-import { profileFromURL } from './services/embedBridge';
+import { autoSelectFromURL, profileFromURL } from './services/embedBridge';
 import { EmbedVisualizer } from './components/Embed/EmbedVisualizer';
 import { installVisualizerSink } from './services/visualizerSink';
 import { useVisualizerStore } from './stores/visualizerStore';
@@ -56,6 +56,18 @@ export function renderVisualizer(options?: { onReady?: () => void }): void {
   // answer and whichever wrote last would win.
   const visualizer = params.get('visualizer');
   if (visualizer) useVisualizerStore.getState().setVisualizerId(visualizer);
+
+  // **Whether to let the server pick one to suit each track** (ADR-0064 point 7), for the same
+  // reason and by the same route: the toggle lives in the native menu, so the app is the source of
+  // truth and the page is told rather than remembering its own answer.
+  //
+  // The *ranking* is done here rather than by the host. This page already has the server's origin
+  // and the profile, and `AudioVisualizer` already asks — so a host-side implementation would be a
+  // second copy of candidate-gathering in Swift, which is how the two come to disagree about what
+  // is loaded. The host supplies the switch; the page, which knows what it actually registered,
+  // supplies the candidates.
+  const autoSelect = autoSelectFromURL(window.location.search);
+  if (autoSelect !== null) useVisualizerStore.getState().setAutoSelect(autoSelect);
 
   const api = params.get('api');
   registerProfileProvider({

--- a/packages/frontend/src/services/__tests__/embedBridge.test.ts
+++ b/packages/frontend/src/services/__tests__/embedBridge.test.ts
@@ -6,8 +6,7 @@ import {
   postNavigateIntent,
   isEmbedSurfaceDocument,
   BRIDGE_HANDLER,
-  type PlayIntent,
-} from '../embedBridge';
+  type PlayIntent, autoSelectFromURL } from '../embedBridge';
 
 /**
  * The seam ADR-0016 names as the main risk of embedding: two clients that were independent now share
@@ -222,5 +221,30 @@ describe('postNavigateIntent', () => {
     });
     expect(() => postNavigateIntent({ to: 'artist', artist: 'M83' })).not.toThrow();
     expect(postNavigateIntent({ to: 'artist', artist: 'M83' })).toBe(false);
+  });
+});
+
+describe('autoSelectFromURL', () => {
+  it('is null when the host says nothing, so the page keeps its own setting', () => {
+    expect(autoSelectFromURL('?visualizer=lyrics')).toBeNull();
+    expect(autoSelectFromURL('')).toBeNull();
+  });
+
+  it('reads the switch on', () => {
+    expect(autoSelectFromURL('?autoSelect=1')).toBe(true);
+    expect(autoSelectFromURL('?autoSelect=true')).toBe(true);
+    expect(autoSelectFromURL('?autoSelect=TRUE')).toBe(true);
+  });
+
+  // The bug this exists to prevent: `"0"` is a non-empty string, so a truthy check at the call
+  // site would read "off" as "on" and the native toggle could never be switched back off.
+  it('reads the switch off, rather than treating "0" as a non-empty string', () => {
+    expect(autoSelectFromURL('?autoSelect=0')).toBe(false);
+    expect(autoSelectFromURL('?autoSelect=false')).toBe(false);
+  });
+
+  it('treats an empty value as nothing said', () => {
+    expect(autoSelectFromURL('?autoSelect=')).toBeNull();
+    expect(autoSelectFromURL('?autoSelect=%20')).toBeNull();
   });
 });

--- a/packages/frontend/src/services/embedBridge.ts
+++ b/packages/frontend/src/services/embedBridge.ts
@@ -78,6 +78,23 @@ export function profileFromURL(search: string = window.location.search): string 
   return value !== null && value.trim() !== '' ? value : null;
 }
 
+/**
+ * Whether the host has switched auto-select on or off (ADR-0064 point 7).
+ *
+ * `null` means the host said nothing, and the page keeps whatever it had — which is what an
+ * ordinary browser gets, where the toggle lives in the picker beside the visualizer.
+ *
+ * **Absence and `0` are different answers**, which is the whole reason this is a function rather
+ * than a truthy check at the call site: `"0"` is a non-empty string, so `if (params.get(...))`
+ * would read "the host turned this off" as "the host turned this on" — and the switch would be
+ * impossible to switch back off from the native menu.
+ */
+export function autoSelectFromURL(search: string = window.location.search): boolean | null {
+  const value = new URLSearchParams(search).get('autoSelect');
+  if (value === null || value.trim() === '') return null;
+  return value === '1' || value.toLowerCase() === 'true';
+}
+
 interface WebKitBridgeWindow {
   webkit?: {
     messageHandlers?: Record<string, { postMessage: (message: unknown) => void } | undefined>;


### PR DESCRIPTION
The Apple half of ADR-0064 — and it turned out to be much smaller than the ADR predicted.

## The ranking already worked on the Apple clients

ADR-0064's follow-up said the catalog must carry `affinity` "for the native host to forward it", assuming Swift would gather candidates and call the endpoint.

It never needed to. The embedded page already has the server's origin and the profile, already renders `AudioVisualizer`, and `AudioVisualizer` already asks the server to rank. **This has been working on the Mac and iPhone since #182 merged.**

What was actually missing is a *switch*: `autoSelect` is off by default and the embedded surface has no picker, so a native listener had no way to turn it on.

Ranking from Swift would have been the same rule in a second language, which ADR-0034 says is how the menu comes to disagree with what actually loaded. The page also knows things the app does not — including drop-in plugins the app has only ever seen as folders.

## What this changes

`autoSelect` travels on the URL beside `visualizer`, for the reason that one does: embedded, the app is the source of truth, or both sides remember an answer and whichever wrote last wins.

**`autoSelectFromURL` is a named function rather than a truthy check**, because absence and `0` are different answers. `"0"` is a non-empty string, so `if (params.get('autoSelect'))` would read "the host turned this off" as "turned it on" — and the native toggle could be switched on but never off. Four tests cover exactly that.

The ADR follow-up is corrected in place rather than deleted, with the general shape recorded: **before building a second implementation for another client, check whether the shared page already does the work.** Here it had, for a week.

`docs/WEB-PARITY.md` goes to ✅✅✅, so the row stops needing its "not a blocker" note and the web player's countdown is unaffected.

## Verification

- **1012 frontend tests**, lint and tsc identical to baseline
- The companion `familiar-apple` PR vendors a bundle built from this commit, so **this should land first**

🤖 Generated with [Claude Code](https://claude.com/claude-code)