### PR TITLE
The backend prerequisites for an offline library cache (ADR-0011)

### DIFF
--- a/backend/app/api/routes/library.py
+++ b/backend/app/api/routes/library.py
@@ -17,6 +17,7 @@ from app.api.routes.library_import import router as import_router
 from app.api.routes.library_maps import router as maps_router
 from app.api.routes.library_missing import router as missing_router
 from app.api.routes.library_sync import router as sync_router
+from app.api.schemas.common import UTCDateTime
 from app.db.models import Track, TrackAnalysis
 
 logger = logging.getLogger(__name__)
@@ -47,6 +48,45 @@ class LibraryStats(BaseModel):
     pending_backfill: int = 0
     pending_melodic: int = 0
     pending_mood_tags: int = 0
+
+
+class LibraryFingerprint(BaseModel):
+    """Whether a cached copy of the library is stale, in one request (ADR-0011 point 5)."""
+
+    track_count: int
+    max_updated_at: UTCDateTime | None = None
+
+
+@router.get("/fingerprint", response_model=LibraryFingerprint)
+async def get_library_fingerprint(db: DbSession) -> LibraryFingerprint:
+    """Cheap staleness check for an offline library cache.
+
+    A client compares both fields against what it holds and refreshes if either moved. The two
+    together are what make the check complete, and each covers a case the other misses:
+
+    - ``max_updated_at`` moves when any active track changes, which is the ordinary case.
+    - ``track_count`` moves when a track leaves the library. Familiar does not delete tracks, it
+      sets ``status`` away from active — so the row disappears from this set without the maximum
+      necessarily changing, and the count is the only thing that notices. This is
+      ADR-0011 point 7's backstop, and it is also what catches a delta that silently missed rows
+      to the cursor race described on ``list_tracks``.
+
+    **Deliberately not ``/library/stats``.** ADR-0011 rejected that endpoint on a mismatch — it
+    counted every row while ``/tracks`` counted active ones — and that specific defect was fixed
+    on 2026-08-16, so the counts now agree. Two reasons survive the fix and are why this endpoint
+    exists anyway: stats carries no ``max(updated_at)``, so it cannot be a cursor at all; and it
+    runs eight aggregates including analysis backlogs, where a check made on every launch should
+    be two.
+
+    Both values are over the active set — the same set ``list_tracks`` pages when no
+    ``updated_since`` is given — so the fingerprint measures exactly the data it guards.
+    """
+    from app.db.models import TrackStatus
+
+    active = Track.status == TrackStatus.ACTIVE
+    track_count = await db.scalar(select(func.count(Track.id)).where(active)) or 0
+    max_updated_at = await db.scalar(select(func.max(Track.updated_at)).where(active))
+    return LibraryFingerprint(track_count=track_count, max_updated_at=max_updated_at)
 
 
 @router.get("/stats", response_model=LibraryStats)

--- a/backend/app/api/routes/tracks/listing.py
+++ b/backend/app/api/routes/tracks/listing.py
@@ -2,6 +2,7 @@
 
 import math
 import random
+from datetime import datetime
 from typing import Any
 from uuid import UUID
 
@@ -302,17 +303,45 @@ async def list_tracks(
     fy_min: float | None = Query(None, ge=0, le=1),
     fy_max: float | None = Query(None, ge=0, le=1),
     include_features: bool = Query(False, description="Include audio analysis features"),
+    updated_since: datetime | None = Query(
+        None,
+        description=(
+            "Return only tracks changed at or after this time, in any status. "
+            "The delta cursor for an offline library cache."
+        ),
+    ),
     sort_by: str | None = Query(None, description="Column to sort by"),
     sort_order: str = Query('asc', pattern='^(asc|desc)$', description="Sort direction"),
 ) -> TrackListResponse:
