### PR TITLE
Make every visualizer editable (ADR-0066, ADR-0067, ADR-0068)

### DIFF
--- a/docs/decisions/ADR-0066-music-video-is-a-player-mode-not-a-visualizer.md
+++ b/docs/decisions/ADR-0066-music-video-is-a-player-mode-not-a-visualizer.md
@@ -68,7 +68,14 @@ not contain every visualizer, and the answer kept having to except this one.
    today. Whichever way this lands, `docs/WEB-PARITY.md` gets a row for it — it currently has none,
    which is how a feature with five endpoints came to have its reachability undiscussed.
 
-5. **Nothing about the backend changes.** No endpoint moves, no route is renamed, no data migrates.
+5. **`docs/VISUALIZER_API.md` stops listing it as a visualizer.** Its "Existing Visualizers" table
+   names `music-video` as one of five, and its manifest table reserves five built-in ids against
+   plugins — both become four. That document is the contract
+   [ADR-0063](ADR-0063-the-visualizer-api-is-published-for-outside-authors.md) point 2 requires to
+   be correct before it is published to outside authors, and leaving it naming a visualizer that is
+   no longer one is the same defect that ADR corrected six entries ago.
+
+6. **Nothing about the backend changes.** No endpoint moves, no route is renamed, no data migrates.
    This is a decision about where a feature is reached from, and the argument for it is that the
    present answer costs a special case in the player and an exception in every rule about
    visualizers.

