### PR TITLE
updated_since must accept the timestamps real clients send

### DIFF
--- a/backend/app/api/routes/tracks/listing.py
+++ b/backend/app/api/routes/tracks/listing.py
@@ -2,7 +2,7 @@
 
 import math
 import random
-from datetime import datetime
+from datetime import UTC, datetime
 from typing import Any
 from uuid import UUID
 
@@ -44,6 +44,7 @@ class TrackIndexResponse(BaseModel):
 
 # --- Weighted shuffle presets ---
 
+
 @router.get("/ids", response_model=TrackIdsResponse)
 async def list_track_ids(
     db: DbSession,
@@ -68,7 +69,7 @@ async def list_track_ids(
     fy_min: float | None = Query(None, ge=0, le=1),
     fy_max: float | None = Query(None, ge=0, le=1),
     sort_by: str | None = Query(None, description="Column to sort by"),
-    sort_order: str = Query('asc', pattern='^(asc|desc)$', description="Sort direction"),
+    sort_order: str = Query("asc", pattern="^(asc|desc)$", description="Sort direction"),
 ) -> TrackIdsResponse:
     """Get all track IDs matching filters.
 
@@ -77,7 +78,9 @@ async def list_track_ids(
     Use start_with to ensure a specific track appears first (useful when shuffle=true).
     """
 
-    has_feature_filter = any(x is not None for x in [energy_min, energy_max, valence_min, valence_max])
+    has_feature_filter = any(
+        x is not None for x in [energy_min, energy_max, valence_min, valence_max]
+    )
     has_fx = bool(fx and fx in FEATURE_FILTER_AXES and any(x is not None for x in [fx_min, fx_max]))
     has_fy = bool(fy and fy in FEATURE_FILTER_AXES and any(x is not None for x in [fy_min, fy_max]))
     has_feature_filter = has_feature_filter or has_fx or has_fy
@@ -135,8 +138,7 @@ async def list_track_ids(
     if preset and profile:
         # Fetch IDs with play history and favorite status
         weighted_query = (
-            query
-            .add_columns(
+            query.add_columns(
                 Track.artist,
                 Track.created_at,
                 ProfilePlayHistory.play_count,
@@ -145,13 +147,12 @@ async def list_track_ids(
             )
             .outerjoin(
                 ProfilePlayHistory,
-                (ProfilePlayHistory.track_id == Track.id) &
-                (ProfilePlayHistory.profile_id == profile.id),
+                (ProfilePlayHistory.track_id == Track.id)
+                & (ProfilePlayHistory.profile_id == profile.id),
             )
             .outerjoin(
                 ProfileFavorite,
-                (ProfileFavorite.track_id == Track.id) &
-                (ProfileFavorite.profile_id == profile.id),
+                (ProfileFavorite.track_id == Track.id) & (ProfileFavorite.profile_id == profile.id),
             )
         )
         result = await db.execute(weighted_query)
@@ -311,7 +312,7 @@ async def list_tracks(
         ),
     ),
     sort_by: str | None = Query(None, description="Column to sort by"),
-    sort_order: str = Query('asc', pattern='^(asc|desc)$', description="Sort direction"),
+    sort_order: str = Query("asc", pattern="^(asc|desc)$", description="Sort direction"),
 ) -> TrackListResponse:
     """List tracks with optional filtering and pagination.
 
@@ -332,14 +333,31 @@ async def list_tracks(
     ``GET /library/fingerprint`` is the backstop that catches that drift.
     """
 
-    has_feature_filter = any(x is not None for x in [energy_min, energy_max, valence_min, valence_max])
-    has_fx_list = bool(fx and fx in FEATURE_FILTER_AXES and any(x is not None for x in [fx_min, fx_max]))
-    has_fy_list = bool(fy and fy in FEATURE_FILTER_AXES and any(x is not None for x in [fy_min, fy_max]))
+    has_feature_filter = any(
+        x is not None for x in [energy_min, energy_max, valence_min, valence_max]
+    )
+    has_fx_list = bool(
+        fx and fx in FEATURE_FILTER_AXES and any(x is not None for x in [fx_min, fx_max])
+    )
+    has_fy_list = bool(
+        fy and fy in FEATURE_FILTER_AXES and any(x is not None for x in [fy_min, fy_max])
+    )
     has_feature_filter = has_feature_filter or has_fx_list or has_fy_list
 
     # A delta sees every status; a normal listing sees only active ones. See the docstring.
     if updated_since is not None:
-        query = select(Track).where(Track.updated_at >= updated_since)
+        # **Normalised to naive UTC before it reaches the driver.** `Track.updated_at` is
+        # `TIMESTAMP WITHOUT TIME ZONE`, and asyncpg refuses to compare that against an aware
+        # datetime — "can't subtract offset-naive and offset-aware datetimes", surfaced as a 500.
+        #
+        # Every real client hits this. The generated Swift client sends RFC 3339 with a `Z`, which
+        # FastAPI parses into an aware datetime; only a hand-written naive string gets through. It
+        # was found by a live slice test against the real server, having passed every fixture test
+        # and every curl by hand, because both supplied the naive form.
+        cursor = updated_since
+        if cursor.tzinfo is not None:
+            cursor = cursor.astimezone(UTC).replace(tzinfo=None)
+        query = select(Track).where(Track.updated_at >= cursor)
     else:
         query = select(Track).where(Track.status == TrackStatus.ACTIVE)
 
@@ -371,8 +389,7 @@ async def list_tracks(
     # Audio feature filters
     if has_feature_filter:
         query = query.join(
-            TrackAnalysis,
-            (Track.id == TrackAnalysis.track_id) & (TrackAnalysis.bpm.isnot(None))
+            TrackAnalysis, (Track.id == TrackAnalysis.track_id) & (TrackAnalysis.bpm.isnot(None))
         )
         if energy_min is not None:
             query = query.where(TrackAnalysis.energy >= energy_min)
@@ -494,7 +511,7 @@ async def get_track_index(
     fy_min: float | None = Query(None, ge=0, le=1),
     fy_max: float | None = Query(None, ge=0, le=1),
     sort_by: str | None = Query(None),
-    sort_order: str = Query('asc', pattern='^(asc|desc)$'),
+    sort_order: str = Query("asc", pattern="^(asc|desc)$"),
 ) -> TrackIndexResponse:
     """Get the 0-based index of a track in the sorted list.
 
@@ -507,8 +524,12 @@ async def get_track_index(
     has_feature_filter = any(
         x is not None for x in [energy_min, energy_max, valence_min, valence_max]
     )
-    has_fx_idx = bool(fx and fx in FEATURE_FILTER_AXES and any(x is not None for x in [fx_min, fx_max]))
-    has_fy_idx = bool(fy and fy in FEATURE_FILTER_AXES and any(x is not None for x in [fy_min, fy_max]))
+    has_fx_idx = bool(
+        fx and fx in FEATURE_FILTER_AXES and any(x is not None for x in [fx_min, fx_max])
+    )
+    has_fy_idx = bool(
+        fy and fy in FEATURE_FILTER_AXES and any(x is not None for x in [fy_min, fy_max])
+    )
     has_feature_filter = has_feature_filter or has_fx_idx or has_fy_idx
 
     base_query = select(Track.id).where(Track.status == TrackStatus.ACTIVE)
@@ -535,8 +556,7 @@ async def get_track_index(
 
     if has_feature_filter:
         base_query = base_query.join(
-            TrackAnalysis,
-            (Track.id == TrackAnalysis.track_id) & (TrackAnalysis.bpm.isnot(None))
+            TrackAnalysis, (Track.id == TrackAnalysis.track_id) & (TrackAnalysis.bpm.isnot(None))
         )
         if energy_min is not None:
             base_query = base_query.where(TrackAnalysis.energy >= energy_min)
@@ -564,24 +584,50 @@ async def get_track_index(
     if sort_by and (sort_by in SORT_FIELD_MAP or sort_by in SORT_FEATURE_FIELDS):
         if sort_by in SORT_FIELD_MAP:
             sort_col = SORT_FIELD_MAP[sort_by]
-            if sort_by == 'lastPlayed' and profile:
+            if sort_by == "lastPlayed" and profile:
                 base_query = base_query.outerjoin(
                     ProfilePlayHistory,
-                    (ProfilePlayHistory.track_id == Track.id) &
-                    (ProfilePlayHistory.profile_id == profile.id),
+                    (ProfilePlayHistory.track_id == Track.id)
+                    & (ProfilePlayHistory.profile_id == profile.id),
                 )
-            if sort_order == 'desc':
-                order_clauses = [nulls_last(sort_col.desc()), Track.artist, Track.album, Track.track_number, Track.id]
+            if sort_order == "desc":
+                order_clauses = [
+                    nulls_last(sort_col.desc()),
+                    Track.artist,
+                    Track.album,
+                    Track.track_number,
+                    Track.id,
+                ]
             else:
-                order_clauses = [nulls_last(sort_col.asc()), Track.artist, Track.album, Track.track_number, Track.id]
+                order_clauses = [
+                    nulls_last(sort_col.asc()),
+                    Track.artist,
+                    Track.album,
+                    Track.track_number,
+                    Track.id,
+                ]
         else:
             needs_analysis_join = not has_feature_filter
             sort_col_attr = getattr(TrackAnalysis, sort_by, None)
-            sort_expr = cast(sort_col_attr, Float) if sort_col_attr is not None else TrackAnalysis.bpm
-            if sort_order == 'desc':
-                order_clauses = [nulls_last(sort_expr.desc()), Track.artist, Track.album, Track.track_number, Track.id]
+            sort_expr = (
+                cast(sort_col_attr, Float) if sort_col_attr is not None else TrackAnalysis.bpm
+            )
+            if sort_order == "desc":
+                order_clauses = [
+                    nulls_last(sort_expr.desc()),
+                    Track.artist,
+                    Track.album,
+                    Track.track_number,
+                    Track.id,
+                ]
             else:
-                order_clauses = [nulls_last(sort_expr.asc()), Track.artist, Track.album, Track.track_number, Track.id]
+                order_clauses = [
+                    nulls_last(sort_expr.asc()),
+                    Track.artist,
+                    Track.album,
+                    Track.track_number,
+                    Track.id,
+                ]
     else:
         # Must match `list_tracks` exactly, `Track.id` tiebreaker included: this endpoint reports
         # a track's row number in that same ordering, so any divergence returns an index the
@@ -609,11 +655,7 @@ async def get_track_index(
 @router.get("/{track_id}", response_model=TrackResponse)
 async def get_track(db: DbSession, track_id: UUID) -> TrackResponse:
     """Get a single track with its latest analysis."""
-    query = (
-        select(Track)
-        .options(selectinload(Track.analyses))
-        .where(Track.id == track_id)
-    )
+    query = select(Track).options(selectinload(Track.analyses)).where(Track.id == track_id)
     result = await db.execute(query)
     track = result.scalar_one_or_none()
 

--- a/backend/tests/test_library_delta_cursor.py
+++ b/backend/tests/test_library_delta_cursor.py
@@ -140,6 +140,51 @@ async def test_the_boundary_row_is_returned_again_not_skipped(
 
 
 @pytest.mark.asyncio
+async def test_the_cursor_accepts_an_aware_timestamp(async_db, client: TestClient, test_profile):
+    """The form every generated client actually sends.
+
+    `Track.updated_at` is TIMESTAMP WITHOUT TIME ZONE, and asyncpg refuses to compare that against
+    an aware datetime — it raises, and FastAPI turns it into a 500. The Swift client sends RFC 3339
+    with a `Z`, so this was broken for every real caller while passing all of the tests above and
+    every curl by hand, because those all send the naive form.
+
+    Found by a live slice test against the real server, which is the only thing that spoke the same
+    dialect as the app.
+    """
+    await _track_at(async_db, NEW, title="Edited")
+
+    resp = client.get(
+        "/api/v1/tracks",
+        params={"updated_since": "2024-06-01T12:00:00Z"},
+        headers=make_profile_headers(test_profile),
+    )
+
+    assert resp.status_code == 200, resp.text
+    assert _titles(resp) == ["Edited"]
+
+
+@pytest.mark.asyncio
+async def test_an_offset_cursor_is_converted_rather_than_truncated(
+    async_db, client: TestClient, test_profile
+):
+    """An offset cursor names an instant, and the conversion has to preserve it.
+
+    14:00+02:00 is 12:00 UTC. Dropping the tzinfo instead of converting would read it as 14:00 and
+    silently skip two hours of changes — a delta that loses rows rather than failing.
+    """
+    await _track_at(async_db, datetime(2024, 6, 1, 13, 0, 0), title="After noon UTC")
+
+    resp = client.get(
+        "/api/v1/tracks",
+        params={"updated_since": "2024-06-01T14:00:00+02:00"},
+        headers=make_profile_headers(test_profile),
+    )
+
+    assert resp.status_code == 200, resp.text
+    assert _titles(resp) == ["After noon UTC"], "the cursor is 12:00 UTC, not 14:00"
+
+
+@pytest.mark.asyncio
 async def test_the_fingerprint_measures_the_set_it_guards(async_db, client: TestClient):
     """Active rows only — the same set `/tracks` pages when no cursor is given."""
     await _track_at(async_db, OLD, title="One")
@@ -155,9 +200,7 @@ async def test_the_fingerprint_measures_the_set_it_guards(async_db, client: Test
 
 
 @pytest.mark.asyncio
-async def test_a_removal_moves_the_fingerprint_through_the_count(
-    async_db, client: TestClient
-):
+async def test_a_removal_moves_the_fingerprint_through_the_count(async_db, client: TestClient):
     """The count is the backstop, and this is the case that proves it is needed.
 
     A removed track's `updated_at` leaves the active set with it, so `max_updated_at` can sit

--- a/docs/decisions/ADR-0010-played-bytes-are-cached-downloads-are-pinned.md
+++ b/docs/decisions/ADR-0010-played-bytes-are-cached-downloads-are-pinned.md
@@ -171,10 +171,28 @@ benefit for half the disk. Both clear the 15% bar under the hostile sensitivity 
 `PlayCacheStoreTests` asserting point 8's invariant directly. Recency is the file's modification
 date rather than an index, so the filesystem stays the single truth per ADR-0009 point 4.
 
-**Not yet built:** point 1's destination provider in `NativeAudioEngine`, the read path through
-`PlaybackSource.resolve`, and points 4, 5, 6 and 7's wiring. The store therefore has no caller yet —
-deliberately a phase boundary, not an oversight, but ADR-0077's rule applies if the next phase does
-not follow.
+**Phase 2 — the engine seam, the read path and promotion** (`familiar-apple` #139). Points 1, 3, 5,
+6 and 7 are built and the store has its callers.
+
+Three of the engine's five temp-file deletions had to learn about ownership. Two are pre-move clears
+and must stay unconditional, because `moveItem` fails onto an existing file; the other three fire on
+a **superseded** load and would otherwise destroy a legitimately cached file because that particular
+load lost a race.
+
+`PlayCacheStore.promote`, added in phase 1, was **removed in phase 2 rather than shipped uncalled**.
+Point 6's real seam is `DownloadStore.store(fileAt:)`, which also writes the index entry — a file
+moved without one is the filesystem/index disagreement ADR-0009 point 4 keeps reconciliation for.
+
+**Point 4 is vacuous today, and this is the honest statement of it.** The rule is that the offline
+manifest carries the pinned set only. Nothing posts a manifest: `/queue/offline-manifest` has no
+caller in either repository, which `ADR-0074` records independently while scoping the `queue` tag. So
+the rule is satisfied structurally — the cache is a separate directory and a separate type, with no
+path from it to the manifest — but nothing asserts it, because there is no caller to assert against.
+**Whoever builds the manifest owes point 4 its test at that moment**, and should not read this
+absence as the rule having been checked.
+
+**Not yet exercised against real playback.** The cache fills only when a track actually streams
+through `NativeAudioEngine`, which needs the app running rather than a test.
 
 ## Alternatives Considered
 


### PR DESCRIPTION
A 500 on the delta endpoint for **every real client**, found by a live slice test written to close a gap I had flagged as untested.

## The bug

`Track.updated_at` is `TIMESTAMP WITHOUT TIME ZONE`. asyncpg refuses to compare it against an *aware* datetime — it raises, and FastAPI turns that into `500 Database error`.

The generated Swift client sends RFC 3339 with a `Z`, which FastAPI parses into an aware datetime. So `updated_since` failed for the only kind of caller it exists to serve.

**It passed every fixture test and every hand-run `curl`**, because all of those supplied the naive form — including mine, which is why I concluded earlier today that the production code was already correct after hitting this same offset-naive/aware trap in a test fixture. It wasn't; I had only tested the dialect I happened to write by hand.

## The fix

Convert rather than truncate. `14:00+02:00` is `12:00` UTC, and dropping the tzinfo would read it as `14:00` and silently skip two hours of changes — a delta that *loses rows* rather than one that fails. There is a test for exactly that, because it is the failure that would not announce itself.

## Verified against the real server

Deployed to the NAS and re-ran the live slice: all three pass, including a genuine 132-request full refresh of 26,422 tracks in 9.9s with every id distinct and the total matching `/library/fingerprint` independently.

## Also here

ADR-0010's `Implementation:` block now records phase 2, and states plainly that **point 4 is vacuous**: nothing posts an offline manifest, so "the manifest carries pinned only" is satisfied structurally and asserted by nothing. Whoever builds the manifest owes it a test then rather than inheriting the assumption that it was checked.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01Emjrwedq7W1scadHdgiLfs