### PR TITLE
Propose ADR-0087: a visualizer is a document, not a component

### DIFF
--- a/docs/decisions/ADR-0034-visualizers-are-drop-in-bundles.md
+++ b/docs/decisions/ADR-0034-visualizers-are-drop-in-bundles.md
@@ -1,7 +1,8 @@
 # ADR-0034: Visualizers Are Drop-In Bundles
 
 Status: accepted — points 1 and 3 superseded by
-[ADR-0087](ADR-0087-a-visualizer-is-a-document-not-a-component.md)
+[ADR-0087](ADR-0087-a-visualizer-is-a-document-not-a-component.md), point 4's two-source model by
+[ADR-0089](ADR-0089-the-app-bundle-seeds-the-folder-and-is-not-a-source.md)
 
 Date: 2026-08-06
 
@@ -163,7 +164,11 @@ permissible at all.
    sample that uses three.js already externalises all four in its rollup config. The other two
    externalise only React, which is not a counter-example: a plugin externalises what it imports.
 
-4. **Two sources, and only two: shipped and local.** Shipped bundles live in the app bundle's
+4. **Two sources, and only two: shipped and local.**
+   *(Superseded by [ADR-0089](ADR-0089-the-app-bundle-seeds-the-folder-and-is-not-a-source.md):
+   there is one source, the folder, and the app bundle seeds it. The per-platform directory this
+   point specifies is unaffected and still governs.)*
+ Shipped bundles live in the app bundle's
    resources and are what a fresh install has. Local bundles live in a `Visualizers/` directory the
    user can open, which a button in Settings reveals in Finder or the Files app. There is no third
    source in this ADR.

--- a/docs/decisions/ADR-0034-visualizers-are-drop-in-bundles.md
+++ b/docs/decisions/ADR-0034-visualizers-are-drop-in-bundles.md
@@ -1,6 +1,7 @@
 # ADR-0034: Visualizers Are Drop-In Bundles
 
-Status: accepted
+Status: accepted — points 1 and 3 superseded by
+[ADR-0087](ADR-0087-a-visualizer-is-a-document-not-a-component.md)
 
 Date: 2026-08-06
 

--- a/docs/decisions/ADR-0067-the-plugin-api-exposes-what-a-first-party-visualizer-uses.md
+++ b/docs/decisions/ADR-0067-the-plugin-api-exposes-what-a-first-party-visualizer-uses.md
@@ -1,6 +1,18 @@
 # ADR-0067: The Plugin API Exposes What a First-Party Visualizer Uses
 
-Status: proposed
+Status: rejected — superseded before acceptance by
+[ADR-0087](ADR-0087-a-visualizer-is-a-document-not-a-component.md)
+
+**Rejected because its subject no longer exists.** This ADR decided *what* the host should expose on
+`window.Familiar` — React, THREE, `@react-three/fiber`, drei and a set of hooks — having concluded
+that the list should be what a first-party visualizer actually uses. `ADR-0087` removes the global
+entirely: a visualizer is a document that brings its own libraries, so there is nothing left to
+choose the contents of.
+
+Its reasoning was sound for the contract it was written against, and one observation outlived it:
+the note that Music Video was the only built-in needing `playerStore` and an API client, and that its
+absence is what kept this surface small. That was evidence the component contract was wrong, and
+`ADR-0087` cites it as such.
 
 Date: 2026-08-18
 

--- a/docs/decisions/ADR-0068-built-in-visualizers-ship-as-drop-in-bundles.md
+++ b/docs/decisions/ADR-0068-built-in-visualizers-ship-as-drop-in-bundles.md
@@ -1,6 +1,21 @@
 # ADR-0068: Built-In Visualizers Ship as Drop-In Bundles
 
-Status: proposed
+Status: rejected — superseded before acceptance by
+[ADR-0087](ADR-0087-a-visualizer-is-a-document-not-a-component.md) and
+[ADR-0088](ADR-0088-every-visualizer-ships-as-a-document.md)
+
+**Rejected because the format it converts to was replaced.** This ADR would have built the four
+built-ins as IIFE bundles against the globals `ADR-0067` exposes, so that shipped and drop-in
+visualizers were one shape. `ADR-0087` deletes that format, and `ADR-0088` reaches the same
+destination by a different route: every visualizer, shipped or dropped in, is a folder with an
+`index.html`.
+
+**Its central argument survived and is why `ADR-0088` exists.** Point 3 said each visualizer should
+be built once and shipped once, because "two builds of one visualizer would drift, and nothing in CI
+could see it". That is precisely the reasoning `ADR-0088` used to refuse a smaller shipped set with
+the rest demoted to drop-ins — two categories that drift are no better than two builds that do.
+Point 2's reversal, letting a local plugin shadow a built-in, is inherited unchanged: with one shape
+there is nothing special about a shipped id.
 
 Date: 2026-08-18
 

--- a/docs/decisions/ADR-0087-a-visualizer-is-a-document-not-a-component.md
+++ b/docs/decisions/ADR-0087-a-visualizer-is-a-document-not-a-component.md
@@ -1,6 +1,7 @@
 # ADR-0087: A Visualizer Is a Document, Not a Component
 
-Status: accepted
+Status: accepted — point 8 superseded by
+[ADR-0088](ADR-0088-every-visualizer-ships-as-a-document.md)
 
 Date: 2026-08-20
 