--- a/docs/decisions/ADR-0066-music-video-is-a-player-mode-not-a-visualizer.md
+++ b/docs/decisions/ADR-0066-music-video-is-a-player-mode-not-a-visualizer.md
@@ -1,0 +1,124 @@
+# ADR-0066: Music Video Is a Player Mode, Not a Visualizer
+
+Status: proposed
+
+Date: 2026-08-18
+
+Extends [ADR-0034](ADR-0034-visualizers-are-drop-in-bundles.md) by removing something from the set
+it governs. The drop-in format, the two sources and the refusal rules are untouched; what changes is
+that one of the five compile-time visualizers stops being one.
+
+## Context
+
+**`music-video` is in the visualizer registry and is not a visualizer.** It plays a YouTube video
+instead of drawing the audio. That has been true since it was written, and it has been paid for in
+four separate places — none of which looked like a symptom on its own.
+
+- **It is the only visualizer id special-cased anywhere.** `FullPlayer.tsx` reads `isMusicVideo` in
+  three places to decide whether to show inline artwork and what the content area contains. No other
+  visualizer needs the surrounding interface to behave differently; a grep for the other four ids
+  outside the registry, the picker and their tests returns nothing.
+- **It is the only one registered `usesMetadata: false`.** It uses neither the artwork nor the
+  analysis nor the lyrics — that is to say, nothing `VisualizerProps` exists to provide.
+- **It is the only one that cannot declare affinity.**
+  [ADR-0064](ADR-0064-visualizers-declare-affinity-and-the-server-ranks-them.md) shipped it with no
+  affinity block on purpose, and said why: *"it plays a video rather than drawing the audio, so no
+  property of the analysis makes it more apt — it is a different way of watching, not a scene that
+  suits some music."* That is a description of something that does not belong in the set, written
+  while adding a feature to the set.
+- **It is the only one that reaches outside the plugin API**, importing `stores/playerStore` for the
+  playhead.
+
+**That last one is a live defect, not only a smell.** `MusicVideo` reads `currentTime` from
+`playerStore`, and on the visualizer surface that store is never mounted — `renderVisualizer.tsx`
+starts no player, because [ADR-0017](ADR-0017-the-embedded-surface-gets-a-null-audio-engine.md)
+gives that page a null audio engine. So the value is 0 for the length of every track, and Music
+Video's sync has been broken on the Mac and the phone since
+[ADR-0033](ADR-0033-the-embed-bridge-gains-a-return-channel.md) put it there. `VisualizerProps`
+already carries `currentTime`, correctly, on both surfaces.
+
+**The feature underneath is real and larger than its one affordance.** `backend/app/api/routes/videos.py`
+serves five endpoints — search, status, download, stream and delete — against
+`backend/app/services/video.py`. All of that is reachable only by choosing a visualizer, which is
+also the only way to *stop* watching, and which competes for a menu whose other entries are scenes.
+
+**This was noticed from the outside.** The prompt was a question about why the visualizer folder did
+not contain every visualizer, and the answer kept having to except this one.
+
+## Decision
+
+1. **The full player has three backgrounds, not two: artwork, a visualizer, or the music video.**
+   `showsVisualizer` becomes a three-state mode rather than a boolean. This is what the interface
+   already does — `isMusicVideo` exists precisely because the video needs different treatment — and
+   it stops being expressed as a special case inside the visualizer that is not one.
+
+2. **`music-video` leaves the visualizer registry.** Four built-ins remain: `reactive-terrain`,
+   `beat-tiles`, `lyrics` and `lyric-storm`. Its id stops being reserved against plugins, and the
+   ranking of [ADR-0064](ADR-0064-visualizers-declare-affinity-and-the-server-ranks-them.md) stops
+   carrying a candidate that can never be scored.
+
+3. **The video reads the playhead from the same place every visualizer does.** Whatever hosts it
+   takes `currentTime` from the player on the web app and from the analysis frames when embedded —
+   the two sources `VisualizerProps` already reconciles — rather than from `playerStore`, which is
+   absent on the surface where the Apple clients run it. This is the defect above, and fixing it is
+   part of this rather than a follow-up.
+
+4. **It is a mode on every client, or it is browser-only and says so.** The `videos` tag is not in
+   the generated surface, so the Apple clients reach the feature solely through the embedded page
+   today. Whichever way this lands, `docs/WEB-PARITY.md` gets a row for it — it currently has none,
+   which is how a feature with five endpoints came to have its reachability undiscussed.
+
+5. **Nothing about the backend changes.** No endpoint moves, no route is renamed, no data migrates.
+   This is a decision about where a feature is reached from, and the argument for it is that the
+   present answer costs a special case in the player and an exception in every rule about
+   visualizers.
+
+## Alternatives Considered
+
+- **Leave it where it is.** It works, people can find it, and moving it is churn against a feature
+  nobody has complained about. Genuinely the cheapest option, and it is what has been chosen by
+  default four times — once for each of the exceptions above. Rejected because the cost is not
+  static: [ADR-0068](ADR-0068-built-in-visualizers-ship-as-drop-in-bundles.md) would have to convert
+  it into a standalone bundle that needs the player store, which would force playback state into a
+  public plugin API for the sake of one entry that is not a visualizer.
+
+- **Keep it a visualizer but give it a real affinity block**, so at least it ranks. Rejected because
+  there is no honest block to write: no property of a track's analysis makes a video more or less
+  apt, which is the same reason `ADR-0064` shipped it declaring nothing.
+
+- **Make it a fourth "source" of visualizers — a video plugin type**, alongside `visualizer` and the
+  excluded `browser`. Rejected as the wrong axis: a plugin type describes who wrote something, and
+  the problem here is what the thing *is*. It would also reopen `ADR-0034` point 9's boundary for a
+  first-party feature, which is the argument that boundary exists to prevent.
+
+- **Move it out of the full player entirely — a separate screen for music videos.** Arguably the
+  most honest reading of "core feature", and it would give the five endpoints a surface of their
+  own. Rejected as more than this decision needs: the video is something you watch *while a track
+  plays*, so it belongs where the player is. A screen of its own is a product decision that can be
+  made later on top of this one, and does not have to be made to fix the special-casing.
+
+## Consequences
+
+- **Positive:** Three special cases leave `FullPlayer`. The player says what it is showing instead
+  of inferring it from which visualizer is selected.
+- **Positive:** Music Video's playhead works when embedded, for the first time since it was
+  embedded.
+- **Positive:** Every rule about visualizers loses its exception — `usesMetadata`, affinity, the
+  plugin API boundary, and the reserved-id list all become uniform over four entries.
+- **Positive:** [ADR-0067](ADR-0067-the-plugin-api-exposes-what-a-first-party-visualizer-uses.md)
+  gets substantially smaller, because the only built-in needing `playerStore` and the API client is
+  the one leaving.
+- **Tradeoff:** A listener who reaches Music Video by picking it from the visualizer menu will look
+  for it there and not find it. That is a real relearning cost for the one affordance this feature
+  has ever had.
+- **Tradeoff:** `showsVisualizer` becomes a three-state value stored where a boolean was, per
+  profile, on both platforms. An old stored `true` has to mean "visualizer" and not "video".
+- **Tradeoff:** The native menu currently toggles the visualizer on press and picks one on hold.
+  A third mode has to fit that shape without turning one glyph into three questions.
+- **Follow-up:** Whether music videos become a destination of their own, per the rejected
+  alternative. Five endpoints with one affordance is the kind of imbalance that usually means yes,
+  and this ADR deliberately does not decide it.
+- **Follow-up:** `docs/WEB-PARITY.md` has no row for music videos at all, and the `videos` tag is
+  browser-only. Point 4 requires the row; whether the ❌s in it are blockers under
+  [ADR-0060](ADR-0060-the-players-removal-trigger-must-be-reachable.md) is a separate question that
+  the row will make askable.

