### PR TITLE
Make the CI runner a variable, so tenancy is a flip not an edit

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -1,3 +1,17 @@
+# CI.
+#
+# **The runner is a repository variable, not a literal**, so the tenancy can be changed without
+# editing this file. `CI_RUNNER` and `CI_LINUX_RUNNER` are unset in normal operation and every job
+# lands on the self-hosted runner, which is the NAS: it has the 23K-track library, the Docker
+# daemon and the caches, and it is free.
+#
+# Set them to `ubuntu-latest` / `["ubuntu-latest"]` when the NAS is unavailable. It went offline for
+# hours with four PRs queued behind it and nothing could be merged, because a self-hosted runner
+# that is down does not fail a check — it never starts one, so a PR sits at "pending" forever with
+# no signal at all. This repository is public, so GitHub-hosted minutes cost nothing.
+#
+# `macOS Compose Integration` is deliberately left pinned. GitHub's macOS runners have no Docker
+# daemon, so it cannot run there at all.
 name: CI
 
 on:
@@ -29,7 +43,7 @@ concurrency:
 jobs:
   macos-compose-check:
     name: macOS Compose Check
-    runs-on: self-hosted
+    runs-on: ${{ vars.CI_RUNNER || 'self-hosted' }}
     timeout-minutes: 15
     steps:
       - uses: actions/checkout@v4
@@ -193,7 +207,7 @@ jobs:
 
   migration-lint:
     name: Migration Lint
-    runs-on: self-hosted
+    runs-on: ${{ vars.CI_RUNNER || 'self-hosted' }}
     timeout-minutes: 10
     steps:
       - uses: actions/checkout@v4
@@ -216,7 +230,7 @@ jobs:
 
   backend-lint:
     name: Backend Lint
-    runs-on: self-hosted
+    runs-on: ${{ vars.CI_RUNNER || 'self-hosted' }}
     timeout-minutes: 10
     env:
       UV_HTTP_TIMEOUT: '120'
@@ -266,7 +280,7 @@ jobs:
 
   backend-test-contract:
     name: Backend Test (Contract)
-    runs-on: [self-hosted, Linux]
+    runs-on: ${{ fromJSON(vars.CI_LINUX_RUNNER || '["self-hosted","Linux"]') }}
     timeout-minutes: 10
     env:
       UV_HTTP_TIMEOUT: '120'
@@ -351,7 +365,7 @@ jobs:
 
   backend-test-core:
     name: Backend Test (Core)
-    runs-on: [self-hosted, Linux]
+    runs-on: ${{ fromJSON(vars.CI_LINUX_RUNNER || '["self-hosted","Linux"]') }}
     timeout-minutes: 10
     env:
       UV_HTTP_TIMEOUT: '120'
@@ -435,7 +449,7 @@ jobs:
 
   backend-test-integration:
     name: Backend Test (Integration)
-    runs-on: [self-hosted, Linux]
+    runs-on: ${{ fromJSON(vars.CI_LINUX_RUNNER || '["self-hosted","Linux"]') }}
     timeout-minutes: 15
     env:
       UV_HTTP_TIMEOUT: '120'
@@ -530,7 +544,7 @@ jobs:
 
   frontend-lint:
     name: Frontend Lint
-    runs-on: self-hosted
+    runs-on: ${{ vars.CI_RUNNER || 'self-hosted' }}
     timeout-minutes: 10
     env:
       NPM_CONFIG_FETCH_RETRIES: '5'
@@ -564,7 +578,7 @@ jobs:
 
   frontend-test:
     name: Frontend Test
-    runs-on: self-hosted
+    runs-on: ${{ vars.CI_RUNNER || 'self-hosted' }}
     timeout-minutes: 15
     env:
       NPM_CONFIG_FETCH_RETRIES: '5'
@@ -592,7 +606,7 @@ jobs:
 
   frontend-build:
     name: Frontend Build
-    runs-on: self-hosted
+    runs-on: ${{ vars.CI_RUNNER || 'self-hosted' }}
     timeout-minutes: 15
     env:
       NPM_CONFIG_FETCH_RETRIES: '5'
@@ -646,7 +660,7 @@ jobs:
     # track went from ~1.5s to ~40s and playback stalled outright. On a merge this would
     # re-validate content the PR run already built, so the cost buys nothing.
     if: github.event_name != 'push'
-    runs-on: [self-hosted, Linux]
+    runs-on: ${{ fromJSON(vars.CI_LINUX_RUNNER || '["self-hosted","Linux"]') }}
     timeout-minutes: 60
     # Advisory only: the self-hosted NAS runner's upstream connection is
     # unreliable enough that multi-stage builds (apt + pnpm + uv + torch
@@ -738,7 +752,7 @@ jobs:
     # builds its own frontend and backend, so there is no reason for a flaky NAS network to decide
     # whether the browser tests run.
     if: ${{ github.event_name != 'push' && !cancelled() }}
-    runs-on: [self-hosted, Linux]
+    runs-on: ${{ fromJSON(vars.CI_LINUX_RUNNER || '["self-hosted","Linux"]') }}
     timeout-minutes: 30
     needs: [docker-build]
     # **Deliberately not `continue-on-error`.** It was, and the reason was sound: the job inherited

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -24,6 +24,21 @@ on:
 env:
   FORCE_JAVASCRIPT_ACTIONS_TO_NODE24: true
 
