### PR TITLE
Propose ADR-0091: visualizers leave the server repo

### DIFF
--- a/docs/decisions/ADR-0091-visualizers-leave-the-server-repo.md
+++ b/docs/decisions/ADR-0091-visualizers-leave-the-server-repo.md
@@ -60,67 +60,62 @@ mention visualizers, not visualizer hosting.
 
 ## Decision
 
-1. **`familiar-apple` owns the shipped visualizer set.** `App/Shared/Visualizers.bundle/` becomes
-   the source of truth rather than a vendored copy, and `scripts/vendor-visualizers.sh` is deleted
-   along with `packages/web/public/visualizers/`.
+**Scope narrowed before merge.** The proposal bundled the server removal with moving the build and
+the plugin folders into `familiar-apple`. Implementation showed those are not alike: the folders are
+authored in place and cheap to move, but `VisualizerBundle.html` is a React app whose source reaches
+through `renderVisualizer` into `EmbedVisualizer`, `visualizerSink`, `visualizerStore`, `api/base`,
+`embedBridge`, `index.css` and Tailwind. Moving it means moving a subtree of `packages/frontend` —
+which contradicted this ADR's own Tradeoff, where the fate of those modules was explicitly *not*
+being decided. Both could not be true. The relocation is now
+[ADR-0092](ADR-0092-the-visualizer-document-build-moves-to-the-app.md), where a React subtree can get
+the alternatives it deserves. What is left here is the part that stands on its own.
 
-2. **The build moves with the sources it builds.** `vite.visualizer.config.ts`,
-   `scripts/inline-visualizer.mjs` and `scripts/build-visualizer.sh` move to `familiar-apple`, which
-   gains a `package.json` used only to produce `VisualizerBundle.html` and the plugin folders. Xcode
-   still must not require a build step — the artifacts stay committed, as ADR-0087 point 6 requires.
-
-3. **The server stops serving visualizer content.** `/visualizer`, the `/visualizers` mount and the
+1. **The server stops serving visualizer content.** `/visualizer`, the `/visualizers` mount and the
    `visualizers/` entry in `NON_SPA_PREFIXES` are removed from `backend/app/main.py`, along with
-   `serve_visualizer`.
+   `serve_visualizer`. This is the whole of the finding in Context: neither surface has a caller.
 
-4. **The document contract test moves too.** `visualizer-document-contract.spec.ts` follows the
-   documents into `familiar-apple`. It is the only check that the ADR-0087 handshake still works,
-   and ADR-0087's own note that *"nothing else tests it"* is the reason it must not simply be
-   deleted with the mount it depends on.
+2. **The contract test loses its dependency on the server, and stays.** It is the only check that
+   the ADR-0087 handshake works, and that ADR says so itself. Rather than being deleted with the
+   mount, it serves the plugin document to the page directly. It moves to `familiar-apple` under
+   ADR-0092, with the documents it tests.
 
-5. **`ADR-0064`'s ranking endpoint is untouched.** The server keeps scoring affinity declarations
-   against analysis. Point 3 removes content, not ranking.
+3. **`ADR-0064`'s ranking endpoint is untouched.** The server keeps scoring affinity declarations
+   against analysis. Point 1 removes content, not ranking.
 
 ## Alternatives Considered
 
-**Leave it as it is.** Costs nothing today, and the vendoring works. Rejected because it already
-misleads: this session resolved a merge conflict in `VisualizerBundle.html` by re-running a
-generator in a *different repository*, and added a server mount whose only consumer is a test. Both
-are symptoms of the source of truth being in the wrong place, and both will recur.
+**Leave both surfaces in place.** Costs nothing today. Rejected because it already misleads: the
+`/visualizers` mount was added three weeks ago to fix a real defect and its only consumer turned out
+to be a test, which is precisely the shape ADR-0077 names. A surface kept alive for its own test is
+not a surface.
 
-**Move the visualizers to their own repository.** The precedent exists —
-`familiar-plugin-lyric-pulse` and `familiar-plugin-non-places` are real repositories. Rejected for
-the shipped set specifically: a third repository has to be checked out, released and versioned in
-step with the app that embeds it, and ADR-0087 point 6 already forbids the app requiring another
-checkout to build. Drop-in plugins authored elsewhere keep working exactly as they do now — that is
-what the folder in the user's directory is for.
+**Delete `/visualizer` but keep `/visualizers`.** Tempting, since the mount is new and fixed a real
+bug. Rejected for the same reason: the bug it fixed was the SPA catch-all answering `200` with
+`index.html`, and once nothing fetches plugin documents from the server there is nothing left to
+answer wrongly.
 