--- a/docs/decisions/ADR-0067-the-plugin-api-exposes-what-a-first-party-visualizer-uses.md
+++ b/docs/decisions/ADR-0067-the-plugin-api-exposes-what-a-first-party-visualizer-uses.md
@@ -1,0 +1,127 @@
+# ADR-0067: The Plugin API Exposes What a First-Party Visualizer Uses
+
+Status: proposed
+
+Date: 2026-08-18
+
+Extends [ADR-0034](ADR-0034-visualizers-are-drop-in-bundles.md) point 3, which decided what the host
+hands a plugin. That list grows here. Depends on
+[ADR-0066](ADR-0066-music-video-is-a-player-mode-not-a-visualizer.md), which removes the one
+built-in that would have forced playback state into this surface.
+
+## Context
+
+`ADR-0034` point 3 gave plugins React, three.js, `@react-three/fiber` and `@react-three/drei` on
+`window.Familiar`, plus nine hooks — `useAudioAnalyser`, `getAudioData`, `useArtworkPalette`,
+`useBeatSync`, `getBeatPhase`, `getBeatSine`, `useLyricTiming`, `getUpcomingLyrics` and
+`getWordTiming`. That is enough to draw something. It is **not** enough to write any of the
+visualizers this project ships.
+
+Audited on 2026-08-18, the four remaining built-ins import, beyond that surface:
+
+| Module | Used by | What it is |
+|---|---|---|
+| `components/Visualizer/effects/AudioReactiveEffects` | `ReactiveTerrain`, `BeatTiles` | The shared post-processing chain the Glow slider drives |
+| `components/Visualizer/effects/FrameScheduler` | `ReactiveTerrain`, `BeatTiles` | Frame pacing |
+| `components/Visualizer/visualizers/LyricWordField` | `ScrollingLyrics`, `LyricStorm` | A drifting field of the song's words, shared by both |
+| `player/audio/analysisMetrics` | `ScrollingLyrics` | Nine exports over the analysis buffers |
+| `utils/platform` | `ReactiveTerrain`, `BeatTiles` | Three exports |
+
+**So the documented plugin API cannot express the visualizers that document it.** An author who
+reads `docs/VISUALIZER_API.md`, copies a built-in, and tries to build it as a drop-in bundle finds
+that half its imports do not exist. That gap has been there since the format was adopted and has
+never been stated, because until now nothing tried to build a built-in as a plugin.
+
+**`GPUParticles` is in the same directory and used by none of the four.** It is a capability the
+effects folder offers that nothing currently takes up — worth listing here so the decision about it
+is deliberate rather than inherited.
+
+**The cost of widening is the point of the argument, and it has a measured precedent.**
+`ADR-0034`'s own Consequences record that handing plugins `@react-three/drei` cost **1.59 MB**,
+because `import * as Drei` cannot be tree-shaken — the inlined visualizer document went 1,782 kB to
+3,375 kB. Everything added here is first-party code already in the bundle, so the byte cost is
+different in kind; the cost that matters is that these modules stop being internal.
+
+**Music Video is not in the table above**, and that is the whole reason this ADR is modest.
+`ADR-0066` moves it out of the visualizer set; while it was in, this surface would have had to
+include `stores/playerStore`, the API client and `@tanstack/react-query` — that is, playback state
+and network access — for one entry that draws nothing.
+
+## Decision
+
+1. **`window.Familiar` gains exactly what the built-ins use**: the effects chain and frame
+   scheduler, `LyricWordField`, the analysis metrics, and the platform helpers. Nothing is added
+   speculatively. The test for inclusion is that a shipped visualizer imports it, which is a
+   question with an answer rather than a judgement about what someone might want.
+
+2. **`GPUParticles` is included, and it is the one exception to point 1.** No built-in uses it, but
+   it sits in the same directory, is written to the same shape, and omitting it would mean an author
+   reading the effects folder finds one of its members unavailable for no reason they can see. This
+   is recorded as an exception so it is not read as precedent.
+
+3. **`apiVersion` stays 1.** Every addition is additive: no existing bundle reads a global that
+   changes meaning, so nothing that loads today stops loading. `ADR-0034` point 7 refuses a manifest
+   declaring a version the host does not implement, so a bump would refuse both shipped examples and
+   every third-party bundle to add capability none of them uses.
+
+4. **What is exposed becomes a contract, and the ADR says so rather than discovering it later.**
+   Once `FrameScheduler` is on the global, its signature is public: changing it breaks bundles this
+   project did not build and cannot test. These five modules are frozen in the sense that
+   `VisualizerProps` is frozen — changeable, but only the way a public interface is changeable.
+
+5. **`stores/playerStore`, the API client and react-query are deliberately not exposed.** No
+   remaining built-in needs them once `ADR-0066` lands, and each is a much larger claim than
+   drawing: the store is playback control, and the API client is credentialed network access from
+   code the app did not ship. A plugin that needs the playhead has `VisualizerProps.currentTime`,
+   which is correct on every surface — including the embedded one, where the store is not mounted at
+   all.
+
+6. **`docs/VISUALIZER_API.md` documents the additions with the same weight as the originals.** An
+   API surface that exists but is undocumented is the gap this ADR was written to close, and adding
+   to it silently would reproduce that gap one level down.
+
+## Alternatives Considered
+
+- **Leave the surface as it is, and rewrite the built-ins to use only what plugins get.** Genuinely
+  attractive: it keeps the API narrow, and it would prove the contract is sufficient by construction
+  rather than by assertion. Rejected because the shared modules exist for good reasons — `BeatTiles`
+  and `ReactiveTerrain` share an effects chain so the Glow slider drives both, and `LyricWordField`
+  is shared so `ScrollingLyrics` and `LyricStorm` cannot drift apart. Duplicating them into each
+  visualizer to satisfy a boundary would make the code worse to make the rule true.
+
+- **Expose the whole frontend module graph** — hand plugins everything and let them import what they
+  like. Simple to implement and never wrong about what is needed. Rejected because it makes every
+  internal a public contract at once, which is the cost point 4 accepts deliberately for five
+  modules and refuses to accept for hundreds.
+
+- **Version the added surface separately from `apiVersion`** — a `familiar.effectsVersion`, say, so
+  the wider API can move without touching the core. Rejected as machinery ahead of need: there is
+  one version number and no evidence yet that these two things want to move at different rates.
+  Point 4's contract is a promise, and a second version number would be a way of making a weaker
+  promise without saying so.
+
+- **Expose the modules but mark them unstable** — a `window.Familiar.unstable` namespace. Attractive
+  because it is honest about the risk in point 4. Rejected because it does not change what happens:
+  a plugin that uses an unstable module still breaks when it changes, and the label mostly moves the
+  blame. If these modules cannot be kept stable, they should not be exposed.
+
+## Consequences
+
+- **Positive:** The documented API becomes sufficient to write the visualizers that document it —
+  which is what an author copying a built-in has always assumed was true.
+- **Positive:** [ADR-0068](ADR-0068-built-in-visualizers-ship-as-drop-in-bundles.md) becomes
+  possible. It is the reason this is being done now, and it is not the only reason to do it.
+- **Tradeoff:** Five internal modules become public. Refactoring `FrameScheduler` or
+  `analysisMetrics` now has a cost outside this repository, and nothing in CI can tell you when you
+  have broken a stranger's visualizer.
+- **Tradeoff:** The exposed surface can only grow. Removing something from `window.Familiar` is an
+  `apiVersion` bump under `ADR-0034` point 7, which refuses every existing bundle — so a module
+  added here in error is expensive to take back.
+- **Tradeoff:** Point 2 admits one thing nothing uses. That is a small, deliberate breach of point
+  1's own rule, and it is the kind of exception that becomes a precedent if it is not labelled.
+- **Follow-up:** Nothing tests that a bundle built against the published globals actually loads.
+  `familiar-plugin-non-places` is the only artefact exercising the shared three.js globals today,
+  and after this there will be five more globals with no such artefact.
+- **Follow-up:** `ADR-0034` point 3 says a plugin "must not carry its own" copy of what the host
+  provides, and nothing enforces it. That contract now covers five more modules, and duplicating
+  `LyricWordField` in particular would produce two three.js scenes that look identical and diverge.

