### PR TITLE
Propose ADR-0085 and ADR-0086: music videos become a Mac function

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -148,6 +148,28 @@ compatibility branch alive for one API. **Adopting `NavigationStack` is delibera
 — that is the payoff, recorded as a follow-up, and a navigation rewrite should not ride along with a
 deployment-target bump.
 
+**`ADR-0085`–`ADR-0086` bring music videos to the Mac as a function of their own** (both `proposed`,
+2026-08-18). **Execution order is `0086` then `0085`** — server work every client inherits first.
+`0086` makes the existing feature a real resource: `track_videos` has been declared, exported and
+created by the baseline's `create_all` while being read and written by nothing, the stream handler
+advertises `Accept-Ranges` and never parses a `Range`, and `videos` is not one of the eleven
+vendored tags, so no generated client can reach it. `0085` then says the thing the PWA got wrong:
+**a music video is a way of playing a track, not a visualizer**. The evidence is that the visualizer
+route was never wired on this host — `VisualizerChoice` already offers `music-video`, but
+`MusicVideo.tsx` reads `usePlayerStore` instead of the `currentTime` prop the native frame feeds, so
+the Mac's copy never seeks. That is the **fourth** instance of the mounted-affordance defect
+`ADR-0017`'s record tracks, and the first to arrive through a hand-mirrored list rather than a
+missing screen.
+
+**Point 9 — deleting the web visualizer — is where three things meet, so read it before severing
+it.** It removes one of the two `queueStore` pins `docs/REMOVING-THE-WEB-PLAYER.md` records; it is
+the premise `ADR-0067` and `ADR-0068` each rest on ("the whole reason this ADR is modest"); and it
+is what makes point 10's parity row ❌ in the Web column, which excludes music video from the
+player's removal countdown under `ADR-0060` point 1's second rule. Keep the web visualizer and the
+row becomes ✅ ✅ ❌, which *joins* the countdown and blocks the player's removal. **The phone loses
+music video either way** — `VisualizerChoice.musicVideo` lives in the shared `FullPlayerView`, and
+the four replacement surfaces are Mac-only by `ADR-0013` point 2.
+
 ## Key Directories
 
 ```

--- a/docs/decisions/ADR-0085-music-videos-are-a-mac-function-not-a-visualizer.md
+++ b/docs/decisions/ADR-0085-music-videos-are-a-mac-function-not-a-visualizer.md
@@ -1,0 +1,185 @@
+# ADR-0085: Music Videos Are a Mac Function, Not a Visualizer
+
+Status: proposed
+
+Date: 2026-08-18
+
+Extends [ADR-0013](ADR-0013-the-mac-is-a-management-surface-too.md), and takes point 2 at its word:
+this lands on the Mac and not the phone. Depends on
+[ADR-0086](ADR-0086-music-videos-become-a-persisted-resource.md), which **executes first** — the
+list endpoint and range support this ADR's surfaces are built on do not exist yet.
+
+## Context
+
+The web app has had music videos since Phase 5, shaped as a **visualizer**: `music-video` is one of
+the five ids the registry actually holds (`ADR-0063` records the list;
+`packages/frontend/src/components/Visualizer/visualizers/MusicVideo.tsx`, 290 lines), it draws in
+the player's artwork area, and it syncs a muted `<video>` to the audio.
+`ADR-0064` point 2 already noticed the shape was odd — it is the one built-in that declares no
+affinity, because "it plays a video rather than drawing the audio, so no honest claim exists".
+
+That shape does not survive contact with the Mac. A visualizer there is the web bundle in a
+`WKWebView` (`ADR-0034`), reached from a menu in the player and confined to the player's background.
+It cannot own a fullscreen presentation, it cannot be a sidebar destination, and it cannot carry a
+management action like matching a video to a track. Those are the three things wanted.
+
+**The visualizer route is also, today, not actually wired on this host.**
+`App/Shared/ServerConfiguration.swift:392` already offers `case musicVideo = "music-video"` in the
+native picker, so the affordance is there. But `packages/frontend/src/components/Embed/EmbedVisualizer.tsx:47`
+feeds visualizers `currentTime={state.position}` from the native frame, and `MusicVideo.tsx:33`
+deliberately ignores that prop — `// Read currentTime directly from store (avoids prop cascade from
+FullPlayer)` — reading `usePlayerStore` instead, which on `/visualizer` is never driven. Selecting
+Music Video on the Mac gives a video that responds to play and pause and never seeks to the audio.
+
+This is the fourth instance of one shape, and the record should say so plainly: an affordance whose
+destination is not mounted, failing silently. `ADR-0017`'s record already lists three —
+zero-height virtualised lists (`familiar` #70), a play that posted no intent (#74), and "Listening
+Ideas" with no chat to open (#76). The lesson there was to check what an affordance reaches. This
+one was reached by a *mirrored list*: `VisualizerChoice` is hand-copied from the page's registry,
+and copying the id is exactly the half that cannot tell you whether the thing works.
+
+The synchronisation clock available on this side is `Playhead`
+(`familiar-apple/Sources/FamiliarKit/Playhead.swift:31`), published by `FamiliarPlayer` under
+`ADR-0041` and updated "roughly four times a second while playing". That is the real bound on how
+tight video sync can be, and it is stated here rather than discovered later.
+
+## Decision
+
+1. **A music video is a way of playing a track, not a way of decorating one.** On the Mac it is not
+   a visualizer, does not appear in the visualizer picker, and is not a candidate for the
+   auto-selector `ADR-0064` point 7 added. It is a mode the current track can be put into, and a
+   thing the library can be browsed by.
+
+2. **The library file stays the source of truth; the video is muted.** Audio comes from the existing
+   engine, so crossfade (`ADR-0026`), effects (`ADR-0015`), listening events (`ADR-0004`) and
+   scrobbling (`ADR-0030`) are untouched, and a play is a play whether or not it was watched.
+   Nothing downstream needs to learn that video exists.
+
+3. **Sync is correction-on-threshold against `Playhead`.** `AVPlayer` runs at rate 1.0 while the
+   engine plays; on each playhead update, a drift past a threshold triggers a seek with zero
+   tolerance in both directions. An explicit seek, a pause, and a track change re-anchor
+   immediately rather than waiting for drift. **The threshold must sit comfortably above the
+   sampling jitter of a 4 Hz clock**, or the correction fires on its own measurement noise and the
+   video stutters — the failure mode is a tighter threshold making sync visibly *worse*.
+
+4. **Sync quality is bounded by that 4 Hz clock, and this ADR does not raise it.** If it reads loose
+   in real use, the fix is the engine publishing a host-time-anchored position that `AVPlayer` can
+   be scheduled against, which is an audio-engine decision and belongs in its own ADR. Recorded as a
+   follow-up so the bound is a known limit rather than a surprise.
+
+5. **Video and the visualizer are mutually exclusive occupants of the player's background.**
+   `App/Shared/FullPlayerView.swift:91` already makes that slot *either* the visualizer *or* the
+   cover; video is a third occupant of the same slot, and turning it on turns the visualizer off —
+   the state is one choice, not two independent toggles beside
+   `ServerConfiguration`'s `showsVisualizer(profileID:)`. This is `ADR-0064`'s own defect — album
+   art drawn over a playing video, because two places each read "which visualizer is on"
+   separately, recorded in that ADR's `## Implementation` — prevented rather than repeated in a
+   second place.
+
+6. **The crossfade boundary is not mirrored.** During a crossfade two tracks overlap and only one
+   video can be on screen; the video follows the current track and cuts at the boundary. Two
+   overlapping videos is not being built, and saying so here stops it being read as a bug.
+
+7. **Four surfaces, all on the Mac** (`ADR-0013` point 2 keeps the phone on the listening path):
+   - **A Watch control on `FullPlayerView`**, enabled only when the track has a video, disabled
+     with a reason when it does not. Not hidden: the same screen is where you would go to get one.
+   - **A Videos row in the sidebar's Library section**, beside Music Map and Discover — a way of
+     *finding* something to play, not something done *to* the library, which is the distinction
+     `LibrarySidebar.swift` already draws between its Library and Manage sections. Built on
+     `ADR-0086` point 3's list endpoint.
+   - **Match and download, as an action on a track** — search, choose, download — alongside
+     `uploadArtwork` and `removeArtwork` in `App/Shared/RowActions.swift` (`:181`, `:221`), which
+     are the closest existing precedent: an external asset attached to a track from its row.
+   - **Fullscreen playback** with transport controls, which is the thing a visualizer could never
+     be given.
+
+8. **The routing change goes through `LibraryRouting.swift`, and the sidebar row is added by hand.**
+   `ADR-0032` point 7's argument applies unchanged: a `SidebarItem` case makes
+   `LibraryRoot.init(selecting:)`, `sidebarItem(section:)` and `LibraryView`'s exhaustive switches
+   fail to compile until handled. **The sidebar row itself is not one of those sites** —
+   `LibrarySidebar.swift:82` records that the rows are literals rather than a `ForEach` over
+   `allCases`, so the compiler is no help and a forgotten row is a destination that exists and
+   cannot be reached. Stated as a decision point because it is the step this ADR is most likely to
+   lose.
+
+9. **The `music-video` visualizer is removed from the web registry**, along with
+   `VisualizerChoice.musicVideo` in the native picker. What would remain is the broken copy
+   described in `## Context`, advertising on the Mac a function that now exists properly elsewhere.
+   It also pays for itself on work already in flight: `docs/REMOVING-THE-WEB-PLAYER.md:68` and `:86`
+   name `MusicVideo.tsx → stores/playerStore` as one of the two pins holding `queueStore`
+   (`packages/frontend/src/player/queueStore.ts`, 1,193 lines) into the visualizer bundle. Removing
+   the visualizer removes the pin. **This point is severable in the sense that 1–8 stand without
+   it — but severing it is not free, and two other things now depend on it.**
+
+   - `ADR-0067` says Music Video's absence from the plugin API "is the whole reason this ADR is
+     modest", and `ADR-0068` calls it "the one conversion requiring playback state and network
+     access in a public plugin API". Keep the web visualizer and both re-expand.
+   - Point 10's parity row turns on it. With the web copy gone the row is ❌ in the Web column and
+     is excluded from the player's countdown automatically; with it kept the row is ✅ ✅ ❌ and
+     **joins** the countdown.
+
+10. **`docs/WEB-PARITY.md` gains a music video row, and it reads `❌ | ✅ | ❌`.** The file has no row
+    for this feature at all today, which is how something with five endpoints came to have its
+    reachability never discussed. The phone column is the honest one and it is a **loss**, not an
+    omission: `App/Shared/FullPlayerView.swift`'s `visualizerChoices` is not inside an
+    `#if os(macOS)`, so `VisualizerChoice.musicVideo` is on the iPhone today and point 9 removes it.
+
+    **No new exclusion ADR is needed, provided point 9 is taken.** `ADR-0060` point 1's second rule
+    — a row ❌ in the Web column too "is not something the browser provides and cannot be a reason to
+    keep it" — applies mechanically, exactly as it did for New Releases detail. `ADR-0060` point 3's
+    requirement of an ADR is for adding a row to the *by-decision* list, which this is not.
+
+## Alternatives Considered
+
+**Let the video's own audio play and stand the engine down for the duration.** Much simpler: no sync
+problem at all, no 4 Hz bound, no drift correction to tune. Rejected because it silently changes
+what the app is doing — effects, crossfade and the spectrum tap all apply to the engine and none
+would apply to the video; the audio would be a YouTube encode rather than the file in the library
+that was analysed; and "what counts as a play" (`ADR-0004`) would have to be redefined for a stream
+that is not your file. The listening history is the asset here, and this would put a hole in it
+every time a video was watched.
+
+**Start the video with the audio and never re-seek.** Cheapest correct-looking option, and it holds
+for exactly one uninterrupted playthrough. Rejected because any pause, seek, or slow first frame
+desynchronises it permanently, and the PWA's own implementation shows the correction is the cheap
+part — `MusicVideo.tsx` does it in five lines with a 0.5 s threshold.
+
+**Fix `MusicVideo.tsx` to read its `currentTime` prop and leave it a visualizer.** This would work,
+and it is a real option — one line, and the Mac's existing picker entry starts syncing. Rejected
+because working is not the same as being the right shape: a visualizer cannot own fullscreen, cannot
+be a sidebar destination, and cannot carry the match-and-download action, which together are the
+whole request. Worth recording that the cheap fix exists, because if this ADR is rejected that fix
+should be applied anyway — the current state advertises something broken.
+
+**Build it on the phone as well.** Deferred rather than rejected. `ADR-0013` point 2 keeps
+management off the phone, so at minimum the match-and-download half would not go; and video files
+are the largest thing this app would put on a device, landing on the one with least room. If phone
+playback is wanted later it extends this ADR rather than reopening it.
+
+**A Videos row under Manage rather than Library.** Arguable, since attaching a video to a track is
+management. Rejected on the same reasoning the sidebar already applies to Music Map and Discover:
+the *destination* is a way of finding something to play. The management half is the row action in
+point 7, which is where the management shape belongs.
+
+## Consequences
+
+- **Positive** — the Mac gains the function the PWA only ever gestured at, in a shape that can hold
+  fullscreen, a destination, and an action.
+- **Positive** — a fourth instance of the mounted-affordance defect is closed rather than left to be
+  found a fifth time, and the mirrored-list mechanism that produced it is named.
+- **Positive** — point 9, if taken, removes one of the two Dexie pins that
+  `docs/REMOVING-THE-WEB-PLAYER.md` records as blocking the web player's removal.
+- **Tradeoff** — sync is bounded by a 4 Hz playhead and will not be frame-accurate. Point 4 says so
+  rather than implying otherwise.
+- **Tradeoff** — **the phone loses a capability it has today**, rather than simply not gaining one.
+  `VisualizerChoice.musicVideo` is in the shared `FullPlayerView`, so an iPhone can select Music
+  Video now; point 9 removes it and the four replacement surfaces are Mac-only. What it loses is a
+  half-working copy — the same one that never seeks, per `## Context` — but it plays, and it will
+  stop. A video downloaded on the Mac is watchable only there.
+- **Tradeoff** — video files are large and `videos_path` is already in the S3 backup set
+  (`backend/app/services/s3_backup.py:312`), so making videos easier to acquire makes backups grow.
+- **Follow-up** — a host-time-anchored position on the audio engine, if point 4's bound proves too
+  loose in use.
+- **Follow-up** — whether `match_confirmed_by` on `track_videos` is written by point 7's action.
+  `ADR-0086`'s own follow-up says the column should be removed if nothing claims it, and this action
+  is its only plausible caller.

