### PR TITLE
Group the server-operations tags (ADR-0076)

### DIFF
--- a/backend/app/api/routes/admin_artists.py
+++ b/backend/app/api/routes/admin_artists.py
@@ -28,7 +28,7 @@ from app.services.artist_resolver import _canonicalize_for_match
 
 logger = logging.getLogger(__name__)
 
-router = APIRouter(prefix="/admin/artists", tags=["admin"])
+router = APIRouter(prefix="/admin/artists", tags=["artists"])
 
 MAX_MERGE_BATCH = 20
 

--- a/backend/app/api/routes/background.py
+++ b/backend/app/api/routes/background.py
@@ -12,7 +12,7 @@ from app.services.tasks import get_sync_progress
 
 logger = logging.getLogger(__name__)
 
-router = APIRouter(prefix="/background", tags=["background"])
+router = APIRouter(prefix="/background", tags=["system"])
 
 
 class JobProgress(BaseModel):

--- a/backend/app/api/routes/diagnostics.py
+++ b/backend/app/api/routes/diagnostics.py
@@ -15,7 +15,7 @@ from app.api.deps import CurrentProfile, DbSession
 from app.config import FEATURES_VERSION, get_app_version
 from app.utils.time import to_rfc3339, utcnow
 
-router = APIRouter(tags=["diagnostics"])
+router = APIRouter(tags=["system"])
 
 
 def get_system_info() -> dict[str, Any]:

--- a/backend/app/api/routes/download.py
+++ b/backend/app/api/routes/download.py
@@ -28,7 +28,7 @@ from app.services.smart_playlists import SmartPlaylistService
 
 logger = logging.getLogger(__name__)
 
-router = APIRouter(prefix="/download", tags=["download"])
+router = APIRouter(prefix="/download", tags=["exports"])
 
 MAX_TRACKS = 500
 MAX_SIZE_BYTES = 2 * 1024 * 1024 * 1024  # 2GB

--- a/backend/app/api/routes/export_import/__init__.py
+++ b/backend/app/api/routes/export_import/__init__.py
@@ -6,7 +6,7 @@ from app.api.routes.export_import.backup import router as backup_router
 from app.api.routes.export_import.library import router as library_router
 from app.api.routes.export_import.profile import router as profile_router
 
-router = APIRouter(prefix="/export-import", tags=["export-import"])
+router = APIRouter(prefix="/export-import", tags=["transfer"])
 router.include_router(profile_router)
 router.include_router(library_router)
 router.include_router(backup_router)

--- a/backend/app/api/routes/health.py
+++ b/backend/app/api/routes/health.py
@@ -14,7 +14,7 @@ from app.db.models import Track, TrackAnalysis
 
 logger = logging.getLogger(__name__)
 
-router = APIRouter(tags=["health"])
+router = APIRouter(tags=["system"])
 
 
 class ServiceStatus(BaseModel):

--- a/backend/app/api/routes/s3_backup.py
+++ b/backend/app/api/routes/s3_backup.py
@@ -12,7 +12,7 @@ from app.services.s3_backup import get_s3_backup_service
 
 logger = logging.getLogger(__name__)
 
-router = APIRouter(prefix="/s3-backup", tags=["s3-backup"])
+router = APIRouter(prefix="/s3-backup", tags=["backup"])
 
 
 # ── Request/Response Models ──────────────────────────────────────────

--- a/backend/app/api/routes/updates.py
+++ b/backend/app/api/routes/updates.py
@@ -3,7 +3,7 @@
 from fastapi import APIRouter
 from pydantic import BaseModel
 
-router = APIRouter(prefix="/updates", tags=["updates"])
+router = APIRouter(prefix="/updates", tags=["system"])
 
 
 class UpdateStatus(BaseModel):

--- a/backend/app/main.py
+++ b/backend/app/main.py
@@ -379,17 +379,23 @@ OPENAPI_TAGS = [
     {"name": "organizer", "description":
         "File-organisation previews. Preview only: no route moves a file, so there is nothing to "
         "apply. Renamed from `Library Organization` by ADR-0072 point 3."},
-    {"name": "admin", "description":
-        "Artist-merge operations. The `admin` name is a misnomer under ADR-0058 — most of this API "
-        "is administration — and ADR-0076 point 5 is the proposal to rename it `artists`."},
+    {"name": "artists", "description":
+        "Artist-merge operations, named for what they act on. Was `admin`, a name promising a "
+        "namespace two-thirds of this API would qualify for and only these three used. The "
+        "`/admin/artists/` prefix has not moved with the tag — that needs ADR-0079's alias module, "
+        "which is accepted and unbuilt."},
 
     # Transfer and backup — getting data out, and back.
-    {"name": "export-import", "description":
-        "Moving a profile or a library between servers."},
-    {"name": "s3-backup", "description":
-        "Scheduled backup to S3-compatible storage, and restore from it."},
-    {"name": "download", "description":
-        "ZIP exports of playlists, track sets and analysis reports."},
+    {"name": "backup", "description":
+        "Durability — scheduled backup to S3-compatible storage, and restore from it. Paths stay "
+        "under `/s3-backup/`; the tag names the activity, not the storage backend (ADR-0076)."},
+    {"name": "transfer", "description":
+        "Portability — moving a profile or a library between servers. The line against `backup` is "
+        "durability versus portability, which is the line a user is already on when choosing a "
+        "screen."},
+    {"name": "exports", "description":
+        "ZIP exports of playlists, track sets and analysis reports. Was `download`, which named a "
+        "transport rather than what the operations produce."},
 
     # Server — operating the thing.
     {"name": "profiles", "description":
@@ -398,11 +404,11 @@ OPENAPI_TAGS = [
     {"name": "auth", "description": "Server-token administration (ADR-0045)."},
     {"name": "settings", "description":
         "Server configuration — library paths, API keys, provider choice."},
-    {"name": "health", "description":
-        "Liveness. `GET /api/v1/health` is a container probe, not a client-facing endpoint."},
-    {"name": "diagnostics", "description": "Logs and runtime introspection."},
-    {"name": "background", "description": "Background job state."},
-    {"name": "updates", "description": "Application update checks."},
+    {"name": "system", "description":
+        "The state of the running server: liveness, database and worker health, logs, metrics, "
+        "background jobs and update checks. Four tags merged here under ADR-0076 — the paths did "
+        "not move with them, because each already names its resource honestly (ADR-0072 point 4). "
+        "`GET /api/v1/health` in particular is a container probe and stays where it is forever."},
 ]
 
 # The seven areas, in render order. Point 5 says the areas are published rather than implied; this
@@ -416,10 +422,9 @@ OPENAPI_TAG_GROUPS = [
     {"name": "Discovery", "tags": ["discover", "lastfm", "new-releases", "external-albums"]},
     {"name": "Curation", "tags": [
         "ingest", "metadata", "identification", "duplicates",
-        "pending-review", "proposed-changes", "organizer", "admin"]},
-    {"name": "Transfer and backup", "tags": ["export-import", "s3-backup", "download"]},
-    {"name": "Server", "tags": [
-        "profiles", "auth", "settings", "health", "diagnostics", "background", "updates"]},
+        "pending-review", "proposed-changes", "organizer", "artists"]},
+    {"name": "Transfer and backup", "tags": ["backup", "transfer", "exports"]},
+    {"name": "Server", "tags": ["profiles", "auth", "settings", "system"]},
 ]
 
 

