### PR TITLE
The server stops serving visualizers (ADR-0091)

### DIFF
--- a/backend/app/main.py
+++ b/backend/app/main.py
@@ -610,15 +610,6 @@ NON_SPA_PREFIXES = (
     "openapi.json",
     "health",
     "mcp",
-    # Visualizer documents (ADR-0087). Normally the `/visualizers` mount answers these and nothing
-    # here is reached — this is the backstop for the build that has no such folder, where the SPA
-    # would otherwise return `index.html` with **HTTP 200** for a plugin document. An iframe then
-    # loads the entire web app, never sends `familiar:ready`, and the failure looks like a broken
-    # handshake rather than a missing file. A missing visualizer should look missing.
-    #
-    # This is also the half of the fix a test can hold onto: the mount only exists when `static/`
-    # does, which is never the case under pytest, so `spa_fallback` is the only reachable seam.
-    "visualizers/",
     # An MCP host probes these before connecting, to find out whether the server has an
     # authorisation server. **A 404 is the answer that means "no, connect anonymously."** Served by
     # the SPA they returned `200 text/html`, which reads as "yes, here it is" — so Claude Desktop
@@ -655,23 +646,6 @@ async def serve_embed() -> FileResponse:
     return FileResponse(embed)
 
 
-async def serve_visualizer() -> FileResponse:
-    """Serve the embedded visualizer's own document (ADR-0033).
-
-    A sibling of :func:`serve_embed`, and separate for the same reason: the SPA fallback answers any
-    unknown path with ``index.html`` — HTTP 200, the whole web app, ``WebAudioEngine`` and all. A
-    native host loading that would get a second audio engine inside a web view inside an app that is
-    already playing, which is the one thing ADR-0016 point 4 exists to prevent.
-
-    404s rather than falling through when the build predates this surface, so the app can say the
-    server is too old instead of showing a visualizer that will never receive a frame.
-    """
-    visualizer = STATIC_DIR / "visualizer.html"
-    if not visualizer.exists():
-        raise NotFoundError("This server has no embedded visualizer build.")
-    return FileResponse(visualizer)
-
-
 async def spa_fallback(full_path: str) -> FileResponse:
     """Serve index.html for SPA routing (catches all non-API routes).
 
@@ -704,23 +678,6 @@ if STATIC_DIR.exists():
     app.mount("/assets", StaticFiles(directory=STATIC_DIR / "assets"), name="assets")
     app.mount("/icons", StaticFiles(directory=STATIC_DIR / "icons"), name="icons")
 
-    # Every visualizer is a folder of files under here (ADR-0087), so this must be a mount and not a
-    # route: `index.html` sits beside a manifest and whatever assets the document brings with it.
-    #
-    # Unmounted, `/visualizers/spectrum/index.html` fell through to the SPA catch-all and came back
-    # as **`index.html` with HTTP 200** — the whole web app, in the iframe, in place of the plugin
-    # document. It never sends `familiar:ready`, so the handshake simply never happened and the
-    # contract spec timed out against a page that had loaded perfectly well. This is the failure
-    # `serve_visualizer` below already describes for `/visualizer`; the folders that ADR-0087 added
-    # needed the same protection and did not get it.
-    #
-    # `check_dir=False` so a server whose build predates these folders still answers **404** here
-    # rather than handing back the SPA. A missing visualizer should look missing.
-    app.mount(
-        "/visualizers",
-        StaticFiles(directory=STATIC_DIR / "visualizers", check_dir=False),
-        name="visualizers",
-    )
 
     # The PWA is retired (ADR-0059) — no manifest, no `registerSW.js`, no `workbox-*` chunks.
     #
@@ -742,7 +699,6 @@ if STATIC_DIR.exists():
     # Registered before the catch-all below, which would otherwise swallow them and hand the web
     # view the full app.
     app.get("/embed", response_model=None)(serve_embed)
-    app.get("/visualizer", response_model=None)(serve_visualizer)
 
     # SPA fallback - serve index.html for all non-API routes
     app.get("/{full_path:path}", response_model=None)(spa_fallback)

--- a/backend/tests/test_contract_error_shapes.py
+++ b/backend/tests/test_contract_error_shapes.py
@@ -144,48 +144,6 @@ async def test_spa_fallback_still_serves_the_app_for_client_routes() -> None:
         assert isinstance(await spa_fallback(path), FileResponse)
 
 
-async def test_spa_fallback_never_answers_for_a_visualizer_document() -> None:
-    """A visualizer document must 404 when it is missing, not come back as the web app.
-
-    ADR-0087 makes every visualizer a folder served under `/visualizers`. Those folders were added
-    without a mount, so `/visualizers/spectrum/index.html` fell through to here and returned
-    `index.html` with **HTTP 200** — the whole web app, loaded into the iframe in place of the
-    plugin document. It never sends `familiar:ready`, so the contract spec timed out on the
-    handshake while the page had in fact loaded fine, which points at the plugin rather than at
-    routing.
-
-    The mount is the real fix; this is the backstop, and the only half a test can reach — the mount
-    is registered only when `static/` exists, which never happens under pytest.
-    """
-    import pytest
-
-    from app.api.exceptions import NotFoundError
-    from app.main import spa_fallback
-
-    for path in (
-        "visualizers/spectrum/index.html",
-        "visualizers/beat-tiles/familiar-plugin.json",
-        "visualizers/index.json",
-    ):
-        with pytest.raises(NotFoundError) as caught:
-            await spa_fallback(path)
-        assert caught.value.status_code == 404
-
-
-async def test_spa_fallback_still_serves_the_singular_visualizer_entry_point() -> None:
-    """`/visualizer` is a route, `/visualizers/…` is a mount, and one must not shadow the other.
-
-    The prefix guarding the folders is `visualizers/` with the slash for exactly this reason: the
-    embedded visualizer document (ADR-0033) is a sibling name one character shorter, and turning it
-    into a 404 would take the Mac's visualizer web view down.
-    """
-    from fastapi.responses import FileResponse
-
-    from app.main import spa_fallback
-
-    assert isinstance(await spa_fallback("visualizer"), FileResponse)
-
-
 async def test_embed_route_serves_its_own_document_not_the_app() -> None:
     """The embedded surface must never be handed `index.html` (ADR-0017).
 
@@ -211,44 +169,6 @@ async def test_embed_route_serves_its_own_document_not_the_app() -> None:
 
     assert isinstance(response, FileResponse)
     assert response.path.name == "embed.html", "the embed route must not serve index.html"
-
-
-async def test_visualizer_route_serves_its_own_document_not_the_app() -> None:
-    """And the visualizer surface must never be handed `index.html` either (ADR-0033).
-
-    Same failure as the Discover surface's, with an extra edge: this document is loaded while the
-    native app is *already playing*, so a `WebAudioEngine` arriving here would contend for the audio
-    session with audio in progress rather than merely being available to.
-    """
-    from pathlib import Path
-    from unittest.mock import patch
-
-    from fastapi.responses import FileResponse
-
-    from app import main
-
-    with patch.object(main, "STATIC_DIR", Path(__file__).parent):
-        with patch.object(Path, "exists", lambda self: True):
-            response = await main.serve_visualizer()
-
-    assert isinstance(response, FileResponse)
-    assert response.path.name == "visualizer.html", "the visualizer route must not serve index.html"
-
-
-async def test_visualizer_route_404s_when_the_build_predates_it() -> None:
-    """A server too old to have the visualizer document says so.
-
-    The native side turns this into "redeploy the server" rather than a black screen that never
-    receives a frame — which is what a 200 with the wrong document would produce.
-    """
-    import pytest
-
-    from app import main
-    from app.api.exceptions import NotFoundError
-
-    with pytest.raises(NotFoundError) as caught:
-        await main.serve_visualizer()
-    assert caught.value.status_code == 404
 
 
 async def test_embed_route_404s_when_the_build_predates_it() -> None:

--- a/packages/web/e2e/visualizer-document-contract.spec.ts
+++ b/packages/web/e2e/visualizer-document-contract.spec.ts
@@ -1,4 +1,7 @@
 import { test, expect } from '@playwright/test';
+import * as fs from 'fs';
+import * as path from 'path';
+import { fileURLToPath } from 'url';
 
 /**
  * ADR-0087: a visualizer is a document that receives events.
@@ -10,8 +13,23 @@ import { test, expect } from '@playwright/test';
  *
  * The harness is written inline rather than shipped in `public/`, so the assertions and the thing
  * they assert against cannot drift apart.
+ *
+ * **The document is served from disk, not by the server** (ADR-0091 point 2). The `/visualizers`
+ * mount existed only for this test and left with the rest of the server's visualizer surfaces; in
+ * production these paths are answered by `VisualizerSchemeHandler` out of the app bundle, never
+ * over HTTP. Reading the file here tests the same bytes the app ships and lets the spec move to
+ * `familiar-apple` under ADR-0092 as a file rather than a rewrite.
  */
 const PLUGIN = '/visualizers/spectrum/index.html';
+
+const PLUGIN_FILE = path.join(
+  path.dirname(fileURLToPath(import.meta.url)),
+  '..',
+  'public',
+  'visualizers',
+  'spectrum',
+  'index.html',
+);
 
 const HARNESS = `<!doctype html><meta charset="utf-8">
 <style>html,body{margin:0;height:100%}iframe{width:640px;height:360px;border:0}</style>
@@ -57,6 +75,17 @@ test.describe('the visualizer document contract (ADR-0087)', () => {
       if (HARNESS_SERVICE_WORKER_ERROR.test(String(e))) return;
       errors.push(String(e));
     });
+
+    // The document, from disk. Without this the path falls through to the SPA catch-all and comes
+    // back as `index.html` with HTTP 200 — the whole web app in the iframe, which loads fine and
+    // never sends `familiar:ready`. That is the defect the mount used to paper over.
+    await page.route(`**${PLUGIN}`, (route) =>
+      route.fulfill({
+        status: 200,
+        contentType: 'text/html; charset=utf-8',
+        body: fs.readFileSync(PLUGIN_FILE, 'utf8'),
+      }),
+    );
 
     await page.goto(`${baseURL}/`);
     await page.setContent(HARNESS);


### PR DESCRIPTION
Two surfaces with **no callers**, removed from `backend/app/main.py`:

- `/visualizer` and `serve_visualizer`
- the `/visualizers` static mount, and the `visualizers/` entry in `NON_SPA_PREFIXES`

## Nothing fetched either one

- The web app has no visualizer surface — `App.tsx` and `routes.ts` contain zero references since the player left (ADR-0057 point 5, ADR-0071).
- The Apple clients read documents out of the app bundle over `familiar-visualizer://`, answered by `VisualizerSchemeHandler`. They never ask the server.
- `visualizerCatalog.ts` *does* name `/visualizers/index.json` and `/visualizers/{id}/{main}` — but it runs **inside** that bundled document, so those resolve against the bundle too.

ADR-0077: a surface with no caller is deleted, not documented.

## ADR-0064's ranking is untouched

`POST /tracks/{id}/visualizer-ranking` and `visualizer_affinity.py` stay exactly as they are. The client posts its candidates, the server scores them against analysis and is never told what the device holds — analysis work that mentions visualizers, not visualizer hosting.

## The contract test keeps its subject

Rather than being deleted with the mount it depended on, it now serves the plugin document from disk via `page.route`. That is honest about what it tests — the same bytes the app ships — and lets it move to `familiar-apple` under ADR-0092 as a file rather than a rewrite. Verified against a built `dist/`: passes.

Four backend tests went with the surfaces they guarded (two on the `visualizers/` prefix, two on `serve_visualizer`). The `spa_fallback` and `/embed` tests are untouched and still pass.

## Known and deliberate

`packages/web/public/visualizers/` still exists and vite still copies it into `dist/`, so those paths now fall through to the SPA catch-all again on a real server. That is inert — nothing requests them — and **ADR-0092 deletes the folders**. It is why this is not the whole of ADR-0091's original proposal; see #199 for why the scope was narrowed.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01Emjrwedq7W1scadHdgiLfs