--- a/docs/decisions/ADR-0086-music-videos-become-a-persisted-resource.md
+++ b/docs/decisions/ADR-0086-music-videos-become-a-persisted-resource.md
@@ -1,0 +1,151 @@
+# ADR-0086: Music Videos Become a Persisted Resource
+
+Status: proposed
+
+Date: 2026-08-18
+
+Extends [ADR-0007](ADR-0007-clients-are-generated-from-openapi.md), whose vendored surface this adds
+one tag to, and whose point 8 it leans on for the one handler that stays outside. Prerequisite for
+[ADR-0085](ADR-0085-music-videos-are-a-mac-function-not-a-visualizer.md) — **this one executes
+first**, on the principle that server-side work every client inherits comes before client work.
+
+## Context
+
+Music video support has been in the product since Phase 5 and was never removed. That is worth
+stating because it has already been got wrong once:
+[ADR-0055](ADR-0055-the-site-is-restructured-around-five-things.md) lines 50–55 record an audit that
+concluded the support had been deleted, on a grep that used the wrong term. What was removed is a
+row on the website's comparison table (`docs/SITE-CLAIMS.md:101`), not the feature. The router is
+mounted at `app/main.py:515`.
+
+What exists, verified at write time:
+
+- `app/api/routes/videos.py` (254 lines) — five operations under `/videos`, all keyed by track:
+  `search`, `status`, `download`, `stream`, `delete`.
+- `app/services/video.py` (280 lines) — yt-dlp search and download, one file per track at
+  `settings.videos_path` (`app/config.py:41`, default `data/videos`), already in the S3 backup set
+  (`app/services/s3_backup.py:312`).
+- `TrackVideo`, table `track_videos` (`app/db/models/tracks.py:339`) — `source`, `source_id`,
+  `source_url`, `file_path`, `is_audio_only`, `file_size_bytes`, `video_metadata`,
+  `match_confirmed_by`, `downloaded_at`, `last_played_at`, with a unique constraint on
+  `(track_id, source, source_id)`.
+
+Three findings make this ADR necessary rather than optional, and all three were checked rather than
+assumed:
+
+1. **`videos` is not in the generated surface.** `scripts/lint_openapi.py:59` lists eleven vendored
+   tags and `videos` is not among them, so a generated client cannot reach these operations at all.
+2. **`track_videos` is orphaned.** It is declared and exported (`app/db/models/__init__.py:39`), and
+   the table does exist — the baseline builds fresh databases with `Base.metadata.create_all()`
+   (`migrations/versions/20241231_000000_baseline.py`), so it is created without a named migration
+   ever mentioning it. **Nothing in the application reads or writes it.** No migration file in
+   `migrations/versions/` contains the string `video` at all. The service's own
+   `VideoDownloadStatus` is an unrelated in-memory dataclass whose similar name is the reason this
+   is easy to miss.
+3. **The stream handler advertises range support it does not implement.** It sets
+   `Accept-Ranges: bytes` and then reads the file from byte 0 on every request; the `Range` request
+   header is not parsed anywhere in the file. A player that seeks gets the whole file again from the
+   start.
+
+A fourth fact shapes the scope: **download state lives only in process memory.**
+`VideoService._downloads` is a `dict` (`app/services/video.py:43`) populated by `set_pending` and
+the download coroutine, and the download itself runs in FastAPI `BackgroundTasks`. A restart loses
+every in-flight download and every record of which YouTube video a file came from — `has_video()`
+is a check that `{track_id}.mp4` exists on disk, and nothing more.
+
+The consequence that matters for `ADR-0085` is that **there is no way to ask which tracks have
+videos.** Every operation is keyed by a track id you already have. A destination that lists them has
+nothing to call.
+
+There are **no functional tests for this feature** on either side. The only test that mentions
+`/videos/` is `tests/test_contract_error_shapes.py`, which asserts an error envelope.
+
+## Decision
+
+1. **`track_videos` becomes the record of what was downloaded.** A completed download writes a
+   `TrackVideo` row — `source` (`youtube`), `source_id`, `source_url`, `file_path`,
+   `file_size_bytes`, `downloaded_at`, and the yt-dlp metadata worth keeping in `video_metadata`.
+   The columns already exist and are adequate; this is a service that starts using its table, not a
+   schema change. `delete_video` removes the row with the file.
+
+2. **`has_video` and `get_download_status` resolve against the database first.** The in-memory dict
+   stays as the progress cache for a download that is currently running — that is what it is good
+   at — but a restart no longer erases the fact that a video exists, and "which video" becomes
+   answerable. Where the two disagree, the file on disk wins for existence and the row wins for
+   identity; a row whose `file_path` is gone is deleted rather than reported.
+
+3. **`GET /videos` lists tracks that have a video**, paged, ordered, returning enough to draw a row
+   — track id, title, artist, the source id, and `downloaded_at`. This is the operation
+   `ADR-0085`'s destination is built on, and it is the one thing the current surface cannot do.
+
+4. **`GET /videos/{track_id}/stream` honours `Range`.** Parse the header, return `206` with a
+   correct `Content-Range` and only the requested bytes, and return `200` with the whole file when
+   there is no header. `Accept-Ranges: bytes` then stops being a claim the handler cannot keep.
+   **`release_connection(db)` stays exactly where it is** — the comment above it records why, and it
+   is the fix for a defect that turned 834 downloads into 83-byte error bodies: a `yield` dependency
+   otherwise holds a database connection for the length of the video.
+
+5. **The `videos` tag joins `VENDORED_TAGS`** (`scripts/lint_openapi.py:59`) — **except the stream
+   handler, which stays out under ADR-0007 point 8.** That point already excludes
+   `/tracks/{id}/stream` for exactly this reason: range requests are handled by `URLSession`
+   directly, and generated clients handle them badly. The video stream is the same kind of thing and
+   `AVPlayer` is the caller, so it is written by hand on the client. Search, status, download, list
+   and delete are ordinary JSON and are generated.
+
+6. **The video stream is media, and inherits ADR-0045's media exemption.** That ADR decided on
+   2026-08-09 that artwork and audio streams are exempt from the authentication gate, because a
+   media element cannot send a header and a cast target holds no credential. A video element is the
+   same case. This is recorded so it is not re-litigated when point 5 of that ADR ships, and so
+   nobody adds a profile header to an `AVURLAsset` to work around a gate that does not apply.
+
+7. **Every point above gets a test.** The feature has none today, which is why three of the findings
+   in `## Context` survived this long: range correctness (a `206` with the right `Content-Range` and
+   the right bytes, and a `200` without the header), the list endpoint's shape, and a download that
+   writes its row. The lint script already fails if the vendored tag set and the schema disagree, so
+   point 5 tests itself.
+
+## Alternatives Considered
+
+**Leave the endpoints un-vendored and hand-write all five calls in Swift.** Tempting because the
+stream has to be hand-written anyway, so the split feels like an inconsistency. Rejected because
+ADR-0007's carve-out is specifically about *bodies generated clients handle badly* — range requests
+and SSE — and search results, status and a paged list are ordinary JSON. Hand-writing them buys a
+false tidiness and gives up the schema check that catches a response shape changing underneath the
+client.
+
+**Move the download to the Redis worker system** (`app/services/background.py`, `tasks.py`) instead
+of `BackgroundTasks`. Genuinely better for a long download that should survive a deploy, and
+rejected here on scope: it is a decision about where background work runs, it would apply to more
+than videos, and `BackgroundTasks` is adequate for one user-initiated download of a few minutes.
+Making the record durable (point 1) removes the sharp edge — a lost in-flight download is now
+visibly incomplete rather than invisibly forgotten.
+
+**Keep file existence as the source of truth and answer `GET /videos` with a directory scan.**
+Cheapest possible list endpoint, and it works, since the filenames are track ids. Rejected because
+it cannot answer *which* video is attached, which is what a re-match needs, and because it makes the
+orphaned table permanent — a schema that describes something the code refuses to use is worse than
+no schema at all.
+
+**Add `has_video` to the track model's serialisation instead of a list endpoint.** Would let any
+existing list filter on it with no new operation. Rejected: it puts a per-track filesystem or join
+cost on every track response in the app to serve one screen, and the filter belongs where the
+question is asked.
+
+## Consequences
+
+- **Positive** — the Mac can ask what has a video, which is the single blocker on `ADR-0085`'s
+  destination.
+- **Positive** — `AVPlayer` can seek, and so can any browser `<video>` element; the header stops
+  being a promise the handler breaks.
+- **Positive** — a table that has been declared, exported and unused becomes load-bearing, and the
+  `(track_id, source, source_id)` unique constraint starts doing the job it was written for.
+- **Positive** — the first functional tests this feature has ever had.
+- **Tradeoff** — existence is now answered from two places (a row and a file) and they can disagree.
+  Point 2 states which wins for which question rather than leaving it to be discovered.
+- **Tradeoff** — a download that dies with the process still leaves no row, so it looks like a
+  download that never started. Better than the current behaviour, but not the same as durable.
+- **Follow-up** — moving the download to the worker system, if a video that survives a deploy turns
+  out to matter.
+- **Follow-up** — `is_audio_only`, `match_confirmed_by` and `last_played_at` stay unused after this
+  ADR. They are not removed, because `ADR-0085`'s match-and-download action is the natural caller
+  for `match_confirmed_by`; if it ships without one, they should go.


