### PR TITLE
Take the frontend jobs off the shared Mac

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -577,7 +577,16 @@ jobs:
 
   frontend-lint:
     name: Frontend Lint
-    runs-on: ${{ vars.CI_RUNNER || 'self-hosted' }}
+    # **Linux, not bare `self-hosted`.** These three are Node jobs with no reason to want macOS, and
+    # a bare label let them pile onto the one Mac — which is shared with `familiar-apple`'s CI and is
+    # the only runner that can take the macOS jobs. Four workers started there within two minutes on
+    # 2026-08-26, all unpacking the same action archives into the shared `_actions/` tree, and one
+    # hung in `tar -xzf` of `pnpm/action-setup` before a single step ran. GitHub killed it at twenty
+    # minutes and reported `cancelled`, which reads as a failure on the pull request.
+    #
+    # That happened five times in a day, always to `Frontend Build`. Moving them here leaves the Mac
+    # for the two jobs that genuinely need it.
+    runs-on: ${{ fromJSON(vars.CI_LINUX_RUNNER || '["self-hosted","Linux"]') }}
     timeout-minutes: 10
     env:
       NPM_CONFIG_FETCH_RETRIES: '5'
@@ -611,7 +620,16 @@ jobs:
 
   frontend-test:
     name: Frontend Test
-    runs-on: ${{ vars.CI_RUNNER || 'self-hosted' }}
+    # **Linux, not bare `self-hosted`.** These three are Node jobs with no reason to want macOS, and
+    # a bare label let them pile onto the one Mac — which is shared with `familiar-apple`'s CI and is
+    # the only runner that can take the macOS jobs. Four workers started there within two minutes on
+    # 2026-08-26, all unpacking the same action archives into the shared `_actions/` tree, and one
+    # hung in `tar -xzf` of `pnpm/action-setup` before a single step ran. GitHub killed it at twenty
+    # minutes and reported `cancelled`, which reads as a failure on the pull request.
+    #
+    # That happened five times in a day, always to `Frontend Build`. Moving them here leaves the Mac
+    # for the two jobs that genuinely need it.
+    runs-on: ${{ fromJSON(vars.CI_LINUX_RUNNER || '["self-hosted","Linux"]') }}
     timeout-minutes: 15
     env:
       NPM_CONFIG_FETCH_RETRIES: '5'
@@ -639,7 +657,16 @@ jobs:
 
   frontend-build:
     name: Frontend Build
-    runs-on: ${{ vars.CI_RUNNER || 'self-hosted' }}
+    # **Linux, not bare `self-hosted`.** These three are Node jobs with no reason to want macOS, and
+    # a bare label let them pile onto the one Mac — which is shared with `familiar-apple`'s CI and is
+    # the only runner that can take the macOS jobs. Four workers started there within two minutes on
+    # 2026-08-26, all unpacking the same action archives into the shared `_actions/` tree, and one
+    # hung in `tar -xzf` of `pnpm/action-setup` before a single step ran. GitHub killed it at twenty
+    # minutes and reported `cancelled`, which reads as a failure on the pull request.
+    #
+    # That happened five times in a day, always to `Frontend Build`. Moving them here leaves the Mac
+    # for the two jobs that genuinely need it.
+    runs-on: ${{ fromJSON(vars.CI_LINUX_RUNNER || '["self-hosted","Linux"]') }}
     timeout-minutes: 15
     env:
       NPM_CONFIG_FETCH_RETRIES: '5'


### PR DESCRIPTION
`Frontend Build` was reported failing on **five** pull requests today (#201, #205, #204 ×2, #53). It never failed — it was **cancelled** every time, and `gh pr checks` renders that as `fail`.

## What the runner's own log says

```
17:30:26  job assigned
17:30:28  Starting process: /usr/bin/tar -xzf .../pnpm-action-setup.tar.gz
17:50:26  cancelled by GitHub, twenty minutes later
```

The worker log **stops at that `tar` line and never writes again**. The job never reached a step — `Set up job` has no completion time. A successful run of this job takes **18–34 seconds**.

## Why

**Four workers started on that Mac within two minutes** — 17:28:11, 17:29:01, 17:29:42, 17:30:26 — sibling jobs from one run, each unpacking the same action archives into the shared `_actions/` tree. One hung.

Worth noting from the same log: `Force kill process on cancellation: 'False'`. Cancelling the job does **not** kill the `tar`, so a wedged extraction can outlive the job that started it.

That Mac is also the only runner that can take the macOS jobs, and it is shared with `familiar-apple`'s CI — so it is the one place where piling work up actually costs something.

## Fix

These three are Node jobs with no reason to want macOS. A bare `self-hosted` label is what let them land there — the same ambiguity put Python jobs on the Mac earlier today and broke them differently (#206).

The Mac now takes only the two jobs that genuinely need it:

| runner | jobs |
|---|---|
| macOS | `macos-compose-check`, `macos-compose-integration` |
| Linux | everything else |

## Honest limit

This reduces contention; it does not cure the underlying race, which is in the runner's action unpacking. If it recurs on Linux, the next levers are pre-seeding `_actions/` or serialising setup.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01Emjrwedq7W1scadHdgiLfs