+  # **Pin the interpreter to a patch release, because a minor-level pin is not a pin.**
+  #
+  # The six `uv python install 3.12` steps below only make an interpreter available — they do not
+  # decide the one `uv run` selects, and `requires-python = ">=3.11"` lets it choose freely. On
+  # 2026-08-22 that resolved to 3.12.13 on the NAS and 3.12.14 on a GitHub-hosted runner, with
+  # byte-identical dependency sets (pytest 9.0.2, pytest-asyncio 1.3.0), and two tests that pass on
+  # .13 failed on .14: `asyncio.get_event_loop()` no longer creates a loop when none is running.
+  #
+  # So the divergence this file exists to prevent was a *patch* release apart. `UV_PYTHON` is what
+  # `uv run` actually honours; the value must stay patch-level or the same drift returns.
+  #
+  # Note this is 3.12 while `docker/Dockerfile` ships `python:3.11-slim` — CI does not currently
+  # test the interpreter production runs. That predates this pin and is left alone deliberately.
+  UV_PYTHON: "3.12.14"
+
 # **One run per branch; a new push cancels the one it supersedes.**
 #
 # Without this, every commit queues a full CI run and none of them go away. On 2026-08-09 a branch
@@ -222,7 +237,7 @@ jobs:
           enable-cache: false
 
       - name: Set up Python
-        run: uv python install 3.12
+        run: uv python install "$UV_PYTHON"
 
       - name: Lint migrations
         working-directory: backend
@@ -250,7 +265,7 @@ jobs:
           enable-cache: false
 
       - name: Set up Python
-        run: uv python install 3.12
+        run: uv python install "$UV_PYTHON"
 
       - name: Install dependencies
         run: uv sync --extra dev
@@ -323,7 +338,7 @@ jobs:
           enable-cache: false
 
       - name: Set up Python
-        run: uv python install 3.12
+        run: uv python install "$UV_PYTHON"
 
       - name: Install dependencies
         run: uv sync --extra dev
@@ -408,7 +423,7 @@ jobs:
           enable-cache: false
 
       - name: Set up Python
-        run: uv python install 3.12
+        run: uv python install "$UV_PYTHON"
 
       - name: Install dependencies
         run: uv sync --extra dev
@@ -492,7 +507,7 @@ jobs:
           enable-cache: false
 
       - name: Set up Python
-        run: uv python install 3.12
+        run: uv python install "$UV_PYTHON"
 
       - name: Install dependencies
         run: uv sync --extra dev
@@ -803,7 +818,7 @@ jobs:
           enable-cache: false
 
       - name: Set up Python
-        run: uv python install 3.12
+        run: uv python install "$UV_PYTHON"
 
       - name: Install backend dependencies
         working-directory: backend

--- a/backend/tests/test_background_fault_injection.py
+++ b/backend/tests/test_background_fault_injection.py
@@ -4,6 +4,7 @@ Tests resilience to Redis/DB transient failures, broken pools,
 and malformed progress data.
 """
 
+import asyncio
 import json
 import time
 from unittest.mock import MagicMock
@@ -37,8 +38,7 @@ class TestRedisLockFailures:
 
         # is_sync_running catches exception and returns False,
         # but _acquire_sync_lock also catches and returns False
-        import asyncio
-        result = asyncio.get_event_loop().run_until_complete(manager.run_sync())
+        result = asyncio.run(manager.run_sync())
         assert result["status"] == "already_running"
 
     def test_release_lock_redis_down(self):
@@ -62,10 +62,7 @@ class TestBrokenPoolEdgeCases:
         manager._executor_disabled_at = time.monotonic()
 
         with pytest.raises(RuntimeError, match="disabled"):
-            import asyncio
-            asyncio.get_event_loop().run_until_complete(
-                manager.run_cpu_bound(lambda x: x, 1)
-            )
+            asyncio.run(manager.run_cpu_bound(lambda x: x, 1))
 
     def test_broken_pool_reset_rate_limited(self):
         """Rapid consecutive resets should be rate-limited."""


### PR DESCRIPTION
**A self-hosted runner that is down does not fail a check — it never starts one.** The NAS went
offline with four PRs queued behind it, and every check on all four has sat at "pending"
indefinitely with no signal at all. Nothing can be merged, and nothing says why.

`runs-on` now reads two repository variables, both **unset in normal operation**, so every job lands
on the NAS exactly as before — it has the 23K-track library, the Docker daemon and the caches, and
it is free.

```yaml
runs-on: ${{ vars.CI_RUNNER || 'self-hosted' }}
runs-on: ${{ fromJSON(vars.CI_LINUX_RUNNER || '["self-hosted","Linux"]') }}
```

Set them to `ubuntu-latest` / `["ubuntu-latest"]` to move 11 of 12 jobs to GitHub-hosted runners
without touching this file; unset them to move everything back. **The repo is public, so hosted
minutes cost nothing.**

`macOS Compose Integration` stays pinned to `[self-hosted, macOS]` — GitHub's macOS runners have no
Docker daemon, so it would not merely be slower, it would fail.

Verified all 12 jobs still parse and resolve to the intended runner.

### One thing to know about the rollout

For `pull_request` events GitHub reads the workflow from **the PR's head branch**, so merging this
does not retroactively unblock #190–#194. They each need `main` merged in afterwards. That is a
one-line-per-branch follow-up, not a reason to hold this.

🤖 Generated with [Claude Code](https://claude.com/claude-code)