-    """List tracks with optional filtering and pagination."""
+    """List tracks with optional filtering and pagination.
+
+    ``updated_since`` is the delta cursor for the offline library cache (ADR-0011 points 6 and 7).
+    Two things about it are deliberate and load-bearing:
+
+    **It returns rows in every status, not just active.** A cursor query cannot see a deleted row,
+    but Familiar does not delete tracks — it sets ``status`` away from active, which is an ORM
+    update, so ``updated_at`` moves. Returning those rows is what lets a client drop them from its
+    cache. Filtering to active here would make removals invisible, and a cache would drift in the
+    one direction nobody notices.
+
+    **The comparison is ``>=``, so the boundary row comes back again.** A client passing back the
+    ``max(updated_at)`` it last saw re-receives the rows carrying exactly that timestamp, which is
+    an idempotent re-write on its side. ``>`` would silently skip any row sharing the boundary
+    instant. This does not close the general cursor race — a row committed during a refresh with a
+    timestamp below the cursor is missed by either comparison — and the active count from
+    ``GET /library/fingerprint`` is the backstop that catches that drift.
+    """
 
     has_feature_filter = any(x is not None for x in [energy_min, energy_max, valence_min, valence_max])
     has_fx_list = bool(fx and fx in FEATURE_FILTER_AXES and any(x is not None for x in [fx_min, fx_max]))
     has_fy_list = bool(fy and fy in FEATURE_FILTER_AXES and any(x is not None for x in [fy_min, fy_max]))
     has_feature_filter = has_feature_filter or has_fx_list or has_fy_list
 
-    query = select(Track).where(Track.status == TrackStatus.ACTIVE)
+    # A delta sees every status; a normal listing sees only active ones. See the docstring.
+    if updated_since is not None:
+        query = select(Track).where(Track.updated_at >= updated_since)
+    else:
+        query = select(Track).where(Track.status == TrackStatus.ACTIVE)
 
     # Include analysis features if requested
     if include_features:
@@ -386,7 +415,13 @@ async def list_tracks(
         # 2,846 rows share an ordering key, and OFFSET paging over a non-unique order may
         # repeat or skip rows between pages — silently omitting tracks from anything that
         # pages the whole library.
-        query = query.order_by(Track.artist, Track.album, Track.track_number, Track.id)
+        if updated_since is not None:
+            # A delta pages in cursor order, for the same uniqueness reason: the client is
+            # walking a changed set, and ordering it by artist would interleave rows whose
+            # position moves as the set changes underneath the paging.
+            query = query.order_by(Track.updated_at, Track.id)
+        else:
+            query = query.order_by(Track.artist, Track.album, Track.track_number, Track.id)
 
     query = query.offset((page - 1) * page_size).limit(page_size)
 

--- a/backend/app/api/schemas/tracks.py
+++ b/backend/app/api/schemas/tracks.py
@@ -49,6 +49,11 @@ class TrackResponse(BaseModel):
     # `Track.created_at`, which is what ADR-0021's `dateAdded` column sorts by — the sort
     # shipped without the field, so the column was built, seen blank on every row, and removed.
     created_at: UTCDateTime | None = None
+    # The delta cursor for the offline library cache (ADR-0011 point 6). `Track.updated_at` carries
+    # `onupdate=func.now()`, and an ordinary rescan goes through `_update_track` — plain ORM
+    # attribute assignment — so the timestamp moves when a track's tags change. A client keeps the
+    # highest value it has seen and passes it back as `updated_since`.
+    updated_at: UTCDateTime | None = None
     features: TrackFeaturesResponse | None = None
     # Play history (profile-specific, populated when profile header is present)
     last_played_at: UTCDateTime | None = None

--- a/backend/openapi.json
+++ b/backend/openapi.json
@@ -3657,6 +3657,14 @@
               "null"
             ]
           },
+          "updated_at": {
+            "format": "date-time",
+            "title": "Updated At",
+            "type": [
+              "string",
+              "null"
+            ]
+          },
           "year": {
             "title": "Year",
             "type": [
@@ -4639,6 +4647,28 @@
           }
         },
         "title": "LibraryFilters",
+        "type": "object"
+      },
+      "LibraryFingerprint": {
+        "description": "Whether a cached copy of the library is stale, in one request (ADR-0011 point 5).",
+        "properties": {
+          "max_updated_at": {
+            "format": "date-time",
+            "title": "Max Updated At",
+            "type": [
+              "string",
+              "null"
+            ]
+          },
+          "track_count": {
+            "title": "Track Count",
+            "type": "integer"
+          }
+        },
+        "required": [
+          "track_count"
+        ],
+        "title": "LibraryFingerprint",
         "type": "object"
       },
       "LibraryImportExecuteRequest": {
@@ -10344,6 +10374,14 @@
               "null"
             ]
           },