-**Keep the build in `familiar` and vendor only.** The status quo with the mount deleted. Rejected
-because it leaves the awkward half in place: `familiar-apple` would still be unable to change a
-visualizer without a commit in another repository and a script run, which is the friction this ADR
-exists to remove.
+**Delete the contract test along with the mount.** The cheapest option, and wrong. ADR-0087 says
+outright that nothing else tests the handshake, and the surface it guards is rendered inside a
+`WKWebView` on two platforms. Point 2 removes its dependency on the server instead, which is what
+made deleting it look necessary.
 
-**Delete `/visualizer` but keep `/visualizers`.** Tempting, because the mount is three weeks old and
-fixes a real bug. Rejected: keeping a static mount alive for a test is the shape ADR-0077 names, and
-point 4 moves the test rather than stranding it.
+**Move the folders and the build now, as first proposed.** Rejected on discovering the two halves
+are not alike — see the note above the points. Deferred to ADR-0092 rather than abandoned.
 
 ## Consequences
 
-- **Positive.** A visualizer change is one commit in one repository, with no cross-repo script run
-  and no chance of the two copies disagreeing.
-- **Positive.** The server loses two surfaces with no callers, and `main.py`'s static-serving block
-  gets smaller rather than continuing to accumulate special cases.
-- **Positive.** ADR-0087's contract test ends up beside the documents it tests, where a change to
-  either is visible in one diff.
-- **Tradeoff.** `familiar-apple` gains a Node toolchain it did not have. It is build-time only and
-  never required by Xcode, but it is a second ecosystem in a Swift repository.
-- **Tradeoff.** The web repo's `visualizerPlugins.ts`, `visualizerCatalog.ts` and the three
-  visualizer stores become unreferenced once the documents leave. Deciding their fate is deliberately
-  **not** part of this ADR — they are the host side of a page that no longer has a home in the
-  browser, and that is a separate question.
-- **Follow-up.** `packages/web/dist-visualizer` is listed in `.gitignore` and was tracked anyway
-  until `git rm -r --cached` on 2026-08-08. Whatever moves should not bring that back.
+- **Positive.** Two surfaces with no callers are gone, and `main.py`'s static-serving block stops
+  accumulating special cases for content nothing requests.
+- **Positive.** The contract test no longer needs a server to run, which is what lets it move
+  repositories cleanly under ADR-0092.
+- **Positive.** The server's remaining relationship to visualizers is exactly one thing — ranking,
+  under ADR-0064 — and it is a pure function of analysis and posted candidates.
+- **Tradeoff.** `packages/web/public/visualizers/` and `scripts/vendor-visualizers.sh` stay for now,
+  so the web repo is still where a visualizer is edited. That friction is the thing ADR-0092
+  removes; this ADR only stops the server serving them.
+- **Follow-up.** ADR-0092 moves the folders, the build and the contract test. Until it lands, the
+  vendoring script is still the way a change reaches the app.
 - **Follow-up.** Neither `familiar-plugin-lyric-pulse` nor `familiar-plugin-non-places` has been
   ported to a document — both are still `"main": "dist/index.js"` components from ADR-0034. If the
-  worked examples ADR-0065 asks for are still wanted, porting them belongs after this move, in the
+  worked examples ADR-0065 asks for are still wanted, porting them belongs after the move, in the
   repository that will then own them.

--- a/docs/decisions/ADR-0091-visualizers-leave-the-server-repo.md
+++ b/docs/decisions/ADR-0091-visualizers-leave-the-server-repo.md
@@ -1,12 +1,18 @@
 # ADR-0091: Visualizers Leave the Server Repo
 
-Status: proposed
+Status: accepted
 
 Date: 2026-08-25
 
-Extends [ADR-0087](ADR-0087-a-visualizer-is-a-document-not-a-component.md) and supersedes
-[ADR-0088](ADR-0088-every-visualizer-ships-as-a-document.md) point 2's choice of *where* the shipped
-set lives. It does not touch [ADR-0064](ADR-0064-visualizers-declare-affinity-and-the-server-ranks-them.md).
+Extends [ADR-0087](ADR-0087-a-visualizer-is-a-document-not-a-component.md) and
+[ADR-0088](ADR-0088-every-visualizer-ships-as-a-document.md). It does not touch
+[ADR-0064](ADR-0064-visualizers-declare-affinity-and-the-server-ranks-them.md).
+
+**It supersedes nothing, and that is the finding.** Neither ADR-0087 nor ADR-0088 ever decided where
+the shipped set lives — checked 2026-08-25, and neither mentions `packages/web/public/visualizers`,
+a source of truth, or a repository at all. ADR-0088's four points are about *what* ships and how it
+is built, not where it sits. The location was never chosen; it followed the build, which was in the
+web repo because the browser once rendered visualizers.
 
 ## Context
 
