### PR TITLE
Split the queue tag, and build the alias mechanism (ADR-0074, ADR-0079)

### DIFF
--- a/backend/app/api/routes/__init__.py
+++ b/backend/app/api/routes/__init__.py
@@ -25,6 +25,7 @@ from app.api.routes import (
     analysis,
     artwork,
     background,
+    compat,
     diagnostics,
     download,
     export_import,
@@ -33,6 +34,7 @@ from app.api.routes import (
     health,
     lastfm,
     library,
+    listening,
     mixtapes,
     new_releases,
     organizer,
@@ -42,7 +44,6 @@ from app.api.routes import (
     playlists,
     profiles,
     proposed_changes,
-    queue,
     s3_backup,
     smart_playlists,
     tracks,
@@ -87,7 +88,7 @@ api_router.include_router(analysis.router)
 api_router.include_router(download.router)
 api_router.include_router(updates.router)
 api_router.include_router(playback.router)
-api_router.include_router(queue.router)
+api_router.include_router(listening.router)
 api_router.include_router(external_albums.router)
 api_router.include_router(new_releases.router)
 api_router.include_router(admin_artists.router)
@@ -95,5 +96,9 @@ api_router.include_router(admin_artists.router)
 api_router.include_router(pending_review.group_router)
 api_router.include_router(pending_review.bulk_router)
 api_router.include_router(pending_review.router)
+
+# Moved paths, registered last and invisible to the schema (ADR-0079). Last because these are
+# compatibility spellings: a real route should always win a match against an alias.
+api_router.include_router(compat.router)
 
 __all__ = ["DEFAULT_ERROR_RESPONSES", "api_router"]

--- a/backend/app/api/routes/compat.py
+++ b/backend/app/api/routes/compat.py
@@ -1,0 +1,108 @@
+"""Compatibility routes for paths that have moved (ADR-0079).
+
+**Every alias in this API is in this file.** That is ADR-0079 point 5, and the reason for it is
+that an alias scattered beside its handler is an alias nobody deletes. The set is countable by
+reading one module, and removing it is one file's worth of work.
+
+How they work, and what each property is for:
+
+- **Invisible.** Every route here is `include_in_schema=False`, so none of them appears in
+  `openapi.json`, `/docs`, `/redoc`, the generated Swift client, or anything `lint_openapi.py`
+  counts. A newcomer reading the API cannot see them, which is what makes compatibility compatible
+  with the goal rather than a compromise of it (point 1).
+
+- **Delegation, never a copy.** Each alias registers the *same function object* the new path
+  registers. Not a wrapper that calls it — the same object, so FastAPI resolves identical
+  dependencies, validation and response models. Two implementations of one endpoint would drift,
+  and the second one would be the untested one (point 2).
+
+- **Announced to machines, not to people.** `Deprecation: true` and a `Sunset` date (RFC 8594) go
+  on every response, via a router-level dependency rather than per route. Anything still calling an
+  old path can be found in logs, so the removal decision is made on evidence (point 3).
+
+**The removal trigger, written down as point 4 requires.** These five come out when no App Store
+build calling `/queue/*` is still offered. At the time of writing the shipping line is `1.2`; check
+App Store Connect for `com.familiar.player` before deleting, and note that a self-hosted server may
+be older than any app. This is a condition to check, not a date to wait for.
+
+Adding an alias here is not free — see ADR-0079's Tradeoff. Each one is a path the server answers on
+that is absent from its own contract.
+"""
+
+import re
+from collections.abc import Callable
+from typing import Any
+
+from fastapi import APIRouter
+from starlette.datastructures import MutableHeaders
+from starlette.types import ASGIApp, Message, Receive, Scope, Send
+
+from app.api.routes.listening import offline, session
+from app.api.routes.listening import radio as radio_routes
+
+# RFC 8594 wants an HTTP-date. Fixed rather than computed: a `Sunset` that moves every time the
+# server restarts tells a client nothing.
+#
+# **It is indicative, not the trigger.** ADR-0079 point 4 removes an alias when the last app build
+# using the old path is no longer offered — a condition someone checks, not a date that arrives. The
+# header exists because RFC 8594 requires one for `Deprecation` to be actionable by a machine; if
+# the date passes and the build is still shipping, move the date, not the alias.
+SUNSET = "Tue, 31 Aug 2027 23:59:59 GMT"
+
+
+router = APIRouter(include_in_schema=False)
+
+# ADR-0074 moved these. **Five paths, six routes** — `/queue/session` answers GET and PUT, and the
+# ADR's "five aliases" counts paths. Left column is what shipped clients call; the handler is the
+# one the new path uses, passed by reference so there is exactly one implementation.
+_ALIASES: list[tuple[str, list[str], Callable[..., Any]]] = [
+    ("/queue/session", ["GET"], session.get_playback_session),
+    ("/queue/session", ["PUT"], session.put_playback_session),
+    ("/queue/session/archive", ["GET"], session.list_archived_sessions),
+    ("/queue/session/archive/{archive_id}/restore", ["POST"], session.restore_archived_session),
+    ("/queue/suggestions", ["POST"], radio_routes.suggestions),
+    ("/queue/offline-manifest", ["POST"], offline.offline_manifest),
+]
+
+for _path, _methods, _endpoint in _ALIASES:
+    router.add_api_route(_path, _endpoint, methods=_methods)
+
+
+# The alias paths as they arrive on the wire, including the `/api/v1` mount prefix.
+_ALIAS_PATTERNS = [
+    re.compile("^/api/v1" + re.sub(r"\{[^}]+\}", "[^/]+", path) + "/?$") for path, _, _ in _ALIASES
+]
+
+
+class DeprecatedPathHeaders:
+    """Attach `Deprecation` and `Sunset` to every response from a moved path (ADR-0079 point 3).
+
+    **This is middleware rather than a dependency, and the reason is the failure it fixes.** A
+    dependency taking `Response` sets headers on an object the *success* path returns; when a
+    handler raises — a 401 from `RequiredProfile`, a 503 from a disabled flag — the exception
+    handler builds a fresh response and those headers are silently dropped.
+
+    That would have been close to useless in practice. Point 3 exists so the alias can be found in
+    logs, and a shipped app calling a moved path *without a valid profile* is precisely a call worth
+    finding. Announcing only on success would have hidden the noisiest callers.
+
+    Operating at ASGI level means the headers are attached to whatever response is actually sent,
+    by any route, handler or exception handler.
+    """
+
+    def __init__(self, app: ASGIApp) -> None:
+        self.app = app
+
+    async def __call__(self, scope: Scope, receive: Receive, send: Send) -> None:
+        if scope["type"] != "http" or not any(p.match(scope["path"]) for p in _ALIAS_PATTERNS):
+            await self.app(scope, receive, send)
+            return
+
+        async def send_with_headers(message: Message) -> None:
+            if message["type"] == "http.response.start":
+                headers = MutableHeaders(scope=message)
+                headers["Deprecation"] = "true"
+                headers["Sunset"] = SUNSET
+            await send(message)
+
+        await self.app(scope, receive, send_with_headers)

--- a/backend/app/api/routes/listening/__init__.py
+++ b/backend/app/api/routes/listening/__init__.py
@@ -1,0 +1,26 @@
+"""What the server keeps about a listening session (ADR-0074).
+
+Three features that used to share one 700-line `queue.py` and one `queue` tag:
+
+- `session.py` — the durable playback session (ADR-0003, ADR-0028), tag `playback-session`
+- `radio.py` — what to play next (ADR-0005), tag `radio`
+- `offline.py` — the precomputed offline manifest (ADR-0006), tag `offline`
+
+**`/listening/` is a prefix, not a resource**, and ADR-0074 point 5 says so deliberately: it groups
+the session under the activity it belongs to. `/session` alone would have collided with the
+listening-sessions feature ADR-0070 removed, which is the confusion worth not inheriting.
+
+No tag is set here — the leaf routers own theirs (ADR-0072 point 2), and an aggregator that also
+tagged would concatenate onto all six operations.
+"""
+
+from fastapi import APIRouter
+
+from app.api.routes.listening import offline, radio, session
+
+router = APIRouter()
+router.include_router(session.router)
+router.include_router(radio.router)
+router.include_router(offline.router)
+
+__all__ = ["offline", "radio", "router", "session"]

--- a/backend/app/api/routes/listening/offline.py
+++ b/backend/app/api/routes/listening/offline.py
@@ -1,0 +1,116 @@
+"""The precomputed offline ranking manifest (ADR-0006).
+
+Ranks a device's downloaded tracks against each other with the same `score_candidate()` the
+online path uses, so offline and online rankings are identical by construction rather than by
+a second implementation agreeing with the first.
+
+The server keeps no record of what a device has downloaded (ADR-0006 point 3), so the client
+supplies it on every request.
+"""
+
+from uuid import UUID
+
+from fastapi import APIRouter
+from pydantic import BaseModel, Field
+
+from app.api.deps import DbSession, RequiredProfile
+from app.services.offline_manifest import (
+    DEFAULT_NEIGHBOURS,
+    build_manifest,
+    eligible_seed_ids,
+    known_presets,
+)
+from app.services.ranking_profiles import AMBIENT, RADIO
+
+router = APIRouter(prefix="/offline", tags=["offline"])
+
+
+# Ceiling on a manifest request. Generation for ~1,700 tracks measures well under two
+# seconds, so this is headroom rather than a tight limit — but the work is quadratic-ish
+# in the set size and a request should not be able to ask for unbounded compute.
+MAX_OFFLINE_TRACKS = 10_000
+class OfflineManifestRequest(BaseModel):
+    """The tracks this device has downloaded.
+
+    The server keeps no record of that (ADR-0006 decision point 3), so the client supplies
+    it. Bounded because an unbounded list is an unbounded amount of work in a request.
+    """
+
+    track_ids: list[UUID] = Field(..., max_length=MAX_OFFLINE_TRACKS)
+    neighbours: int = Field(default=DEFAULT_NEIGHBOURS, ge=1, le=50)
+
+
+class ManifestNeighbour(BaseModel):
+    track_id: UUID
+    score: float
+
+
+class ManifestEntryResponse(BaseModel):
+    track_id: UUID
+    neighbours: list[ManifestNeighbour]
+
+
+class ManifestVariant(BaseModel):
+    """One (weight profile, filter preset) combination."""
+
+    profile: str
+    filter_preset: str
+    entries: list[ManifestEntryResponse]
+    # Tracks fit to begin a session, for the offline equivalent of "surprise me".
+    seed_track_ids: list[UUID]
+
+
+class OfflineManifestResponse(BaseModel):
+    """Everything a client needs to rank offline without carrying a scorer."""
+
+    variants: list[ManifestVariant]
+    # Echoed so the client can tell a stale manifest from a current one.
+    track_count: int
+@router.post("/manifest", response_model=OfflineManifestResponse)
+async def offline_manifest(
+    request: OfflineManifestRequest,
+    db: DbSession,
+    profile: RequiredProfile,
+) -> OfflineManifestResponse:
+    """Precompute offline rankings for a device's downloaded tracks.
+
+    Ranks the supplied set against itself with the same `score_candidate()` the online
+    path uses, so offline and online rankings are identical by construction rather than
+    by two implementations intending to agree (ADR-0006).
+    """
+    variants: list[ManifestVariant] = []
+
+    # Presets change the eligible pool, and the client already passes one, so a manifest
+    # per preset is needed. Radio has no preset control, hence the single 'all' variant.
+    combinations = [(AMBIENT, preset) for preset in known_presets()]
+    combinations.append((RADIO, "all"))
+
+    for ranking_profile, preset in combinations:
+        entries = await build_manifest(
+            db,
+            request.track_ids,
+            ranking_profile,
+            filter_preset=preset,
+            neighbours=request.neighbours,
+        )
+        seeds = await eligible_seed_ids(db, request.track_ids, filter_preset=preset)
+
+        variants.append(
+            ManifestVariant(
+                profile=ranking_profile.name,
+                filter_preset=preset,
+                entries=[
+                    ManifestEntryResponse(
+                        track_id=e.track_id,
+                        neighbours=[
+                            ManifestNeighbour(track_id=tid, score=round(score, 4))
+                            for tid, score in e.neighbours
+                        ],
+                    )
+                    for e in entries
+                ],
+                seed_track_ids=seeds,
+            )
+        )
+
+    return OfflineManifestResponse(variants=variants, track_count=len(request.track_ids))

--- a/backend/app/api/routes/listening/radio.py
+++ b/backend/app/api/routes/listening/radio.py
@@ -1,0 +1,120 @@
+"""Radio — what to play next (ADR-0005).
+
+Tracks the listener is likely to enjoy, slipped into a queue they are already playing. It reuses
+the ambient ranking engine under the `RADIO` weight profile rather than being a second
+recommender — see `services/ranking_profiles.py`.
+
+Unlike the ambient routes this is **profile-aware**. Ambient ranks purely on musical
+compatibility with the current track and needs no notion of who is listening; radio weighs taste
+and past skips, which are per-profile by definition. `ambient` is allowlisted as profile-less in
+`scripts/lint_profile_contracts.py`; this module deliberately does not inherit that exemption.
+
+This docstring described the whole of `queue.py` before ADR-0074 split it — which was the
+clearest evidence of the conflation, a file named for a queue and documented as radio.
+"""
+
+from uuid import UUID
+
+from fastapi import APIRouter
+from pydantic import BaseModel, Field
+from sqlalchemy import select
+from sqlalchemy.orm import selectinload
+
+from app.api.deps import DbSession, RequiredProfile
+from app.api.exceptions import (
+    TrackNotFoundError,
+    ValidationError,
+)
+from app.api.schemas.tracks import TrackResponse
+from app.db.models import Track
+from app.services.ambient import get_candidates
+from app.services.ranking_profiles import get_profile
+
+router = APIRouter(prefix="/radio", tags=["radio"])
+
+
+class SuggestionsRequest(BaseModel):
+    """What to suggest from, and what to avoid repeating."""
+
+    # UUID rather than str: the ambient routes take strings and call bare `UUID(...)`,
+    # so a malformed id raises ValueError and surfaces as a 500 instead of a 422.
+    current_track_id: UUID
+    recent_track_ids: list[UUID] = Field(default_factory=list)
+    recent_artist_names: list[str] = Field(default_factory=list)
+    profile: str = Field(default="radio", description="Ranking profile: 'radio' or 'ambient'")
+    limit: int = Field(default=5, ge=1, le=20)
+
+
+class Suggestion(BaseModel):
+    """One suggested track and how well it scored."""
+
+    track: TrackResponse
+    score: float
+class SuggestionsResponse(BaseModel):
+    """Ranked suggestions for insertion into the playing queue."""
+
+    suggestions: list[Suggestion]
+    # Size of the retrieved candidate pool before ranking, and whether it was too small
+    # to rank meaningfully — the client can use this to stay quiet rather than insert
+    # something arbitrary.
+    pool_size: int
+    pool_collapsed: bool
+@router.post("/suggestions", response_model=SuggestionsResponse)
+async def suggestions(
+    request: SuggestionsRequest,
+    db: DbSession,
+    profile: RequiredProfile,
+) -> SuggestionsResponse:
+    """Rank tracks to insert into the queue, weighted by this profile's taste."""
+    try:
+        ranking_profile = get_profile(request.profile)
+    except ValueError as exc:
+        raise ValidationError(str(exc)) from exc
+
+    candidates, pool_size, pool_collapsed = await get_candidates(
+        db,
+        current_track_id=request.current_track_id,
+        recent_track_ids=request.recent_track_ids,
+        recent_artist_names=request.recent_artist_names,
+        limit=request.limit,
+        profile=ranking_profile,
+        profile_id=profile.id,
+    )
+
+    if not candidates:
+        # An unanalyzed or unknown seed collapses the pool rather than erroring, which is
+        # ambient's existing contract; preserve it so the client can just not insert.
+        return SuggestionsResponse(
+            suggestions=[], pool_size=pool_size, pool_collapsed=pool_collapsed
+        )
+
+    # The ranker works in descriptors, so fetch the tracks themselves for the handful
+    # that survived — the client inserts tracks, not descriptors. `analyses` is eagerly
+    # loaded because `Track.analysis_version` returns 0 when it is not.
+    ordered_ids = [c.descriptor.track_id for c in candidates]
+    tracks = (
+        (
+            await db.execute(
+                select(Track).options(selectinload(Track.analyses)).where(Track.id.in_(ordered_ids))
+            )
+        )
+        .scalars()
+        .all()
+    )
+    by_id = {t.id: t for t in tracks}
+
+    if not by_id:
+        raise TrackNotFoundError("Suggested tracks could not be loaded")
+
+    return SuggestionsResponse(
+        suggestions=[
+            Suggestion(
+                track=TrackResponse.model_validate(by_id[c.descriptor.track_id]),
+                score=round(c.compatibility_score, 4),
+            )
+            for c in candidates
+            if c.descriptor.track_id in by_id
+        ],
+        pool_size=pool_size,
+        pool_collapsed=pool_collapsed,
+    )

--- a/backend/app/api/routes/listening/session.py
+++ b/backend/app/api/routes/listening/session.py
@@ -1,14 +1,11 @@
-"""Queue suggestion endpoints (ADR-0005).
+"""The durable playback session (ADR-0003, ADR-0028).
 
-Radio: tracks the listener is likely to enjoy, slipped into a queue they are already
-playing. It reuses the ambient ranking engine under the `RADIO` weight profile rather
-than being a second recommender — see `services/ranking_profiles.py`.
+The **queue is a client concept** — the Apple client builds and owns it (ADR-0028). What the
+server keeps is a *session*: the queue a listener left behind, so another device can pick it up.
+That distinction is why this module is no longer called `queue.py` (ADR-0074).
 
-Unlike the ambient routes this is **profile-aware**. Ambient ranks purely on musical
-compatibility with the current track and needs no notion of who is listening; radio
-weighs taste and past skips, which are per-profile by definition. `ambient` is
-allowlisted as profile-less in `scripts/lint_profile_contracts.py`; this module
-deliberately does not inherit that exemption.
+Conflict resolution runs on the client's `updated_at`, because only the client knows when an
+offline edit happened. Nothing is destroyed on conflict — the loser is archived and restorable.
 """
 
 import hashlib
@@ -19,37 +16,21 @@ from uuid import UUID
 from fastapi import APIRouter
 from pydantic import BaseModel, Field
 from sqlalchemy import delete, select
-from sqlalchemy.orm import selectinload
 
 from app.api.deps import DbSession, RequiredProfile
 from app.api.exceptions import (
     ConflictError,
     NotFoundError,
     ServiceUnavailableError,
-    TrackNotFoundError,
-    ValidationError,
 )
 from app.api.schemas.common import UTCDateTime, error_responses
-from app.api.schemas.tracks import TrackResponse
-from app.db.models import PlaybackSession, PlaybackSessionArchive, Track
+from app.db.models import PlaybackSession, PlaybackSessionArchive
 from app.db.models.profiles import PlaybackSessionPayload
-from app.services.ambient import get_candidates
 from app.services.app_settings import get_app_settings_service
-from app.services.offline_manifest import (
-    DEFAULT_NEIGHBOURS,
-    build_manifest,
-    eligible_seed_ids,
-    known_presets,
-)
-from app.services.ranking_profiles import AMBIENT, RADIO, get_profile
 from app.utils.time import to_naive_utc, utcnow
 
-router = APIRouter(prefix="/queue", tags=["queue"])
+router = APIRouter(prefix="/listening/session", tags=["playback-session"])
 
-# Ceiling on a manifest request. Generation for ~1,700 tracks measures well under two
-# seconds, so this is headroom rather than a tight limit — but the work is quadratic-ish
-# in the set size and a request should not be able to ask for unbounded compute.
-MAX_OFFLINE_TRACKS = 10_000
 
 # Ceilings on a session write. The materialised queue is a window plus whatever has been
 # refilled into it, so it stays small; the reservoir is the whole eligible library, which
@@ -66,71 +47,6 @@ ARCHIVE_LIMIT = 10
 # offline edit happened — which means a device with a badly wrong clock could otherwise
 # win every conflict forever.
 MAX_CLOCK_SKEW = timedelta(minutes=5)
-
-
-# ============================================================================
-# Request / Response schemas
-# ============================================================================
-
-
-class SuggestionsRequest(BaseModel):
-    """What to suggest from, and what to avoid repeating."""
-
-    # UUID rather than str: the ambient routes take strings and call bare `UUID(...)`,
-    # so a malformed id raises ValueError and surfaces as a 500 instead of a 422.
-    current_track_id: UUID
-    recent_track_ids: list[UUID] = Field(default_factory=list)
-    recent_artist_names: list[str] = Field(default_factory=list)
-    profile: str = Field(default="radio", description="Ranking profile: 'radio' or 'ambient'")
-    limit: int = Field(default=5, ge=1, le=20)
-
-
-class Suggestion(BaseModel):
-    """One suggested track and how well it scored."""
-
-    track: TrackResponse
-    score: float
-
-
-class OfflineManifestRequest(BaseModel):
-    """The tracks this device has downloaded.
-
-    The server keeps no record of that (ADR-0006 decision point 3), so the client supplies
-    it. Bounded because an unbounded list is an unbounded amount of work in a request.
-    """
-
-    track_ids: list[UUID] = Field(..., max_length=MAX_OFFLINE_TRACKS)
-    neighbours: int = Field(default=DEFAULT_NEIGHBOURS, ge=1, le=50)
-
-
-class ManifestNeighbour(BaseModel):
-    track_id: UUID
-    score: float
-
-
-class ManifestEntryResponse(BaseModel):
-    track_id: UUID
-    neighbours: list[ManifestNeighbour]
-
-
-class ManifestVariant(BaseModel):
-    """One (weight profile, filter preset) combination."""
-
-    profile: str
-    filter_preset: str
-    entries: list[ManifestEntryResponse]
-    # Tracks fit to begin a session, for the offline equivalent of "surprise me".
-    seed_track_ids: list[UUID]
-
-
-class OfflineManifestResponse(BaseModel):
-    """Everything a client needs to rank offline without carrying a scorer."""
-
-    variants: list[ManifestVariant]
-    # Echoed so the client can tell a stale manifest from a current one.
-    track_count: int
-
-
 class LibraryFilters(BaseModel):
     """The library filters a queue was built from.
 
@@ -229,24 +145,6 @@ class ArchivedSessionResponse(BaseModel):
 
 class ArchivedSessionsResponse(BaseModel):
     sessions: list[ArchivedSessionResponse]
-
-
-class SuggestionsResponse(BaseModel):
-    """Ranked suggestions for insertion into the playing queue."""
-
-    suggestions: list[Suggestion]
-    # Size of the retrieved candidate pool before ranking, and whether it was too small
-    # to rank meaningfully — the client can use this to stay quiet rather than insert
-    # something arbitrary.
-    pool_size: int
-    pool_collapsed: bool
-
-
-# ============================================================================
-# Playback session helpers
-# ============================================================================
-
-
 def reservoir_digest(ids: list[str]) -> str | None:
     """Hash a reservoir so an unchanged one can be referenced instead of resent.
 
@@ -402,15 +300,8 @@ async def _load_session(db: DbSession, profile_id: UUID) -> PlaybackSession | No
     return (
         await db.execute(select(PlaybackSession).where(PlaybackSession.profile_id == profile_id))
     ).scalar_one_or_none()
-
-
-# ============================================================================
-# Endpoints
-# ============================================================================
-
-
 @router.get(
-    "/session",
+    "",
     response_model=PlaybackSessionResponse,
     # 503 is control flow too: these four are gated behind `queue_sync_enabled`, so "the server
     # does not do this" is an ordinary answer a client must expect on its very first call, not a
@@ -436,7 +327,7 @@ async def get_playback_session(
 
 
 @router.put(
-    "/session",
+    "",
     response_model=PlaybackSessionResponse,
     # 409 is control flow here, not an error condition: it means the client named a reservoir
     # hash the server does not hold and must resend `reservoir_ids` in full. A client that cannot
@@ -501,7 +392,7 @@ async def put_playback_session(
 
 
 @router.get(
-    "/session/archive",
+    "/archive",
     response_model=ArchivedSessionsResponse,
     responses=error_responses(503),
 )
@@ -544,7 +435,7 @@ async def list_archived_sessions(
 
 
 @router.post(
-    "/session/archive/{archive_id}/restore",
+    "/archive/{archive_id}/restore",
     response_model=PlaybackSessionResponse,
     responses=error_responses(404, 503),
 )
@@ -587,114 +478,3 @@ async def restore_archived_session(
     await db.commit()
     await db.refresh(session)
     return _to_response(session)
-
-
-@router.post("/suggestions", response_model=SuggestionsResponse)
-async def suggestions(
-    request: SuggestionsRequest,
-    db: DbSession,
-    profile: RequiredProfile,
-) -> SuggestionsResponse:
-    """Rank tracks to insert into the queue, weighted by this profile's taste."""
-    try:
-        ranking_profile = get_profile(request.profile)
-    except ValueError as exc:
-        raise ValidationError(str(exc)) from exc
-
-    candidates, pool_size, pool_collapsed = await get_candidates(
-        db,
-        current_track_id=request.current_track_id,
-        recent_track_ids=request.recent_track_ids,
-        recent_artist_names=request.recent_artist_names,
-        limit=request.limit,
-        profile=ranking_profile,
-        profile_id=profile.id,
-    )
-
-    if not candidates:
-        # An unanalyzed or unknown seed collapses the pool rather than erroring, which is
-        # ambient's existing contract; preserve it so the client can just not insert.
-        return SuggestionsResponse(
-            suggestions=[], pool_size=pool_size, pool_collapsed=pool_collapsed
-        )
-
-    # The ranker works in descriptors, so fetch the tracks themselves for the handful
-    # that survived — the client inserts tracks, not descriptors. `analyses` is eagerly
-    # loaded because `Track.analysis_version` returns 0 when it is not.
-    ordered_ids = [c.descriptor.track_id for c in candidates]
-    tracks = (
-        (
-            await db.execute(
-                select(Track).options(selectinload(Track.analyses)).where(Track.id.in_(ordered_ids))
-            )
-        )
-        .scalars()
-        .all()
-    )
-    by_id = {t.id: t for t in tracks}
-
-    if not by_id:
-        raise TrackNotFoundError("Suggested tracks could not be loaded")
-
-    return SuggestionsResponse(
-        suggestions=[
-            Suggestion(
-                track=TrackResponse.model_validate(by_id[c.descriptor.track_id]),
-                score=round(c.compatibility_score, 4),
-            )
-            for c in candidates
-            if c.descriptor.track_id in by_id
-        ],
-        pool_size=pool_size,
-        pool_collapsed=pool_collapsed,
-    )
-
-
-@router.post("/offline-manifest", response_model=OfflineManifestResponse)
-async def offline_manifest(
-    request: OfflineManifestRequest,
-    db: DbSession,
-    profile: RequiredProfile,
-) -> OfflineManifestResponse:
-    """Precompute offline rankings for a device's downloaded tracks.
-
-    Ranks the supplied set against itself with the same `score_candidate()` the online
-    path uses, so offline and online rankings are identical by construction rather than
-    by two implementations intending to agree (ADR-0006).
-    """
-    variants: list[ManifestVariant] = []
-
-    # Presets change the eligible pool, and the client already passes one, so a manifest
-    # per preset is needed. Radio has no preset control, hence the single 'all' variant.
-    combinations = [(AMBIENT, preset) for preset in known_presets()]
-    combinations.append((RADIO, "all"))
-
-    for ranking_profile, preset in combinations:
-        entries = await build_manifest(
-            db,
-            request.track_ids,
-            ranking_profile,
-            filter_preset=preset,
-            neighbours=request.neighbours,
-        )
-        seeds = await eligible_seed_ids(db, request.track_ids, filter_preset=preset)
-
-        variants.append(
-            ManifestVariant(
-                profile=ranking_profile.name,
-                filter_preset=preset,
-                entries=[
-                    ManifestEntryResponse(
-                        track_id=e.track_id,
-                        neighbours=[
-                            ManifestNeighbour(track_id=tid, score=round(score, 4))
-                            for tid, score in e.neighbours
-                        ],
-                    )
-                    for e in entries
-                ],
-                seed_track_ids=seeds,
-            )
-        )
-
-    return OfflineManifestResponse(variants=variants, track_count=len(request.track_ids))

--- a/backend/app/main.py
+++ b/backend/app/main.py
@@ -30,6 +30,7 @@ from starlette.types import ASGIApp, Message, Receive, Scope, Send
 from app.api.exceptions import FamiliarError, NotFoundError
 from app.api.ratelimit import limiter
 from app.api.routes import api_router
+from app.api.routes.compat import DeprecatedPathHeaders
 from app.config import AUDIO_EXTENSIONS, MUSIC_LIBRARY_PATH, get_app_version
 from app.config import settings as app_config
 from app.logging_config import get_logger, setup_logging
@@ -354,9 +355,16 @@ OPENAPI_TAGS = [
     {"name": "favorites", "description": "Per-profile favourites."},
 
     # Playback — what is playing, and where.
-    {"name": "queue", "description":
-        "The server-owned playback queue and its radio suggestions (ADR-0003, ADR-0005). "
-        "ADR-0074 is the proposal that this tag names three different things."},
+    {"name": "playback-session", "description":
+        "The durable playback session — the queue a listener left behind, so another device can "
+        "pick it up (ADR-0003, ADR-0028). The queue itself is a client concept; what the server "
+        "keeps is the session, which is why neither this tag nor its path says \"queue\"."},
+    {"name": "radio", "description":
+        "What to play next: tracks ranked for this profile's taste and skip history, to slip into "
+        "a queue already playing (ADR-0005)."},
+    {"name": "offline", "description":
+        "The precomputed offline ranking manifest (ADR-0006), so a client can rank without "
+        "carrying a scorer."},
     {"name": "playback", "description":
         "Transport state reported by a client, so other surfaces can show what is playing."},
     {"name": "outputs", "description":
@@ -418,7 +426,8 @@ OPENAPI_TAG_GROUPS = [
     {"name": "Music", "tags": ["library", "tracks", "map", "analysis", "artwork"]},
     {"name": "Collections", "tags": ["playlists", "smart-playlists", "mixtapes", "favorites"]},
     {"name": "Playback", "tags": [
-        "queue", "playback", "plays", "outputs", "videos", "visualizers"]},
+        "playback-session", "radio", "offline", "playback", "plays", "outputs", "videos",
+        "visualizers"]},
     {"name": "Discovery", "tags": ["discover", "lastfm", "new-releases", "external-albums"]},
     {"name": "Curation", "tags": [
         "ingest", "metadata", "identification", "duplicates",
@@ -609,6 +618,10 @@ async def generic_exception_handler(request: Request, exc: Exception) -> JSONRes
 # shape the server actually sends. Routes add their own statuses on top where one is real control
 # flow.
 app.include_router(api_router, prefix="/api/v1")
+
+# Moved paths announce themselves (ADR-0079 point 3). Registered as middleware rather than as a
+# route dependency because the headers must survive an error response — see the class docstring.
+app.add_middleware(DeprecatedPathHeaders)
 
 
 def _openapi_with_global_security() -> dict[str, Any]:

--- a/backend/openapi.json
+++ b/backend/openapi.json
@@ -18879,6 +18879,384 @@
         ]
       }
     },
+    "/api/v1/listening/session": {
+      "get": {
+        "description": "Return this profile's durable queue.\n\nAn empty session rather than a 404 when there is none: \"no queue yet\" is the ordinary\nstarting state, not an error, and a client adopting it should not have to special-case\na status code.",
+        "operationId": "playback-session_get_playback_session",
+        "responses": {
+          "200": {
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/PlaybackSessionResponse"
+                }
+              }
+            },
+            "description": "Successful Response"
+          },
+          "400": {
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/ErrorEnvelope"
+                }
+              }
+            },
+            "description": "Bad Request"
+          },
+          "401": {
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/ErrorEnvelope"
+                }
+              }
+            },
+            "description": "Unauthorized"
+          },
+          "404": {
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/ErrorEnvelope"
+                }
+              }
+            },
+            "description": "Not Found"
+          },
+          "422": {
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/ErrorEnvelope"
+                }
+              }
+            },
+            "description": "Unprocessable Entity"
+          },
+          "500": {
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/ErrorEnvelope"
+                }
+              }
+            },
+            "description": "Internal Server Error"
+          },
+          "503": {
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/ErrorEnvelope"
+                }
+              }
+            },
+            "description": "Service Unavailable"
+          }
+        },
+        "security": [
+          {
+            "ProfileHeader": []
+          }
+        ],
+        "summary": "Get Playback Session",
+        "tags": [
+          "playback-session"
+        ]
+      },
+      "put": {
+        "description": "Upsert this profile's durable queue.\n\nOrdinary case: the client's `version` matches what is stored, so this is the next step\nin one device's own history and simply overwrites.\n\nConflict case: the client wrote from a stale version, meaning two devices diverged \u2014\ntypically because one was offline. The later `updated_at` wins and the loser is\narchived, never dropped (ADR-0003 point 6). A losing write still gets the winning\nsession back, so the client adopts rather than retries.",
+        "operationId": "playback-session_put_playback_session",
+        "requestBody": {
+          "content": {
+            "application/json": {
+              "schema": {
+                "$ref": "#/components/schemas/PlaybackSessionWrite"
+              }
+            }
+          },
+          "required": true
+        },
+        "responses": {
+          "200": {
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/PlaybackSessionResponse"
+                }
+              }
+            },
+            "description": "Successful Response"
+          },
+          "400": {
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/ErrorEnvelope"
+                }
+              }
+            },
+            "description": "Bad Request"
+          },
+          "401": {
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/ErrorEnvelope"
+                }
+              }
+            },
+            "description": "Unauthorized"
+          },
+          "404": {
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/ErrorEnvelope"
+                }
+              }
+            },
+            "description": "Not Found"
+          },
+          "409": {
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/ErrorEnvelope"
+                }
+              }
+            },
+            "description": "Conflict"
+          },
+          "422": {
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/ErrorEnvelope"
+                }
+              }
+            },
+            "description": "Unprocessable Entity"
+          },
+          "500": {
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/ErrorEnvelope"
+                }
+              }
+            },
+            "description": "Internal Server Error"
+          },
+          "503": {
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/ErrorEnvelope"
+                }
+              }
+            },
+            "description": "Service Unavailable"
+          }
+        },
+        "security": [
+          {
+            "ProfileHeader": []
+          }
+        ],
+        "summary": "Put Playback Session",
+        "tags": [
+          "playback-session"
+        ]
+      }
+    },
+    "/api/v1/listening/session/archive": {
+      "get": {
+        "description": "List queues that lost a conflict and can still be restored.",
+        "operationId": "playback-session_list_archived_sessions",
+        "responses": {
+          "200": {
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/ArchivedSessionsResponse"
+                }
+              }
+            },
+            "description": "Successful Response"
+          },
+          "400": {
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/ErrorEnvelope"
+                }
+              }
+            },
+            "description": "Bad Request"
+          },
+          "401": {
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/ErrorEnvelope"
+                }
+              }
+            },
+            "description": "Unauthorized"
+          },
+          "404": {
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/ErrorEnvelope"
+                }
+              }
+            },
+            "description": "Not Found"
+          },
+          "422": {
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/ErrorEnvelope"
+                }
+              }
+            },
+            "description": "Unprocessable Entity"
+          },
+          "500": {
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/ErrorEnvelope"
+                }
+              }
+            },
+            "description": "Internal Server Error"
+          },
+          "503": {
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/ErrorEnvelope"
+                }
+              }
+            },
+            "description": "Service Unavailable"
+          }
+        },
+        "security": [
+          {
+            "ProfileHeader": []
+          }
+        ],
+        "summary": "List Archived Sessions",
+        "tags": [
+          "playback-session"
+        ]
+      }
+    },
+    "/api/v1/listening/session/archive/{archive_id}/restore": {
+      "post": {
+        "description": "Make an archived queue current again.\n\nSymmetrical with the conflict rule: whatever is live now is archived in its place, so\nrestoring cannot itself destroy a queue.",
+        "operationId": "playback-session_restore_archived_session",
+        "parameters": [
+          {
+            "in": "path",
+            "name": "archive_id",
+            "required": true,
+            "schema": {
+              "format": "uuid",
+              "title": "Archive Id",
+              "type": "string"
+            }
+          }
+        ],
+        "responses": {
+          "200": {
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/PlaybackSessionResponse"
+                }
+              }
+            },
+            "description": "Successful Response"
+          },
+          "400": {
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/ErrorEnvelope"
+                }
+              }
+            },
+            "description": "Bad Request"
+          },
+          "401": {
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/ErrorEnvelope"
+                }
+              }
+            },
+            "description": "Unauthorized"
+          },
+          "404": {
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/ErrorEnvelope"
+                }
+              }
+            },
+            "description": "Not Found"
+          },
+          "422": {
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/ErrorEnvelope"
+                }
+              }
+            },
+            "description": "Unprocessable Entity"
+          },
+          "500": {
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/ErrorEnvelope"
+                }
+              }
+            },
+            "description": "Internal Server Error"
+          },
+          "503": {
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/ErrorEnvelope"
+                }
+              }
+            },
+            "description": "Service Unavailable"
+          }
+        },
+        "security": [
+          {
+            "ProfileHeader": []
+          }
+        ],
+        "summary": "Restore Archived Session",
+        "tags": [
+          "playback-session"
+        ]
+      }
+    },
     "/api/v1/mixtapes": {
       "get": {
         "description": "List the current profile's mixtapes, newest first.\n\nFor rows that are still pending/rendering, merges live phase + progress\nfrom Redis so the header indicator can render phase labels without\npolling each id individually.",
@@ -19793,6 +20171,93 @@
         "summary": "Dismiss Release",
         "tags": [
           "new-releases"
+        ]
+      }
+    },
+    "/api/v1/offline/manifest": {
+      "post": {
+        "description": "Precompute offline rankings for a device's downloaded tracks.\n\nRanks the supplied set against itself with the same `score_candidate()` the online\npath uses, so offline and online rankings are identical by construction rather than\nby two implementations intending to agree (ADR-0006).",
+        "operationId": "offline_offline_manifest",
+        "requestBody": {
+          "content": {
+            "application/json": {
+              "schema": {
+                "$ref": "#/components/schemas/OfflineManifestRequest"
+              }
+            }
+          },
+          "required": true
+        },
+        "responses": {
+          "200": {
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/OfflineManifestResponse"
+                }
+              }
+            },
+            "description": "Successful Response"
+          },
+          "400": {
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/ErrorEnvelope"
+                }
+              }
+            },
+            "description": "Bad Request"
+          },
+          "401": {
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/ErrorEnvelope"
+                }
+              }
+            },
+            "description": "Unauthorized"
+          },
+          "404": {
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/ErrorEnvelope"
+                }
+              }
+            },
+            "description": "Not Found"
+          },
+          "422": {
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/ErrorEnvelope"
+                }
+              }
+            },
+            "description": "Unprocessable Entity"
+          },
+          "500": {
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/ErrorEnvelope"
+                }
+              }
+            },
+            "description": "Internal Server Error"
+          }
+        },
+        "security": [
+          {
+            "ProfileHeader": []
+          }
+        ],
+        "summary": "Offline Manifest",
+        "tags": [
+          "offline"
         ]
       }
     },