+          "updated_at": {
+            "format": "date-time",
+            "title": "Updated At",
+            "type": [
+              "string",
+              "null"
+            ]
+          },
           "year": {
             "title": "Year",
             "type": [
@@ -10647,6 +10685,14 @@
             "title": "Track Number",
             "type": [
               "integer",
+              "null"
+            ]
+          },
+          "updated_at": {
+            "format": "date-time",
+            "title": "Updated At",
+            "type": [
+              "string",
               "null"
             ]
           },
@@ -17514,6 +17560,78 @@
         "summary": "Get Listening Profile External Albums",
         "tags": [
           "library",
+          "library"
+        ]
+      }
+    },
+    "/api/v1/library/fingerprint": {
+      "get": {
+        "description": "Cheap staleness check for an offline library cache.\n\nA client compares both fields against what it holds and refreshes if either moved. The two\ntogether are what make the check complete, and each covers a case the other misses:\n\n- ``max_updated_at`` moves when any active track changes, which is the ordinary case.\n- ``track_count`` moves when a track leaves the library. Familiar does not delete tracks, it\n  sets ``status`` away from active \u2014 so the row disappears from this set without the maximum\n  necessarily changing, and the count is the only thing that notices. This is\n  ADR-0011 point 7's backstop, and it is also what catches a delta that silently missed rows\n  to the cursor race described on ``list_tracks``.\n\n**Deliberately not ``/library/stats``.** ADR-0011 rejected that endpoint on a mismatch \u2014 it\ncounted every row while ``/tracks`` counted active ones \u2014 and that specific defect was fixed\non 2026-08-16, so the counts now agree. Two reasons survive the fix and are why this endpoint\nexists anyway: stats carries no ``max(updated_at)``, so it cannot be a cursor at all; and it\nruns eight aggregates including analysis backlogs, where a check made on every launch should\nbe two.\n\nBoth values are over the active set \u2014 the same set ``list_tracks`` pages when no\n``updated_since`` is given \u2014 so the fingerprint measures exactly the data it guards.",
+        "operationId": "library_get_library_fingerprint",
+        "responses": {
+          "200": {
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/LibraryFingerprint"
+                }
+              }
+            },
+            "description": "Successful Response"
+          },
+          "400": {
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/ErrorEnvelope"
+                }
+              }
+            },
+            "description": "Bad Request"
+          },
+          "401": {
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/ErrorEnvelope"
+                }
+              }
+            },
+            "description": "Unauthorized"
+          },
+          "404": {
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/ErrorEnvelope"
+                }
+              }
+            },
+            "description": "Not Found"
+          },
+          "422": {
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/ErrorEnvelope"
+                }
+              }
+            },
+            "description": "Unprocessable Entity"
+          },
+          "500": {
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/ErrorEnvelope"
+                }
+              }
+            },
+            "description": "Internal Server Error"
+          }
+        },
+        "summary": "Get Library Fingerprint",
+        "tags": [
           "library"
         ]
       }