@@ -40,10 +46,11 @@ fix a real defect — the SPA catch-all was answering `200` with `index.html` fo
 and its only consumer is `packages/web/e2e/visualizer-document-contract.spec.ts`. It fixed the test,
 and the test was the only thing that needed it.
 
-**A contradicted premise, recorded so it is not re-derived.** ADR-0088 put the shipped set in the
-web repo because that is where the build was, and at the time the browser still rendered
-visualizers. The second half stopped being true when the player was deleted; only the build
-remained, and a build is a reason to keep a *toolchain* somewhere, not a source of truth.
+**A contradicted premise, recorded so it is not re-derived.** It is tempting to say ADR-0088 put the
+shipped set in the web repo; it did not, and no ADR did. The set is there because the *build* is
+there, and the build is there because the browser once rendered visualizers. That second reason
+stopped being true when the player was deleted, leaving only the build — and a build is a reason to
+keep a *toolchain* somewhere, not a source of truth.
 
 **What the server legitimately keeps.** `POST /tracks/{id}/visualizers/rank` and
 `services/visualizer_affinity.py` stay exactly as they are. ADR-0064's shape is that *the client

--- a/docs/decisions/ADR-0091-visualizers-leave-the-server-repo.md
+++ b/docs/decisions/ADR-0091-visualizers-leave-the-server-repo.md
@@ -1,0 +1,119 @@
+# ADR-0091: Visualizers Leave the Server Repo
+
+Status: proposed
+
+Date: 2026-08-25
+
+Extends [ADR-0087](ADR-0087-a-visualizer-is-a-document-not-a-component.md) and supersedes
+[ADR-0088](ADR-0088-every-visualizer-ships-as-a-document.md) point 2's choice of *where* the shipped
+set lives. It does not touch [ADR-0064](ADR-0064-visualizers-declare-affinity-and-the-server-ranks-them.md).
+
+## Context
+
+Visualizer documents are authored and built in `familiar`, in `packages/web/public/visualizers/`,
+and vendored into `familiar-apple` by `scripts/vendor-visualizers.sh`. `VisualizerBundle.html` is
+built there too, by `scripts/build-visualizer.sh`, from `vite.visualizer.config.ts`. The server also
+serves them: `/visualizer` for the single-document surface and, since
+[#192](https://github.com/seethroughlab/familiar/pull/192), a `/visualizers` static mount.
+
+**Nothing fetches either one.** Checked 2026-08-25:
+
+- **The web app has no visualizer surface at all.** `App.tsx` and `routes.ts` contain **zero**
+  visualizer references — it left with the fallback player under ADR-0057 point 5 and ADR-0071.
+- **The one production module that names those paths is not asking the server.**
+  `services/visualizerCatalog.ts` requests `/visualizers/index.json` (line 80) and
+  `/visualizers/{id}/{main}` (line 141) — but it runs *inside the visualizer document*, which the
+  Apple clients load over a custom scheme, so those URLs resolve against the app bundle.
+  `VisualizerSchemeHandler` answers all three shapes through `VisualizerPlugins.route(path:)`:
+  `.document`, `.index` (built by `indexJSON`) and `.file`. Every other `/visualizers/...` string in
+  `packages/frontend/src` is a fixture, in five `__tests__` files.
+- **The Apple clients never ask the server.** `EmbeddedVisualizerView` registers a
+  `familiar-visualizer://` scheme handler and reads the documents out of the app bundle. That is
+  ADR-0033's own decision, and its reason still holds: a custom scheme is a real origin, so
+  `localStorage` works and the chosen visualizer survives a relaunch. There is no code path in
+  `familiar-apple` that requests `/visualizer` or `/visualizers` over HTTP.
+
+So the server hosts a capability with no caller, which is exactly what
+[ADR-0077](ADR-0077-a-surface-with-no-caller-is-deleted-not-documented.md) says to delete rather than
+document. The `/visualizers` mount is a partial exception and worth stating plainly: it was added to
+fix a real defect — the SPA catch-all was answering `200` with `index.html` for plugin documents —
+and its only consumer is `packages/web/e2e/visualizer-document-contract.spec.ts`. It fixed the test,
+and the test was the only thing that needed it.
+
+**A contradicted premise, recorded so it is not re-derived.** ADR-0088 put the shipped set in the
+web repo because that is where the build was, and at the time the browser still rendered
+visualizers. The second half stopped being true when the player was deleted; only the build
+remained, and a build is a reason to keep a *toolchain* somewhere, not a source of truth.
+
+**What the server legitimately keeps.** `POST /tracks/{id}/visualizers/rank` and
+`services/visualizer_affinity.py` stay exactly as they are. ADR-0064's shape is that *the client
+sends its candidates and the server ranks them* — the server scores declarations against a track's
+analysis and is never told which visualizers a device holds. That is analysis work that happens to
+mention visualizers, not visualizer hosting.
+
+## Decision
+
+1. **`familiar-apple` owns the shipped visualizer set.** `App/Shared/Visualizers.bundle/` becomes
+   the source of truth rather than a vendored copy, and `scripts/vendor-visualizers.sh` is deleted
+   along with `packages/web/public/visualizers/`.
+
+2. **The build moves with the sources it builds.** `vite.visualizer.config.ts`,
+   `scripts/inline-visualizer.mjs` and `scripts/build-visualizer.sh` move to `familiar-apple`, which
+   gains a `package.json` used only to produce `VisualizerBundle.html` and the plugin folders. Xcode
+   still must not require a build step — the artifacts stay committed, as ADR-0087 point 6 requires.
+
+3. **The server stops serving visualizer content.** `/visualizer`, the `/visualizers` mount and the
+   `visualizers/` entry in `NON_SPA_PREFIXES` are removed from `backend/app/main.py`, along with
+   `serve_visualizer`.
+
+4. **The document contract test moves too.** `visualizer-document-contract.spec.ts` follows the
+   documents into `familiar-apple`. It is the only check that the ADR-0087 handshake still works,
+   and ADR-0087's own note that *"nothing else tests it"* is the reason it must not simply be
+   deleted with the mount it depends on.
+
+5. **`ADR-0064`'s ranking endpoint is untouched.** The server keeps scoring affinity declarations
+   against analysis. Point 3 removes content, not ranking.
+
+## Alternatives Considered
+
+**Leave it as it is.** Costs nothing today, and the vendoring works. Rejected because it already
+misleads: this session resolved a merge conflict in `VisualizerBundle.html` by re-running a
+generator in a *different repository*, and added a server mount whose only consumer is a test. Both
+are symptoms of the source of truth being in the wrong place, and both will recur.
+
+**Move the visualizers to their own repository.** The precedent exists —
+`familiar-plugin-lyric-pulse` and `familiar-plugin-non-places` are real repositories. Rejected for
+the shipped set specifically: a third repository has to be checked out, released and versioned in
+step with the app that embeds it, and ADR-0087 point 6 already forbids the app requiring another
+checkout to build. Drop-in plugins authored elsewhere keep working exactly as they do now — that is
+what the folder in the user's directory is for.
+
+**Keep the build in `familiar` and vendor only.** The status quo with the mount deleted. Rejected
+because it leaves the awkward half in place: `familiar-apple` would still be unable to change a
+visualizer without a commit in another repository and a script run, which is the friction this ADR
+exists to remove.
+
+**Delete `/visualizer` but keep `/visualizers`.** Tempting, because the mount is three weeks old and
+fixes a real bug. Rejected: keeping a static mount alive for a test is the shape ADR-0077 names, and
+point 4 moves the test rather than stranding it.
+
+## Consequences
+
+- **Positive.** A visualizer change is one commit in one repository, with no cross-repo script run
+  and no chance of the two copies disagreeing.
+- **Positive.** The server loses two surfaces with no callers, and `main.py`'s static-serving block
+  gets smaller rather than continuing to accumulate special cases.
+- **Positive.** ADR-0087's contract test ends up beside the documents it tests, where a change to
+  either is visible in one diff.
+- **Tradeoff.** `familiar-apple` gains a Node toolchain it did not have. It is build-time only and
+  never required by Xcode, but it is a second ecosystem in a Swift repository.
+- **Tradeoff.** The web repo's `visualizerPlugins.ts`, `visualizerCatalog.ts` and the three
+  visualizer stores become unreferenced once the documents leave. Deciding their fate is deliberately
+  **not** part of this ADR — they are the host side of a page that no longer has a home in the
+  browser, and that is a separate question.
+- **Follow-up.** `packages/web/dist-visualizer` is listed in `.gitignore` and was tracked anyway
+  until `git rm -r --cached` on 2026-08-08. Whatever moves should not bring that back.
+- **Follow-up.** Neither `familiar-plugin-lyric-pulse` nor `familiar-plugin-non-places` has been
+  ported to a document — both are still `"main": "dist/index.js"` components from ADR-0034. If the
+  worked examples ADR-0065 asks for are still wanted, porting them belongs after this move, in the
+  repository that will then own them.

--- a/docs/decisions/ADR-0092-the-visualizer-document-build-moves-to-the-app.md
+++ b/docs/decisions/ADR-0092-the-visualizer-document-build-moves-to-the-app.md
@@ -1,0 +1,96 @@
+# ADR-0092: The Visualizer Document Build Moves to the App
+
+Status: proposed
+
+Date: 2026-08-25
+
+Extends [ADR-0091](ADR-0091-visualizers-leave-the-server-repo.md), which stopped the server *serving*
+visualizers and deferred moving them. Extends
+[ADR-0087](ADR-0087-a-visualizer-is-a-document-not-a-component.md) and
+[ADR-0088](ADR-0088-every-visualizer-ships-as-a-document.md) without superseding either — as ADR-0091
+records, neither ever decided where the shipped set lives.
+
+## Context
+
+ADR-0091 was proposed as one move and narrowed on contact with the code. The reason is worth keeping,
+because it is the whole of this decision: **the two things that live in `familiar` are not alike.**
+
+**The plugin folders are authored in place.** `packages/web/public/visualizers/<id>/` holds
+`index.html`, `app.js`, `style.css` and `familiar-plugin.json`, written by hand — `spectrum`'s own
+manifest says "One file, no build step, no libraries". Nothing generates them. The only built thing
+beside them is `index.json`, produced by `scripts/build-visualizer-index.mjs`, and it exists because
+a browser cannot enumerate a directory. The Swift side does not even use it: `VisualizerPlugins`
+builds its own listing with `indexJSON(folders)` from the real folders. Moving these is a `git mv`.
+
+**`VisualizerBundle.html` is a React application.** `scripts/build-visualizer.sh` runs
+`vite.visualizer.config.ts` over `packages/web/visualizer.html`, whose entry is
+`packages/web/src/visualizer.tsx`, which imports `NullAudioEngine`, `registerEngineFactory` and
+`renderVisualizer` — and `renderVisualizer` reaches `EmbedVisualizer`, `visualizerSink`,
+`visualizerStore`, `api/base`, `embedBridge` and `index.css`, which is Tailwind. The output is
+353 kB inlined into a single file by `scripts/inline-visualizer.mjs`.
+
+So "move the build" means moving a subtree of `packages/frontend` and a Tailwind pipeline into a
+Swift repository. ADR-0091's proposal said `familiar-apple` "gains a `package.json` used only to
+produce `VisualizerBundle.html`" while its own Tradeoff said the fate of `visualizerPlugins.ts`,
+`visualizerCatalog.ts` and the stores was **not** being decided. Both could not be true, and that
+contradiction is why this is a separate ADR.
+
+**What is genuinely shared.** `EmbedVisualizer` and the visualizer stores are reachable only from
+`renderVisualizer`, but `api/base` and `embedBridge` are also used by `/embed`, which stays in the web
+repo under ADR-0016 and ADR-0017. A move that takes them breaks Discover; a move that copies them
+creates two of the thing ADR-0020 point 2 caps at two messages precisely to avoid.
+
+## Decision
+
+1. **The plugin folders move, and `familiar-apple` owns them.**
+   `packages/web/public/visualizers/` and `scripts/build-visualizer-index.mjs` are deleted;
+   `App/Shared/Visualizers.bundle/` becomes the source of truth rather than a vendored copy, and
+   `scripts/vendor-visualizers.sh` goes with them.
+
+2. **The host document's build stays in `familiar` for now, and the artifact keeps being vendored.**
+   `scripts/build-visualizer.sh` continues to produce `VisualizerBundle.html` and copy it across.
+   Moving a Tailwind React subtree that `/embed` still shares is a larger decision than this one, and
+   doing it badly costs more than the friction it removes.
+
+3. **The contract test moves with the folders.** `visualizer-document-contract.spec.ts` goes to
+   `familiar-apple`, which gains Playwright for it. ADR-0091 point 2 already removed its dependency
+   on a running server, so it moves as a file rather than as a rewrite.
+
+4. **A plugin folder is never built.** Point 1 is a relocation, not a pipeline. If a visualizer ever
+   needs a build step it brings its own, as the three `@react-three/fiber` scenes already do, and
+   ADR-0088 point 2's acceptance of duplication stands.
+
+## Alternatives Considered
+
+**Move everything, including the host document build.** The original ADR-0091 proposal. Rejected for
+now: it takes `api/base` and `embedBridge`, which `/embed` still uses, so it either breaks Discover
+or duplicates the modules. Point 2 leaves the door open — this is "not yet", not "never".
+
+**Move the host build and leave the folders.** The opposite split. Rejected because it is the wrong
+half: the folders are what someone edits when they change a visualizer, and the friction ADR-0091
+identified is having to commit in another repository to do it. The bundle is regenerated rarely and
+by a script.
+
+**Keep everything where it is and accept the vendoring.** Rejected on the evidence ADR-0091 already
+gathered: a merge conflict in a generated file was resolved this month by running a generator in a
+different repository, and the folders' only remaining consumer is an app that carries its own copy.
+
+**Give the plugin folders their own repository.** Rejected for the same reason ADR-0091 rejected it
+for the whole set: ADR-0087 point 6 forbids the app requiring another checkout to build, and a third
+repository has to be released in step with the app that embeds it.
+
+## Consequences
+
+- **Positive.** Editing a shipped visualizer becomes one commit in the repository that ships it, with
+  no script run and no second copy to drift.
+- **Positive.** The contract test sits beside the documents it tests, so a change to either shows up
+  in one diff.
+- **Tradeoff.** `familiar-apple` gains Playwright, and therefore Node, for one test. That is a second
+  ecosystem in a Swift repository, and it is the price of the test living where its subject does.
+- **Tradeoff.** `VisualizerBundle.html` is still vendored, so one cross-repo artifact remains. It is
+  the one that is regenerated by script rather than edited by hand, which is the better half to leave.
+- **Follow-up.** Once the folders are gone, `visualizerCatalog.ts`'s `/visualizers/...` URLs are
+  served only by `VisualizerSchemeHandler`. That is already true in production — ADR-0091 records it —
+  but it becomes the only truth, and the web repo's copies of those modules should be revisited then.
+- **Follow-up.** Whether the host document build ever follows is left open by point 2, and depends on
+  what happens to `/embed`'s shared modules.


### PR DESCRIPTION
**The server hosts visualizer content that nothing fetches.** Proposed, not applied — the move is five points across both repositories.

## What the investigation found (2026-08-25)

- `App.tsx` and `routes.ts` contain **zero** visualizer references. The browser's visualizer surface left with the fallback player (ADR-0057 point 5, ADR-0071).
- `services/visualizerCatalog.ts` *does* request `/visualizers/index.json` and `/visualizers/{id}/{main}` — but it runs **inside the visualizer document**, which the Apple clients load over `familiar-visualizer://`. Those URLs resolve against the app bundle, and `VisualizerSchemeHandler` answers them via `VisualizerPlugins.route(path:)` (`.document`, `.index`, `.file`). Every other such string in `packages/frontend/src` is a test fixture.
- Nothing in `familiar-apple` requests `/visualizer` or `/visualizers` over HTTP at all.

Both server surfaces therefore have no caller, which is what **ADR-0077** says to delete rather than document.

Worth saying plainly: the `/visualizers` mount is three weeks old and I added it myself in #192, to fix a real defect — the SPA catch-all was answering `200` with `index.html` for plugin documents. Its only consumer is `visualizer-document-contract.spec.ts`. It fixed the test, and the test was the only thing that needed it. Point 4 moves that test rather than stranding it.

## What the server keeps

**ADR-0064's ranking is untouched.** `POST /tracks/{id}/visualizers/rank` and `visualizer_affinity.py` stay exactly as they are — the client sends its candidates, the server scores them against the track's analysis and is never told what the device holds. That is analysis work that mentions visualizers, not visualizer hosting.

## Supersedes

ADR-0088 point 2's choice of *where* the shipped set lives. Its original reason — that the build was in the web repo and the browser rendered visualizers — lost its second half when the player was deleted, and a build is a reason to keep a toolchain somewhere, not a source of truth.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01Emjrwedq7W1scadHdgiLfs