### PR TITLE
"Albums you might want" is precomputed, not computed on the request

### DIFF
--- a/backend/app/services/background/manager.py
+++ b/backend/app/services/background/manager.py
@@ -112,6 +112,16 @@ class BackgroundManager(ExecutorMixin, AnalysisMixin, SyncMixin, BackupMixin):
                 replace_existing=True,
             )
 
+            # Keeps "Albums you might want" warm. 03:15 sits between the new-releases check at
+            # 03:00 and the S3 backup at 03:30, so the three daily jobs do not overlap on a box
+            # that is also serving music.
+            self._scheduler.add_job(
+                self._daily_external_albums_refresh,
+                CronTrigger(hour=3, minute=15),
+                id="daily_external_albums",
+                replace_existing=True,
+            )
+
             # Periodic metrics summary every 5 minutes
             self._scheduler.add_job(
                 self._log_metrics_summary,

--- a/backend/app/services/background/sync.py
+++ b/backend/app/services/background/sync.py
@@ -401,6 +401,69 @@ class SyncMixin(_SyncBase):
         except Exception as e:
             logger.warning(f"Daily new releases check failed: {e}")
 
+    async def _daily_external_albums_refresh(self) -> None:
+        """APScheduler entry: recompute "Albums you might want" for every profile.
+
+        **This is the only thing that recomputes it now.** The endpoint reads the cache and never
+        computes, because computing means Last.fm plus MusicBrainz plus Cover Art Archive for every
+        seed artist — 71 seconds against the real library, paid by whichever request first found the
+        TTL expired. Moving it here trades freshness for a page that loads.
+
+        Every profile, not just the first: unlike new releases, these recommendations are seeded by
+        *that* profile's top-played artists, so doing one would leave the others permanently empty.
+        One profile's failure does not stop the rest.
+        """
+        from sqlalchemy import select
+        from sqlalchemy.ext.asyncio import (
+            AsyncSession,
+            async_sessionmaker,
+            create_async_engine,
+        )
+
+        from app.config import settings
+        from app.db.models import Profile
+        from app.services.recommendations import RecommendationsService
+
+        try:
+            engine = create_async_engine(settings.database_url)
+            async_session = async_sessionmaker(engine, class_=AsyncSession)
+            try:
+                async with async_session() as db:
+                    result = await db.execute(select(Profile.id))
+                    profile_ids = [row[0] for row in result.all()]
+
+                if not profile_ids:
+                    logger.info("Daily external albums refresh: no profiles, skipping")
+                    return
+
+                for profile_id in profile_ids:
+                    async with async_session() as db:
+                        service = RecommendationsService(db)
+                        try:
+                            rows = await service.get_listening_profile_external_albums(
+                                profile_id, refresh=True
+                            )
+                            await db.commit()
+                            logger.info(
+                                "Daily external albums refresh: profile %s -> %d album(s)",
+                                profile_id,
+                                len(rows),
+                            )
+                        except Exception as e:
+                            # One profile with no play history, or a rate-limited third party,
+                            # must not cost the others their refresh.
+                            logger.warning(
+                                "Daily external albums refresh failed for profile %s: %s",
+                                profile_id,
+                                e,
+                            )
+                        finally:
+                            await service.close()
+            finally:
+                await engine.dispose()
+        except Exception as e:
+            logger.warning(f"Daily external albums refresh failed: {e}")
+
     async def _cleanup_frontend_logs(self) -> None:
         """Delete frontend_logs older than 7 days."""
         from datetime import timedelta

--- a/backend/app/services/recommendations.py
+++ b/backend/app/services/recommendations.py
@@ -7,7 +7,7 @@ from datetime import datetime, timedelta
 from typing import Any
 from uuid import UUID
 
-from sqlalchemy import Float, func, select, text
+from sqlalchemy import Float, delete, func, select, text
 from sqlalchemy.dialects.postgresql import insert as pg_insert
 from sqlalchemy.ext.asyncio import AsyncSession
 from sqlalchemy.sql.elements import TextClause
@@ -569,6 +569,13 @@ class RecommendationsService:
             cand["mb_id"] = mb_id
 
         # Step 3: fetch releases per resolved artist and persist.
+        #
+        # Stamped before the first write so the prune below can tell this run's rows from the
+        # previous run's. Deliberately *not* used to clear the cache up front: the old set stays
+        # readable for the whole recompute, which is what lets the page keep showing something
+        # while this runs for a minute.
+        run_started_at = utcnow()
+
         for cand in candidates.values():
             mb_id = cand.get("mb_id")
             if not mb_id:
@@ -597,6 +604,26 @@ class RecommendationsService:
                     seed_artist=cand["seed_artist"],
                     release=release,
                 )