--- a/docs/decisions/ADR-0087-a-visualizer-is-a-document-not-a-component.md
+++ b/docs/decisions/ADR-0087-a-visualizer-is-a-document-not-a-component.md
@@ -1,6 +1,6 @@
 # ADR-0087: A Visualizer Is a Document, Not a Component
 
-Status: proposed
+Status: accepted
 
 Date: 2026-08-20
 

--- a/docs/decisions/ADR-0087-a-visualizer-is-a-document-not-a-component.md
+++ b/docs/decisions/ADR-0087-a-visualizer-is-a-document-not-a-component.md
@@ -69,10 +69,20 @@ Support on macOS, `Documents/Visualizers` on iOS (`ADR-0034` point 4) — exists
    browsing context. Whatever is inside it — canvas, WebGL, shaders, p5, three.js, a `<video>`, or
    plain DOM — is the plugin's business.
 
-2. **The host sends data and lends nothing.** Track metadata and audio frames arrive as events on
-   the plugin's own window. There is no `window.Familiar` library surface: no React, no THREE, no
-   `@react-three/fiber`, no `Drei`. What `ADR-0034` point 6 defined as `VisualizerProps` and
-   `AudioData` survives as the *payload*; only the delivery changes.
+2. **The host sends data and lends nothing.** There is no `window.Familiar` library surface: no
+   React, no THREE, no `@react-three/fiber`, no `Drei`. The whole API is three inbound events and
+   one outbound handshake:
+
+   | | |
+   |---|---|
+   | `familiar:track` | the track changed — id, title, artist, album, artwork URL, features, lyrics |
+   | `familiar:audio` | an analysis frame — the `AudioData` shape `ADR-0034` point 6 already defines |
+   | `familiar:state` | playing or paused, and the playhead |
+   | `familiar:ready` (out) | the document is listening, so the host knows a blank frame is loading rather than broken |
+
+   What `ADR-0034` point 6 defined as `VisualizerProps` and `AudioData` survives as the *payload*.
+   Only the delivery changes. **A visualizer that ignores every event and draws nothing is still a
+   valid visualizer** — the contract obliges a plugin to receive, never to implement.
 
 3. **`ADR-0034` point 3 is superseded outright.** "The host provides four libraries and a bundle
    must not carry its own" was the source of the coupling, of the version contract `ADR-0063` was
@@ -92,12 +102,26 @@ Support on macOS, `Documents/Visualizers` on iOS (`ADR-0034` point 4) — exists
    is a traversal surface that a single known filename was not. This is the one place the change
    adds risk rather than removing it, and it is named here so it is designed rather than discovered.
 
-7. **The built-ins become documents too, and sharing becomes something a plugin opts into by URL.**
-   One shape, not two. The shipped visualizers may load a vendored copy of THREE served by the same
-   handler with an ordinary `<script src>` — which is different in kind from an injected global,
-   because it is the plugin's choice, visible in its own source, and versioned by the URL it names.
+7. **There is no sharing mechanism at all, and the existing visualizers are not a constraint on
+   this.** Every visualizer is a document that carries what it needs. No injected globals, no
+   host-vendored library served by URL, no externals in a plugin's build config.
 
-8. **`familiar.apiVersion` (`ADR-0034` point 7) now versions the event contract**, which is a much
+   **This is the point where the decision was made deliberately against the current set.** The
+   simplest contract and the survival of three `@react-three/fiber` scene graphs are in tension: a
+   sharing mechanism exists only to spare them each bundling THREE. Asked directly, the answer was
+   that a solid, simple contract matters more than any particular visualizer. So the hatch is not
+   built, and the three r3f built-ins are rewritten as self-contained documents, demoted to
+   optional drop-ins, or dropped — a question for whoever does the work, not a constraint on the
+   contract.
+
+8. **The shipped set is deliberately small, and elaborate visualizers are drop-ins.** Point 7's cost
+   is paid in the app bundle if the shipped set is large — three self-contained r3f documents is
+   several copies of a 2.4 MB library. The answer is not a sharing mechanism but fewer shipped
+   visualizers: one or two cheap ones that prove the contract and give a fresh install something to
+   look at. Anything heavier is something a listener installs, which is what `ADR-0034` point 4's
+   two sources were for.
+
+9. **`familiar.apiVersion` (`ADR-0034` point 7) now versions the event contract**, which is a much
    smaller thing to keep compatible than four libraries.
 
 ## Alternatives Considered
@@ -116,6 +140,13 @@ ship your own React.
 familiar authoring experience with isolation added. Rejected because injecting a framework into a
 document that could simply `<script src>` it is strictly worse than letting it choose: same version
 contract, more machinery.
+
+**Keep one sharing mechanism — let a plugin load a host-vendored THREE by URL.** This is what
+point 7 said in the first draft, and it exists solely to spare the three r3f built-ins from each
+bundling a 2.4 MB library. Rejected on the explicit steer that a solid, simple contract matters more
+than any particular visualizer: a sharing mechanism is a version contract wearing a different hat,
+and the first plugin that loads a *different* THREE alongside it finds out the hard way. Point 8
+answers the bundle-size worry by shipping fewer visualizers instead.
 
 **Convert plugins to documents but leave the built-ins as components in the host page.** Cheapest
 path, and it is what the code would do if nobody decided otherwise. Rejected under point 7:
@@ -136,9 +167,13 @@ sidestep by deleting the feature's premise.
   no build step. Today the minimum viable plugin is a rollup config that externalises four packages.
 - **Positive** — Lyric Pulse's failure mode becomes unrepresentable.
 - **Positive** — crash isolation stops depending on an error boundary in shared memory.
-- **Tradeoff** — every plugin ships its own libraries, so folders get bigger. On disk that is cheap;
-  for the *shipped* built-ins it is why point 7 allows an opt-in vendored copy rather than three
-  independent 2.4 MB bundles.
+- **Tradeoff** — every plugin ships its own libraries, so folders get bigger. On disk that is cheap.
+  In the *app bundle* it is not, which is why point 8 shrinks the shipped set rather than adding a
+  sharing mechanism to preserve it.
+- **Tradeoff** — **the current visualizers are not preserved by this decision, and that was chosen
+  rather than overlooked.** The three r3f scene graphs are rewritten, demoted to drop-ins, or
+  dropped. Anyone reading this later should not treat their loss as a regression to be fixed by
+  reintroducing shared libraries.
 - **Tradeoff** — **`ADR-0067` and `ADR-0068` were aimed at the wrong contract.** 0067 shrinks to
   almost nothing, which is a good outcome reached by an unwelcome route; 0068's conversion work is
   redirected rather than executed. Both are `proposed`, so nothing shipped is being unwound, but