@@ -25880,475 +26345,10 @@
         ]
       }
     },
-    "/api/v1/queue/offline-manifest": {
-      "post": {
-        "description": "Precompute offline rankings for a device's downloaded tracks.\n\nRanks the supplied set against itself with the same `score_candidate()` the online\npath uses, so offline and online rankings are identical by construction rather than\nby two implementations intending to agree (ADR-0006).",
-        "operationId": "queue_offline_manifest",
-        "requestBody": {
-          "content": {
-            "application/json": {
-              "schema": {
-                "$ref": "#/components/schemas/OfflineManifestRequest"
-              }
-            }
-          },
-          "required": true
-        },
-        "responses": {
-          "200": {
-            "content": {
-              "application/json": {
-                "schema": {
-                  "$ref": "#/components/schemas/OfflineManifestResponse"
-                }
-              }
-            },
-            "description": "Successful Response"
-          },
-          "400": {
-            "content": {
-              "application/json": {
-                "schema": {
-                  "$ref": "#/components/schemas/ErrorEnvelope"
-                }
-              }
-            },
-            "description": "Bad Request"
-          },
-          "401": {
-            "content": {
-              "application/json": {
-                "schema": {
-                  "$ref": "#/components/schemas/ErrorEnvelope"
-                }
-              }
-            },
-            "description": "Unauthorized"
-          },
-          "404": {
-            "content": {
-              "application/json": {
-                "schema": {
-                  "$ref": "#/components/schemas/ErrorEnvelope"
-                }
-              }
-            },
-            "description": "Not Found"
-          },
-          "422": {
-            "content": {
-              "application/json": {
-                "schema": {
-                  "$ref": "#/components/schemas/ErrorEnvelope"
-                }
-              }
-            },
-            "description": "Unprocessable Entity"
-          },
-          "500": {
-            "content": {
-              "application/json": {
-                "schema": {
-                  "$ref": "#/components/schemas/ErrorEnvelope"
-                }
-              }
-            },
-            "description": "Internal Server Error"
-          }
-        },
-        "security": [
-          {
-            "ProfileHeader": []
-          }
-        ],
-        "summary": "Offline Manifest",
-        "tags": [
-          "queue"
-        ]
-      }
-    },
-    "/api/v1/queue/session": {
-      "get": {
-        "description": "Return this profile's durable queue.\n\nAn empty session rather than a 404 when there is none: \"no queue yet\" is the ordinary\nstarting state, not an error, and a client adopting it should not have to special-case\na status code.",
-        "operationId": "queue_get_playback_session",
-        "responses": {
-          "200": {
-            "content": {
-              "application/json": {
-                "schema": {
-                  "$ref": "#/components/schemas/PlaybackSessionResponse"
-                }
-              }
-            },
-            "description": "Successful Response"
-          },
-          "400": {
-            "content": {
-              "application/json": {
-                "schema": {
-                  "$ref": "#/components/schemas/ErrorEnvelope"
-                }
-              }
-            },
-            "description": "Bad Request"
-          },
-          "401": {
-            "content": {
-              "application/json": {
-                "schema": {
-                  "$ref": "#/components/schemas/ErrorEnvelope"
-                }
-              }
-            },
-            "description": "Unauthorized"
-          },
-          "404": {
-            "content": {
-              "application/json": {
-                "schema": {
-                  "$ref": "#/components/schemas/ErrorEnvelope"
-                }
-              }
-            },
-            "description": "Not Found"
-          },
-          "422": {
-            "content": {
-              "application/json": {
-                "schema": {
-                  "$ref": "#/components/schemas/ErrorEnvelope"
-                }
-              }
-            },
-            "description": "Unprocessable Entity"
-          },
-          "500": {
-            "content": {
-              "application/json": {
-                "schema": {
-                  "$ref": "#/components/schemas/ErrorEnvelope"
-                }
-              }
-            },
-            "description": "Internal Server Error"
-          },
-          "503": {
-            "content": {
-              "application/json": {
-                "schema": {
-                  "$ref": "#/components/schemas/ErrorEnvelope"
-                }
-              }
-            },
-            "description": "Service Unavailable"
-          }
-        },
-        "security": [
-          {
-            "ProfileHeader": []
-          }
-        ],
-        "summary": "Get Playback Session",
-        "tags": [
-          "queue"
-        ]
-      },
-      "put": {
-        "description": "Upsert this profile's durable queue.\n\nOrdinary case: the client's `version` matches what is stored, so this is the next step\nin one device's own history and simply overwrites.\n\nConflict case: the client wrote from a stale version, meaning two devices diverged \u2014\ntypically because one was offline. The later `updated_at` wins and the loser is\narchived, never dropped (ADR-0003 point 6). A losing write still gets the winning\nsession back, so the client adopts rather than retries.",
-        "operationId": "queue_put_playback_session",
-        "requestBody": {
-          "content": {
-            "application/json": {
-              "schema": {
-                "$ref": "#/components/schemas/PlaybackSessionWrite"
-              }
-            }
-          },
-          "required": true
-        },
-        "responses": {
-          "200": {
-            "content": {
-              "application/json": {
-                "schema": {
-                  "$ref": "#/components/schemas/PlaybackSessionResponse"
-                }
-              }
-            },
-            "description": "Successful Response"
-          },
-          "400": {
-            "content": {
-              "application/json": {
-                "schema": {
-                  "$ref": "#/components/schemas/ErrorEnvelope"
-                }
-              }
-            },
-            "description": "Bad Request"
-          },
-          "401": {
-            "content": {
-              "application/json": {
-                "schema": {
-                  "$ref": "#/components/schemas/ErrorEnvelope"
-                }
-              }
-            },
-            "description": "Unauthorized"
-          },
-          "404": {
-            "content": {
-              "application/json": {
-                "schema": {
-                  "$ref": "#/components/schemas/ErrorEnvelope"
-                }
-              }
-            },
-            "description": "Not Found"
-          },
-          "409": {
-            "content": {
-              "application/json": {
-                "schema": {
-                  "$ref": "#/components/schemas/ErrorEnvelope"
-                }
-              }
-            },
-            "description": "Conflict"
-          },
-          "422": {
-            "content": {
-              "application/json": {
-                "schema": {
-                  "$ref": "#/components/schemas/ErrorEnvelope"
-                }
-              }
-            },
-            "description": "Unprocessable Entity"
-          },
-          "500": {
-            "content": {
-              "application/json": {
-                "schema": {
-                  "$ref": "#/components/schemas/ErrorEnvelope"
-                }
-              }
-            },
-            "description": "Internal Server Error"
-          },
-          "503": {
-            "content": {
-              "application/json": {
-                "schema": {
-                  "$ref": "#/components/schemas/ErrorEnvelope"
-                }
-              }
-            },
-            "description": "Service Unavailable"
-          }
-        },
-        "security": [
-          {
-            "ProfileHeader": []
-          }
-        ],
-        "summary": "Put Playback Session",
-        "tags": [
-          "queue"
-        ]
-      }
-    },
-    "/api/v1/queue/session/archive": {
-      "get": {
-        "description": "List queues that lost a conflict and can still be restored.",
-        "operationId": "queue_list_archived_sessions",
-        "responses": {
-          "200": {
-            "content": {
-              "application/json": {
-                "schema": {
-                  "$ref": "#/components/schemas/ArchivedSessionsResponse"
-                }
-              }
-            },
-            "description": "Successful Response"
-          },
-          "400": {
-            "content": {
-              "application/json": {
-                "schema": {
-                  "$ref": "#/components/schemas/ErrorEnvelope"
-                }
-              }
-            },
-            "description": "Bad Request"
-          },
-          "401": {
-            "content": {
-              "application/json": {
-                "schema": {
-                  "$ref": "#/components/schemas/ErrorEnvelope"
-                }
-              }
-            },
-            "description": "Unauthorized"
-          },
-          "404": {
-            "content": {
-              "application/json": {
-                "schema": {
-                  "$ref": "#/components/schemas/ErrorEnvelope"
-                }
-              }
-            },
-            "description": "Not Found"
-          },
-          "422": {
-            "content": {
-              "application/json": {
-                "schema": {
-                  "$ref": "#/components/schemas/ErrorEnvelope"
-                }
-              }
-            },
-            "description": "Unprocessable Entity"
-          },
-          "500": {
-            "content": {
-              "application/json": {
-                "schema": {
-                  "$ref": "#/components/schemas/ErrorEnvelope"
-                }
-              }
-            },
-            "description": "Internal Server Error"
-          },
-          "503": {
-            "content": {
-              "application/json": {
-                "schema": {
-                  "$ref": "#/components/schemas/ErrorEnvelope"
-                }
-              }
-            },
-            "description": "Service Unavailable"
-          }
-        },
-        "security": [
-          {
-            "ProfileHeader": []
-          }
-        ],
-        "summary": "List Archived Sessions",
-        "tags": [
-          "queue"
-        ]
-      }
-    },
-    "/api/v1/queue/session/archive/{archive_id}/restore": {
-      "post": {
-        "description": "Make an archived queue current again.\n\nSymmetrical with the conflict rule: whatever is live now is archived in its place, so\nrestoring cannot itself destroy a queue.",
-        "operationId": "queue_restore_archived_session",
-        "parameters": [
-          {
-            "in": "path",
-            "name": "archive_id",
-            "required": true,
-            "schema": {
-              "format": "uuid",
-              "title": "Archive Id",
-              "type": "string"
-            }
-          }
-        ],
-        "responses": {
-          "200": {
-            "content": {
-              "application/json": {
-                "schema": {
-                  "$ref": "#/components/schemas/PlaybackSessionResponse"
-                }
-              }
-            },
-            "description": "Successful Response"
-          },
-          "400": {
-            "content": {
-              "application/json": {
-                "schema": {
-                  "$ref": "#/components/schemas/ErrorEnvelope"
-                }
-              }
-            },
-            "description": "Bad Request"
-          },
-          "401": {
-            "content": {
-              "application/json": {
-                "schema": {
-                  "$ref": "#/components/schemas/ErrorEnvelope"
-                }
-              }
-            },
-            "description": "Unauthorized"
-          },
-          "404": {
-            "content": {
-              "application/json": {
-                "schema": {
-                  "$ref": "#/components/schemas/ErrorEnvelope"
-                }
-              }
-            },
-            "description": "Not Found"
-          },
-          "422": {
-            "content": {
-              "application/json": {
-                "schema": {
-                  "$ref": "#/components/schemas/ErrorEnvelope"
-                }
-              }
-            },
-            "description": "Unprocessable Entity"
-          },
-          "500": {
-            "content": {
-              "application/json": {
-                "schema": {
-                  "$ref": "#/components/schemas/ErrorEnvelope"
-                }
-              }
-            },
-            "description": "Internal Server Error"
-          },
-          "503": {
-            "content": {
-              "application/json": {
-                "schema": {
-                  "$ref": "#/components/schemas/ErrorEnvelope"
-                }
-              }
-            },
-            "description": "Service Unavailable"
-          }
-        },
-        "security": [
-          {
-            "ProfileHeader": []
-          }
-        ],
-        "summary": "Restore Archived Session",
-        "tags": [
-          "queue"
-        ]
-      }
-    },
-    "/api/v1/queue/suggestions": {
+    "/api/v1/radio/suggestions": {
       "post": {
         "description": "Rank tracks to insert into the queue, weighted by this profile's taste.",
-        "operationId": "queue_suggestions",
+        "operationId": "radio_suggestions",
         "requestBody": {
           "content": {
             "application/json": {
@@ -26428,7 +26428,7 @@
         ],
         "summary": "Suggestions",
         "tags": [
-          "queue"
+          "radio"
         ]
       }
     },
@@ -33274,8 +33274,16 @@
       "name": "favorites"
     },
     {
-      "description": "The server-owned playback queue and its radio suggestions (ADR-0003, ADR-0005). ADR-0074 is the proposal that this tag names three different things.",
-      "name": "queue"
+      "description": "The durable playback session \u2014 the queue a listener left behind, so another device can pick it up (ADR-0003, ADR-0028). The queue itself is a client concept; what the server keeps is the session, which is why neither this tag nor its path says \"queue\".",
+      "name": "playback-session"
+    },
+    {
+      "description": "What to play next: tracks ranked for this profile's taste and skip history, to slip into a queue already playing (ADR-0005).",
+      "name": "radio"
+    },
+    {
+      "description": "The precomputed offline ranking manifest (ADR-0006), so a client can rank without carrying a scorer.",
+      "name": "offline"
     },
     {
       "description": "Transport state reported by a client, so other surfaces can show what is playing.",
@@ -33369,7 +33377,9 @@
     {
       "name": "Playback",
       "tags": [
-        "queue",
+        "playback-session",
+        "radio",
+        "offline",
         "playback",
         "plays",
         "outputs",

--- a/backend/scripts/lint_openapi.py
+++ b/backend/scripts/lint_openapi.py
@@ -82,7 +82,13 @@ VENDORED_TAGS = {
     "favorites",
     # Radio and offline ranking (ADR-0005, ADR-0006). Native clients consume these directly — the
     # whole point of ADR-0006 is that they carry no ranking code.
-    "queue",
+    #
+    # Three tags since ADR-0074 split `queue`, which named a session, a recommender and a manifest
+    # at once. All three stay generated: Swift calls the session and radio today, and ADR-0077
+    # point 4 kept the offline manifest precisely because ADR-0006 says its client is coming.
+    "playback-session",
+    "radio",
+    "offline",
     # Management surfaces the Mac app gained (ADR-0013, generated per ADR-0014). Not on iOS, which
     # ADR-0013 point 2 keeps on the listening path — but the generated client is shared by both
     # targets, so iOS compiles these and never calls them.

--- a/backend/tests/test_compat_aliases.py
+++ b/backend/tests/test_compat_aliases.py
@@ -1,0 +1,124 @@
+"""The moved paths still answer (ADR-0079).
+
+**This file is the reason aliases are safe to have.** An alias is invisible — absent from
+`openapi.json`, from `/docs`, from the generated client, and from everything `lint_openapi.py`
+counts. Nothing else in the build would notice if one stopped working, and the clients that depend
+on it are *already installed*: shipped iOS and macOS builds call `/queue/session` and
+`/queue/suggestions`, and cannot be fixed by editing this repository.
+
+So the two properties are asserted directly:
+
+1. **The old path reaches the same handler**, with the same auth and validation behaviour. A 404
+   here means a shipped app has silently lost a feature.
+2. **The alias is invisible**, which is what stops it becoming a second public spelling of the API.
+
+The bar is deliberately low per test — reaching the handler, not exercising its logic, which
+`test_playback_session.py`, `test_queue_suggestions.py` and `test_offline_manifest.py` already do
+against the new paths. What matters is *routing*, since that is the only thing the move can break.
+"""
+
+import pytest
+from fastapi.testclient import TestClient
+
+from app.api.routes.compat import _ALIASES, SUNSET
+
+# (method, old path, new path). Five paths, six routes — `/queue/session` answers GET and PUT.
+MOVED = [
+    ("GET", "/api/v1/queue/session", "/api/v1/listening/session"),
+    ("PUT", "/api/v1/queue/session", "/api/v1/listening/session"),
+    ("GET", "/api/v1/queue/session/archive", "/api/v1/listening/session/archive"),
+    (
+        "POST",
+        "/api/v1/queue/session/archive/00000000-0000-0000-0000-000000000000/restore",
+        "/api/v1/listening/session/archive/00000000-0000-0000-0000-000000000000/restore",
+    ),
+    ("POST", "/api/v1/queue/suggestions", "/api/v1/radio/suggestions"),
+    ("POST", "/api/v1/queue/offline-manifest", "/api/v1/offline/manifest"),
+]
+
+
+def _ids(param):
+    return f"{param[0]}-{param[1].replace('/api/v1/', '')}"
+
+
+@pytest.mark.parametrize(("method", "old", "new"), MOVED, ids=[_ids(m) for m in MOVED])
+def test_the_old_path_is_still_routed(client: TestClient, method: str, old: str, new: str) -> None:
+    """The alias reaches a handler rather than the 404 a deleted route would give.
+
+    Sent without a profile header, so every one of these answers 401 from `RequiredProfile`
+    (ADR-0045). That is the point: a 401 proves the request got *into* the handler's dependency
+    chain. A 404 would mean the path no longer resolves at all.
+    """
+    response = getattr(client, method.lower())(old)
+    assert response.status_code != 404, (
+        f"{method} {old} returned 404 — a shipped app calling this path has lost the feature. "
+        f"The alias in app/api/routes/compat.py is missing or misregistered."
+    )
+    assert response.status_code == 401
+
+
+@pytest.mark.parametrize(("method", "old", "new"), MOVED, ids=[_ids(m) for m in MOVED])
+def test_the_old_and_new_paths_agree(client: TestClient, method: str, old: str, new: str) -> None:
+    """Delegation, not duplication (ADR-0079 point 2).
+
+    The same request to both spellings must be answered the same way. If these ever diverge, the
+    alias has become a second implementation — the failure the point exists to prevent.
+    """
+    old_response = getattr(client, method.lower())(old)
+    new_response = getattr(client, method.lower())(new)
+    assert old_response.status_code == new_response.status_code
+
+    # `request_id` is per-request by construction and says nothing about the handler.
+    def _comparable(payload: dict) -> dict:
+        return {k: v for k, v in payload.items() if k != "request_id"}
+
+    assert _comparable(old_response.json()) == _comparable(new_response.json())
+
+
+@pytest.mark.parametrize(("method", "old", "new"), MOVED, ids=[_ids(m) for m in MOVED])
+def test_the_alias_announces_itself(client: TestClient, method: str, old: str, new: str) -> None:
+    """`Deprecation` and `Sunset` on the old path only (ADR-0079 point 3).
+
+    They go to machines, not people: a log query for these headers is how the removal decision in
+    point 4 gets made on evidence. The new path must not carry them, or the signal is worthless.
+    """
+    old_response = getattr(client, method.lower())(old)
+    assert old_response.headers.get("Deprecation") == "true"
+    assert old_response.headers.get("Sunset") == SUNSET
+
+    new_response = getattr(client, method.lower())(new)
+    assert "Deprecation" not in new_response.headers
+    assert "Sunset" not in new_response.headers
+
+
+def test_the_aliases_are_absent_from_the_schema(client: TestClient) -> None:
+    """Point 1: a newcomer reading the API cannot see these.
+
+    Asserted over the whole schema rather than per path, so a future alias added without
+    `include_in_schema=False` fails here too.
+    """
+    schema = client.get("/openapi.json").json()
+    leaked = [path for path in schema["paths"] if path.startswith("/api/v1/queue")]
+    assert leaked == [], f"alias paths leaked into the published schema: {leaked}"
+
+
+def test_every_registered_alias_is_covered_by_this_file() -> None:
+    """The table above and the module must not drift.
+
+    Without this, adding an alias to `compat.py` and forgetting to test it looks exactly like
+    having tested it — and the thing untested is a path no other test, lint or build touches.
+    """
+    registered = {(tuple(methods)[0], path) for path, methods, _ in _ALIASES}
+    covered = {(method, old.replace("/api/v1", "")) for method, old, _ in MOVED}
+    # The restore alias carries a path parameter; compare its template rather than the filled id.
+    covered = {
+        (m, "/queue/session/archive/{archive_id}/restore")
+        if "/restore" in p
+        else (m, p)
+        for m, p in covered
+    }
+    assert registered == covered, (
+        f"compat.py and this test disagree.\n"
+        f"  registered but untested: {sorted(registered - covered)}\n"
+        f"  tested but not registered: {sorted(covered - registered)}"
+    )

--- a/backend/tests/test_contract_auth_matrix.py
+++ b/backend/tests/test_contract_auth_matrix.py
@@ -24,7 +24,7 @@ REQUIRED_PROFILE_ENDPOINTS = [
     # Radio suggestions weigh this profile's taste and skip history, so they cannot
     # run profile-less (ADR-0005). The `ambient` routes used to be the contrast here;
     # ADR-0077 deleted them, the service they wrapped staying put.
-    ("POST", "/api/v1/queue/suggestions"),
+    ("POST", "/api/v1/radio/suggestions"),
 ]
 
 

--- a/backend/tests/test_offline_manifest.py
+++ b/backend/tests/test_offline_manifest.py
@@ -215,14 +215,14 @@ class TestSeeds:
 
 class TestEndpoint:
     async def test_requires_a_profile(self, client):
-        r = client.post("/api/v1/queue/offline-manifest", json={"track_ids": []})
+        r = client.post("/api/v1/offline/manifest", json={"track_ids": []})
         assert r.status_code == 401
 
     async def test_returns_a_variant_per_profile_and_preset(self, client, test_profile):
         from tests.conftest import make_profile_headers
 
         r = client.post(
-            "/api/v1/queue/offline-manifest",
+            "/api/v1/offline/manifest",
             json={"track_ids": []},
             headers=make_profile_headers(test_profile),
         )
@@ -236,7 +236,7 @@ class TestEndpoint:
         from tests.conftest import make_profile_headers
 
         r = client.post(
-            "/api/v1/queue/offline-manifest",
+            "/api/v1/offline/manifest",
             json={"track_ids": [str(uuid4()) for _ in range(10_001)]},
             headers=make_profile_headers(test_profile),
         )

--- a/backend/tests/test_playback_session.py
+++ b/backend/tests/test_playback_session.py
@@ -22,12 +22,12 @@ from uuid import uuid4
 
 import pytest
 
-from app.api.routes.queue import ARCHIVE_LIMIT, reservoir_digest
+from app.api.routes.listening.session import ARCHIVE_LIMIT, reservoir_digest
 from tests.conftest import make_profile_headers
 
 pytestmark = pytest.mark.asyncio
 
-SESSION_URL = "/api/v1/queue/session"
+SESSION_URL = "/api/v1/listening/session"
 
 
 @pytest.fixture(autouse=True)
@@ -290,7 +290,7 @@ class TestConflicts:
     async def test_a_wildly_future_clock_cannot_keep_winning(self, client, test_profile):
         from datetime import datetime, timedelta
 
-        from app.api.routes.queue import MAX_CLOCK_SKEW
+        from app.api.routes.listening.session import MAX_CLOCK_SKEW
         from app.utils.time import to_naive_utc, utcnow
 
         _put(client, test_profile, track_ids=[str(uuid4())])

--- a/backend/tests/test_queue_suggestions.py
+++ b/backend/tests/test_queue_suggestions.py
@@ -243,7 +243,7 @@ class TestRetrieval:
 
 class TestEndpoint:
     async def test_requires_a_profile(self, client):
-        r = client.post("/api/v1/queue/suggestions", json={"current_track_id": str(uuid4())})
+        r = client.post("/api/v1/radio/suggestions", json={"current_track_id": str(uuid4())})
         assert r.status_code == 401
 
     async def test_unknown_profile_name_is_a_validation_error_not_a_500(
@@ -253,7 +253,7 @@ class TestEndpoint:
         from tests.conftest import make_profile_headers
 
         r = client.post(
-            "/api/v1/queue/suggestions",
+            "/api/v1/radio/suggestions",
             json={"current_track_id": str(uuid4()), "profile": "jazz-o-matic"},
             headers=make_profile_headers(test_profile),
         )
@@ -266,7 +266,7 @@ class TestEndpoint:
         from tests.conftest import make_profile_headers
 
         r = client.post(
-            "/api/v1/queue/suggestions",
+            "/api/v1/radio/suggestions",
             json={"current_track_id": "not-a-uuid"},
             headers=make_profile_headers(test_profile),
         )
@@ -276,7 +276,7 @@ class TestEndpoint:
         from tests.conftest import make_profile_headers
 
         r = client.post(
-            "/api/v1/queue/suggestions",
+            "/api/v1/radio/suggestions",
             json={"current_track_id": str(uuid4())},
             headers=make_profile_headers(test_profile),
         )

--- a/docs/decisions/ADR-0074-the-queue-tag-names-three-different-things.md
+++ b/docs/decisions/ADR-0074-the-queue-tag-names-three-different-things.md
@@ -1,11 +1,44 @@
 # ADR-0074: The Queue Tag Names Three Different Things
 
-Status: proposed
+Status: accepted
 
 Date: 2026-08-18
 
 Extends [ADR-0072](ADR-0072-paths-name-resources-tags-name-functions.md). Moves paths under
 [ADR-0079](ADR-0079-a-moved-path-keeps-an-invisible-alias.md).
+
+Implementation:
+
+- **Shipped 2026-08-28**, both repositories on `adr-0074-queue-split`, stacked on `ADR-0076`'s.
+  Six operations retagged and moved, `queue.py` split three ways, six Swift call sites and five web
+  call sites updated, and **`ADR-0079` built** — see below.
+- **This ADR could not be implemented as written, because `ADR-0079` was accepted and unbuilt.**
+  Points 3 and 4 assume a compatibility mechanism that did not exist: no module, and
+  `include_in_schema=False` occurring once in the whole codebase on an unrelated route. So
+  `app/api/routes/compat.py` is `ADR-0079`'s deliverable, landing here because this is the first
+  path move that needed it.
+- **`ADR-0079` point 3 does not work as a route dependency, and the failure is silent.** A
+  dependency taking `Response` sets headers on the object the *success* path returns; when a handler
+  raises — a 401 from `RequiredProfile`, a 503 from a disabled flag — the exception handler builds a
+  fresh response and the headers are dropped. Since every unauthenticated call to these paths 401s,
+  the first implementation announced nothing on exactly the requests most worth logging. It is ASGI
+  middleware instead, which attaches the headers to whatever response is actually sent.
+- **"Five aliases" is five paths and six routes.** `/queue/session` answers GET and PUT.
+- The split is clean: no session helper is used by radio or offline, so
+  `listening/{session,radio,offline}.py` share nothing but imports. **`queue.py`'s module docstring
+  described only radio** — a file named for a queue, documented as a recommender, holding session
+  persistence. That was the conflation in one artifact.
+- **All three new tags stay in the generated surface**, which preserves the six generated operations
+  exactly. `offline` is generated despite having no Swift caller, because `ADR-0077` point 4 kept it
+  on the grounds that `ADR-0006` says its consumer is coming; dropping it from `filter.tags` here
+  would have quietly reversed that.
+- `ADR-0073`'s trap recurred and was handled: the generated `Operations` enum member types rename in
+  PascalCase alongside the camelCase methods, and `swift build` does not compile `App/Shared`.
+  Verified with `xcodebuild` for both `Familiar-macOS` and `Familiar-iOS`.
+- **The existing tests were moved to the new paths on purpose.** Left alone they would have passed
+  through the aliases, and the suite would have been testing compatibility while appearing to test
+  the contract. `tests/test_compat_aliases.py` covers the aliases deliberately — 20 tests, including
+  one asserting that the table in the test and the table in `compat.py` cannot drift.
 
 ## Context
 

--- a/docs/decisions/ADR-0079-a-moved-path-keeps-an-invisible-alias.md
+++ b/docs/decisions/ADR-0079-a-moved-path-keeps-an-invisible-alias.md
@@ -8,6 +8,27 @@ Extends [ADR-0072](ADR-0072-paths-name-resources-tags-name-functions.md), which 
 axes and establishes that a path is runtime coupling. This says what to do on the rare occasion one
 has to move anyway.
 
+Implementation:
+
+- **Built 2026-08-28** on `adr-0074-queue-split`, as `backend/app/api/routes/compat.py`. This ADR was
+  accepted on 2026-08-18 and sat unbuilt until `ADR-0074` became the first change that actually
+  needed to move a path — which is also how the gap was noticed: `ADR-0076` had been drafted
+  assuming aliases were available.
+- **Point 3 does not work as a route dependency**, and this is the finding worth carrying. Setting
+  `Deprecation`/`Sunset` on an injected `Response` only reaches the success path; a raising handler
+  gets a fresh response from the exception handler and the headers are silently dropped. Every
+  unauthenticated call to a moved path is a 401, so the first implementation announced nothing on
+  the requests most worth finding in logs. It is now ASGI middleware, which attaches the headers to
+  whatever response is sent, by any route or handler.
+- Point 2's "delegation, never a copy" is literal: `add_api_route` is given the **same function
+  object** the new path registers, so FastAPI resolves identical dependencies, validation and
+  response models. There is no wrapper to drift.
+- Point 5 holds — one module, and `tests/test_compat_aliases.py` asserts that the module's alias
+  table and the test's cannot diverge, since an untested alias is invisible to every other check.
+- The `Sunset` date is **indicative, not the trigger**. Point 4's trigger is a condition someone
+  checks; RFC 8594 needs a date for `Deprecation` to be machine-actionable. If the date passes and
+  the build still ships, move the date.
+
 ## Context
 
 `ADR-0072` point 4 keeps path changes rare, and most of the restructure lands in tags. A few paths

--- a/packages/frontend/src/api/queue.ts
+++ b/packages/frontend/src/api/queue.ts
@@ -95,17 +95,17 @@ export const queueApi = {
   getOfflineManifest: async (
     request: OfflineManifestRequest
   ): Promise<OfflineManifestResponse> => {
-    const { data } = await api.post('/queue/offline-manifest', request);
+    const { data } = await api.post('/offline/manifest', request);
     return data;
   },
 
   getSuggestions: async (request: QueueSuggestionsRequest): Promise<QueueSuggestionsResponse> => {
-    const { data } = await api.post('/queue/suggestions', request);
+    const { data } = await api.post('/radio/suggestions', request);
     return data;
   },
 
   getSession: async (): Promise<PlaybackSessionResponse> => {
-    const { data } = await api.get('/queue/session');
+    const { data } = await api.get('/listening/session');
     return data;
   },
 
@@ -119,12 +119,12 @@ export const queueApi = {
     session: PlaybackSessionWrite,
     options?: RequestOptions,
   ): Promise<PlaybackSessionResponse> => {
-    const { data } = await api.put('/queue/session', session, options);
+    const { data } = await api.put('/listening/session', session, options);
     return data;
   },
 
   listArchivedSessions: async (): Promise<{ sessions: ArchivedSession[] }> => {
-    const { data } = await api.get('/queue/session/archive');
+    const { data } = await api.get('/listening/session/archive');
     return data;
   },
 


### PR DESCRIPTION
Implements **ADR-0074** — and **builds ADR-0079**, which it turned out to depend on. **Stacked on #219**; merge order is #216 → #217 → #218 → #219 → this.

Paired with seethroughlab/familiar-apple#147, which **must land with it** — this renames generated Swift methods.

## The split

`queue` was six operations and three unrelated features, behind a prefix naming a data structure none of them is: **the queue belongs to the client** (ADR-0028). What the server keeps is a session, a recommender and a manifest.

| was | tag | path |
|---|---|---|
| session persistence, 4 ops | `playback-session` | `/listening/session…` |
| radio, 1 op | `radio` | `/radio/suggestions` |
| offline manifest, 1 op | `offline` | `/offline/manifest` |

`queue.py` splits three ways to match. **Its module docstring described only radio** — a file named for a queue, documented as a recommender, holding session persistence. That was the conflation in a single artifact.

## ADR-0074 could not be implemented as written

Its points 3 and 4 assume a compatibility mechanism that **did not exist**. ADR-0079 was accepted on 2026-08-18 and never built: no module, and `include_in_schema=False` occurring exactly once in the whole codebase, on an unrelated trailing-slash route.

So `backend/app/api/routes/compat.py` is **ADR-0079's deliverable**, landing here because this is the first change that actually needed to move a path. (The gap was found while scoping #219, which had been drafted assuming aliases were available.)

## ADR-0079 point 3 does not work as a route dependency

Worth reading even if you skip the rest, because the failure is silent.

Setting `Deprecation`/`Sunset` on an injected `Response` only reaches the **success** path. When a handler raises — a 401 from `RequiredProfile`, a 503 from a disabled flag — the exception handler builds a fresh response and those headers are dropped.

Every unauthenticated call to a moved path is a 401. So the first implementation announced nothing on **exactly the requests most worth finding in logs**, which is the entire purpose of point 3. It is ASGI middleware now, attaching the headers to whatever response is actually sent.

Two smaller corrections: "five aliases" is **five paths and six routes** (`/queue/session` answers GET and PUT), and the `Sunset` date is indicative — point 4's trigger is a condition someone checks, not a date that arrives.

## Aliases are delegation, not copies

Each alias registers **the same function object** the new path registers — not a wrapper — so FastAPI resolves identical dependencies, validation and response models. There is nothing to drift.

## The tests were moved deliberately

The existing queue tests were pointed at the new paths. Left alone they would have passed **through the aliases**, and the suite would have been testing compatibility while appearing to test the contract.

`tests/test_compat_aliases.py` covers the aliases on purpose — 20 tests asserting each old path still routes, that old and new agree, that the headers appear on the old path and *not* the new one, that no alias leaks into the schema, and that the test's table and `compat.py`'s cannot drift.

## Verification

- Backend **1687 passed** (up 20 — the new alias tests); same four pre-existing failures.
- `ruff`, `mypy` (199 files), profile contracts, OpenAPI lint, schema freshness — all clean.
- Frontend **372 passed**, no new type errors; five call sites moved to the new paths.
- **All three tags stay generated**, preserving the six generated operations exactly. `offline` is generated despite having no Swift caller because ADR-0077 point 4 kept it for ADR-0006's expected consumer — dropping it from `filter.tags` would have quietly reversed that decision.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01Emjrwedq7W1scadHdgiLfs