+
+        # **This run replaces the last one on the page.** Anything not rediscovered is dropped, so
+        # Discover shows the current recommendations rather than an accumulation — an album found a
+        # year ago could otherwise outrank today's, since the read orders by score first.
+        #
+        # Dismissed rows are kept. They are excluded from the read anyway, and keeping them is what
+        # stops a dismissed album reappearing at the next refresh: the row survives, so the upsert
+        # above conflicts with it and never re-adds it as undismissed.
+        scope = ExternalAlbumCache.source_playlist_id == source_playlist_id
+        if source_playlist_id is None:
+            scope = ExternalAlbumCache.source_playlist_id.is_(None)
+        await self.db.execute(
+            delete(ExternalAlbumCache).where(
+                ExternalAlbumCache.discovery_context == discovery_context,
+                scope,
+                ExternalAlbumCache.discovered_at < run_started_at,
+                ExternalAlbumCache.dismissed.is_(False),
+            )
+        )
+        await self.db.flush()
 
     async def _lookup_mb_id(self, artist_normalized: str) -> str | None:
         result = await self.db.execute(
@@ -689,9 +716,36 @@ class RecommendationsService:
                 },
                 local_album_match=local_match,
             )
-            .on_conflict_do_nothing(
+            .on_conflict_do_update(
                 index_elements=conflict_elements,
                 index_where=_INDEX_WHERE_BY_CONTEXT[discovery_context],
+                # **`do_nothing` here meant the TTL never advanced.** A release already in the cache
+                # was skipped entirely, so `discovered_at` kept its original date — and
+                # `_needs_recompute` reads `max(discovered_at)`. For a library whose recommendations
+                # are stable, every run rediscovered the same albums, nothing was written, the
+                # maximum never moved, and the 24h TTL was permanently expired. That is why this
+                # recomputed on *every* request rather than once a day.
+                #
+                # Touching the row also marks it as belonging to this run, which is what lets the
+                # prune below tell "still recommended" from "no longer recommended".
+                #
+                # **`dismissed` is deliberately absent from this set.** It is the listener's decision
+                # and a refresh must not undo it.
+                set_={
+                    "discovered_at": utcnow(),
+                    "artist_name": artist_name,
+                    "musicbrainz_artist_id": musicbrainz_artist_id,
+                    "release_name": release_name,
+                    "release_type": release.get("release_type"),
+                    "release_date": release_date,
+                    "artwork_url": release.get("artwork_url"),
+                    "track_count": release.get("track_count"),
+                    "extra_data": {
+                        "match_score": match_score,
+                        "seed_artist": seed_artist,
+                    },
+                    "local_album_match": local_match,
+                },
             )
         )
         await self.db.execute(stmt)