--- a/docs/decisions/ADR-0087-a-visualizer-is-a-document-not-a-component.md
+++ b/docs/decisions/ADR-0087-a-visualizer-is-a-document-not-a-component.md
@@ -1,0 +1,153 @@
+# ADR-0087: A Visualizer Is a Document, Not a Component
+
+Status: proposed
+
+Date: 2026-08-20
+
+Supersedes [ADR-0034](ADR-0034-visualizers-are-drop-in-bundles.md) points 1 and 3. Reframes
+[ADR-0067](ADR-0067-the-plugin-api-exposes-what-a-first-party-visualizer-uses.md) and redirects
+[ADR-0068](ADR-0068-built-in-visualizers-ship-as-drop-in-bundles.md), both still `proposed`. Must be
+settled before [ADR-0063](ADR-0063-the-visualizer-api-is-published-for-outside-authors.md) publishes
+the contract to outside authors.
+
+## Context
+
+A visualizer today is a pre-built IIFE, evaluated with `new Function` **inside the host page**,
+which reads `window.Familiar` for `React`, `THREE`, `ReactThreeFiber` and `Drei`, and registers a
+React component. So the contract is: *a visualizer is a React component, and here are our four
+library versions.*
+
+**`ADR-0034` point 1 records that this shape was inherited rather than chosen:**
+
+> "The format is **adopted, not designed** — but adopted because it costs nothing and two working
+> samples already build to it, not because there is an ecosystem that a different choice would
+> strand. **There is not.**"
+
+That was a reasonable call when the samples were the only consumers. It stops being reasonable at
+the moment `ADR-0063` publishes the contract outward, because four library versions in a public API
+are very hard to retract.
+
+**The failure that prompted this.** `ADR-0065` seeds the drop-in folder with worked examples, and
+one of them — `lyric-pulse` — crashed the first time it ever ran, on a freshly built app. Its bundle
+ends `})(window.Familiar.React)` and renders with `jsxRuntime.jsxs(...)`, but **React does not export
+`jsxs`**; the automatic JSX runtime lives in a different module. Verified against the installed
+React 19.2.4:
+
+```
+React.jsxs          undefined
+React.createElement function
+jsx-runtime.jsxs    function
+```
+
+Lyric Pulse draws **divs with a glow**. It is not 3D, it does not touch THREE, and it needs no
+renderer. It was broken by framework plumbing that the contract obliged it to use and that it never
+wanted. That is the shape of the problem, not an unlucky bug: the cost of the component contract is
+paid by every plugin, including the ones with nothing to gain from it.
+
+**How much of the framework is actually earned.** Of the five built-ins, three are
+`@react-three/fiber` scene graphs — `ReactiveTerrain`, `BeatTiles`, `LyricWordField` — where
+declarative THREE genuinely pays for itself. The other two, `ScrollingLyrics` and `MusicVideo`, are
+plain DOM and use React only because everything around them does. `vendor-three` is **2.4 MB
+(764 KB gzipped)**, vendored into the app inside `VisualizerBundle.html`.
+
+**The objection that would sink an event model does not hold here.** The natural worry is that
+real-time audio cannot cross a document boundary fast enough. It already crosses a *process*
+boundary: `player/audio/nativeAnalysisBuffers.ts:20` records that frames "from a native host arrive
+at **10 Hz** against a 60 Hz render loop — macOS clamps `installTap`", and line 26 that the host
+"sends the envelope instead: ~43 Hz of onset resolution inside a 10 Hz channel". The page already
+reconstructs a 60 Hz animation from a 10 Hz feed. A `postMessage` hop into a child document is noise
+against that.
+
+**What the host already serves.** `VisualizerSchemeHandler` routes three kinds of request over a
+custom scheme: the host document, a JSON index of plugins, and a plugin's single `dist/index.js` as
+`text/javascript`. The machinery for serving plugin files from a per-platform folder — Application
+Support on macOS, `Documents/Visualizers` on iOS (`ADR-0034` point 4) — exists and is tested.
+
+## Decision
+
+1. **A visualizer is a folder containing an `index.html`.** The host loads that document in its own
+   browsing context. Whatever is inside it — canvas, WebGL, shaders, p5, three.js, a `<video>`, or
+   plain DOM — is the plugin's business.
+
+2. **The host sends data and lends nothing.** Track metadata and audio frames arrive as events on
+   the plugin's own window. There is no `window.Familiar` library surface: no React, no THREE, no
+   `@react-three/fiber`, no `Drei`. What `ADR-0034` point 6 defined as `VisualizerProps` and
+   `AudioData` survives as the *payload*; only the delivery changes.
+
+3. **`ADR-0034` point 3 is superseded outright.** "The host provides four libraries and a bundle
+   must not carry its own" was the source of the coupling, of the version contract `ADR-0063` was
+   about to publish, and of the Lyric Pulse failure. A plugin brings what it needs.
+
+4. **`ADR-0034` point 2 is unchanged and better served.** Interpreted code the app did not ship is
+   evaluated only inside WebKit, never in the app's process. A document satisfies that more plainly
+   than `new Function` does.
+
+5. **Isolation is a feature, not a side effect.** A plugin that throws takes down its own document
+   and nothing else. The error boundary in `AudioVisualizer` exists because plugins currently share
+   the host's page — `ADR-0034` point 8's "unload a visualizer that throws" becomes structural
+   rather than defensive.
+
+6. **The scheme handler serves a folder, not a file.** `.bundle(source, id)` becomes a path within
+   the plugin's directory, with MIME types by extension and **containment checks**, since a folder
+   is a traversal surface that a single known filename was not. This is the one place the change
+   adds risk rather than removing it, and it is named here so it is designed rather than discovered.
+
+7. **The built-ins become documents too, and sharing becomes something a plugin opts into by URL.**
+   One shape, not two. The shipped visualizers may load a vendored copy of THREE served by the same
+   handler with an ordinary `<script src>` — which is different in kind from an injected global,
+   because it is the plugin's choice, visible in its own source, and versioned by the URL it names.
+
+8. **`familiar.apiVersion` (`ADR-0034` point 7) now versions the event contract**, which is a much
+   smaller thing to keep compatible than four libraries.
+
+## Alternatives Considered
+
+**Keep the component contract and add `jsxRuntime` to the globals.** This is a two-line fix for the
+actual bug, and it should be applied regardless if this ADR is rejected. Rejected as the decision
+because it treats the symptom: the next author writing a DOM-only visualizer still has to satisfy a
+React contract, and `ADR-0063` still publishes four library versions.
+
+**Keep evaluating in the host page, but stop providing libraries.** Removes the version contract
+while avoiding a document boundary. Rejected because it keeps the worst property — a plugin's crash
+is the host's crash — while giving up the only thing the shared page bought, which was not having to
+ship your own React.
+
+**One document per plugin, but keep injecting React into it.** A half-measure that preserves the
+familiar authoring experience with isolation added. Rejected because injecting a framework into a
+document that could simply `<script src>` it is strictly worse than letting it choose: same version
+contract, more machinery.
+
+**Convert plugins to documents but leave the built-ins as components in the host page.** Cheapest
+path, and it is what the code would do if nobody decided otherwise. Rejected under point 7:
+`ADR-0068` was written precisely to stop built-ins and drop-ins being two different things that
+drift, and that argument survives this ADR even though its chosen format does not.
+
+**Render visualizers natively instead.** Out of scope and against `ADR-0016` point 1's test —
+these are large, moving, and expressed in web technology; `ADR-0034` point 2's App Store constraint
+also applies only because they are interpreted, which native rendering would not fix so much as
+sidestep by deleting the feature's premise.
+
+## Consequences
+
+- **Positive** — the public contract shrinks from "a React component plus four library versions" to
+  "an HTML document that receives events". That is the thing `ADR-0063` publishes, and it is one a
+  newcomer can hold in their head.
+- **Positive** — a plugin can be written in anything, including a single file of vanilla canvas with
+  no build step. Today the minimum viable plugin is a rollup config that externalises four packages.
+- **Positive** — Lyric Pulse's failure mode becomes unrepresentable.
+- **Positive** — crash isolation stops depending on an error boundary in shared memory.
+- **Tradeoff** — every plugin ships its own libraries, so folders get bigger. On disk that is cheap;
+  for the *shipped* built-ins it is why point 7 allows an opt-in vendored copy rather than three
+  independent 2.4 MB bundles.
+- **Tradeoff** — **`ADR-0067` and `ADR-0068` were aimed at the wrong contract.** 0067 shrinks to
+  almost nothing, which is a good outcome reached by an unwelcome route; 0068's conversion work is
+  redirected rather than executed. Both are `proposed`, so nothing shipped is being unwound, but
+  effort was spent.
+- **Tradeoff** — the event contract has to be designed. `VisualizerProps` to events is not purely
+  mechanical: props are pull, events are push, and the 10 Hz feed means the plugin now owns the
+  interpolation the host does today.
+- **Tradeoff** — point 6 introduces path traversal as a concern the current handler does not have.
+- **Follow-up** — `docs/VISUALIZER_API.md` is rewritten rather than amended, and it is the document
+  `ADR-0063` publishes.
+- **Follow-up** — `lyric-pulse` is fixed or reseeded either way. A seeded example that crashes on
+  first run is worse than shipping no examples at all.

