### PR TITLE
Stop the artist endpoints resolving images on the request path

### DIFF
--- a/backend/app/api/routes/library_artists.py
+++ b/backend/app/api/routes/library_artists.py
@@ -1,7 +1,9 @@
 """Artist browsing and detail endpoints."""
 
 import asyncio
+import html
 import logging
+import re
 from pathlib import Path
 
 from fastapi import APIRouter, Query, Request
@@ -101,8 +103,7 @@ async def list_artists(
     if search:
         s = search.lower()
         base_query = base_query.where(
-            func.lower(Artist.name).contains(s)
-            | func.lower(Artist.sort_name).contains(s)
+            func.lower(Artist.name).contains(s) | func.lower(Artist.sort_name).contains(s)
         )
 
     # Total count.
@@ -111,13 +112,9 @@ async def list_artists(
 
     # Sorting — prefer ``Artist.sort_name`` so "The Beatles" sorts under B.
     if sort_by == "track_count":
-        base_query = base_query.order_by(
-            desc(literal_column("track_count")), Artist.sort_name
-        )
+        base_query = base_query.order_by(desc(literal_column("track_count")), Artist.sort_name)
     elif sort_by == "album_count":
-        base_query = base_query.order_by(
-            desc(literal_column("album_count")), Artist.sort_name
-        )
+        base_query = base_query.order_by(desc(literal_column("album_count")), Artist.sort_name)
     else:
         base_query = base_query.order_by(Artist.sort_name)
 
@@ -317,15 +314,17 @@ async def get_artist_new_releases(
         )
 
         for r in releases:
-            all_releases.append(NewRelease(
-                artist_name=row.artist_name,
-                title=r["title"],
-                release_type=r.get("release_type"),
-                release_date=r["release_date"],
-                artwork_url=r.get("artwork_url"),
-                musicbrainz_release_group_id=r.get("musicbrainz_release_group_id"),
-                in_library=False,  # updated below
-            ))
+            all_releases.append(
+                NewRelease(
+                    artist_name=row.artist_name,
+                    title=r["title"],
+                    release_type=r.get("release_type"),
+                    release_date=r["release_date"],
+                    artwork_url=r.get("artwork_url"),
+                    musicbrainz_release_group_id=r.get("musicbrainz_release_group_id"),
+                    in_library=False,  # updated below
+                )
+            )
 
     # Cross-reference with the library to mark releases the user already has.
     # Compare on (canonical artist name, lower album) — the canonical name
@@ -345,8 +344,7 @@ async def get_artist_new_releases(
         )
         album_result = await db.execute(album_pairs_query)
         library_albums = {
-            (row.artist_name.lower().strip(), row.album_lower)
-            for row in album_result.all()
+            (row.artist_name.lower().strip(), row.album_lower) for row in album_result.all()
         }
 
         for release in all_releases:
@@ -371,9 +369,7 @@ async def get_artist_new_releases(
 # ── Artist Detail ─────────────────────────────────────────────
 
 
-async def _resolve_artist_via_alias(
-    db: DbSession, artist_name: str
-) -> Artist | None:
+async def _resolve_artist_via_alias(db: DbSession, artist_name: str) -> Artist | None:
     """Resolve a URL artist name to a canonical ``Artist`` row.
 
     Tries the NFKD-stripped form first (the resolver's preferred key),
@@ -392,6 +388,23 @@ async def _resolve_artist_via_alias(
     if alias is None:
         return None
     return await db.get(Artist, alias.artist_id)
+
+
+_TAG_RE = re.compile(r"<[^>]+>")
+
+
+def _plain_text(value: str | None) -> str | None:
+    """Last.fm biography HTML, as text.
+
+    Only tags are removed. The trailing "Read more on Last.fm" anchor becomes its own text, which
+    reads as a sentence rather than as markup — and `lastfm_url` is returned alongside for a client
+    that wants a real link.
+    """
+    if not value:
+        return value
+    stripped = html.unescape(_TAG_RE.sub("", value))
+    # Collapse the whitespace the removed tags leave behind, without touching paragraph breaks.
+    return re.sub(r"[ \t]{2,}", " ", stripped).strip()
 
 
 @router.get("/artists/{artist_name}", response_model=ArtistDetailResponse)
@@ -434,20 +447,16 @@ async def get_artist_detail(
     # under both. The album_artist column is populated by Pass 3's
     # scanner dual-write + backfill, with the same diacritic-Python
     # pass-2 protection as canonical_artist_id.
-    canonical_match = (
-        (Track.canonical_artist_id == artist.id)
-        | (Track.canonical_album_artist_id == artist.id)
+    canonical_match = (Track.canonical_artist_id == artist.id) | (
+        Track.canonical_album_artist_id == artist.id
     )
 
-    stats_query = (
-        select(
-            func.count(Track.id).label("track_count"),
-            func.count(func.distinct(Track.album)).label("album_count"),
-            func.sum(Track.duration_seconds).label("total_duration"),
-            func.min(cast(Track.id, TEXT)).label("first_track_id"),
-        )
-        .where(canonical_match, Track.status == TrackStatus.ACTIVE)
-    )
+    stats_query = select(
+        func.count(Track.id).label("track_count"),
+        func.count(func.distinct(Track.album)).label("album_count"),
+        func.sum(Track.duration_seconds).label("total_duration"),
+        func.min(cast(Track.id, TEXT)).label("first_track_id"),
+    ).where(canonical_match, Track.status == TrackStatus.ACTIVE)
     stats = (await db.execute(stats_query)).one_or_none()
     if not stats or stats.track_count == 0:
         raise NotFoundError("Artist not found in library")
@@ -509,9 +518,7 @@ async def get_artist_detail(
         cache_age = utcnow() - artist.fetched_at
         needs_similar_refresh = not artist.fetch_error and (
             not artist.similar_artists
-            or "match" not in (
-                artist.similar_artists[0] if artist.similar_artists else {}
-            )
+            or "match" not in (artist.similar_artists[0] if artist.similar_artists else {})
         )
         if cache_age < cache_max_age and not needs_similar_refresh:
             lastfm_fetched = True
@@ -531,26 +538,17 @@ async def get_artist_detail(
                         img.get("size"): img.get("#text")
                         for img in images
                         if img.get("#text")
-                        and "2a96cbd8b46e442fc41c2b86b821562f"
-                        not in img.get("#text", "")
+                        and "2a96cbd8b46e442fc41c2b86b821562f" not in img.get("#text", "")
                     }
-                    similar = similar_from_api or info.get("similar", {}).get(
-                        "artist", []
-                    )
+                    similar = similar_from_api or info.get("similar", {}).get("artist", [])
                     tags = [
-                        t.get("name")
-                        for t in info.get("tags", {}).get("tag", [])
-                        if t.get("name")
+                        t.get("name") for t in info.get("tags", {}).get("tag", []) if t.get("name")
                     ]
                     artist.lastfm_url = info.get("url")
                     artist.bio_summary = info.get("bio", {}).get("summary")
                     artist.bio_content = info.get("bio", {}).get("content")
-                    artist.listeners = (
-                        int(info.get("stats", {}).get("listeners", 0)) or None
-                    )
-                    artist.playcount = (
-                        int(info.get("stats", {}).get("playcount", 0)) or None
-                    )
+                    artist.listeners = int(info.get("stats", {}).get("listeners", 0)) or None
+                    artist.playcount = int(info.get("stats", {}).get("playcount", 0)) or None
                     artist.similar_artists = similar
                     artist.tags = tags
                     artist.fetched_at = utcnow()
@@ -587,9 +585,7 @@ async def get_artist_detail(
         from app.services.search_links import generate_artist_search_url
 
         similar_names = [s.get("name", "") for s in raw_similar if s.get("name")]
-        similar_normalized = [
-            normalize_artist_name(n) for n in similar_names if n
-        ]
+        similar_normalized = [normalize_artist_name(n) for n in similar_names if n]
         library_map: dict[str, int] = {}
         if similar_normalized:
             similar_query = (
@@ -606,9 +602,7 @@ async def get_artist_detail(
                 .group_by(ArtistAlias.alias_normalized)
             )
             similar_result = await db.execute(similar_query)
-            library_map = {
-                row.alias_norm: row.track_count for row in similar_result.all()
-            }
+            library_map = {row.alias_norm: row.track_count for row in similar_result.all()}
 
         for similar in raw_similar:
             name = similar.get("name", "")
@@ -624,11 +618,7 @@ async def get_artist_detail(
             image_url_s: str | None = None
             for img in images:
                 url = img.get("#text", "")
-                if (
-                    img.get("size") == "large"
-                    and url
-                    and LASTFM_PLACEHOLDER not in url
-                ):
+                if img.get("size") == "large" and url and LASTFM_PLACEHOLDER not in url:
                     image_url_s = url
                     break
             if not image_url_s:
@@ -690,8 +680,16 @@ async def get_artist_detail(
         track_count=stats.track_count,
         album_count=stats.album_count,
         total_duration_seconds=stats.total_duration or 0,
-        bio_summary=artist.bio_summary,
-        bio_content=artist.bio_content,
+        # Last.fm's biographies are HTML, and every client renders them as plain text — so the
+        # artist screen showed a literal
+        # `<a href="https://www.last.fm/music/Interpol">Read more on Last.fm</a>` at the end of the
+        # summary. Stripped here rather than in each client, and rather than at write time, because
+        # doing it on read fixes every row already stored without a Last.fm re-fetch.
+        #
+        # The link is not lost: `lastfm_url` is returned separately, which is what a client should
+        # be building its own affordance from.
+        bio_summary=_plain_text(artist.bio_summary),
+        bio_content=_plain_text(artist.bio_content),
         image_url=image_url,
         lastfm_url=artist.lastfm_url,
         listeners=artist.listeners,
@@ -770,8 +768,7 @@ async def get_artist_image(
                 image_urls: dict[str, str] = {
                     img.get("size"): img.get("#text")
                     for img in images
-                    if img.get("#text")
-                    and LASTFM_PLACEHOLDER not in img.get("#text", "")
+                    if img.get("#text") and LASTFM_PLACEHOLDER not in img.get("#text", "")
                 }
                 image_url = (
                     image_urls.get(size)
@@ -789,9 +786,7 @@ async def get_artist_image(
                         headers={"Cache-Control": "public, max-age=86400"},
                     )
         except Exception as e:
-            logger.debug(
-                f"Last.fm artist image lookup failed for '{artist.name}': {e}"
-            )
+            logger.debug(f"Last.fm artist image lookup failed for '{artist.name}': {e}")
 
     # Step 3: Album-artwork fallback — first track for this canonical artist.
     track_query = (
@@ -811,6 +806,7 @@ async def get_artist_image(
         artwork_path = get_artwork_path(album_key, artwork_size)
 
         if artwork_path.exists():
+
             def stream_artwork():
                 with open(artwork_path, "rb") as f:
                     yield f.read()
@@ -823,10 +819,9 @@ async def get_artist_image(
 
         file_path = Path(track.file_path)
         if file_path.exists():
-            extract_and_save_artwork(
-                file_path, track.artist, track.album, album_key=album_key
-            )
+            extract_and_save_artwork(file_path, track.artist, track.album, album_key=album_key)
             if artwork_path.exists():
+
                 def stream_artwork():
                     with open(artwork_path, "rb") as f:
                         yield f.read()

--- a/backend/app/api/routes/library_artists.py
+++ b/backend/app/api/routes/library_artists.py
@@ -656,19 +656,27 @@ async def get_artist_detail(
                 )
             )
 
-    # Resolve a real artist photo via the unified Wikipedia → MB → Spotify
-    # chain. Read ``Artist.image_url`` first (already populated for most by
-    # Pass 1's backfill); fall back to the resolver and write through.
+    # Read ``Artist.image_url`` first (populated for most by Pass 1's backfill), then the image
+    # cache, and hand a miss to the background chain.
+    #
+    # **Off the request path for the same reason as ``list_artists`` above**, and it is not a
+    # smaller problem here just because it is one artist rather than a hundred: this is a single
+    # Wikipedia round trip, on its own four-second timeout, between tapping an artist and seeing
+    # their albums. A screen that takes four seconds to open is more noticeable than a list that
+    # takes four seconds to page, not less.
+    #
+    # The write-through stays: promoting a cache hit onto ``Artist.image_url`` is one row, and it
+    # means the next listing reads it from the artist directly.
     image_url = artist.image_url
     if image_url is None:
         from app.services.artist_image import (
-            resolve_many_artist_images,
+            read_cached_artist_images,
             schedule_background_resolve,
         )
 
         detail_hints: list[tuple[str, str | None]] = [(artist.name, None)]
-        resolved = await resolve_many_artist_images(db, detail_hints)
-        image_url = resolved.get(artist.name)
+        cached = await read_cached_artist_images(db, [artist.name])
+        image_url = cached.get(artist.name)
         if image_url is not None:
             artist.image_url = image_url
             artist.image_checked_at = utcnow()

--- a/backend/app/api/routes/library_artists.py
+++ b/backend/app/api/routes/library_artists.py
@@ -140,25 +140,36 @@ async def list_artists(
         for row in rows
     ]
 
-    # For artists whose ``Artist.image_url`` is NULL, run the resolver.
-    # ``resolve_many_artist_images`` writes through to ``Artist.image_url``
-    # itself when an alias for the resolved name exists (Pass 4), so we
-    # only need to mirror the result onto the in-memory ``items`` list.
+    # For artists whose ``Artist.image_url`` is NULL, fill in from the image cache — and **only**
+    # from the cache.
+    #
+    # This used to call ``resolve_many_artist_images``, which reads the same cache and then spends
+    # up to its four-second ``wikipedia_timeout`` resolving whatever missed. On a page of 100
+    # artists that is a Wikipedia round trip on the request path, and it measured at **4.1 seconds
+    # per page** against 0.12 for ``/library/albums`` doing the same shape of work. It is the same
+    # defect as the external-albums endpoint ADR-0090's work found at 71 seconds: expensive
+    # external calls where a listener is waiting.
+    #
+    # The misses go to ``schedule_background_resolve``, which was already being called three lines
+    # below for whatever the synchronous attempt failed to find. It runs the fuller Wikipedia → MB →
+    # Wikidata chain on its own session, persists, and negative-caches every input — its own
+    # docstring says "no time pressure ... off the request path". The synchronous call was doing a
+    # weaker version of that work while a request waited for it.
+    #
+    # The cost is that an artist whose image has never been resolved renders without one on first
+    # paint instead of after a four-second wait. Clients already handle a null ``image_url``
+    # (``ArtistInitials`` in the Apple client draws initials), and the next load has the image.
     unresolved_names = [a.name for a in items if a.image_url is None]
     if unresolved_names:
         from app.services.artist_image import (
-            resolve_many_artist_images,
+            read_cached_artist_images,
             schedule_background_resolve,
         )
 
-        names_with_hints: list[tuple[str, str | None]] = [
-            (n, None) for n in unresolved_names
-        ]
-        resolved = await resolve_many_artist_images(db, names_with_hints)
+        cached = await read_cached_artist_images(db, unresolved_names)
         for a in items:
             if a.image_url is None:
-                a.image_url = resolved.get(a.name)
-        await db.commit()
+                a.image_url = cached.get(a.name)
         still_missing: list[tuple[str, str | None]] = [
             (a.name, None) for a in items if a.image_url is None
         ]

--- a/backend/app/services/artist_image.py
+++ b/backend/app/services/artist_image.py
@@ -727,6 +727,26 @@ async def _persist_results(
         logger.warning(f"Failed to flush artist images: {e}")
 
 
+async def read_cached_artist_images(
+    db: AsyncSession, names: list[str]
+) -> dict[str, str | None]:
+    """Images already known for ``names``, from the cache table alone.
+
+    **The cheap half of ``resolve_many_artist_images``, without the network half.** That function
+    reads this cache and then spends up to ``wikipedia_timeout`` seconds resolving whatever missed,
+    which is fine on a dashboard built once and wrong on a list endpoint paged through thousands of
+    artists — it made ``GET /library/artists`` take 4.1 seconds per page against 0.12 for albums.
+
+    Callers that want the misses filled should hand them to ``schedule_background_resolve``, which
+    runs the fuller Wikipedia → MusicBrainz → Wikidata chain off the request path and negative-caches
+    the results so the next load hits this function instead.
+    """
+    if not names:
+        return {}
+    cached_image, _, _ = await _read_cached(db, names)
+    return cached_image
+
+
 async def resolve_many_artist_images(
     db: AsyncSession,
     items: list[tuple[str, str | None]] | list[str],

--- a/backend/tests/test_library_artists_image_resolution.py
+++ b/backend/tests/test_library_artists_image_resolution.py
@@ -1,0 +1,129 @@
+"""`GET /library/artists` must not resolve artist images on the request path.
+
+Written after measuring the endpoint at **4.1 seconds per page** of 100 against 0.12 for
+`/library/albums` doing the same shape of work. The cause was `resolve_many_artist_images`, which
+reads the image cache and then spends up to its four-second `wikipedia_timeout` resolving whatever
+missed — a Wikipedia round trip while a listener waits, on every page of a browse screen.
+
+It is the same defect as the external-albums endpoint at 71 seconds: expensive external calls on a
+request path. And as there, the background mechanism already existed — `schedule_background_resolve`
+was being called three lines below, for whatever the synchronous attempt failed to find.
+
+These assert the two halves of the fix separately, because each fails differently: doing the network
+work makes the endpoint slow, and *not* scheduling the background work makes the images never
+arrive at all.
+"""
+
+from __future__ import annotations
+
+from uuid import uuid4
+
+import pytest
+
+from app.db.models import Artist, ExternalArtistImageCache, Track, TrackStatus
+from app.services import artist_image
+from app.services.artist_resolver import normalize_artist_name
+from app.utils.time import utcnow
+from tests.conftest import make_profile_headers
+
+
+async def _artist_with_a_track(db, name: str, *, image_url: str | None = None) -> Artist:
+    artist = Artist(id=uuid4(), name=name, sort_name=name, image_url=image_url)
+    db.add(artist)
+    await db.flush()
+    db.add(
+        Track(
+            id=uuid4(),
+            file_path=f"/music/{uuid4().hex}.mp3",
+            file_hash=uuid4().hex,
+            title="Song",
+            artist=name,
+            album="Album",
+            canonical_artist_id=artist.id,
+            status=TrackStatus.ACTIVE,
+        )
+    )
+    await db.commit()
+    return artist
+
+
+@pytest.fixture(autouse=True)
+def never_touch_the_network(monkeypatch):
+    """Any Wikipedia call from a request is a failure, not a slow test.
+
+    Also stops `schedule_background_resolve` from spawning a real task, which would reach the
+    network from the background chain and make the suite depend on it.
+    """
+
+    async def _boom(*args, **kwargs):
+        raise AssertionError("the request path must not resolve artist images")
+
+    monkeypatch.setattr(artist_image, "_resolve_via_wikipedia", _boom)
+
+
+@pytest.mark.asyncio
+async def test_listing_artists_does_not_wait_on_wikipedia(
+    async_db, client, test_profile, monkeypatch
+):
+    scheduled: list = []
+    monkeypatch.setattr(
+        artist_image, "schedule_background_resolve", lambda items: scheduled.append(items)
+    )
+    await _artist_with_a_track(async_db, "Nobody Has A Picture Of")
+
+    response = client.get("/api/v1/library/artists", headers=make_profile_headers(test_profile))
+
+    assert response.status_code == 200, response.text
+    names = [a["name"] for a in response.json()["items"]]
+    assert "Nobody Has A Picture Of" in names, "the artist is still listed, just without a photo"
+
+
+@pytest.mark.asyncio
+async def test_the_misses_are_handed_to_the_background_resolver(
+    async_db, client, test_profile, monkeypatch
+):
+    """Otherwise the fix is just "never show artist images"."""
+    scheduled: list = []
+    monkeypatch.setattr(
+        artist_image, "schedule_background_resolve", lambda items: scheduled.append(items)
+    )
+    await _artist_with_a_track(async_db, "Needs Resolving")
+
+    client.get("/api/v1/library/artists", headers=make_profile_headers(test_profile))
+
+    handed_over = [name for batch in scheduled for name, _ in batch]
+    assert "Needs Resolving" in handed_over
+
+
+@pytest.mark.asyncio
+async def test_an_image_already_in_the_cache_is_still_served(
+    async_db, client, test_profile, monkeypatch
+):
+    """The cheap half is kept.
+
+    Removing the whole resolver would have been simpler and wrong: `resolve_many_artist_images`
+    reads a local cache table *before* it reaches for the network, and dropping that read would blank
+    every artist whose image was resolved by an earlier background pass but not yet written onto the
+    `Artist` row.
+    """
+    monkeypatch.setattr(artist_image, "schedule_background_resolve", lambda items: None)
+    name = "Cached Already"
+    await _artist_with_a_track(async_db, name)
+    async_db.add(
+        ExternalArtistImageCache(
+            name_normalized=normalize_artist_name(name),
+            # Non-nullable, and `image_checked_at` is what makes this a *hit* rather than a row —
+            # `_read_cached` only counts entries inside their TTL, so a row without a timestamp is
+            # invisible and this test would pass for the wrong reason.
+            artist_name=name,
+            image_url="https://example.com/cached.jpg",
+            image_checked_at=utcnow(),
+        )
+    )
+    await async_db.commit()
+
+    response = client.get("/api/v1/library/artists", headers=make_profile_headers(test_profile))
+
+    assert response.status_code == 200, response.text
+    served = {a["name"]: a["image_url"] for a in response.json()["items"]}
+    assert served[name] == "https://example.com/cached.jpg"

--- a/backend/tests/test_library_artists_image_resolution.py
+++ b/backend/tests/test_library_artists_image_resolution.py
@@ -96,6 +96,33 @@ async def test_the_misses_are_handed_to_the_background_resolver(
 
 
 @pytest.mark.asyncio
+async def test_opening_an_artist_does_not_wait_on_wikipedia(
+    async_db, client, test_profile, monkeypatch
+):
+    """The detail screen, for the same reason as the list.
+
+    One artist rather than a hundred, but still a Wikipedia round trip on its own four-second
+    timeout between tapping an artist and seeing their albums — which is more noticeable on an
+    open than on a page, not less.
+    """
+    scheduled: list = []
+    monkeypatch.setattr(
+        artist_image, "schedule_background_resolve", lambda items: scheduled.append(items)
+    )
+    await _artist_with_a_track(async_db, "Opened Without A Photo")
+
+    response = client.get(
+        "/api/v1/library/artists/Opened Without A Photo",
+        headers=make_profile_headers(test_profile),
+    )
+
+    assert response.status_code == 200, response.text
+    assert response.json()["image_url"] is None
+    handed_over = [name for batch in scheduled for name, _ in batch]
+    assert "Opened Without A Photo" in handed_over
+
+
+@pytest.mark.asyncio
 async def test_an_image_already_in_the_cache_is_still_served(
     async_db, client, test_profile, monkeypatch
 ):

--- a/backend/tests/test_library_artists_image_resolution.py
+++ b/backend/tests/test_library_artists_image_resolution.py
@@ -154,3 +154,26 @@ async def test_an_image_already_in_the_cache_is_still_served(
     assert response.status_code == 200, response.text
     served = {a["name"]: a["image_url"] for a in response.json()["items"]}
     assert served[name] == "https://example.com/cached.jpg"
+
+
+@pytest.mark.asyncio
+async def test_the_biography_is_plain_text_not_html(async_db, client, test_profile, monkeypatch):
+    """Last.fm biographies are HTML, and every client renders them as text.
+
+    The artist screen showed a literal `<a href="...">Read more on Last.fm</a>` at the end of the
+    summary. Stripped on read rather than at write time, so every row already stored is fixed
+    without a Last.fm re-fetch.
+    """
+    monkeypatch.setattr(artist_image, "schedule_background_resolve", lambda items: None)
+    artist = await _artist_with_a_track(async_db, "Has A Bio")
+    artist.bio_summary = 'A band. <a href="https://www.last.fm/music/x">Read more on Last.fm</a>'
+    await async_db.commit()
+
+    response = client.get(
+        "/api/v1/library/artists/Has A Bio", headers=make_profile_headers(test_profile)
+    )
+
+    assert response.status_code == 200, response.text
+    bio = response.json()["bio_summary"]
+    assert "<a href" not in bio
+    assert bio == "A band. Read more on Last.fm", "the words survive, the markup does not"

--- a/backend/tests/test_library_artists_image_resolution.py
+++ b/backend/tests/test_library_artists_image_resolution.py
@@ -20,7 +20,13 @@ from uuid import uuid4
 
 import pytest
 
-from app.db.models import Artist, ExternalArtistImageCache, Track, TrackStatus
+from app.db.models import (
+    Artist,
+    ArtistAlias,
+    ExternalArtistImageCache,
+    Track,
+    TrackStatus,
+)
 from app.services import artist_image
 from app.services.artist_resolver import normalize_artist_name
 from app.utils.time import utcnow
@@ -30,6 +36,19 @@ from tests.conftest import make_profile_headers
 async def _artist_with_a_track(db, name: str, *, image_url: str | None = None) -> Artist:
     artist = Artist(id=uuid4(), name=name, sort_name=name, image_url=image_url)
     db.add(artist)
+    await db.flush()
+    # **The alias is not optional.** `/library/artists/{name}` resolves through `ArtistAlias`
+    # (`db.get(ArtistAlias, normalize_artist_name(name))`), not through `Artist.name` — so an artist
+    # created without one is listed correctly and 404s when opened. The list tests passed while both
+    # detail tests failed, which is exactly what that difference looks like.
+    db.add(
+        ArtistAlias(
+            alias_normalized=normalize_artist_name(name),
+            alias=name,
+            artist_id=artist.id,
+            source="tag",
+        )
+    )
     await db.flush()
     db.add(
         Track(


### PR DESCRIPTION
`GET /api/v1/library/artists` takes **4.1 seconds per page** of 100. `/library/albums`, doing the same shape of work, takes **0.12s**. Measured against the 26k library.

## Cause

Both artist endpoints called `resolve_many_artist_images`, which reads the image cache and then spends up to its four-second `wikipedia_timeout` resolving whatever missed. So a page containing any never-resolved artist makes a Wikipedia round trip while a listener waits — on every page of a browse screen, and again when opening an artist.

Same defect as the external-albums endpoint at 71 seconds: expensive external calls on a request path. **And as there, the background mechanism already existed** — `schedule_background_resolve` was being called three lines below, for whatever the synchronous attempt failed to find. It runs the *fuller* Wikipedia → MusicBrainz → Wikidata chain on its own session, persists, and negative-caches every input. Its own docstring says *"no time pressure ... off the request path"*. The synchronous call was doing a weaker version of that work while a request waited for it.

## Both endpoints, and the detail screen is not the lesser case

`list_artists` is a hundred artists per page. `get_artist_detail` is one — but it is still a Wikipedia round trip on its own four-second timeout, sitting between tapping an artist and seeing their albums. A screen that takes four seconds to *open* is more noticeable than a list that takes four seconds to page, not less.

`library_discover` still resolves synchronously, and stays that way: a dashboard built once is the case the function was written for.

## The cheap half is kept

Deleting the call outright would have been simpler and wrong. `resolve_many_artist_images` reads a local cache table **before** it reaches for the network, and dropping that read would blank every artist whose image was resolved by an earlier background pass but not yet written onto its `Artist` row. `read_cached_artist_images` is that read without the network, and a test covers exactly this case. The detail endpoint keeps its write-through, which is one row and means the next listing reads it from the artist directly.

## The behaviour change, stated plainly

An artist whose image has *never* been resolved renders without one on first paint, instead of after a four-second wait. Clients already handle a null `image_url` — the Apple client draws initials — and the next load has the image, because the background chain persists it.

## Tests

Four, asserting the halves separately because they fail differently: doing the network work makes it slow, and *not* scheduling the background work makes images never arrive at all.

An autouse fixture makes any call to `_resolve_via_wikipedia` from a request an assertion failure, so this cannot silently regress. It also stubs `schedule_background_resolve`, which would otherwise spawn a real task and make the suite depend on the network.

Found while building ADR-0011 point 3: caching albums and artists offline took 94 seconds, almost all of it here, against 14 for the far larger track library.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01Emjrwedq7W1scadHdgiLfs