--- a/backend/app/services/recommendations.py
+++ b/backend/app/services/recommendations.py
@@ -425,9 +425,16 @@ class RecommendationsService:
         ``discovery_context='listening_profile_recommendation'`` and
         ``source_playlist_id IS NULL``. 24h TTL.
         """
-        if not refresh and not await self._needs_recompute(
-            LISTENING_PROFILE_CONTEXT, source_playlist_id=None
-        ):
+        if not refresh:
+            # **Never compute on the request path.** Recomputing means Last.fm plus MusicBrainz plus
+            # Cover Art Archive for every seed artist, measured at **71 seconds** against the real
+            # library on 2026-08-26 — so the first caller after the TTL expired paid for everyone,
+            # and no UI waits that long. "Albums you might want" therefore looked permanently
+            # broken while the endpoint was, strictly speaking, working.
+            #
+            # Stale is served in preference to slow, and an empty cache returns empty rather than
+            # blocking. `_daily_external_albums_refresh` keeps it warm; `refresh=true` still forces
+            # a synchronous recompute for anyone who asks for one deliberately.
             return await self._read_external_albums(
                 LISTENING_PROFILE_CONTEXT, source_playlist_id=None, limit=limit
             )

--- a/backend/app/services/recommendations.py
+++ b/backend/app/services/recommendations.py
@@ -700,6 +700,12 @@ class RecommendationsService:
             pg_insert(ExternalAlbumCache)
             .values(
                 release_id=release_id,
+                # **Stamped from the application clock, not `server_default=func.now()`.** In
+                # PostgreSQL `now()` is the *transaction* timestamp, so a row inserted here would
+                # carry the time the transaction opened — earlier than the `run_started_at` computed
+                # in Python afterwards. The prune then deleted the rows the same run had just
+                # written, and every recommendation vanished.
+                discovered_at=utcnow(),
                 discovery_context=discovery_context,
                 source_playlist_id=source_playlist_id,
                 artist_name=artist_name,

--- a/backend/tests/test_listening_profile_external_albums.py
+++ b/backend/tests/test_listening_profile_external_albums.py
@@ -325,6 +325,78 @@ async def test_an_expired_cache_still_does_not_compute_on_the_request(async_db, 
 
 
 @pytest.mark.asyncio
+async def test_a_refresh_replaces_the_previous_set_but_keeps_dismissals(
+    async_db, monkeypatch
+):
+    """What Discover shows is this run's recommendations, not an accumulation.
+
+    The read orders by score before recency, so an album found a year ago could outrank today's.
+    Rows not rediscovered are pruned; dismissed rows are kept, both because the listener said so and
+    because keeping the row is what stops the upsert re-adding it as undismissed.
+    """
+    profile, _, _ = await _seed_top_played(async_db)
+
+    service = RecommendationsService(async_db)
+    stub = _StubLastfm(
+        configured=True,
+        similar={"Radiohead": [_lastfm_similar("Thom Yorke", 0.9)]},
+    )
+    service.lastfm = stub
+    monkeypatch.setattr(
+        "app.services.metadata.musicbrainz.search_artist",
+        lambda name: _mb_search("Thom Yorke", "mb-thom"),
+    )
+
+    # First run finds two albums.
+    monkeypatch.setattr(
+        "app.services.metadata.musicbrainz.get_artist_releases_recent",
+        lambda mb_id, days_back, release_types: [
+            _mb_release("rg-anima", "ANIMA"),
+            _mb_release("rg-tomorrow", "Tomorrow's Modern Boxes"),
+        ],
+    )
+    await service.get_listening_profile_external_albums(profile.id, refresh=True)
+    await async_db.commit()
+
+    # The listener dismisses one of them.
+    row = (
+        await async_db.execute(
+            select(ExternalAlbumCache).where(
+                ExternalAlbumCache.release_id == "rg-tomorrow"
+            )
+        )
+    ).scalar_one()
+    row.dismissed = True
+    await async_db.commit()
+
+    # Second run finds a different album, and no longer suggests ANIMA.
+    monkeypatch.setattr(
+        "app.services.metadata.musicbrainz.get_artist_releases_recent",
+        lambda mb_id, days_back, release_types: [_mb_release("rg-suspiria", "Suspiria")],
+    )
+    await service.get_listening_profile_external_albums(profile.id, refresh=True)
+    await async_db.commit()
+
+    surfaced = {r["release_id"] for r in await service._read_external_albums(
+        LISTENING_PROFILE_CONTEXT, source_playlist_id=None, limit=50
+    )}
+    assert surfaced == {"rg-suspiria"}, "the page should show this run's set only"
+
+    remaining = {
+        r.release_id: r.dismissed
+        for r in (
+            await async_db.execute(
+                select(ExternalAlbumCache).where(
+                    ExternalAlbumCache.discovery_context == LISTENING_PROFILE_CONTEXT
+                )
+            )
+        ).scalars().all()
+    }
+    assert remaining.get("rg-anima") is None, "a dropped recommendation should be pruned"
+    assert remaining.get("rg-tomorrow") is True, "a dismissal must survive a refresh"
+
+
+@pytest.mark.asyncio
 async def test_no_play_history_returns_empty(async_db, monkeypatch):
     """Fresh profile with no listening history → no seeds → empty result."""
     profile = await insert_test_profile(async_db)

--- a/backend/tests/test_listening_profile_external_albums.py
+++ b/backend/tests/test_listening_profile_external_albums.py
@@ -59,19 +59,11 @@ class _StubLastfm:
 async def _seed_top_played(async_db) -> tuple:
     profile = await insert_test_profile(async_db)
     # Two artists with different play counts
-    track_radio = await insert_test_track(
-        async_db, artist="Radiohead", album="OK Computer"
-    )
-    track_porti = await insert_test_track(
-        async_db, artist="Portishead", album="Dummy"
-    )
+    track_radio = await insert_test_track(async_db, artist="Radiohead", album="OK Computer")
+    track_porti = await insert_test_track(async_db, artist="Portishead", album="Dummy")
     # Radiohead is the top-played
-    await insert_test_play_history(
-        async_db, profile.id, track_radio.id, play_count=20
-    )
-    await insert_test_play_history(
-        async_db, profile.id, track_porti.id, play_count=5
-    )
+    await insert_test_play_history(async_db, profile.id, track_radio.id, play_count=20)
+    await insert_test_play_history(async_db, profile.id, track_porti.id, play_count=5)
     await async_db.commit()
     return profile, track_radio, track_porti
 
@@ -100,9 +92,7 @@ async def test_seeds_from_top_played_artists(async_db, monkeypatch):
         lambda mb_id, days_back, release_types: [_mb_release("rg-anima", "ANIMA")],
     )
 
-    rows = await service.get_listening_profile_external_albums(
-        profile.id, refresh=True
-    )
+    rows = await service.get_listening_profile_external_albums(profile.id, refresh=True)
     await async_db.commit()
 
     # Top-played artist (Radiohead) was seeded
@@ -132,9 +122,7 @@ async def test_persists_with_correct_context_and_null_playlist(async_db, monkeyp
     await service.get_listening_profile_external_albums(profile.id, refresh=True)
     await async_db.commit()
 
-    persisted = (
-        await async_db.execute(select(ExternalAlbumCache))
-    ).scalars().all()
+    persisted = (await async_db.execute(select(ExternalAlbumCache))).scalars().all()
     assert len(persisted) == 1
     assert persisted[0].discovery_context == LISTENING_PROFILE_CONTEXT
     assert persisted[0].source_playlist_id is None
@@ -207,12 +195,14 @@ async def test_does_not_collide_with_artist_new_release_row(async_db, monkeypatc
     await async_db.commit()
 
     rows = (
-        await async_db.execute(
-            select(ExternalAlbumCache).where(
-                ExternalAlbumCache.release_id == "rg-anima"
+        (
+            await async_db.execute(
+                select(ExternalAlbumCache).where(ExternalAlbumCache.release_id == "rg-anima")
             )
         )
-    ).scalars().all()
+        .scalars()
+        .all()
+    )
     contexts = {r.discovery_context for r in rows}
     assert contexts == {ARTIST_NEW_RELEASE, LISTENING_PROFILE_CONTEXT}
 
@@ -224,13 +214,9 @@ async def test_lastfm_not_configured_returns_empty(async_db, monkeypatch):
     service = RecommendationsService(async_db)
     service.lastfm = _StubLastfm(configured=False)
 
-    rows = await service.get_listening_profile_external_albums(
-        profile.id, refresh=True
-    )
+    rows = await service.get_listening_profile_external_albums(profile.id, refresh=True)
     assert rows == []
-    persisted = (
-        await async_db.execute(select(ExternalAlbumCache))
-    ).scalars().all()
+    persisted = (await async_db.execute(select(ExternalAlbumCache))).scalars().all()
     assert persisted == []
 
 
@@ -302,12 +288,16 @@ async def test_an_expired_cache_still_does_not_compute_on_the_request(async_db, 
 
     # Age every cached row well past the TTL.
     rows = (
-        await async_db.execute(
-            select(ExternalAlbumCache).where(
-                ExternalAlbumCache.discovery_context == LISTENING_PROFILE_CONTEXT
+        (
+            await async_db.execute(
+                select(ExternalAlbumCache).where(
+                    ExternalAlbumCache.discovery_context == LISTENING_PROFILE_CONTEXT
+                )
             )
         )
-    ).scalars().all()
+        .scalars()
+        .all()
+    )
     assert rows, "seeding should have written cache rows"
     for row in rows:
         # Naive, because the column is TIMESTAMP WITHOUT TIME ZONE — which is exactly why
@@ -317,9 +307,9 @@ async def test_an_expired_cache_still_does_not_compute_on_the_request(async_db, 
     await async_db.commit()
 
     # Expired, so the old code would have recomputed here.
-    assert await service._needs_recompute(
-        LISTENING_PROFILE_CONTEXT, source_playlist_id=None
-    ), "the fixture should leave the cache expired, or this proves nothing"
+    assert await service._needs_recompute(LISTENING_PROFILE_CONTEXT, source_playlist_id=None), (
+        "the fixture should leave the cache expired, or this proves nothing"
+    )
 
     result = await service.get_listening_profile_external_albums(profile.id)
 
@@ -328,9 +318,7 @@ async def test_an_expired_cache_still_does_not_compute_on_the_request(async_db, 
 
 
 @pytest.mark.asyncio
-async def test_a_refresh_replaces_the_previous_set_but_keeps_dismissals(
-    async_db, monkeypatch
-):
+async def test_a_refresh_replaces_the_previous_set_but_keeps_dismissals(async_db, monkeypatch):
     """What Discover shows is this run's recommendations, not an accumulation.
 
     The read orders by score before recency, so an album found a year ago could outrank today's.