--- a/docs/decisions/ADR-0087-a-visualizer-is-a-document-not-a-component.md
+++ b/docs/decisions/ADR-0087-a-visualizer-is-a-document-not-a-component.md
@@ -10,6 +10,41 @@ Supersedes [ADR-0034](ADR-0034-visualizers-are-drop-in-bundles.md) points 1 and 
 settled before [ADR-0063](ADR-0063-the-visualizer-api-is-published-for-outside-authors.md) publishes
 the contract to outside authors.
 
+## Implementation
+
+**Point 6 landed first**, on `familiar-apple` `feature/visualizer-documents`: the scheme handler
+serves any file inside a plugin's folder, with content types by extension and containment enforced
+in two places — the router refuses an empty, `.` or `..` component, and `resolve(relativePath:in:)`
+standardises the URL before comparing against the plugin's own directory with a trailing separator.
+Nine tests cover both layers independently. One existing test changed meaning rather than being
+deleted: `testAnythingElseUnderPluginsIsTheDocumentRatherThanAFileRead` had encoded `ADR-0034`'s "no
+request carries a path", which is exactly what this ADR reverses.
+
+**The isolation question was spiked before anything was built on it.** Point 1 says "its own
+browsing context" and the host embeds the plugin in an `<iframe>`; whether that iframe could be
+`sandbox="allow-scripts"` — opaque origin, no ambient authority — was unknown, because a custom
+scheme plus an opaque origin is where a surprise would hide. A standalone `WKWebView` harness ran
+both cases:
+
+| | `sandbox="allow-scripts"` | no sandbox |
+|---|---|---|
+| subresources fetched over the scheme | `index.html`, `style.css`, `app.js` — all | all |
+| script ran, stylesheet applied | yes | yes |
+| `window.origin` | **`null`** | `familiar-visualizer://plugin` |
+| reaches the host's DOM | no | no |
+| `postMessage` both directions | yes | yes |
+
+So the strong form works and is what ships. Two mechanisms stack rather than one doing the work:
+**distinct host components** (`//host` and `//plugin`) already make the plugin a separate origin —
+the control run could not reach the host's DOM either — and **the sandbox attribute** makes it an
+opaque one on top.
+
+**One residual, recorded rather than assumed away.** `allow-scripts` without `allow-same-origin`
+denies cookies, `localStorage` and same-origin access, but **it does not restrict network access**.
+A plugin can still `fetch()` anywhere it likes. The handler serves the plugin document, so it is in
+a position to attach a `Content-Security-Policy` that confines it — that is the next thing to
+decide, not something this ADR has already solved.
+
 ## Context
 
 A visualizer today is a pre-built IIFE, evaluated with `new Function` **inside the host page**,

--- a/docs/decisions/ADR-0088-every-visualizer-ships-as-a-document.md
+++ b/docs/decisions/ADR-0088-every-visualizer-ships-as-a-document.md
@@ -31,9 +31,14 @@ otherwise careful about.
 
 ## Decision
 
-1. **All five existing visualizers are converted to documents and all of them ship.** Nothing is
-   demoted to a drop-in and nothing is dropped. The shipped set is exactly what a fresh install has
-   today, in the new shape.
+1. **Every visualizer is converted to a document and all of them ship.** Nothing is demoted to a
+   drop-in and nothing is dropped.
+
+   **That is four built-ins plus `spectrum`, and it does not include music video.** `ADR-0066`
+   point 2 already removes `music-video` from the registry — *"Four built-ins remain:
+   `reactive-terrain`, `beat-tiles`, `lyrics` and `lyric-storm`"* — and `ADR-0085` makes it a native
+   Mac player mode instead. It is spelled out because the registry in the code still lists it, so
+   anything counting the current state gets five and includes the one that is leaving.
 
 2. **The duplication is accepted rather than engineered around.** Three of them are
    `@react-three/fiber` scenes, so three folders each carry their own THREE. That is the cost of
@@ -77,7 +82,7 @@ different THREE finds out what "shipped visualizers are special" means.
 - **Tradeoff** — the app bundle grows by roughly the size of two extra copies of THREE, before
   tree-shaking. This is the cost `ADR-0087` point 8 was avoiding, now paid deliberately.
 - **Tradeoff** — five conversions instead of one, three of them r3f scenes that need their own build
-  configuration. That is the bulk of the work `ADR-0087` implies, and it now all has to happen
+  configuration (`reactive-terrain`, `beat-tiles`, `lyric-storm`). That is the bulk of the work `ADR-0087` implies, and it now all has to happen
   before the registry can be deleted.
 - **Follow-up** — measure the built folders. If tree-shaking does not materially help, point 4's
   optimism should be struck so the next reader does not repeat it.

