### PR TITLE
Assert that renaming an album moves the library fingerprint

### DIFF
--- a/backend/tests/test_library_delta_cursor.py
+++ b/backend/tests/test_library_delta_cursor.py
@@ -200,6 +200,34 @@ async def test_the_fingerprint_measures_the_set_it_guards(async_db, client: Test
 
 
 @pytest.mark.asyncio
+async def test_renaming_an_album_moves_the_library_fingerprint(async_db, client: TestClient):
+    """ADR-0011 point 3's open follow-up, asserted rather than assumed.
+
+    The Apple client caches albums and artists and lets their staleness *ride* the track
+    fingerprint, on the grounds that both are groupings of track tags. The ADR flagged the risk:
+    "an album renamed with no track edit would slip through".
+
+    There is no such operation — an album is renamed *by* editing its tracks' tags, which is an
+    ORM update, so `onupdate` moves `updated_at` and the fingerprint with it. This is the test that
+    makes that a fact rather than an argument. If a future endpoint ever renames an album without
+    touching its tracks, this fails and the client needs its own signal for albums.
+    """
+    track = await _track_at(async_db, OLD, title="Song")
+
+    before = client.get("/api/v1/library/fingerprint").json()
+
+    # No explicit updated_at: the point is that the column moves by itself.
+    track.album = "Renamed After The Fact"
+    await async_db.commit()
+
+    after = client.get("/api/v1/library/fingerprint").json()
+
+    assert after["max_updated_at"] != before["max_updated_at"], (
+        "a tag edit must be visible to the fingerprint that guards the album cache"
+    )
+
+
+@pytest.mark.asyncio
 async def test_a_removal_moves_the_fingerprint_through_the_count(async_db, client: TestClient):
     """The count is the backstop, and this is the case that proves it is needed.
 

--- a/docs/decisions/ADR-0010-played-bytes-are-cached-downloads-are-pinned.md
+++ b/docs/decisions/ADR-0010-played-bytes-are-cached-downloads-are-pinned.md
@@ -191,8 +191,20 @@ path from it to the manifest — but nothing asserts it, because there is no cal
 **Whoever builds the manifest owes point 4 its test at that moment**, and should not read this
 absence as the rule having been checked.
 
-**Not yet exercised against real playback.** The cache fills only when a track actually streams
-through `NativeAudioEngine`, which needs the app running rather than a test.
+**Exercised against real playback** (`familiar-apple` #140). `PlayCacheEngineSliceTests` drives
+`NativeAudioEngine.load` against the live library and asserts the three things fixtures could not:
+a played track leaves real audio in the cache directory, **those bytes survive the following load**,
+and a repeat play resolves to `.local` with a file `AVAudioFile` will open. The second is the whole
+behaviour change — deleting the file exactly there is what the engine did before this ADR.
+
+It produces no audio. `load` downloads, opens an `AVAudioFile` and schedules on the player node, but
+nothing calls `playerNode.play()`. Skipped without `FAMILIAR_BASE_URL`, so CI does not depend on the
+NAS.
+
+**Every decision point is now either built and tested or recorded as vacuous.** The remaining
+follow-ups in the Consequences below — a fixed budget versus a fraction of free space, and
+least-recently-played versus least-recently-started once ADR-0004's events are recorded natively —
+are unchanged and still open.
 
 ## Alternatives Considered
 


### PR DESCRIPTION
ADR-0011 point 3's open follow-up, turned from an argument into a test.

The Apple client caches albums and artists and lets their staleness **ride** the track fingerprint, on the grounds that both are groupings of track tags. The ADR named the risk it was taking: *"an album renamed with no track edit would slip through"*.

There is no such operation — an album is renamed **by** editing its tracks' tags, which is an ORM update, so `onupdate` moves `updated_at` and the fingerprint with it. This asserts it directly. If a future endpoint ever renames an album without touching its tracks, this fails and the client needs its own signal for albums rather than inheriting the tracks'.

Pairs with `familiar-apple` #141.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01Emjrwedq7W1scadHdgiLfs