--- a/docs/decisions/ADR-0068-built-in-visualizers-ship-as-drop-in-bundles.md
+++ b/docs/decisions/ADR-0068-built-in-visualizers-ship-as-drop-in-bundles.md
@@ -1,0 +1,124 @@
+# ADR-0068: Built-In Visualizers Ship as Drop-In Bundles
+
+Status: proposed
+
+Date: 2026-08-18
+
+Supersedes [ADR-0034](ADR-0034-visualizers-are-drop-in-bundles.md) point 2 of its Implementation
+block — "a plugin claiming a built-in id is refused, not allowed to shadow it". The rest of `0034`
+stands. Depends on
+[ADR-0067](ADR-0067-the-plugin-api-exposes-what-a-first-party-visualizer-uses.md), and reads better
+after [ADR-0066](ADR-0066-music-video-is-a-player-mode-not-a-visualizer.md) has removed the entry
+that could not be converted.
+
+## Context
+
+**The ask is that every visualizer be readable and editable on disk**, not only the ones somebody
+dropped in. Today the drop-in folder holds what
+[ADR-0065](ADR-0065-the-app-seeds-the-drop-in-folder-with-worked-examples.md) seeds — two sample
+plugins — while the visualizers people actually watch are React components compiled into
+`VisualizerBundle.html`. Opening the folder shows two things and the menu shows six, and the four
+that are missing are the good ones.
+
+**Two constraints shape every answer, and neither is negotiable.**
+
+*The browser has no drop-in folder.* `visualizerPluginHost.discover()` returns null in an ordinary
+browser — its own comment says "a browser has no drop-in directory" — because the folder is a native
+filesystem the page is told about by the host. So the built-ins cannot simply move out to disk: the
+web app would have no visualizers at all, and `/visualizer` is a surface
+[ADR-0057](ADR-0057-the-web-app-keeps-only-what-has-no-native-answer.md) point 6 keeps out of every
+shrinking decision.
+
+*Shadowing is currently refused, for a reason that still holds.* `ADR-0034`'s Implementation records
+it: `registerVisualizer` overwrites by id and `visualizerRegistry` has no removal, so a plugin
+claiming `lyrics` would make the built-in unrecoverable short of deleting the file. That is a fact
+about the registry, not about the desirability of shadowing — and it is fixable.
+
+**Together they point at one shape.** The built-ins stay compiled in, so every client always has
+them; a local copy with the same id *replaces* the compiled one while it is present, and removing
+the folder gets the original back. Editing `reactive-terrain` on disk then really does change what
+draws, which is what "editable sources" has to mean to be worth anything.
+
+**`music-video` is not among the four.** `ADR-0066` moves it out of the visualizer set, which is
+convenient here and was decided on its own grounds: it would have been the one conversion requiring
+playback state and network access in a public plugin API.
+
+## Decision
+
+1. **The four built-ins are also built as standalone IIFE bundles and shipped as examples**, in the
+   format `ADR-0034` point 1 defines and against the globals `ADR-0067` exposes. They are the same
+   source, built a second way — not a copy maintained by hand, which would diverge within a month.
+
+2. **A local plugin may claim a built-in id, and wins while it is there.** This reverses `ADR-0034`'s
+   refusal. The registry gains removal, or registration is ordered so the compile-time set is
+   re-registered when a local copy disappears; either way the invariant is that **deleting the
+   folder restores the original**, and that is what makes the reversal safe where it was not before.
+
+3. **The compiled visualizers remain, on every client.** They are the fallback, and on the web app
+   they are the only copy — the browser has no folder. A shadowing copy is an override, never a
+   migration.
+
+4. **A shadowed built-in is visible as shadowed.** The picker already has the vocabulary:
+   `ADR-0034`'s Implementation made a shipped bundle losing to a local one report as `shadowed`
+   rather than vanish. The same wording applies here, so someone who edited `lyrics` on disk and
+   broke it can see why the menu changed.
+
+5. **Seeding follows `ADR-0065`.** These land in the same folder, by the same once-only copy, and
+   "Restore Example Visualizers" restores them too. A built-in restored from Settings is byte-identical
+   to the compiled one, which makes restore the way out of a broken edit.
+
+6. **A broken local copy falls back rather than failing.** `ADR-0034` point 8 already unloads a
+   visualizer that throws; here the fallback is specifically the compiled version of the same id, not
+   the album-art square, because one exists and is known good.
+
+## Alternatives Considered
+
+- **Ship the sources as read-only reference — the `.tsx` files, in the folder or beside it.** Much
+  cheaper: no bundling, no shadowing, no registry change, and it answers "I want to see how this
+  works" completely. Rejected because it does not answer "editable": a reader can change the file
+  and nothing happens, which is a worse kind of confusion than an empty folder — it looks like it
+  should work.
+
+- **Move the built-ins out of the app entirely and make everything a drop-in.** The cleanest
+  architecture on paper, and it would make the plugin path the only path, which is the best way to
+  keep it working. Rejected on the first constraint: the browser has no folder, so the web
+  visualizer would have nothing to draw, and a fresh install would depend on seeding having
+  succeeded for the app to have any visualizer at all.
+
+- **Keep the reserved-id refusal and ship the copies under different ids** — `reactive-terrain-example`
+  and so on. No registry change, no shadowing, no risk to the compiled set. Rejected because the
+  menu would then list eight entries, four of them near-duplicates of the others, and editing the
+  example still would not change what the original draws.
+
+- **Let a local copy shadow, but only while a developer flag is set.** Confines the risk to people
+  who asked for it. Rejected as a way of shipping a feature without deciding it: the flag would be
+  the real interface, undocumented, and the failure mode is a user who edits a file and cannot work
+  out why nothing changed.
+
+## Consequences
+
+- **Positive:** Every visualizer becomes readable and editable on disk, and editing one changes what
+  draws. That is the request, met literally rather than approximately.
+- **Positive:** The plugin path stops being a side entrance. The four visualizers people watch most
+  would run through the same loader as a stranger's, which is the strongest guarantee that the
+  loader keeps working — today it carries two samples nobody watches.
+- **Positive:** The registry gains removal, which `ADR-0034` recorded as the reason shadowing was
+  refused. That unblocks more than this ADR.
+- **Tradeoff:** Each built-in needs a build config producing an IIFE against the shared globals, and
+  a place in the app bundle. Four more artefacts to keep in step with their sources, and nothing
+  fails loudly if one is stale — the app would simply run yesterday's `lyrics`.
+- **Tradeoff:** Two ways to run the same visualizer, and the shadowing copy is the one users edit.
+  A bug reproducible in one and not the other is a genuinely confusing report, and "delete the
+  folder and try again" becomes a support answer.
+- **Tradeoff:** Point 2 widens what third-party code can do: a dropped-in plugin can now replace a
+  visualizer the user chose rather than only adding one. `ADR-0034` refused exactly this, and the
+  mitigation is point 4's visibility rather than a restriction.
+- **Tradeoff:** The app bundle grows by four more bundles, on top of the 3.3 MB inlined document
+  they are already inside. They are shipped twice — compiled into the page and again as drop-in
+  copies — and nothing is watching that total.
+- **Follow-up:** Whether the shipped-as-example copies should be built in CI and diffed against the
+  compiled sources, so a stale one fails a build rather than silently drawing last week's scene.
+- **Follow-up:** `ADR-0065` point 7 says a seeded example is not a supported artefact and may stop
+  loading across an `apiVersion` bump. That is a comfortable thing to say about a sample and an
+  uncomfortable one to say about `reactive-terrain`; point 3's compiled fallback is what makes it
+  survivable, and the wording of both should be reconciled.