--- a/docs/decisions/ADR-0088-every-visualizer-ships-as-a-document.md
+++ b/docs/decisions/ADR-0088-every-visualizer-ships-as-a-document.md
@@ -1,0 +1,83 @@
+# ADR-0088: Every Visualizer Ships as a Document
+
+Status: proposed
+
+Date: 2026-08-20
+
+Supersedes [ADR-0087](ADR-0087-a-visualizer-is-a-document-not-a-component.md) point 8, and closes
+the question its point 7 left open.
+
+## Context
+
+`ADR-0087` made a visualizer a folder with an `index.html` and removed every sharing mechanism, so
+a plugin carries its own libraries. Two of its points then had to say what happens to the five that
+exist today, and they said different amounts:
+
+- **Point 7** left the disposition open — the r3f built-ins are "rewritten as self-contained
+  documents, demoted to optional drop-ins, or dropped — a question for whoever does the work".
+- **Point 8** answered the resulting bundle-size problem by shrinking the shipped set: "one or two
+  cheap ones that prove the contract and give a fresh install something to look at. Anything
+  heavier is something a listener installs."
+
+Point 8 is the one that turns out to be wrong, and the reason is that it optimises the wrong thing.
+It trades **what a fresh install can do** against megabytes, in an application that already ships a
+3.2 MB visualizer document and whose library is measured in tens of gigabytes of audio. A listener
+who opens the visualizer and finds one scene has lost something real; the disk it would have cost is
+not something they were counting.
+
+It also leaves the codebase with two categories — shipped and "demoted to a drop-in" — which is the
+distinction `ADR-0068` was written to remove and which `ADR-0087` point 7's "one shape, not two" is
+otherwise careful about.
+
+## Decision
+
+1. **All five existing visualizers are converted to documents and all of them ship.** Nothing is
+   demoted to a drop-in and nothing is dropped. The shipped set is exactly what a fresh install has
+   today, in the new shape.
+
+2. **The duplication is accepted rather than engineered around.** Three of them are
+   `@react-three/fiber` scenes, so three folders each carry their own THREE. That is the cost of
+   `ADR-0087` point 7's refusal of a sharing mechanism, and paying it in disk is the point of having
+   refused: a shared library is a version contract, and this is only bytes.
+
+3. **A shipped visualizer is a plugin in every respect.** Same folder layout, same manifest, same
+   events, loaded the same way. The only difference is where the folder comes from — the app bundle
+   rather than the user's directory — which is `ADR-0034` point 4's existing distinction and needs
+   nothing new.
+
+4. **Per-plugin builds are expected to tree-shake better than the shared bundle did**, since each
+   visualizer imports the part of THREE it actually uses rather than sharing one build sized for all
+   of them. This is a reason the cost may be smaller than three times the current figure, not a
+   requirement — if it does not hold, point 2 still stands.
+
+## Alternatives Considered
+
+**Keep `ADR-0087` point 8 as written — ship one or two.** Smallest bundle, and it is what that ADR
+decided a few hours earlier. Rejected because it makes a fresh install worse to look at in order to
+save space nobody is short of, and because "which two" is a question with no good answer that does
+not amount to deleting working visualizers.
+
+**Ship one and seed the rest into the drop-in folder on first launch**, the way `ADR-0065` seeds
+examples. This keeps the app bundle small while a fresh install still has five. Rejected as a
+distinction without a difference that costs a mechanism: the bytes land on the same disk either way,
+and it makes five visualizers editable-and-breakable by accident when the user never asked to edit
+them.
+
+**Reintroduce a shared THREE for shipped visualizers only.** The bundle-size problem disappears and
+only first-party code depends on it. Rejected because it is `ADR-0087`'s rejected sharing hatch with
+a smaller blast radius — the version contract comes back, and the first drop-in that wants a
+different THREE finds out what "shipped visualizers are special" means.
+
+## Consequences
+
+- **Positive** — one shape, with no second category. A shipped visualizer and a drop-in differ only
+  in which directory they were found in.
+- **Positive** — nothing is lost. `ADR-0087` was explicitly willing to drop visualizers to get a
+  clean contract; it turns out not to be necessary.
+- **Tradeoff** — the app bundle grows by roughly the size of two extra copies of THREE, before
+  tree-shaking. This is the cost `ADR-0087` point 8 was avoiding, now paid deliberately.
+- **Tradeoff** — five conversions instead of one, three of them r3f scenes that need their own build
+  configuration. That is the bulk of the work `ADR-0087` implies, and it now all has to happen
+  before the registry can be deleted.
+- **Follow-up** — measure the built folders. If tree-shaking does not materially help, point 4's
+  optimism should be struck so the next reader does not repeat it.

--- a/docs/decisions/ADR-0088-every-visualizer-ships-as-a-document.md
+++ b/docs/decisions/ADR-0088-every-visualizer-ships-as-a-document.md
@@ -50,6 +50,12 @@ otherwise careful about.
    rather than the user's directory — which is `ADR-0034` point 4's existing distinction and needs
    nothing new.
 
+   > **Superseded by [ADR-0089](ADR-0089-the-app-bundle-seeds-the-folder-and-is-not-a-source.md).**
+   > "Needs nothing new" did not hold: keeping the app bundle as a *runtime source* broke the Xcode
+   > build, stranded the user's drop-ins when the app was sandboxed, and left the picker showing
+   > visualizers that are not in the folder the Settings panel names. The bundle now seeds the folder
+   > and is read by nothing else, so points 1, 2 and 4 stand and this one is how they ship.
+
 4. **Per-plugin builds are expected to tree-shake better than the shared bundle did**, since each
    visualizer imports the part of THREE it actually uses rather than sharing one build sized for all
    of them. This is a reason the cost may be smaller than three times the current figure, not a