--- a/backend/openapi.json
+++ b/backend/openapi.json
@@ -1498,48 +1498,6 @@
         "title": "BatchTracksRequest",
         "type": "object"
       },
-      "Body_export-import_preview_import": {
-        "properties": {
-          "file": {
-            "format": "binary",
-            "title": "File",
-            "type": "string"
-          }
-        },
-        "required": [
-          "file"
-        ],
-        "title": "Body_export-import_preview_import",
-        "type": "object"
-      },
-      "Body_export-import_preview_library_import": {
-        "properties": {
-          "file": {
-            "format": "binary",
-            "title": "File",
-            "type": "string"
-          }
-        },
-        "required": [
-          "file"
-        ],
-        "title": "Body_export-import_preview_library_import",
-        "type": "object"
-      },
-      "Body_export-import_preview_restore": {
-        "properties": {
-          "file": {
-            "format": "binary",
-            "title": "File",
-            "type": "string"
-          }
-        },
-        "required": [
-          "file"
-        ],
-        "title": "Body_export-import_preview_restore",
-        "type": "object"
-      },
       "Body_ingest_import_preview": {
         "properties": {
           "file": {
@@ -1608,6 +1566,48 @@
           "file"
         ],
         "title": "Body_tracks_upload_track_artwork",
+        "type": "object"
+      },
+      "Body_transfer_preview_import": {
+        "properties": {
+          "file": {
+            "format": "binary",
+            "title": "File",
+            "type": "string"
+          }
+        },
+        "required": [
+          "file"
+        ],
+        "title": "Body_transfer_preview_import",
+        "type": "object"
+      },
+      "Body_transfer_preview_library_import": {
+        "properties": {
+          "file": {
+            "format": "binary",
+            "title": "File",
+            "type": "string"
+          }
+        },
+        "required": [
+          "file"
+        ],
+        "title": "Body_transfer_preview_library_import",
+        "type": "object"
+      },
+      "Body_transfer_preview_restore": {
+        "properties": {
+          "file": {
+            "format": "binary",
+            "title": "File",
+            "type": "string"
+          }
+        },
+        "required": [
+          "file"
+        ],
+        "title": "Body_transfer_preview_restore",
         "type": "object"
       },
       "BulkAnalysisRequest": {
@@ -10738,7 +10738,7 @@
     "/api/v1/admin/artists/merge": {
       "post": {
         "description": "Merge several ``Artist`` rows into one canonical row.\n\nAtomic. Locks the source rows so the scanner's resolver can't\ninsert a new alias pointing at any merge_id mid-merge. Aliases\nthat would collide with one already on the keep artist are\ndropped (keep-side wins). ``tracks.canonical_artist_id`` is\nrepointed BEFORE the artist DELETE \u2014 the FK is ON DELETE SET\nNULL, which would silently null tracks if the order were\nreversed.\n\nIdempotency: re-running with the same payload finds the\nmerge_ids gone and returns 404 \u2014 honest signal, not 200.",
-        "operationId": "admin_merge_artists",
+        "operationId": "artists_merge_artists",
         "requestBody": {
           "content": {
             "application/json": {
@@ -10818,14 +10818,14 @@
         ],
         "summary": "Merge Artists",
         "tags": [
-          "admin"
+          "artists"
         ]
       }
     },
     "/api/v1/admin/artists/merge-suggestions": {
       "get": {
         "description": "Return groups of artists whose canonicalized names collide.\n\nThe obvious \"Beatles\" + \"The Beatles\" + \"Beatles, The\" cluster.\nPure-Python pass over a fetched-once list \u2014 ~3.5k artists fits in\n<5MB Python overhead, sub-50ms group. Each suggestion ranks\nMBID-bearing candidates first (likely canonical winner); UI\nguards against merging two non-matching MBIDs.\n\nLong-tail rename cases (\"Antony\" \u2192 \"ANOHNI\", \"Ceephax\" \u2192 \"Ceephax\nAcid Crew\") aren't surfaced here \u2014 different canonical forms. The\nuser picks those manually via the merge UI's search panel.",
-        "operationId": "admin_get_merge_suggestions",
+        "operationId": "artists_get_merge_suggestions",
         "parameters": [
           {
             "in": "query",
@@ -10907,14 +10907,14 @@
         ],
         "summary": "Get Merge Suggestions",
         "tags": [
-          "admin"
+          "artists"
         ]
       }
     },
     "/api/v1/admin/artists/search": {
       "get": {
         "description": "Substring search across canonical artist names + sort_names.\n\nPowers the merge UI's manual-search panel \u2014 finds long-tail rename\nor abbreviation cases that the canonical-form-collision suggestions\ncan't see (e.g. \"Various\" vs \"Various Artists\", \"Se\u00f1or Coconut\"\nvs \"Se\u00f1or Coconut and His Orchestra\"). Trim/lower the query, ILIKE\nagainst name + sort_name, order by track count desc.",
-        "operationId": "admin_search_artists",
+        "operationId": "artists_search_artists",
         "parameters": [
           {
             "in": "query",
@@ -11005,7 +11005,7 @@
         ],
         "summary": "Search Artists",
         "tags": [
-          "admin"
+          "artists"
         ]
       }
     },
@@ -12041,7 +12041,7 @@
     "/api/v1/background/jobs": {
       "get": {
         "description": "Get status of all background jobs.\n\nReturns all jobs that are currently running or have recently completed.\nOnly includes jobs with active progress tracking.",
-        "operationId": "background_get_background_jobs",
+        "operationId": "system_get_background_jobs",
         "responses": {
           "200": {
             "content": {
@@ -12106,14 +12106,14 @@
         },
         "summary": "Get Background Jobs",
         "tags": [
-          "background"
+          "system"
         ]
       }
     },
     "/api/v1/diagnostics/export": {
       "get": {
         "description": "Export comprehensive diagnostics for issue reporting.\n\nThis endpoint gathers system health, recent logs, and configuration\ninformation to help diagnose issues. Sensitive data (API keys, paths)\nis excluded or redacted.",
-        "operationId": "diagnostics_export_diagnostics",
+        "operationId": "system_export_diagnostics",
         "responses": {
           "200": {
             "content": {
@@ -12178,14 +12178,14 @@
         },
         "summary": "Export Diagnostics",
         "tags": [
-          "diagnostics"
+          "system"
         ]
       }
     },
     "/api/v1/diagnostics/frontend-logs": {
       "delete": {
         "description": "Delete all frontend log entries.",
-        "operationId": "diagnostics_clear_frontend_logs",
+        "operationId": "system_clear_frontend_logs",
         "responses": {
           "200": {
             "content": {
@@ -12250,12 +12250,12 @@
         },
         "summary": "Clear Frontend Logs",
         "tags": [
-          "diagnostics"
+          "system"
         ]
       },
       "get": {
         "description": "Query frontend logs with optional filters.\n\nSet format=text for plain-text output suitable for curl | grep.",
-        "operationId": "diagnostics_query_frontend_logs",
+        "operationId": "system_query_frontend_logs",
         "parameters": [
           {
             "in": "query",
@@ -12356,7 +12356,7 @@
             "content": {
               "application/json": {
                 "schema": {
-                  "title": "Response Diagnostics Query Frontend Logs"
+                  "title": "Response System Query Frontend Logs"
                 }
               }
             },
@@ -12415,12 +12415,12 @@
         },
         "summary": "Query Frontend Logs",
         "tags": [
-          "diagnostics"
+          "system"
         ]
       },
       "post": {
         "description": "Ingest a batch of frontend log entries.",
-        "operationId": "diagnostics_ingest_frontend_logs",
+        "operationId": "system_ingest_frontend_logs",
         "requestBody": {
           "content": {
             "application/json": {
@@ -12500,14 +12500,14 @@
         ],
         "summary": "Ingest Frontend Logs",
         "tags": [
-          "diagnostics"
+          "system"
         ]
       }
     },
     "/api/v1/diagnostics/metrics": {
       "get": {
         "description": "Get application metrics snapshot (request timing + background gauges).",
-        "operationId": "diagnostics_get_metrics",
+        "operationId": "system_get_metrics",
         "responses": {
           "200": {
             "content": {
@@ -12572,14 +12572,14 @@
         },
         "summary": "Get Metrics",
         "tags": [
-          "diagnostics"
+          "system"
         ]
       }
     },
     "/api/v1/download/analyses": {
       "post": {
         "description": "Download track analyses as a ZIP of markdown reports.\n\nFast path: all tracks already analyzed -> returns ZIP immediately (200).\nSlow path: some need analysis -> kicks off background task -> returns 202 with task_id.",
-        "operationId": "download_download_analyses_zip",
+        "operationId": "exports_download_analyses_zip",
         "requestBody": {
           "content": {
             "application/json": {
@@ -12657,14 +12657,14 @@
         ],
         "summary": "Download Analyses Zip",
         "tags": [
-          "download"
+          "exports"
         ]
       }
     },
     "/api/v1/download/analyses/{task_id}/download": {
       "get": {
         "description": "Download the analysis ZIP once background processing is ready.",
-        "operationId": "download_download_analysis_zip_result",
+        "operationId": "exports_download_analysis_zip_result",
         "parameters": [
           {
             "in": "path",
@@ -12743,14 +12743,14 @@
         ],
         "summary": "Download Analysis Zip Result",
         "tags": [
-          "download"
+          "exports"
         ]
       }
     },
     "/api/v1/download/analyses/{task_id}/status": {
       "get": {
         "description": "Poll progress of analysis-for-download task.",
-        "operationId": "download_get_analysis_download_status",
+        "operationId": "exports_get_analysis_download_status",
         "parameters": [
           {
             "in": "path",
@@ -12768,7 +12768,7 @@
               "application/json": {
                 "schema": {
                   "additionalProperties": true,
-                  "title": "Response Download Get Analysis Download Status",
+                  "title": "Response Exports Get Analysis Download Status",
                   "type": "object"
                 }
               }
@@ -12828,14 +12828,14 @@
         },
         "summary": "Get Analysis Download Status",
         "tags": [
-          "download"
+          "exports"
         ]
       }
     },
     "/api/v1/download/playlist/{playlist_id}": {
       "get": {
         "description": "Download all tracks in a playlist as a ZIP file.",
-        "operationId": "download_download_playlist_zip",
+        "operationId": "exports_download_playlist_zip",
         "parameters": [
           {
             "in": "path",
@@ -12915,14 +12915,14 @@
         ],
         "summary": "Download Playlist Zip",
         "tags": [
-          "download"
+          "exports"
         ]
       }
     },
     "/api/v1/download/smart-playlist/{playlist_id}": {
       "get": {
         "description": "Download all tracks matching a smart playlist as a ZIP file.",
-        "operationId": "download_download_smart_playlist_zip",
+        "operationId": "exports_download_smart_playlist_zip",
         "parameters": [
           {
             "in": "path",
@@ -13002,14 +13002,14 @@
         ],
         "summary": "Download Smart Playlist Zip",
         "tags": [
-          "download"
+          "exports"
         ]
       }
     },
     "/api/v1/download/tracks": {
       "post": {
         "description": "Download a set of tracks as a ZIP file.",
-        "operationId": "download_download_tracks_zip",
+        "operationId": "exports_download_tracks_zip",
         "requestBody": {
           "content": {
             "application/json": {
@@ -13087,14 +13087,14 @@
         ],
         "summary": "Download Tracks Zip",
         "tags": [
-          "download"
+          "exports"
         ]
       }
     },
     "/api/v1/export-import/backup": {
       "post": {
         "description": "Create a backup of profile and/or library data.\n\nReturns a streaming download of JSON (optionally gzipped).\nIncludes what was selected: profile data (playlists, favorites, play history)\nand/or library analysis data (features, embeddings, fingerprints).",
-        "operationId": "export-import_create_backup",
+        "operationId": "transfer_create_backup",
         "requestBody": {
           "content": {
             "application/json": {
@@ -13172,14 +13172,14 @@
         ],
         "summary": "Create Backup",
         "tags": [
-          "export-import"
+          "transfer"
         ]
       }
     },
     "/api/v1/export-import/export": {
       "post": {
         "description": "Export profile data as JSON.\n\nReturns a JSON file containing all selected data categories.\nTrack references use ISRC, MusicBrainz ID, and metadata for matching.",
-        "operationId": "export-import_export_profile_data",
+        "operationId": "transfer_export_profile_data",
         "requestBody": {
           "content": {
             "application/json": {
@@ -13257,14 +13257,14 @@
         ],
         "summary": "Export Profile Data",
         "tags": [
-          "export-import"
+          "transfer"
         ]
       }
     },
     "/api/v1/export-import/import/execute": {
       "post": {
         "description": "Execute an import from a previewed session.\n\nRequires a valid session_id from /import/preview.\n\nModes:\n- merge: Add new data, combine play counts, skip existing playlists\n- overwrite: Replace all data in selected categories",
-        "operationId": "export-import_execute_import",
+        "operationId": "transfer_execute_import",
         "requestBody": {
           "content": {
             "application/json": {
@@ -13344,19 +13344,19 @@
         ],
         "summary": "Execute Import",
         "tags": [
-          "export-import"
+          "transfer"
         ]
       }
     },
     "/api/v1/export-import/import/preview": {
       "post": {
         "description": "Preview an import file and get matching statistics.\n\nUpload a Familiar export JSON file to see:\n- Summary of data categories\n- Track matching results (how many tracks can be matched to your library)\n- Warnings about potential issues\n\nReturns a session_id to use with /import/execute.",
-        "operationId": "export-import_preview_import",
+        "operationId": "transfer_preview_import",
         "requestBody": {
           "content": {
             "multipart/form-data": {
               "schema": {
-                "$ref": "#/components/schemas/Body_export-import_preview_import"
+                "$ref": "#/components/schemas/Body_transfer_preview_import"
               }
             }
           },
@@ -13431,14 +13431,14 @@
         ],
         "summary": "Preview Import",
         "tags": [
-          "export-import"
+          "transfer"
         ]
       }
     },
     "/api/v1/export-import/library/export": {
       "post": {
         "description": "Export full library data for migration to another machine.\n\nIncludes:\n- Track metadata\n- Analysis features\n- Audio embeddings (optional)\n- User overrides\n\nReturns a streaming download of JSON (optionally gzipped).",
-        "operationId": "export-import_export_library",
+        "operationId": "transfer_export_library",
         "requestBody": {
           "content": {
             "application/json": {
@@ -13511,14 +13511,14 @@
         },
         "summary": "Export Library",
         "tags": [
-          "export-import"
+          "transfer"
         ]
       }
     },
     "/api/v1/export-import/library/import/execute": {
       "post": {
         "description": "Execute a library import from a previewed session.\n\nRequires a valid session_id from /library/import/preview.\n\nModes:\n- match_only: Only apply data to tracks found in library\n- merge: Fill gaps in existing data\n- replace: Overwrite existing data",
-        "operationId": "export-import_execute_library_import",
+        "operationId": "transfer_execute_library_import",
         "requestBody": {
           "content": {
             "application/json": {
@@ -13593,19 +13593,19 @@
         },
         "summary": "Execute Library Import",
         "tags": [
-          "export-import"
+          "transfer"
         ]
       }
     },
     "/api/v1/export-import/library/import/preview": {
       "post": {
         "description": "Preview a library import file and get matching statistics.\n\nUpload a Familiar library export file to see:\n- How many tracks can be matched by file_hash, acoustid, ISRC, etc.\n- Warnings about potential issues\n- Summary of importable data\n\nReturns a session_id to use with /library/import/execute.\nSupports both .json and .json.gz files.",
-        "operationId": "export-import_preview_library_import",
+        "operationId": "transfer_preview_library_import",
         "requestBody": {
           "content": {
             "multipart/form-data": {
               "schema": {
-                "$ref": "#/components/schemas/Body_export-import_preview_library_import"
+                "$ref": "#/components/schemas/Body_transfer_preview_library_import"
               }
             }
           },
@@ -13675,14 +13675,14 @@
         },
         "summary": "Preview Library Import",
         "tags": [
-          "export-import"
+          "transfer"
         ]
       }
     },
     "/api/v1/export-import/restore/execute": {
       "post": {
         "description": "Execute a restore from a previewed session.\n\nRequires a valid session_id from /restore/preview.\n\nProfile modes:\n- merge: Add new data, combine play counts, skip existing playlists\n- overwrite: Replace all data in selected categories\n\nLibrary modes:\n- match_only: Only apply to matched tracks\n- merge: Fill gaps in existing data\n- replace: Overwrite existing data",
-        "operationId": "export-import_execute_restore",
+        "operationId": "transfer_execute_restore",
         "requestBody": {
           "content": {
             "application/json": {
@@ -13762,19 +13762,19 @@
         ],
         "summary": "Execute Restore",
         "tags": [
-          "export-import"
+          "transfer"
         ]
       }
     },
     "/api/v1/export-import/restore/preview": {
       "post": {
         "description": "Preview a backup file and get matching statistics.\n\nAccepts backup files (.json or .json.gz).\nReturns a session_id to use with /restore/execute.",
-        "operationId": "export-import_preview_restore",
+        "operationId": "transfer_preview_restore",
         "requestBody": {
           "content": {
             "multipart/form-data": {
               "schema": {
-                "$ref": "#/components/schemas/Body_export-import_preview_restore"
+                "$ref": "#/components/schemas/Body_transfer_preview_restore"
               }
             }
           },
@@ -13849,7 +13849,7 @@
         ],
         "summary": "Preview Restore",
         "tags": [
-          "export-import"
+          "transfer"
         ]
       }
     },
@@ -14653,7 +14653,7 @@
     "/api/v1/health": {
       "get": {
         "description": "Basic liveness check.",
-        "operationId": "health_health_check",
+        "operationId": "system_health_check",
         "responses": {
           "200": {
             "content": {
@@ -14718,14 +14718,14 @@
         },
         "summary": "Health Check",
         "tags": [
-          "health"
+          "system"
         ]
       }
     },
     "/api/v1/health/db": {
       "get": {
         "description": "Database connectivity check.",
-        "operationId": "health_db_health_check",
+        "operationId": "system_db_health_check",
         "responses": {
           "200": {
             "content": {
@@ -14790,14 +14790,14 @@
         },
         "summary": "Db Health Check",
         "tags": [
-          "health"
+          "system"
         ]
       }
     },
     "/api/v1/health/system": {
       "get": {
         "description": "Comprehensive system health check.\n\nChecks all required services:\n- Database (PostgreSQL)\n- Redis\n- Background task status\n- Analysis backlog status\n- Library paths accessibility",
-        "operationId": "health_system_health_check",
+        "operationId": "system_system_health_check",
         "responses": {
           "200": {
             "content": {
@@ -14862,14 +14862,14 @@
         },
         "summary": "System Health Check",
         "tags": [
-          "health"
+          "system"
         ]
       }
     },
     "/api/v1/health/workers": {
       "get": {
         "description": "Get detailed status of background processing and task queues.",
-        "operationId": "health_get_worker_status",
+        "operationId": "system_get_worker_status",
         "responses": {
           "200": {
             "content": {
@@ -14934,7 +14934,7 @@
         },
         "summary": "Get Worker Status",
         "tags": [
-          "health"
+          "system"
         ]
       }
     },
@@ -26435,7 +26435,7 @@
     "/api/v1/s3-backup/cancel": {
       "post": {
         "description": "Cancel a running backup.",
-        "operationId": "s3-backup_cancel_backup",
+        "operationId": "backup_cancel_backup",
         "responses": {
           "200": {
             "content": {
@@ -26444,7 +26444,7 @@
                   "additionalProperties": {
                     "type": "string"
                   },
-                  "title": "Response S3-Backup Cancel Backup",
+                  "title": "Response Backup Cancel Backup",
                   "type": "object"
                 }
               }
@@ -26504,14 +26504,14 @@
         },
         "summary": "Cancel Backup",
         "tags": [
-          "s3-backup"
+          "backup"
         ]
       }
     },
     "/api/v1/s3-backup/estimate": {
       "get": {
         "description": "Estimate S3 backup costs based on actual library data sizes.",
-        "operationId": "s3-backup_get_cost_estimate",
+        "operationId": "backup_get_cost_estimate",
         "responses": {
           "200": {
             "content": {
@@ -26576,14 +26576,14 @@
         },
         "summary": "Get Cost Estimate",
         "tags": [
-          "s3-backup"
+          "backup"
         ]
       }
     },
     "/api/v1/s3-backup/history": {
       "get": {
         "description": "Get backup history (last 10 runs).",
-        "operationId": "s3-backup_get_backup_history",
+        "operationId": "backup_get_backup_history",
         "responses": {
           "200": {
             "content": {
@@ -26593,7 +26593,7 @@
                     "additionalProperties": true,
                     "type": "object"
                   },
-                  "title": "Response S3-Backup Get Backup History",
+                  "title": "Response Backup Get Backup History",
                   "type": "array"
                 }
               }
@@ -26653,14 +26653,14 @@
         },
         "summary": "Get Backup History",
         "tags": [
-          "s3-backup"
+          "backup"
         ]
       }
     },
     "/api/v1/s3-backup/manifest": {
       "get": {
         "description": "Get backup contents from manifest (instant, stored in S3 Standard).",
-        "operationId": "s3-backup_get_manifest",
+        "operationId": "backup_get_manifest",
         "responses": {
           "200": {
             "content": {
@@ -26725,14 +26725,14 @@
         },
         "summary": "Get Manifest",
         "tags": [
-          "s3-backup"
+          "backup"
         ]
       }
     },
     "/api/v1/s3-backup/progress": {
       "get": {
         "description": "Poll backup progress.",
-        "operationId": "s3-backup_get_progress",
+        "operationId": "backup_get_progress",
         "responses": {
           "200": {
             "content": {
@@ -26797,14 +26797,14 @@
         },
         "summary": "Get Progress",
         "tags": [
-          "s3-backup"
+          "backup"
         ]
       }
     },
     "/api/v1/s3-backup/restore": {
       "post": {
         "description": "Initiate Glacier retrieval for backed-up files.\n\nThis sends RestoreObject requests to start the 12-48 hour retrieval process.",
-        "operationId": "s3-backup_initiate_restore",
+        "operationId": "backup_initiate_restore",
         "requestBody": {
           "content": {
             "application/json": {
@@ -26821,7 +26821,7 @@
               "application/json": {
                 "schema": {
                   "additionalProperties": true,
-                  "title": "Response S3-Backup Initiate Restore",
+                  "title": "Response Backup Initiate Restore",
                   "type": "object"
                 }
               }
@@ -26881,21 +26881,21 @@
         },
         "summary": "Initiate Restore",
         "tags": [
-          "s3-backup"
+          "backup"
         ]
       }
     },
     "/api/v1/s3-backup/restore/check": {
       "post": {
         "description": "Check if Glacier retrieval is complete (HEAD requests on sample).",
-        "operationId": "s3-backup_check_restore_availability",
+        "operationId": "backup_check_restore_availability",
         "responses": {
           "200": {
             "content": {
               "application/json": {
                 "schema": {
                   "additionalProperties": true,
-                  "title": "Response S3-Backup Check Restore Availability",
+                  "title": "Response Backup Check Restore Availability",
                   "type": "object"
                 }
               }
@@ -26955,14 +26955,14 @@
         },
         "summary": "Check Restore Availability",
         "tags": [
-          "s3-backup"
+          "backup"
         ]
       }
     },
     "/api/v1/s3-backup/restore/download": {
       "post": {
         "description": "Download restored files from S3 and apply.\n\nRequires confirm=true. Creates a local safety backup first.",
-        "operationId": "s3-backup_download_and_restore",
+        "operationId": "backup_download_and_restore",
         "requestBody": {
           "content": {
             "application/json": {
@@ -26979,7 +26979,7 @@
               "application/json": {
                 "schema": {
                   "additionalProperties": true,
-                  "title": "Response S3-Backup Download And Restore",
+                  "title": "Response Backup Download And Restore",
                   "type": "object"
                 }
               }
@@ -27039,14 +27039,14 @@
         },
         "summary": "Download And Restore",
         "tags": [
-          "s3-backup"
+          "backup"
         ]
       }
     },
     "/api/v1/s3-backup/restore/progress": {
       "get": {
         "description": "Get restore download progress (reuses backup progress key).",
-        "operationId": "s3-backup_get_restore_download_progress",
+        "operationId": "backup_get_restore_download_progress",
         "responses": {
           "200": {
             "content": {
@@ -27111,21 +27111,21 @@
         },
         "summary": "Get Restore Download Progress",
         "tags": [
-          "s3-backup"
+          "backup"
         ]
       }
     },
     "/api/v1/s3-backup/restore/status": {
       "get": {
         "description": "Get Glacier retrieval progress.",
-        "operationId": "s3-backup_get_restore_status",
+        "operationId": "backup_get_restore_status",
         "responses": {
           "200": {
             "content": {
               "application/json": {
                 "schema": {
                   "additionalProperties": true,
-                  "title": "Response S3-Backup Get Restore Status",
+                  "title": "Response Backup Get Restore Status",
                   "type": "object"
                 }
               }
@@ -27185,21 +27185,21 @@
         },
         "summary": "Get Restore Status",
         "tags": [
-          "s3-backup"
+          "backup"
         ]
       }
     },
     "/api/v1/s3-backup/run": {
       "post": {
         "description": "Trigger a manual backup. Runs in background thread.",
-        "operationId": "s3-backup_trigger_backup",
+        "operationId": "backup_trigger_backup",
         "responses": {
           "200": {
             "content": {
               "application/json": {
                 "schema": {
                   "additionalProperties": true,
-                  "title": "Response S3-Backup Trigger Backup",
+                  "title": "Response Backup Trigger Backup",
                   "type": "object"
                 }
               }
@@ -27259,14 +27259,14 @@
         },
         "summary": "Trigger Backup",
         "tags": [
-          "s3-backup"
+          "backup"
         ]
       }
     },
     "/api/v1/s3-backup/status": {
       "get": {
         "description": "Get backup status: enabled, last backup, next scheduled.",
-        "operationId": "s3-backup_get_backup_status",
+        "operationId": "backup_get_backup_status",
         "responses": {
           "200": {
             "content": {
@@ -27331,14 +27331,14 @@
         },
         "summary": "Get Backup Status",
         "tags": [
-          "s3-backup"
+          "backup"
         ]
       }
     },
     "/api/v1/s3-backup/validate": {
       "post": {
         "description": "Validate AWS credentials and required S3 permissions.\n\nCredentials are read from environment variables (S3_BACKUP_ACCESS_KEY_ID,\nS3_BACKUP_SECRET_ACCESS_KEY) or settings.json via get_effective().",
-        "operationId": "s3-backup_validate_credentials",
+        "operationId": "backup_validate_credentials",
         "requestBody": {
           "content": {
             "application/json": {
@@ -27413,7 +27413,7 @@
         },
         "summary": "Validate Credentials",
         "tags": [
-          "s3-backup"
+          "backup"
         ]
       }
     },
@@ -32513,7 +32513,7 @@
     "/api/v1/updates": {
       "get": {
         "description": "Get cached update check result (no GitHub hit).",
-        "operationId": "updates_get_update_status",
+        "operationId": "system_get_update_status",
         "responses": {
           "200": {
             "content": {
@@ -32578,14 +32578,14 @@
         },
         "summary": "Get Update Status",
         "tags": [
-          "updates"
+          "system"
         ]
       }
     },
     "/api/v1/updates/check": {
       "post": {
         "description": "Trigger a fresh update check against GitHub.",
-        "operationId": "updates_trigger_update_check",
+        "operationId": "system_trigger_update_check",
         "responses": {
           "200": {
             "content": {
@@ -32650,7 +32650,7 @@
         },
         "summary": "Trigger Update Check",
         "tags": [
-          "updates"
+          "system"
         ]
       }
     },
@@ -33314,20 +33314,20 @@
       "name": "organizer"
     },
     {
-      "description": "Artist-merge operations. The `admin` name is a misnomer under ADR-0058 \u2014 most of this API is administration \u2014 and ADR-0076 point 5 is the proposal to rename it `artists`.",
-      "name": "admin"
+      "description": "Artist-merge operations, named for what they act on. Was `admin`, a name promising a namespace two-thirds of this API would qualify for and only these three used. The `/admin/artists/` prefix has not moved with the tag \u2014 that needs ADR-0079's alias module, which is accepted and unbuilt.",
+      "name": "artists"
     },
     {
-      "description": "Moving a profile or a library between servers.",
-      "name": "export-import"
+      "description": "Durability \u2014 scheduled backup to S3-compatible storage, and restore from it. Paths stay under `/s3-backup/`; the tag names the activity, not the storage backend (ADR-0076).",
+      "name": "backup"
     },
     {
-      "description": "Scheduled backup to S3-compatible storage, and restore from it.",
-      "name": "s3-backup"
+      "description": "Portability \u2014 moving a profile or a library between servers. The line against `backup` is durability versus portability, which is the line a user is already on when choosing a screen.",
+      "name": "transfer"
     },
     {
-      "description": "ZIP exports of playlists, track sets and analysis reports.",
-      "name": "download"
+      "description": "ZIP exports of playlists, track sets and analysis reports. Was `download`, which named a transport rather than what the operations produce.",
+      "name": "exports"
     },
     {
       "description": "Listener profiles. Familiar has no traditional auth; the profile id in the request header is what scopes taste, history and favourites.",
@@ -33342,20 +33342,8 @@
       "name": "settings"
     },
     {
-      "description": "Liveness. `GET /api/v1/health` is a container probe, not a client-facing endpoint.",
-      "name": "health"
-    },
-    {
-      "description": "Logs and runtime introspection.",
-      "name": "diagnostics"
-    },
-    {
-      "description": "Background job state.",
-      "name": "background"
-    },
-    {
-      "description": "Application update checks.",
-      "name": "updates"
+      "description": "The state of the running server: liveness, database and worker health, logs, metrics, background jobs and update checks. Four tags merged here under ADR-0076 \u2014 the paths did not move with them, because each already names its resource honestly (ADR-0072 point 4). `GET /api/v1/health` in particular is a container probe and stays where it is forever.",
+      "name": "system"
     }
   ],
   "x-tagGroups": [
@@ -33408,15 +33396,15 @@
         "pending-review",
         "proposed-changes",
         "organizer",
-        "admin"
+        "artists"
       ]
     },
     {
       "name": "Transfer and backup",
       "tags": [
-        "export-import",
-        "s3-backup",
-        "download"
+        "backup",
+        "transfer",
+        "exports"
       ]
     },
     {
@@ -33425,10 +33413,7 @@
         "profiles",
         "auth",
         "settings",
-        "health",
-        "diagnostics",
-        "background",
-        "updates"
+        "system"
       ]
     }
   ]

--- a/docs/decisions/ADR-0076-server-operations-are-one-surface.md
+++ b/docs/decisions/ADR-0076-server-operations-are-one-surface.md
@@ -1,12 +1,30 @@
 # ADR-0076: Server Operations Are One Surface
 
-Status: proposed
+Status: accepted
 
 Date: 2026-08-18
 
 Extends [ADR-0072](ADR-0072-paths-name-resources-tags-name-functions.md) and
 [ADR-0058](ADR-0058-the-web-app-is-an-administration-tool.md), whose point 2 named *Server* as one of
 the administration tool's three destinations. The API has no such grouping.
+
+Implementation:
+
+- **Shipped 2026-08-28** on `adr-0076-server-operations`, stacked on `ADR-0073`'s branch. Eight
+  `tags=` edits and one index update — **nothing else**.
+- **The narrowed claim was verified rather than asserted.** Diffing `backend/openapi.json` against
+  its previous revision: **zero paths added, zero removed**, 249 operations unchanged, tags 37 → 34
+  (eight removed, five added). No frontend file was touched, and the generated Swift client came
+  back byte-identical — none of these tags is in `filter.tags`.
+- Points 6 and 7 were **already done before this ADR was implemented**, both by `ADR-0072`. That is
+  the interesting part of this one's history: `0072` reached `organizer` from its tag-shape rule and
+  the aggregated router from its one-registration rule, arriving at two of `0076`'s conclusions from
+  different premises. An ADR whose points get solved by a neighbour is a sign the neighbour found the
+  more general rule.
+- **The ADR's `## Context` and `## Consequences` disagreed with each other**, and the Consequences
+  were right. Anyone drafting in this series should note the shape: the cost sentence was written
+  early, the tradeoff list was written late and after more investigation, and nothing reconciled
+  them.
 
 ## Context
 
@@ -29,49 +47,91 @@ produces.
 
 **None of this is in the generated surface.** `ADR-0014` point 5 keeps `analysis`, `settings`,
 `admin`, `s3-backup` and `export-import` deliberately out, and `health`, `diagnostics`, `background`,
-`updates` and `download` were never in. Every change in this ADR is therefore **class F** — free,
-landing in `familiar` alone, with no regeneration, no coordination and no alias. It is the largest
-legibility gain available at the lowest cost in the whole restructure, which is why it goes first.
+`updates` and `download` were never in. So no Swift regenerates and no cross-repo coordination is
+needed.
 
-**Two defects get fixed on the way past.** `health.router` is the only router registered without
-`DEFAULT_ERROR_RESPONSES` (`main.py:511` against `512-546`), so four operations document a different
-error contract from the other 256 — not by decision but because it is first in a list of 36 lines.
-And `admin` is a tag on exactly one file, `admin_artists.py`, whose three operations are artist
-merging; the name promises a namespace that two-thirds of the API would qualify for and only this
-one uses.
+**The "class F, free, no alias" claim this ADR was drafted on was wrong, and the correction is why
+the path moves are gone from the Decision below.** Free was true of the *tags* and false of the
+*paths*:
+
+- The paths this ADR proposed to move — `/health/*`, `/diagnostics/*`, `/background/jobs`,
+  `/updates*` to `/system/…`, `/download/*` to `/exports/…`, `/admin/artists/*` to `/artists/…` —
+  are **21 operations**, and the web app calls them from **18 sites across five files**
+  (`api/admin.ts`, `api/diagnosticsLogs.ts`, `api/backup.ts`, `api/download.ts`,
+  `stores/connectivityStore.ts`). Under `ADR-0058` that app is the only consumer these endpoints
+  have, so "no client calls them" was never true of this group.
+- The ADR contradicted itself: `## Consequences` already admitted `/download/*` and
+  `/admin/artists/*` "need aliases", while `## Context` said no alias was needed at all. The
+  Consequences were right, and they still understated it by omitting point 1's twelve operations —
+  the largest move of the three.
+- **`ADR-0079` is accepted but unbuilt.** Its point 5 requires a single module holding every
+  compatibility route; there is none, and `include_in_schema=False` occurs once in the codebase, on
+  an unrelated trailing-slash route in `tracks/listing.py`. The aliases these moves depend on have no
+  mechanism yet, which this ADR never noticed it was assuming.
+
+**And the largest path move contradicted the ADR it extends.** `ADR-0072` point 4: *"A path moves
+only when it misnames its resource — not to match a tag, and not for symmetry."* `/health/db`,
+`/diagnostics/metrics`, `/background/jobs` and `/updates` each name their resource honestly; the only
+argument for moving them to `/system/…` was symmetry with the new tag. That is the case point 4
+exists to refuse.
+
+**One defect this ADR claimed has already been fixed elsewhere.** `health.router` was the only router
+registered without `DEFAULT_ERROR_RESPONSES`. `ADR-0072` point 6 landed the aggregated router, so
+`health` now documents the same envelope as every other operation and there is no list left to be
+first in. `Library Organization` likewise became `organizer` under `ADR-0072` point 3. Points 6 and 7
+below are therefore **already done**, and are kept only so the record reads correctly.
+
+What remains true is the reason the ADR was written: `background` and `updates` are single-purpose
+tags of one and two operations, `ADR-0072` point 7 calls that a smell, and `admin` is a tag on one
+file whose three operations are artist merging — a name promising a namespace two-thirds of the API
+would qualify for and only this one uses.
 
 ## Decision
 
-1. **`health`, `diagnostics`, `background` and `updates` merge into one tag, `system`, at
-   `/system/…`.** Twelve operations describing the state of the running server, in one place, matching
-   the destination that consumes them.
+0. **This ADR changes tags and moves no path.** Every point below is a `tags=` edit. That is what
+   makes it free, and it is a narrowing of what was first drafted — see `## Context`. A path move
+   here would need `ADR-0079`'s alias module, which does not exist, and would reach the web app at
+   18 call sites.
+
+1. **`health`, `diagnostics`, `background` and `updates` merge into one tag, `system`.** Twelve
+   operations describing the state of the running server, in one place, matching the destination that
+   consumes them. **Their paths do not move**: `/health/*`, `/diagnostics/*`, `/background/jobs` and
+   `/updates*` each name their resource honestly, and `ADR-0072` point 4 forbids moving a path to
+   match a tag.
 
 2. **`GET /api/v1/health` stays registered at its current path forever**, unschemad, per
    `ADR-0079` point 7. Container probes and platform health checks are not clients, are not
-   versioned, and must not be part of any coordinated anything.
+   versioned, and must not be part of any coordinated anything. Under point 1 this costs nothing —
+   the path was never going to move — but it is worth stating, because the reason it must never move
+   is independent of this ADR.
 
 3. **`s3-backup` and `export-import` become `backup` and `transfer`.** Backup and restore — including
    `export-import`'s backup/restore operations — are one tag; moving a profile or a library between
    servers is another. The line is durability versus portability, and it is the line a user is
    already on when they choose a screen.
 
-4. **`download` becomes `exports`, at `/exports/…`.** The tag named a transport; the operations
-   produce ZIPs of playlists, track sets and analysis reports. Paths move under `ADR-0079`, though
-   the alias burden is small: no Swift calls them.
+4. **`download` becomes `exports`.** The tag named a transport; the operations produce ZIPs of
+   playlists, track sets and analysis reports. **`/download/*` stays where it is** — whether that
+   prefix misnames its resource is arguable in a way `/admin/` is not, and an arguable case does not
+   clear `ADR-0072` point 4's bar.
 
-5. **`admin` becomes `artists`, at `/artists/…`.** Three artist-merge operations named for what they
-   act on. The `/admin/` prefix is retired rather than reassigned — under `ADR-0058` most of this API
-   is administration, so a prefix claiming the word is worse than no prefix.
+5. **`admin` becomes `artists`.** Three artist-merge operations named for what they act on. **The
+   `/admin/` prefix stays for now, and this is the one deferral that is a genuine loss**: unlike the
+   others, `/admin/` really does misname its resource — under `ADR-0058` most of this API is
+   administration, so a prefix claiming the word is worse than no prefix. It clears point 4's bar and
+   is deferred only because `ADR-0079`'s mechanism is unbuilt and nine web-app call sites depend on
+   it. It is recorded as a follow-up rather than dropped.
 
-6. **`Library Organization` becomes `organizer`, and the router nests where its paths already are.**
-   `main.py:523` registers it at app level with prefix `/library/organize` while every other
-   `/library/*` route nests under `library.router`. It becomes its own top-level prefix `/organize`,
-   which is what it always was in everything but the URL.
+6. **`Library Organization` becomes `organizer`** — **already done**, under `ADR-0072` point 3,
+   which reached the same conclusion from the tag-shape rule rather than from this ADR's grouping
+   argument. The router nesting this point also proposed is a path move and is dropped under point 0;
+   `/library/organize` names its resource honestly.
 
-7. **One aggregated router removes the error-response inconsistency by construction.** Per
-   `ADR-0072` point 6, `routes/__init__.py` exports a single `api_router` and `main.py` includes it
-   once with `DEFAULT_ERROR_RESPONSES`. `health` cannot be the exception because there is no longer a
-   list to be first in.
+7. **One aggregated router removes the error-response inconsistency by construction** — **already
+   done**, under `ADR-0072` point 6. `routes/__init__.py` exports a single `api_router` that
+   `main.py` includes once with `DEFAULT_ERROR_RESPONSES`, so `health` cannot be the exception
+   because there is no longer a list to be first in. Recorded here because this ADR is where the
+   defect was found; the fix arrived with the mechanism that made it impossible.
 
 ## Alternatives Considered
 
@@ -95,17 +155,24 @@ is displayed on the same screen as the worker status.
 
 ## Consequences
 
-- **Positive** — the largest reorganisation in the set costs nothing: no regeneration, no
-  coordination, no alias, no risk to installed applications.
-- **Positive** — 32 tags become materially fewer, and three single-purpose tags stop being three.
+- **Positive** — once narrowed to tags, the claim the ADR was drafted on becomes true: no
+  regeneration, no coordination, no alias, no path change, nothing reaching an installed
+  application, and not one line of frontend touched.
+- **Positive** — eight tags become four, and three single-purpose tags stop being three.
 - **Positive** — the `health` error-contract inconsistency and the `Library Organization` tag are
-  both fixed by construction rather than by remembering.
-- **Tradeoff** — `/download/*` and `/admin/artists/*` paths move, so they need aliases, even though
-  no known client calls them. The alias is cheap; assuming there is no client is not, since these
-  are the endpoints a self-hoster is most likely to have scripted.
+  both already fixed, by construction, through `ADR-0072`.
+- **Tradeoff** — the tag and the path now disagree in five places: `/health/*` is tagged `system`,
+  `/download/*` is tagged `exports`, `/admin/artists/*` is tagged `artists`. That is not a defect —
+  `ADR-0072` point 1 says the two axes answer different questions — but it is the first time in this
+  restructure that they visibly diverge, and a reader who expects them to match will be surprised.
 - **Tradeoff** — merging four tags into `system` means a reader who knew where `/background/jobs` was
   has to look somewhere new. That is the point, but it is still a cost paid by the people most
   familiar with the codebase.
+- **Follow-up** — `/admin/artists/*` should still become `/artists/*`; point 5 explains why it is the
+  one path here that genuinely misnames its resource. It needs `ADR-0079`'s alias module built first,
+  and it moves nine web-app call sites.
+- **Follow-up** — **`ADR-0079` is accepted and unbuilt**, which this ADR discovered by depending on
+  it. Every remaining path move in the restructure is blocked behind that module existing.
 - **Follow-up** — after this lands, `docs/REST-API.md` describes an API that no longer exists in any
   of these areas. It is hand-written, unchecked, and covers 33 of 260 operations; reducing it to an
   orientation page that points at `/docs` belongs with this phase.


### PR DESCRIPTION
Implements **ADR-0076**, narrowed. **Stacked on #218** — merge order is #216 → #217 → #218 → this.

Paired with seethroughlab/familiar-apple#146, which is a schema re-vendor only.

## What changes

Eight tags become five. **Tags 37 → 34.**

| from | to |
|---|---|
| `health` + `diagnostics` + `background` + `updates` | `system` |
| `s3-backup` / `export-import` | `backup` / `transfer` |
| `download` | `exports` |
| `admin` | `artists` |

Eight `tags=` edits and one index update. **Nothing else.**

## The ADR was wrong about its own cost, and this narrows it

It was drafted claiming every change was *"class F — free, landing in `familiar` alone, with no regeneration, no coordination and no alias."*

Free was true of the **tags** and false of the **paths**:

- The three path moves it proposed cover **21 operations**, and the web app calls them from **18 sites across five files** (`api/admin.ts`, `api/diagnosticsLogs.ts`, `api/backup.ts`, `api/download.ts`, `stores/connectivityStore.ts`). Under ADR-0058 that app is their *only* consumer, so "no known client calls them" was never true of this group.
- **The ADR contradicted itself.** Its Consequences already admitted `/download/*` and `/admin/artists/*` needed aliases while its Context said no alias was needed at all — and the Consequences still understated it, omitting point 1's twelve operations, the largest move of the three.
- **It silently assumed ADR-0079, which is accepted but unbuilt.** Point 5 of that ADR requires a single module holding every compatibility route. There is none, and `include_in_schema=False` occurs exactly once in the codebase, on an unrelated trailing-slash route in `tracks/listing.py`.

## The largest move also contradicted the ADR it extends

> **ADR-0072 point 4:** *"A path moves only when it misnames its resource — not to match a tag, and not for symmetry."*

`/health/db`, `/diagnostics/metrics`, `/background/jobs` and `/updates` each name their resource honestly. The only argument for moving them to `/system/…` was symmetry with the new tag — the case point 4 exists to refuse.

`/admin/artists/*` is the **one genuine loss**: that prefix really does misname, since under ADR-0058 most of this API is administration. It clears point 4's bar and is deferred only because ADR-0079's mechanism is unbuilt and nine call sites depend on it. Recorded as a follow-up, not dropped.

## Verified rather than asserted

Diffing `backend/openapi.json` against its previous revision:

- **zero paths added, zero removed**
- 249 operations unchanged
- **no frontend file touched**
- generated Swift **byte-identical** — none of these tags is in `filter.tags`

Backend **1667 passed**, same four pre-existing failures. `ruff`, `mypy` (195 files), profile contracts and schema-freshness all clean.

## Points 6 and 7 were already done

Both by ADR-0072 — `organizer` from its tag-shape rule, the aggregated router from its one-registration rule. `0072` arrived at two of `0076`'s conclusions from more general premises, which is worth noticing about this set.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01Emjrwedq7W1scadHdgiLfs