@@ -29954,7 +30072,7 @@
     },
     "/api/v1/tracks": {
       "get": {
-        "description": "List tracks with optional filtering and pagination.",
+        "description": "List tracks with optional filtering and pagination.\n\n``updated_since`` is the delta cursor for the offline library cache (ADR-0011 points 6 and 7).\nTwo things about it are deliberate and load-bearing:\n\n**It returns rows in every status, not just active.** A cursor query cannot see a deleted row,\nbut Familiar does not delete tracks \u2014 it sets ``status`` away from active, which is an ORM\nupdate, so ``updated_at`` moves. Returning those rows is what lets a client drop them from its\ncache. Filtering to active here would make removals invisible, and a cache would drift in the\none direction nobody notices.\n\n**The comparison is ``>=``, so the boundary row comes back again.** A client passing back the\n``max(updated_at)`` it last saw re-receives the rows carrying exactly that timestamp, which is\nan idempotent re-write on its side. ``>`` would silently skip any row sharing the boundary\ninstant. This does not close the general cursor race \u2014 a row committed during a refresh with a\ntimestamp below the cursor is missed by either comparison \u2014 and the active count from\n``GET /library/fingerprint`` is the backstop that catches that drift.",
         "operationId": "tracks_list_tracks",
         "parameters": [
           {
@@ -30214,6 +30332,21 @@
               "description": "Include audio analysis features",
               "title": "Include Features",
               "type": "boolean"
+            }
+          },
+          {
+            "description": "Return only tracks changed at or after this time, in any status. The delta cursor for an offline library cache.",
+            "in": "query",
+            "name": "updated_since",
+            "required": false,
+            "schema": {
+              "description": "Return only tracks changed at or after this time, in any status. The delta cursor for an offline library cache.",
+              "format": "date-time",
+              "title": "Updated Since",
+              "type": [
+                "string",
+                "null"
+              ]
             }
           },
           {

--- a/backend/tests/test_library_delta_cursor.py
+++ b/backend/tests/test_library_delta_cursor.py
@@ -1,0 +1,149 @@
+"""The two backend prerequisites for the offline library cache (ADR-0011 points 5, 6 and 7).
+
+A delta cursor is the kind of feature that looks like it works while being wrong, because the
+failure is *absence* — rows that should have come back and didn't. Nothing on the client can tell
+"nothing changed" from "the query missed it", which is the same shape as the defect ADR-0011's
+Context records: a cache holding 50 tracks of 26,396 looked exactly like a working one.
+
+So these tests pin the three behaviours a client cannot verify for itself:
+
+- a removal is visible through the cursor (it is a status change, not a delete);
+- an ordinary listing still hides removals, so widening the delta did not widen everything;
+- the boundary row is returned again rather than skipped.
+"""
+
+from __future__ import annotations
+
+from datetime import datetime
+
+import pytest
+
+from app.api.routes.library import get_library_fingerprint
+from app.api.routes.tracks.listing import list_tracks
+from app.db.models import TrackStatus
+from tests.factories import insert_test_profile, insert_test_track
+
+# Fixed, naive, and far in the past. Naive because the column is TIMESTAMP WITHOUT TIME ZONE —
+# an aware datetime raises "can't subtract offset-naive and offset-aware datetimes" at the driver.
+OLD = datetime(2020, 1, 1, 12, 0, 0)
+MID = datetime(2024, 6, 1, 12, 0, 0)
+NEW = datetime(2025, 1, 1, 12, 0, 0)
+
+
+async def _track_at(db, updated_at: datetime, *, title: str, status=TrackStatus.ACTIVE):
+    """A track whose `updated_at` is set explicitly.
+
+    Assigning the attribute wins over the column's `onupdate=func.now()`, which only fires when the
+    column is absent from the UPDATE's SET clause.
+    """
+    track = await insert_test_track(db, title=title)
+    track.updated_at = updated_at
+    track.status = status
+    await db.commit()
+    return track
+
+
+@pytest.mark.asyncio
+async def test_the_cursor_is_reachable_by_a_client(async_db):
+    """`updated_at` is on the response, not only in the query.
+
+    Without the field a client has nothing to send back as `updated_since`, so the parameter would
+    exist and be unusable — an affordance whose destination is not mounted.
+    """
+    profile = await insert_test_profile(async_db)
+    await _track_at(async_db, MID, title="Reachable")
+
+    result = await list_tracks(db=async_db, profile=profile)
+
+    assert result.items[0].updated_at == MID
+
+
+@pytest.mark.asyncio
+async def test_the_cursor_returns_only_what_changed(async_db):
+    profile = await insert_test_profile(async_db)
+    await _track_at(async_db, OLD, title="Untouched")
+    await _track_at(async_db, NEW, title="Edited")
+
+    result = await list_tracks(db=async_db, profile=profile, updated_since=MID)
+
+    assert [t.title for t in result.items] == ["Edited"]
+    assert result.total == 1
+
+
+@pytest.mark.asyncio
+async def test_the_cursor_carries_removals(async_db):
+    """ADR-0011 point 7 — the reason the delta needs no separate reconcile pass.
+
+    Familiar does not delete tracks, it moves `status` away from active, which is an ORM update and
+    moves `updated_at`. If the delta filtered to active, the row would simply stop appearing and the
+    client would keep it forever: a track that no longer exists, playable from a cache, failing at
+    the stream. The removal has to arrive *as a row*.
+    """
+    profile = await insert_test_profile(async_db)
+    await _track_at(async_db, NEW, title="Gone", status=TrackStatus.MISSING)
+
+    result = await list_tracks(db=async_db, profile=profile, updated_since=MID)
+
+    assert [t.title for t in result.items] == ["Gone"]
+    assert result.items[0].status != "active", "the client drops it by reading the status back"
+
+
+@pytest.mark.asyncio
+async def test_a_listing_without_the_cursor_still_hides_removals(async_db):
+    """The delta widens itself to every status. It must not widen the ordinary listing too."""
+    profile = await insert_test_profile(async_db)
+    await _track_at(async_db, NEW, title="Present")
+    await _track_at(async_db, NEW, title="Gone", status=TrackStatus.MISSING)
+
+    result = await list_tracks(db=async_db, profile=profile)
+
+    assert [t.title for t in result.items] == ["Present"]
+
+
+@pytest.mark.asyncio
+async def test_the_boundary_row_is_returned_again_not_skipped(async_db):
+    """`>=`, not `>`.
+
+    A client sends back the `max(updated_at)` it last saw. With `>` every row carrying exactly that
+    timestamp is skipped — invisibly, and permanently, since the cursor has already passed them.
+    Returning them again costs an idempotent re-write on the client.
+    """
+    profile = await insert_test_profile(async_db)
+    await _track_at(async_db, MID, title="On the boundary")
+
+    result = await list_tracks(db=async_db, profile=profile, updated_since=MID)
+
+    assert [t.title for t in result.items] == ["On the boundary"]
+
+
+@pytest.mark.asyncio
+async def test_the_fingerprint_measures_the_set_it_guards(async_db):
+    """Active rows only — the same set `list_tracks` pages when no cursor is given."""
+    await _track_at(async_db, OLD, title="One")
+    await _track_at(async_db, NEW, title="Two")
+    await _track_at(async_db, NEW, title="Gone", status=TrackStatus.MISSING)
+
+    fingerprint = await get_library_fingerprint(async_db)
+
+    assert fingerprint.track_count == 2
+    assert fingerprint.max_updated_at == NEW
+
+
+@pytest.mark.asyncio
+async def test_a_removal_moves_the_fingerprint_through_the_count(async_db):
+    """The count is the backstop, and this is the case that proves it is needed.
+
+    A removed track's `updated_at` leaves the active set with it, so `max_updated_at` can sit
+    perfectly still while the library shrinks. Only the count notices.
+    """
+    await _track_at(async_db, NEW, title="Newest")
+    doomed = await _track_at(async_db, OLD, title="Doomed")
+
+    before = await get_library_fingerprint(async_db)
+
+    doomed.status = TrackStatus.MISSING
+    await async_db.commit()
+    after = await get_library_fingerprint(async_db)
+
+    assert after.max_updated_at == before.max_updated_at, "the maximum cannot see this change"
+    assert after.track_count == before.track_count - 1, "so the count has to"

--- a/backend/tests/test_library_delta_cursor.py
+++ b/backend/tests/test_library_delta_cursor.py
@@ -5,11 +5,17 @@ failure is *absence* — rows that should have come back and didn't. Nothing on 
 "nothing changed" from "the query missed it", which is the same shape as the defect ADR-0011's
 Context records: a cache holding 50 tracks of 26,396 looked exactly like a working one.
 
-So these tests pin the three behaviours a client cannot verify for itself:
+So these pin the three behaviours a client cannot verify for itself:
 
 - a removal is visible through the cursor (it is a status change, not a delete);
 - an ordinary listing still hides removals, so widening the delta did not widen everything;
 - the boundary row is returned again rather than skipped.
+
+**These go over HTTP rather than calling the route function.** The first draft called `list_tracks`
+directly, which skips FastAPI's parameter resolution — every `Query(...)` default arrives as a
+`Query` *object* rather than its value, so `updated_since is not None` was true on a request that
+supplied no cursor, and the sentinel went to the driver as a bind parameter. The bug lived in the
+layer a direct call omits.
 """
 
 from __future__ import annotations
@@ -17,14 +23,14 @@ from __future__ import annotations
 from datetime import datetime
 
 import pytest
+from fastapi.testclient import TestClient
 
-from app.api.routes.library import get_library_fingerprint
-from app.api.routes.tracks.listing import list_tracks
 from app.db.models import TrackStatus
-from tests.factories import insert_test_profile, insert_test_track
+from tests.conftest import make_profile_headers
+from tests.factories import insert_test_track
 
-# Fixed, naive, and far in the past. Naive because the column is TIMESTAMP WITHOUT TIME ZONE —
-# an aware datetime raises "can't subtract offset-naive and offset-aware datetimes" at the driver.
+# Fixed, naive, and far apart. Naive because the column is TIMESTAMP WITHOUT TIME ZONE — an aware
+# datetime raises "can't subtract offset-naive and offset-aware datetimes" at the driver.
 OLD = datetime(2020, 1, 1, 12, 0, 0)
 MID = datetime(2024, 6, 1, 12, 0, 0)
 NEW = datetime(2025, 1, 1, 12, 0, 0)
@@ -43,94 +49,115 @@ async def _track_at(db, updated_at: datetime, *, title: str, status=TrackStatus.
     return track
 
 
+def _titles(response) -> list[str]:
+    assert response.status_code == 200, response.text
+    return [t["title"] for t in response.json()["items"]]
+
+
 @pytest.mark.asyncio
-async def test_the_cursor_is_reachable_by_a_client(async_db):
+async def test_the_cursor_is_reachable_by_a_client(async_db, client: TestClient, test_profile):
     """`updated_at` is on the response, not only in the query.
 
     Without the field a client has nothing to send back as `updated_since`, so the parameter would
     exist and be unusable — an affordance whose destination is not mounted.
     """
-    profile = await insert_test_profile(async_db)
     await _track_at(async_db, MID, title="Reachable")
 
-    result = await list_tracks(db=async_db, profile=profile)
+    resp = client.get("/api/v1/tracks", headers=make_profile_headers(test_profile))
 
-    assert result.items[0].updated_at == MID
+    assert resp.status_code == 200, resp.text
+    assert resp.json()["items"][0]["updated_at"].startswith("2024-06-01T12:00:00")
 
 
 @pytest.mark.asyncio
-async def test_the_cursor_returns_only_what_changed(async_db):
-    profile = await insert_test_profile(async_db)
+async def test_the_cursor_returns_only_what_changed(async_db, client: TestClient, test_profile):
     await _track_at(async_db, OLD, title="Untouched")
     await _track_at(async_db, NEW, title="Edited")
 
-    result = await list_tracks(db=async_db, profile=profile, updated_since=MID)
+    resp = client.get(
+        "/api/v1/tracks",
+        params={"updated_since": MID.isoformat()},
+        headers=make_profile_headers(test_profile),
+    )
 
-    assert [t.title for t in result.items] == ["Edited"]
-    assert result.total == 1
+    assert _titles(resp) == ["Edited"]
+    assert resp.json()["total"] == 1
 
 
 @pytest.mark.asyncio
-async def test_the_cursor_carries_removals(async_db):
+async def test_the_cursor_carries_removals(async_db, client: TestClient, test_profile):
     """ADR-0011 point 7 — the reason the delta needs no separate reconcile pass.
 
     Familiar does not delete tracks, it moves `status` away from active, which is an ORM update and
-    moves `updated_at`. If the delta filtered to active, the row would simply stop appearing and the
-    client would keep it forever: a track that no longer exists, playable from a cache, failing at
-    the stream. The removal has to arrive *as a row*.
+    moves `updated_at`. If the delta filtered to active the row would simply stop appearing, and the
+    client would keep it forever: a track that no longer exists, offered from a cache, failing at the
+    stream. The removal has to arrive *as a row*.
     """
-    profile = await insert_test_profile(async_db)
     await _track_at(async_db, NEW, title="Gone", status=TrackStatus.MISSING)
 
-    result = await list_tracks(db=async_db, profile=profile, updated_since=MID)
+    resp = client.get(
+        "/api/v1/tracks",
+        params={"updated_since": MID.isoformat()},
+        headers=make_profile_headers(test_profile),
+    )
 
-    assert [t.title for t in result.items] == ["Gone"]
-    assert result.items[0].status != "active", "the client drops it by reading the status back"
+    assert _titles(resp) == ["Gone"]
+    assert resp.json()["items"][0]["status"] != "active", "the client drops it by reading status"
 
 
 @pytest.mark.asyncio
-async def test_a_listing_without_the_cursor_still_hides_removals(async_db):
+async def test_a_listing_without_the_cursor_still_hides_removals(
+    async_db, client: TestClient, test_profile
+):
     """The delta widens itself to every status. It must not widen the ordinary listing too."""
-    profile = await insert_test_profile(async_db)
     await _track_at(async_db, NEW, title="Present")
     await _track_at(async_db, NEW, title="Gone", status=TrackStatus.MISSING)
 
-    result = await list_tracks(db=async_db, profile=profile)
+    resp = client.get("/api/v1/tracks", headers=make_profile_headers(test_profile))
 
-    assert [t.title for t in result.items] == ["Present"]
+    assert _titles(resp) == ["Present"]
 
 
 @pytest.mark.asyncio
-async def test_the_boundary_row_is_returned_again_not_skipped(async_db):
+async def test_the_boundary_row_is_returned_again_not_skipped(
+    async_db, client: TestClient, test_profile
+):
     """`>=`, not `>`.
 
     A client sends back the `max(updated_at)` it last saw. With `>` every row carrying exactly that
     timestamp is skipped — invisibly, and permanently, since the cursor has already passed them.
     Returning them again costs an idempotent re-write on the client.
     """
-    profile = await insert_test_profile(async_db)
     await _track_at(async_db, MID, title="On the boundary")
 
-    result = await list_tracks(db=async_db, profile=profile, updated_since=MID)
+    resp = client.get(
+        "/api/v1/tracks",
+        params={"updated_since": MID.isoformat()},
+        headers=make_profile_headers(test_profile),
+    )
 
-    assert [t.title for t in result.items] == ["On the boundary"]
+    assert _titles(resp) == ["On the boundary"]
 
 
 @pytest.mark.asyncio
-async def test_the_fingerprint_measures_the_set_it_guards(async_db):
-    """Active rows only — the same set `list_tracks` pages when no cursor is given."""
+async def test_the_fingerprint_measures_the_set_it_guards(async_db, client: TestClient):
+    """Active rows only — the same set `/tracks` pages when no cursor is given."""
     await _track_at(async_db, OLD, title="One")
     await _track_at(async_db, NEW, title="Two")
     await _track_at(async_db, NEW, title="Gone", status=TrackStatus.MISSING)
 
-    fingerprint = await get_library_fingerprint(async_db)
+    resp = client.get("/api/v1/library/fingerprint")
 
-    assert fingerprint.track_count == 2
-    assert fingerprint.max_updated_at == NEW
+    assert resp.status_code == 200, resp.text
+    body = resp.json()
+    assert body["track_count"] == 2
+    assert body["max_updated_at"].startswith("2025-01-01T12:00:00")
 
 
 @pytest.mark.asyncio
-async def test_a_removal_moves_the_fingerprint_through_the_count(async_db):
+async def test_a_removal_moves_the_fingerprint_through_the_count(
+    async_db, client: TestClient
+):
     """The count is the backstop, and this is the case that proves it is needed.
 
     A removed track's `updated_at` leaves the active set with it, so `max_updated_at` can sit
@@ -139,11 +166,11 @@ async def test_a_removal_moves_the_fingerprint_through_the_count(async_db):
     await _track_at(async_db, NEW, title="Newest")
     doomed = await _track_at(async_db, OLD, title="Doomed")
 
-    before = await get_library_fingerprint(async_db)
+    before = client.get("/api/v1/library/fingerprint").json()
 
     doomed.status = TrackStatus.MISSING
     await async_db.commit()
-    after = await get_library_fingerprint(async_db)
+    after = client.get("/api/v1/library/fingerprint").json()
 
-    assert after.max_updated_at == before.max_updated_at, "the maximum cannot see this change"
-    assert after.track_count == before.track_count - 1, "so the count has to"
+    assert after["max_updated_at"] == before["max_updated_at"], "the maximum cannot see this"
+    assert after["track_count"] == before["track_count"] - 1, "so the count has to"

--- a/docs/decisions/ADR-0011-the-library-is-cached-whole-and-refreshed-by-delta.md
+++ b/docs/decisions/ADR-0011-the-library-is-cached-whole-and-refreshed-by-delta.md
@@ -1,6 +1,6 @@
 # ADR-0011: The Library Is Cached Whole, and Refreshed by Delta
 
-Status: proposed
+Status: accepted
 
 Date: 2026-07-31
 
@@ -83,7 +83,14 @@ delta would rest on and none of which existed: a retag moves `updated_at`, an un
 leaves two backend prerequisites below rather than three.
 
 **`/library/stats` cannot serve as the staleness fingerprint**, which is the obvious thing to reach
-for and the reason to look closely. It counts every `Track` row (`library.py:50-59`) while `/tracks`
+for and the reason to look closely. **The specific defect below was fixed on 2026-08-16, after this
+ADR was drafted — read the numbers as history.** `total_tracks` now filters to active, `total_albums`
+groups by `(album_artist, album)` case-insensitively, and `total_artists` reads the canonical `Artist`
+table, so all three agree with the endpoints they mirror and `tests/test_library_stats.py` asserts
+that agreement. Decision point 5 survives the fix on two narrower grounds: stats carries no
+`max(updated_at)`, so it cannot be a cursor at any accuracy; and it runs eight aggregate queries
+including analysis backlogs, where a check made on every launch should be two. What follows is why it
+was rejected at drafting time. It counts every `Track` row (`library.py:50-59`) while `/tracks`
 applies `Track.active_filter()` — 26,462 against 26,396, which is the 66 inactive rows exactly. Its
 `total_albums` is `COUNT(DISTINCT Track.album)` at 3,871 while `/library/albums` groups and reports
 3,925; its `total_artists` is `COUNT(DISTINCT Track.artist)` at 3,662 while `/library/artists` reads
@@ -158,6 +165,25 @@ The client caches the library whole, refreshes it by delta, and never derives wh
    was last refreshed and that it is browsing a cached copy. ADR-0009 point 4 made the filesystem the
    truth for downloads; the equivalent here is that a cache which cannot be verified against the
    server says so.
+
+## Implementation
+
+**Phase 1 — the backend prerequisites (decision points 5, 6, 7)** on
+`feat/adr-0011-library-cache-prereqs`:
+
+- `TrackResponse.updated_at` exposed (`api/schemas/tracks.py`), without which `updated_since` would
+  be a parameter no client could supply a value for.
+- `updated_since` on `list_tracks` (`api/routes/tracks/listing.py`). It selects **every status**, so
+  a removal arrives as a row; the comparison is `>=`, so the boundary row is re-sent rather than
+  skipped; and a delta pages in `(updated_at, id)` order rather than by artist.
+- `GET /library/fingerprint` (`api/routes/library.py`) returning `track_count` and `max_updated_at`
+  over the active set.
+- `tests/test_library_delta_cursor.py` pins the three behaviours a client cannot check for itself:
+  removals travel through the cursor, an ordinary listing still hides them, and the boundary row
+  comes back. It also pins the case that justifies the count: a removal can leave `max_updated_at`
+  perfectly still, so only the count notices.
+
+Point 4's storage decision and points 1, 2, 3, 8 and 9 are the Swift half and are not yet built.
 
 ## Alternatives Considered
 


### PR DESCRIPTION
ADR-0011 is accepted, and this is its first phase: the three server-side changes the Swift half cannot be built without. **Server work every client inherits comes before client work**, so this lands on its own.

## What ships

| | why it is not optional |
|---|---|
| `TrackResponse.updated_at` | without it, `updated_since` is a parameter no client can supply a value for |
| `updated_since` on `list_tracks` | the delta cursor |
| `GET /library/fingerprint` | one request answers "is my cache stale" |

Three details in the cursor are deliberate and each has a comment saying so:

- **It selects every status, not just active.** Familiar does not delete tracks, it moves `status` away from active — an ORM update, so `updated_at` moves. Filtering to active would turn a removal into an *absence*, and a client cannot tell an absence from "nothing changed". The row has to arrive.
- **The comparison is `>=`.** A client sends back the `max(updated_at)` it last saw; `>` would skip every row sharing that instant, invisibly and permanently. `>=` costs an idempotent re-write instead.
- **A delta pages in `(updated_at, id)` order**, not by artist, because the set is changing underneath the paging.

## A premise that changed under the ADR

ADR-0011 rejected `/library/stats` as the fingerprint because it counted a different set than the endpoint it would guard — 26,462 against 26,396. **That was fixed on 2026-08-16, after the ADR was drafted**, so the counts now agree and the Context records the correction rather than leaving someone to re-derive it.

The decision survives on two narrower grounds: stats carries no `max(updated_at)`, so it cannot be a cursor at any accuracy, and it runs eight aggregates including analysis backlogs where a launch-time check should run two.

## Tests

`tests/test_library_delta_cursor.py` pins what a client cannot check for itself — a delta fails by *omission*, and nothing downstream can distinguish a missed row from an unchanged one. That is the same shape as the defect ADR-0011's Context records, where a cache holding 50 tracks of 26,396 looked exactly like a working one.

The last test is the one I would keep if I could keep only one: it deactivates a track and asserts `max_updated_at` does **not** move, so the count is the only thing that notices. That is the case that justifies the fingerprint having two fields instead of one.

## Not in this PR

Decision points 1–4, 8 and 9 are the Swift half. ADR-0010 follows.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01Emjrwedq7W1scadHdgiLfs