--- a/docs/decisions/ADR-0089-the-app-bundle-seeds-the-folder-and-is-not-a-source.md
+++ b/docs/decisions/ADR-0089-the-app-bundle-seeds-the-folder-and-is-not-a-source.md
@@ -1,0 +1,122 @@
+# ADR-0089: The App Bundle Seeds the Folder, and Is Not a Source
+
+Status: proposed
+
+Date: 2026-08-20
+
+Supersedes the two-source model in [ADR-0034](ADR-0034-visualizers-are-drop-in-bundles.md) point 4
+and [ADR-0088](ADR-0088-every-visualizer-ships-as-a-document.md) point 3. Generalises
+[ADR-0065](ADR-0065-the-app-seeds-the-drop-in-folder-with-worked-examples.md) points 1–3 from two
+examples to every visualizer.
+
+## Context
+
+`ADR-0034` point 4 decided there were **two sources, and only two: shipped and local** — shipped
+folders served straight out of the app bundle's resources, local ones out of a directory the user can
+open. `ADR-0088` point 3 reaffirmed it while converting everything to documents, and said the
+distinction *"needs nothing new"*.
+
+It needed a great deal. Everything below was discovered building it, and all of it comes from the
+same root: **two mechanisms doing one job.**
+
+- The bundle half does not survive an ordinary Xcode build. Both app targets take their contents from
+  a `PBXFileSystemSynchronizedRootGroup`, which copies a plain directory's files *flat* into
+  `Resources/`, so five plugins each carrying an `index.html` collide and the build fails. Shipping
+  them at all needed a wrapper extension to make the directory opaque to the sync.
+- The two halves live in different places under the sandbox, and only one of them moved when the app
+  was sandboxed for the App Store — so a user's drop-ins were stranded while the built-ins were not.
+- The picker shows seven visualizers and the folder the Settings panel names contains two. The panel
+  is not lying about the path; the model is lying about where visualizers come from.
+- A shipped visualizer cannot be edited, deleted, or read as a worked example without finding it
+  inside `Familiar.app`. `ADR-0063` publishes the API for outside authors and `ADR-0065` point 1 says
+  a seeded example *"become[s] an ordinary local plugin the moment it lands"* — the built-ins get
+  neither property, for no reason anybody chose.
+
+**The contradicted premise is `ADR-0088` point 3's "needs nothing new".** It was written as a
+restatement of an existing distinction and turned out to be the load-bearing claim in three separate
+defects. Recorded here so nobody re-derives it from the fact that two sources sound harmless.
+
+`ADR-0065` already built the mechanism this ADR wants, and stopped one step short of it. Its point 1
+ships examples in the bundle and copies them into the folder; its point 2 seeds once; its point 3 adds
+an explicit **Restore** that overwrites by id and leaves everything else alone. That is exactly the
+right shape. It was scoped to the two examples because, at the time, the built-ins were a compiled
+registry inside the web bundle and could not be folders at all. `ADR-0087` and `ADR-0088` removed
+that obstacle: every visualizer is now a folder with an `index.html`. Nothing remains that makes a
+built-in different in kind from a drop-in — only the plumbing that predates them being the same
+thing.
+
+## Decision
+
+1. **There is one source: the `Visualizers` folder.** Everything the picker offers is a folder in
+   that directory. The loader has no second place to look, and "built-in" stops being a category the
+   running app knows about.
+
+2. **The app bundle carries the visualizers as seed material, and copies them into the folder.** This
+   is `ADR-0065` point 1 applied to all of them rather than to two examples. They become ordinary
+   plugins the moment they land — editable, deletable, readable as worked examples, indistinguishable
+   to the loader from anything the user put there.
+
+3. **Seeded once, automatically, before the first scan.** `ADR-0065` point 2's marker and its
+   reasoning carry over unchanged: deleting a visualizer means the user meant to delete it, and it
+   does not come back on its own. The ordering is a requirement, not an implementation detail — a
+   scan that runs before seeding shows an empty picker on first launch, which is the worst possible
+   first impression of the feature.
+
+4. **"Restore Visualizers" is explicit, overwrites by id, and leaves everything else alone.**
+   `ADR-0065` point 3, widened to the full set and renamed: it is no longer only about examples. It
+   names what it will overwrite before it does, and a visualizer in the folder that the app does not
+   ship is never touched.
+
+5. **A shipped visualizer is not a supported artefact once it is in the folder.** `ADR-0065` point 7,
+   inherited. The app makes no promise to update or migrate a copy the user now owns; a new app
+   version's copy arrives only through Restore. When one stops loading, the picker says why, like any
+   other plugin.
+
+6. **`Source.shipped` leaves the loader, the scheme handler and the index.** It becomes dead the
+   moment point 1 holds, and dead plumbing that still routes is how `bundle.js` outlived the format
+   it served. The app bundle is read by exactly one thing: the seeder.
+
+## Alternatives Considered
+
+**Keep both sources and fix the symptoms.** The build was already fixed with a wrapper extension, the
+sandbox orphaning with an import affordance, and the Settings copy could name both directories. Each
+fix works. Together they are three mechanisms maintaining a distinction that buys the user nothing —
+and the next symptom is already visible: `ADR-0064`'s ranking, the picker's refusal rows and any
+future editing feature all have to know which half a visualizer came from. Rejected because the
+symptoms were not the problem.
+
+**Seed only the examples, as `ADR-0065` decided, and leave the built-ins in the bundle.** This is the
+status quo and it is coherent — until you ask why one visualizer is editable and another is not, and
+find the answer is when it was written rather than anything about it. Rejected because the boundary
+is historical, not principled.
+
+**Ship nothing and let the folder start empty**, with the visualizers offered as a download. Honest
+about there being one source, and it makes a fresh install useless until the user goes and finds
+something — which is the state `ADR-0065` was written to prevent. Rejected: install-from-URL is
+already deferred by `ADR-0034` point 5, and this would make it a prerequisite.
+
+**Symlink the bundle's folders into the directory** instead of copying. One copy on disk, and the
+folder tells the truth about what is loadable. Rejected because the symlinks would be read-only,
+pointing inside a signed app bundle — so a user who edits a built-in gets a permission error, which
+is worse than not offering to edit it. It also breaks on app update, when the target moves.
+
+## Consequences
+
+- **Positive.** One mechanism, one directory, one answer to "where do visualizers come from". The
+  Settings panel's path becomes the whole truth. Every visualizer Familiar ships is a worked example
+  an author can open, read and change in place, which is what `ADR-0063` publishes the API for.
+- **Positive.** The sandbox-orphaning problem shrinks to the user's *own* drop-ins, because the
+  shipped set arrives in the container on first launch by itself.
+- **Tradeoff.** The visualizers exist twice on disk: once in the app bundle as seed material, once in
+  the folder. This is the same trade `ADR-0088` point 2 already accepted for THREE, and for the same
+  reason — it is only bytes.
+- **Tradeoff.** A user who deletes a built-in has an emptier picker until they press Restore. That is
+  `ADR-0065` point 2's deliberate choice, inherited with its reasoning: the alternative is a
+  visualizer that cannot be removed.
+- **Tradeoff.** A new app version's improved visualizer does not reach a user who already has the old
+  copy until they Restore. Point 5 accepts this; the alternative is overwriting edits on every launch.
+- **Follow-up.** The "Import Older Visualizers" affordance and the
+  `files.user-selected.read-only` entitlement added for it are re-examined once seeding lands — the
+  problem it solves is much smaller than it was.
+- **Follow-up.** `ADR-0065`'s implementation copies two files per example, which was right when an
+  example was a manifest plus an `index.js`. It has to copy folders before it can seed a document.