--- a/docs/decisions/ADR-0068-built-in-visualizers-ship-as-drop-in-bundles.md
+++ b/docs/decisions/ADR-0068-built-in-visualizers-ship-as-drop-in-bundles.md
@@ -67,7 +67,13 @@ playback state and network access in a public plugin API.
    "Restore Example Visualizers" restores them too. A built-in restored from Settings is byte-identical
    to the compiled one, which makes restore the way out of a broken edit.
 
-6. **A broken local copy falls back rather than failing.** `ADR-0034` point 8 already unloads a
+6. **`docs/VISUALIZER_API.md` records the reversal, not just the new capability.** Its manifest
+   table currently tells authors an id "must not be one of the built-ins", which point 2 makes
+   false — and a document that forbids something the loader now permits is worse than one that is
+   merely incomplete, because an author will believe it and pick a worse id. The reserved-id row
+   changes, and the shadowing behaviour and its fallback are documented beside it.
+
+7. **A broken local copy falls back rather than failing.** `ADR-0034` point 8 already unloads a
    visualizer that throws; here the fallback is specifically the compiled version of the same id, not
    the album-art square, because one exists and is known good.
 


### PR DESCRIPTION
Three proposals, no code. They came out of one question — *why doesn't the Visualizers folder contain every visualizer?* — and answering it turned up two things that were more interesting than the question.