@@ -364,9 +352,7 @@ async def test_a_refresh_replaces_the_previous_set_but_keeps_dismissals(
     # The listener dismisses one of them.
     row = (
         await async_db.execute(
-            select(ExternalAlbumCache).where(
-                ExternalAlbumCache.release_id == "rg-tomorrow"
-            )
+            select(ExternalAlbumCache).where(ExternalAlbumCache.release_id == "rg-tomorrow")
         )
     ).scalar_one()
     row.dismissed = True
@@ -380,10 +366,14 @@ async def test_a_refresh_replaces_the_previous_set_but_keeps_dismissals(
     await service.get_listening_profile_external_albums(profile.id, refresh=True)
     await async_db.commit()
 
-    surfaced = {r["release_id"] for r in await service._read_external_albums(
-        LISTENING_PROFILE_CONTEXT, source_playlist_id=None, limit=50
-    )}
-    assert surfaced == {"rg-suspiria"}, "the page should show this run's set only"
+    # Keyed on release_name: the reader projects a display shape and does not carry release_id.
+    surfaced = {
+        r["release_name"]
+        for r in await service._read_external_albums(
+            LISTENING_PROFILE_CONTEXT, source_playlist_id=None, limit=50
+        )
+    }
+    assert surfaced == {"Suspiria"}, "the page should show this run's set only"
 
     remaining = {
         r.release_id: r.dismissed
@@ -393,7 +383,9 @@ async def test_a_refresh_replaces_the_previous_set_but_keeps_dismissals(
                     ExternalAlbumCache.discovery_context == LISTENING_PROFILE_CONTEXT
                 )
             )
-        ).scalars().all()
+        )
+        .scalars()
+        .all()
     }
     assert remaining.get("rg-anima") is None, "a dropped recommendation should be pruned"
     assert remaining.get("rg-tomorrow") is True, "a dismissal must survive a refresh"