### PR DESCRIPTION
One ADR, `proposed`. No code.

The plugin contract today is **"a visualizer is a React component, and here are our four library versions"** — `React`, `THREE`, `@react-three/fiber` and `Drei` on `window.Familiar`, with the bundle evaluated by `new Function` *inside the host page*. **ADR-0063 is about to publish that outward**, after which it is very hard to retract. That timing is why this is worth deciding now.

## The shape was inherited, not chosen

ADR-0034 point 1 says so itself:

> "The format is **adopted, not designed** — but adopted because it costs nothing and two working samples already build to it, not because there is an ecosystem that a different choice would strand. **There is not.**"

## What prompted it

ADR-0065's seeded example `lyric-pulse` **crashed the first time it ever ran**, on a freshly built app. Its bundle ends `})(window.Familiar.React)` and renders with `jsxRuntime.jsxs(...)` — but React does not export `jsxs`; the automatic runtime is a different module. Verified against the installed React 19.2.4:

```
React.jsxs          undefined
React.createElement function
jsx-runtime.jsxs    function
```

It draws **divs with a glow**. Not 3D, no THREE, no renderer needed. It was broken by plumbing the contract obliged it to use. That is the shape of the problem, not an unlucky bug.

## The decision

A visualizer is **a folder with an `index.html`**, loaded in its own browsing context, sent events. The whole API is four names: `familiar:track`, `familiar:audio`, `familiar:state` inbound, `familiar:ready` outbound. No shared libraries, no framework, no `window.Familiar`.

**The objection that would sink an event model does not hold.** Audio already crosses a *process* boundary at **10 Hz** and the page reconstructs 60 Hz from it (`nativeAnalysisBuffers.ts:20`). A `postMessage` hop into a child document is noise against that.

## What this costs, stated rather than buried

- **The current visualizers are not preserved, and that was chosen.** Asked directly whether a solid, simple contract mattered more than saving any particular visualizer, the answer was yes. So there is no sharing hatch, and the three r3f scene graphs are rewritten, demoted to drop-ins, or dropped. Recorded in Consequences so nobody later reads their loss as a regression to fix by reintroducing shared libraries.
- **ADR-0067 and ADR-0068 were aimed at the wrong contract.** Both `proposed`, so nothing shipped unwinds — but the effort was spent, and 0068's conversion work is redirected rather than executed.
- **Point 6 names the one thing this makes worse**: serving a folder is a path-traversal surface that serving one known filename was not.

## If this is rejected

The two-line fix — add a JSX runtime to the globals — should be applied anyway. A seeded example that crashes on first run is worse than shipping no examples.

🤖 Generated with [Claude Code](https://claude.com/claude-code)