Sits on top of **#185** (ADR-0065), which ADR-0068 links; that link resolves when #185 merges.

## ADR-0066 — Music Video is a player mode, not a visualizer

It plays a YouTube video instead of drawing audio, and the code has been paying for that in four places, none of which looked like a symptom alone:

- **The only visualizer id special-cased anywhere** — three places in `FullPlayer` gate layout on `isMusicVideo`. A grep for the other four ids outside the registry and picker returns nothing.
- **The only one registered `usesMetadata: false`** — it uses nothing `VisualizerProps` provides.
- **The only one that cannot declare affinity.** ADR-0064 shipped it declaring none *on purpose*, and the reason it gave — "a different way of watching, not a scene that suits some music" — is a description of something that doesn't belong in the set.
- **The only one reaching outside the plugin API**, for `stores/playerStore`.

That last one is a **live defect**. The store is never mounted on the visualizer surface (ADR-0017's null engine), so `currentTime` reads 0 for the length of every track — Music Video's sync has been broken on the Mac and phone since ADR-0033 embedded it. `VisualizerProps.currentTime` already carries the right value on both surfaces.

The feature underneath is real and larger than its one affordance: five backend endpoints reachable only by picking a visualizer.

## ADR-0067 — the plugin API exposes what a first-party visualizer uses

**The documented API cannot express the visualizers that document it.** The built-ins import a shared effects chain, a frame scheduler, a shared lyric scene, analysis metrics and platform helpers — none of which `window.Familiar` provides. An author who copies a built-in finds half its imports missing, and that has been true since the format was adopted.

Five internal modules become public, which is the actual cost and is stated rather than discovered later. `apiVersion` stays 1: every addition is additive, and a bump would refuse every bundle that loads today.

**ADR-0066 is what makes this modest.** While Music Video was in the set, this surface would have needed `playerStore`, the API client and react-query — playback state and credentialed network access — in a public plugin contract, for one entry that draws nothing.

## ADR-0068 — built-ins ship as drop-in bundles, and a local copy shadows the compiled one

Two constraints force the shape:

- **The browser has no drop-in folder.** `discover()` returns null there by design, so the built-ins can't move out to disk — the web visualizer would have nothing to draw. The compiled set stays as the fallback.
- **Shadowing was refused** because `registerVisualizer` overwrites by id and the registry has no removal. That's a fixable fact about the registry, not an argument against shadowing — and the fix is what makes "delete the folder and get the original back" the invariant.

Editing `reactive-terrain` on disk then really does change what draws, which is what "editable sources" has to mean to be worth anything.

## Reading order

`0066` → `0067` → `0068`. Each is executable on its own; the ordering is what keeps `0067` small.

🤖 Generated with [Claude Code](https://claude.com/claude-code)