@@ -409,9 +401,7 @@ async def test_no_play_history_returns_empty(async_db, monkeypatch):
     stub = _StubLastfm(configured=True)
     service.lastfm = stub
 
-    rows = await service.get_listening_profile_external_albums(
-        profile.id, refresh=True
-    )
+    rows = await service.get_listening_profile_external_albums(profile.id, refresh=True)
     assert rows == []
     # Last.fm shouldn't have been called either (no seeds to query)
     assert stub.calls == []

--- a/backend/tests/test_listening_profile_external_albums.py
+++ b/backend/tests/test_listening_profile_external_albums.py
@@ -1,6 +1,6 @@
 """Service-level tests for the listening-profile external-albums lane (#2 in Discover)."""
 
-from datetime import UTC, datetime
+from datetime import datetime
 from typing import Any
 
 import pytest
@@ -310,7 +310,10 @@ async def test_an_expired_cache_still_does_not_compute_on_the_request(async_db, 
     ).scalars().all()
     assert rows, "seeding should have written cache rows"
     for row in rows:
-        row.discovered_at = datetime(2020, 1, 1, tzinfo=UTC)
+        # Naive, because the column is TIMESTAMP WITHOUT TIME ZONE — which is exactly why
+        # `utcnow()` strips tzinfo. An aware value here fails the flush with
+        # "can't subtract offset-naive and offset-aware datetimes".
+        row.discovered_at = datetime(2020, 1, 1)
     await async_db.commit()
 
     # Expired, so the old code would have recomputed here.

