### PR TITLE
Accept ADR-0088 and ADR-0089

### DIFF
--- a/docs/decisions/ADR-0088-every-visualizer-ships-as-a-document.md
+++ b/docs/decisions/ADR-0088-every-visualizer-ships-as-a-document.md
@@ -1,6 +1,6 @@
 # ADR-0088: Every Visualizer Ships as a Document
 
-Status: proposed
+Status: accepted
 
 Date: 2026-08-20
 

--- a/docs/decisions/ADR-0089-the-app-bundle-seeds-the-folder-and-is-not-a-source.md
+++ b/docs/decisions/ADR-0089-the-app-bundle-seeds-the-folder-and-is-not-a-source.md
@@ -1,6 +1,6 @@
 # ADR-0089: The App Bundle Seeds the Folder, and Is Not a Source
 
-Status: proposed
+Status: accepted
 
 Date: 2026-08-20
 


### PR DESCRIPTION
Status flip only — neither Decision changes, and both Dates stay at proposal time, matching ADR-0087.

Both were proposed on 2026-08-20 and are implemented by #192, which cannot merge while they are unratified. Building against an unapproved decision is the trap **ADR-0089 itself exists to correct**, after the wrong shape got built from ADR-0034.

Approved by Jeff on 2026-08-22.

## Deliberately not included

The eight still-proposed ADRs in #188 — 0073–0077 and 0080–0082 — stay proposed. They govern work that has not started, so ratifying them now would spend approval on decisions nobody has had to live with yet. ADR-0083 is accepted separately, on #188's own branch, because that is where it lives.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01Emjrwedq7W1scadHdgiLfs