### PR TITLE
CI runs the interpreter production runs

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -24,20 +24,26 @@ on:
 env:
   FORCE_JAVASCRIPT_ACTIONS_TO_NODE24: true
 
-  # **Pin the interpreter to a patch release, because a minor-level pin is not a pin.**
+  # **CI runs the interpreter production runs, pinned to the patch.**
   #
-  # The six `uv python install 3.12` steps below only make an interpreter available — they do not
-  # decide the one `uv run` selects, and `requires-python = ">=3.11"` lets it choose freely. On
-  # 2026-08-22 that resolved to 3.12.13 on the NAS and 3.12.14 on a GitHub-hosted runner, with
-  # byte-identical dependency sets (pytest 9.0.2, pytest-asyncio 1.3.0), and two tests that pass on
-  # .13 failed on .14: `asyncio.get_event_loop()` no longer creates a loop when none is running.
+  # This must stay equal to the tag in `docker/Dockerfile`. There is no way to share one value
+  # between a workflow and a Dockerfile, so they are kept in step by hand — change both together.
   #
-  # So the divergence this file exists to prevent was a *patch* release apart. `UV_PYTHON` is what
-  # `uv run` actually honours; the value must stay patch-level or the same drift returns.
+  # Two separate lessons are baked into this line, both learned on 2026-08-22:
   #
-  # Note this is 3.12 while `docker/Dockerfile` ships `python:3.11-slim` — CI does not currently
-  # test the interpreter production runs. That predates this pin and is left alone deliberately.
-  UV_PYTHON: "3.12.14"
+  # 1. **A minor-level pin is not a pin.** The six `uv python install` steps below only make an
+  #    interpreter *available*; they never decided the one `uv run` selects, and
+  #    `requires-python = ">=3.11"` is a floor, not a choice. That resolved to 3.12.13 on the NAS
+  #    and 3.12.14 on a GitHub-hosted runner, with byte-identical dependency sets (pytest 9.0.2,
+  #    pytest-asyncio 1.3.0), and two tests passed on .13 and failed on .14 —
+  #    `asyncio.get_event_loop()` no longer creates a loop when none is running. One patch release
+  #    was the whole difference, so `UV_PYTHON` carries the patch.
+  #
+  # 2. **CI was testing an interpreter nothing ships.** The first pin landed on 3.12 while
+  #    production has always been `python:3.11-slim` — a whole minor version that no test could
+  #    see. Point 1 is the evidence for why that mattered: if two *patch* releases can disagree
+  #    about a core stdlib call, a minor gap between CI and production is not a detail.
+  UV_PYTHON: "3.11.15"
 
 # **One run per branch; a new push cancels the one it supersedes.**
 #

--- a/docker/Dockerfile
+++ b/docker/Dockerfile
@@ -36,7 +36,11 @@ RUN pnpm --filter @familiar/web run build
 # =============================================================================
 # Stage 2: Python base with uv
 # =============================================================================
-FROM python:3.11-slim AS python-base
+# Pinned to the patch, and **must stay equal to `UV_PYTHON` in `.github/workflows/ci.yml`** — that
+# is what makes CI test the interpreter this image ships. `3.11-slim` floated, so the two could
+# drift a patch apart without either file changing; on 2026-08-22 a single patch release was enough
+# to flip two tests, so a floating tag is not close enough. Bump both together.
+FROM python:3.11.15-slim AS python-base
 
 # Install uv
 COPY --from=ghcr.io/astral-sh/uv:latest /uv /usr/local/bin/uv


### PR DESCRIPTION
#195 pinned CI to a patch release, closing a drift between two tenancies. It also recorded a larger gap it deliberately left open: that pin landed on **3.12.14**, while `docker/Dockerfile` has always shipped **`python:3.11-slim`**. CI was testing an interpreter nothing deploys, a whole minor version away, and no test could see it.

The evidence for why that matters is #195 itself. If two *patch* releases can disagree about `asyncio.get_event_loop()` — enough to turn two passing tests red — a minor gap between CI and production is not a detail.

## Direction

CI moves to production's interpreter, not the reverse. `python:3.11-slim` is what deploys, `requires-python` already floors at 3.11, and mypy has always targeted 3.11. **CI was the outlier.**

Both sides now name the same patch, `3.11.15`. The floating `3.11-slim` tag meant the two could drift apart without either file changing — the same defect #195 fixed, one level down.

## Verified before pushing

- `python3.11 -m compileall app migrations scripts tests` clean — nothing uses 3.12-only syntax
- `python:3.11.15-slim` exists and is the same build `3.11-slim` currently resolves to (3.11.15, built 2026-08-05)
- latest uv (0.12.2) installs `cpython-3.11.15`, so the six `uv python install "$UV_PYTHON"` steps have something to fetch

## Tradeoff

There is no way to share one value between a workflow and a Dockerfile, so `UV_PYTHON` and the `FROM` tag are kept in step by hand. Both comments say so. **Bump them together.**

Pinning the base image to a patch also means security updates to `3.11-slim` no longer arrive on their own. That is the cost of reproducibility here, and it is a deliberate trade rather than an oversight.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01Emjrwedq7W1scadHdgiLfs