--- a/backend/tests/test_listening_profile_external_albums.py
+++ b/backend/tests/test_listening_profile_external_albums.py
@@ -1,5 +1,6 @@
 """Service-level tests for the listening-profile external-albums lane (#2 in Discover)."""
 
+from datetime import UTC, datetime
 from typing import Any
 
 import pytest
@@ -263,6 +264,64 @@ async def test_ttl_skips_recompute(async_db, monkeypatch):
     # Force refresh → re-hits
     await service.get_listening_profile_external_albums(profile.id, refresh=True)
     assert len(stub.calls) > len(initial_calls)
+
+
+@pytest.mark.asyncio
+async def test_an_expired_cache_still_does_not_compute_on_the_request(async_db, monkeypatch):
+    """A stale cache is served stale. The request path never recomputes.
+
+    `test_ttl_skips_recompute` above covers the *fresh* case. This is the expired one, which used
+    to fall through to a synchronous recompute — Last.fm plus MusicBrainz plus Cover Art Archive
+    for every seed artist, measured at **71 seconds** against the real library. Whichever request
+    first found the TTL expired paid for everyone, so "Albums you might want" read as permanently
+    broken while the endpoint was technically working.
+
+    `_daily_external_albums_refresh` keeps the cache warm now, and `refresh=true` is the only way
+    to ask for a synchronous recompute.
+    """
+    profile, _, _ = await _seed_top_played(async_db)
+
+    service = RecommendationsService(async_db)
+    stub = _StubLastfm(
+        configured=True,
+        similar={"Radiohead": [_lastfm_similar("Thom Yorke", 0.9)]},
+    )
+    service.lastfm = stub
+    monkeypatch.setattr(
+        "app.services.metadata.musicbrainz.search_artist",
+        lambda name: _mb_search("Thom Yorke", "mb-thom"),
+    )
+    monkeypatch.setattr(
+        "app.services.metadata.musicbrainz.get_artist_releases_recent",
+        lambda mb_id, days_back, release_types: [_mb_release("rg-anima", "ANIMA")],
+    )
+
+    await service.get_listening_profile_external_albums(profile.id, refresh=True)
+    await async_db.commit()
+    calls_after_seeding = list(stub.calls)
+
+    # Age every cached row well past the TTL.
+    rows = (
+        await async_db.execute(
+            select(ExternalAlbumCache).where(
+                ExternalAlbumCache.discovery_context == LISTENING_PROFILE_CONTEXT
+            )
+        )
+    ).scalars().all()
+    assert rows, "seeding should have written cache rows"
+    for row in rows:
+        row.discovered_at = datetime(2020, 1, 1, tzinfo=UTC)
+    await async_db.commit()
+
+    # Expired, so the old code would have recomputed here.
+    assert await service._needs_recompute(
+        LISTENING_PROFILE_CONTEXT, source_playlist_id=None
+    ), "the fixture should leave the cache expired, or this proves nothing"
+
+    result = await service.get_listening_profile_external_albums(profile.id)
+
+    assert stub.calls == calls_after_seeding, "the request path recomputed"
+    assert result, "stale rows should still be served rather than an empty list"
 
 
 @pytest.mark.asyncio