### PR DESCRIPTION
Two ADRs bringing music videos to the Mac as a function of their own, plus the `CLAUDE.md` entry for them. **Execution order is 0086 then 0085** — server work every client inherits comes first.

Both `proposed`. No code changes.

## Renumbered from 0065/0066

They were written on `strip/remove-web-player`, which sits at `bd6476f` — before #185, #186 and #187 landed. Both numbers are taken on `main` by the visualizer series (0065 seeds the drop-in folder, 0066 is *Music Video Is a Player Mode, Not a Visualizer*). Cross-links moved with them; the ADRs are otherwise unchanged in substance.

## What they decide

**ADR-0086 — music videos become a persisted resource.** Three findings, all checked rather than assumed: `videos` is not one of the eleven vendored tags, so no generated client can reach it; `track_videos` is declared, exported, and created by the baseline's `create_all` while **nothing in the application reads or writes it**; and the stream handler sets `Accept-Ranges: bytes` and never parses a `Range`, so a player that seeks gets the whole file from the start. It writes the table, resolves `has_video` against the database, adds `GET /videos`, implements `Range`, joins `VENDORED_TAGS` — **except the stream handler**, which stays out under ADR-0007 point 8, the same carve-out `/tracks/{id}/stream` already has — and gives the feature its first functional tests.

