### PR TITLE
The Python jobs need Linux, not any self-hosted runner

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -228,7 +228,13 @@ jobs:
 
   migration-lint:
     name: Migration Lint
-    runs-on: ${{ vars.CI_RUNNER || 'self-hosted' }}
+    # **Linux, not bare `self-hosted`.** This job runs `uv`, and `UV_PYTHON` is pinned to a patch
+    # release that python-build-standalone publishes for Linux but not for macOS/arm64 — a bare
+    # `self-hosted` label matches the macOS runner too, and the job then dies on
+    # `No download found for request: cpython-3.11.15-macos-aarch64-none` before running a check.
+    # It only surfaced when `CI_RUNNER` was cleared: while it was `ubuntu-latest` these landed on
+    # hosted Linux and the ambiguity never showed.
+    runs-on: ${{ fromJSON(vars.CI_LINUX_RUNNER || '["self-hosted","Linux"]') }}
     timeout-minutes: 10
     steps:
       - uses: actions/checkout@v4
@@ -251,7 +257,13 @@ jobs:
 
   backend-lint:
     name: Backend Lint
-    runs-on: ${{ vars.CI_RUNNER || 'self-hosted' }}
+    # **Linux, not bare `self-hosted`.** This job runs `uv`, and `UV_PYTHON` is pinned to a patch
+    # release that python-build-standalone publishes for Linux but not for macOS/arm64 — a bare
+    # `self-hosted` label matches the macOS runner too, and the job then dies on
+    # `No download found for request: cpython-3.11.15-macos-aarch64-none` before running a check.
+    # It only surfaced when `CI_RUNNER` was cleared: while it was `ubuntu-latest` these landed on
+    # hosted Linux and the ambiguity never showed.
+    runs-on: ${{ fromJSON(vars.CI_LINUX_RUNNER || '["self-hosted","Linux"]') }}
     timeout-minutes: 10
     env:
       UV_HTTP_TIMEOUT: '120'


### PR DESCRIPTION
`backend-lint` and `migration-lint` are failing on `main` and on every open PR with:

```
error: No download found for request: cpython-3.11.15-macos-aarch64-none
```

## Cause

They run `uv`, and `UV_PYTHON` is pinned to a patch release that python-build-standalone publishes for **Linux but not macOS/arm64**. A bare `self-hosted` label matches **every** self-hosted runner, including the Mac — so these jobs could land there and die before running a single check.

**Two changes had to meet for this to appear.** The patch-level pin came in with the interpreter work (#196); the runner ambiguity was harmless while `CI_RUNNER` was `ubuntu-latest`, because everything went to hosted Linux. Clearing that variable to put CI back on the NAS is what let a Python job onto a Mac. Both were mine.

## Fix

Both now use the selector the other backend jobs already used:

```
runs-on: ${{ fromJSON(vars.CI_LINUX_RUNNER || '["self-hosted","Linux"]') }}
```

Nothing about them ever wanted macOS — one lints Python, the other lints Alembic migrations.

## Left alone deliberately

`frontend-lint`, `frontend-test` and `frontend-build` keep the loose label: Node runs on either platform and there is no pinned toolchain to miss. `macos-compose-check` is about compose files, not Python.

## Unblocks

#203 and #204, whose only failures are these two jobs.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01Emjrwedq7W1scadHdgiLfs