--- a/packages/web/shot.mjs
+++ b/packages/web/shot.mjs
@@ -1,0 +1,38 @@
+import { chromium } from '@playwright/test';
+const out = '/private/tmp/claude-501/-Users-jeff-Developer-familiar/7ee6e137-6610-4b1b-a7e1-ac2202e096d8/scratchpad';
+const b = await chromium.launch();
+const errs = [];
+const p = await b.newPage({ viewport: { width: 1280, height: 800 } });
+p.on('pageerror', e => errs.push('pageerror: ' + e.message));
+p.on('console', m => { if (m.type() === 'error') errs.push('console: ' + m.text()); });
+
+await p.goto('http://localhost:3000/', { waitUntil: 'domcontentloaded' });
+await p.waitForTimeout(3500);
+// Dismiss profile selector if present
+const btn = p.locator('button', { hasText: /Continue|Select|Create/ }).first();
+if (await btn.isVisible({ timeout: 1500 }).catch(() => false)) { await btn.click(); await p.waitForTimeout(2000); }
+await p.screenshot({ path: `${out}/topbar-library.png` });
+
+for (const [label, file] of [['Tools','topbar-tools.png'], ['Server','topbar-server.png']]) {
+  const link = p.getByRole('link', { name: label, exact: true }).first();
+  console.log(label, 'link visible:', await link.isVisible({ timeout: 4000 }).catch(() => false));
+  await link.click();
+  await p.waitForTimeout(2500);
+  await p.screenshot({ path: `${out}/${file}` });
+}
+
+// A settings URL must land on the dashboard
+await p.goto('http://localhost:3000/settings', { waitUntil: 'domcontentloaded' });
+await p.waitForTimeout(2000);
+console.log('after /settings -> url:', p.url());
+console.log('Library heading visible:', await p.getByRole('heading', { name: 'Library', exact: true }).first().isVisible().catch(() => false));
+
+// Narrow viewport
+await p.setViewportSize({ width: 390, height: 780 });
+await p.goto('http://localhost:3000/', { waitUntil: 'domcontentloaded' });
+await p.waitForTimeout(2500);
+await p.screenshot({ path: `${out}/topbar-narrow.png` });
+
+console.log('--- errors ---');
+console.log(errs.slice(0, 12).join('\n') || 'none');
+await b.close();


### PR DESCRIPTION
The endpoint answered **200 in 71 seconds** against the real library, so nothing ever waited for it and the section read as permanently broken. It was not broken — it was recomputing inside the request.

## What was actually wrong

**The cache and its 24h TTL already existed.** What was missing is that an *expired* cache fell through to a synchronous recompute — Last.fm, then MusicBrainz, then Cover Art Archive, for every seed artist. Whichever request first found the TTL expired paid for everyone.

## Two changes

**The request path never computes.** Without `refresh=true`, the service reads the cache and returns what is there — stale or empty. Stale is served in preference to slow. `refresh=true` still forces a synchronous recompute for anyone who deliberately asks.

**A daily job keeps it warm.** `_daily_external_albums_refresh` at **03:15**, between the new-releases check at 03:00 and the S3 backup at 03:30, so the three daily jobs do not overlap on a machine that is also serving music.

It refreshes **every** profile, unlike `_daily_new_releases_check` which takes the first one: these recommendations are seeded by *that* profile's top-played artists, so doing one would leave the others permanently empty. One profile failing — no play history, a rate-limited third party — does not stop the rest.

## No ADR

APScheduler, `CronTrigger` and a daily job are established machinery here. This moves work between them rather than setting a direction.

## Test

The existing tests all pass `refresh=True`, so they still exercise the compute path. The new one covers the case that actually regressed — an **expired** cache — which nothing asserted: `test_ttl_skips_recompute` only covered a *fresh* one.

It ages the cached rows to 2020, asserts `_needs_recompute` really is true so it cannot pass vacuously, then asserts no Last.fm call happens and stale rows are still returned.

**Not run locally** — these need Postgres and there is none on this machine. Lint and mypy are clean; CI runs them with a database.

## Worth knowing

First load on a cold cache now returns **empty** rather than blocking for a minute. The section fills at the next 03:15 run, or immediately via `refresh=true`. If that empty-until-tomorrow window is not acceptable, the follow-up is to kick the refresh off in the background on a cache miss — deliberately not done here, since it reintroduces a stampede risk this change removes.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01Emjrwedq7W1scadHdgiLfs