**ADR-0085 — a music video is a way of playing a track, not a way of decorating one.** Four Mac surfaces: a Watch control, a Videos row in the sidebar's Library section, match-and-download as a row action, and fullscreen playback — the thing a visualizer could never be given. The library file stays the source of truth with `AVPlayer` muted, so crossfade, effects, listening events and scrobbling are untouched.

Its sync design is the part worth reading: correction-on-threshold against `Playhead`, which updates at **4 Hz**, with the bound stated as a limit rather than discovered later — and the warning that too tight a threshold makes sync visibly *worse*, because the correction fires on its own sampling noise.

## Two additions from reconciling against what is already decided

**Point 10 — a `WEB-PARITY.md` row, reading `❌ | ✅ | ❌`.** The feature has never had one, which is how something with five endpoints had its reachability never discussed. **No exclusion ADR is needed**: ADR-0060 point 1's second rule already excludes a row that is ❌ in the Web column, exactly as it did for New Releases detail.

**Point 9 is annotated rather than left marked severable without qualification.** Deleting the web visualizer is where three things meet:

- it removes one of the two `queueStore` pins `docs/REMOVING-THE-WEB-PLAYER.md` records;
- it is the premise ADR-0067 and ADR-0068 each rest on — 0067 calls it "the whole reason this ADR is modest";
- it is what makes the Web column ❌.

**Sever it and the row becomes `✅ ✅ ❌`, which joins the countdown and blocks the web player's removal.** So severing is not the cheap option it looks like.

## The phone loses music video, and that is stated as a loss

`VisualizerChoice.musicVideo` lives in the shared `App/Shared/FullPlayerView.swift`, and `visualizerChoices` is **not** inside an `#if os(macOS)` — so an iPhone can select Music Video today. It is the half-working copy that never seeks (the defect ADR-0085's Context describes), but it plays, and point 9 stops it. The four replacement surfaces are Mac-only under ADR-0013 point 2.

## Supersedes ADR-0084

`ADR-0084` in #188 answered ADR-0066's open point 4 and is withdrawn there. It was wrong in one place that matters: it had the `videos` tag joining the generated surface with **no stream carve-out**, which is exactly what ADR-0007 point 8 exists to prevent.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
