### PR TITLE
Move the artist-merge endpoints off /admin (ADR-0076 point 5)

### DIFF
--- a/backend/app/api/routes/admin_artists.py
+++ b/backend/app/api/routes/admin_artists.py
@@ -28,7 +28,11 @@ from app.services.artist_resolver import _canonicalize_for_match
 
 logger = logging.getLogger(__name__)
 
-router = APIRouter(prefix="/admin/artists", tags=["artists"])
+# `/artists`, not `/admin/artists` (ADR-0076 point 5, deferred there and taken here). The `/admin/`
+# prefix promised a namespace two-thirds of this API would qualify for and only these three used —
+# under ADR-0058 most of Familiar's API *is* administration, so a prefix claiming the word is worse
+# than no prefix. Distinct from `/library/artists`, which browses; this merges.
+router = APIRouter(prefix="/artists", tags=["artists"])
 
 MAX_MERGE_BATCH = 20
 

--- a/backend/app/api/routes/compat.py
+++ b/backend/app/api/routes/compat.py
@@ -37,7 +37,7 @@ from fastapi import APIRouter
 from starlette.datastructures import MutableHeaders
 from starlette.types import ASGIApp, Message, Receive, Scope, Send
 
-from app.api.routes import commands
+from app.api.routes import admin_artists, commands
 from app.api.routes.listening import offline, session
 from app.api.routes.listening import radio as radio_routes
 
@@ -71,6 +71,12 @@ _ALIASES: list[tuple[str, list[str], Callable[..., Any]]] = [
     # watches. Removing it means grepping that file in the oldest offered build (ADR-0075 point 4).
     ("/playback/commands", ["GET"], commands.playback_commands),
     ("/playback/artifacts/{request_id}", ["POST"], commands.upload_artifact),
+    # ADR-0076 point 5's deferred move, taken once this module existed. Unlike the `/queue/*` pair
+    # above, no shipped app calls these — the admin app is served by the same deploy — but a
+    # self-hoster may well have scripted them, which is the risk ADR-0077's Tradeoff names.
+    ("/admin/artists/merge", ["POST"], admin_artists.merge_artists),
+    ("/admin/artists/merge-suggestions", ["GET"], admin_artists.get_merge_suggestions),
+    ("/admin/artists/search", ["GET"], admin_artists.search_artists),
 ]
 
 for _path, _methods, _endpoint in _ALIASES:

--- a/backend/openapi.json
+++ b/backend/openapi.json
@@ -10735,7 +10735,7 @@
         "summary": "Root"
       }
     },
-    "/api/v1/admin/artists/merge": {
+    "/api/v1/artists/merge": {
       "post": {
         "description": "Merge several ``Artist`` rows into one canonical row.\n\nAtomic. Locks the source rows so the scanner's resolver can't\ninsert a new alias pointing at any merge_id mid-merge. Aliases\nthat would collide with one already on the keep artist are\ndropped (keep-side wins). ``tracks.canonical_artist_id`` is\nrepointed BEFORE the artist DELETE \u2014 the FK is ON DELETE SET\nNULL, which would silently null tracks if the order were\nreversed.\n\nIdempotency: re-running with the same payload finds the\nmerge_ids gone and returns 404 \u2014 honest signal, not 200.",
         "operationId": "artists_merge_artists",
@@ -10822,7 +10822,7 @@
         ]
       }
     },
-    "/api/v1/admin/artists/merge-suggestions": {
+    "/api/v1/artists/merge-suggestions": {
       "get": {
         "description": "Return groups of artists whose canonicalized names collide.\n\nThe obvious \"Beatles\" + \"The Beatles\" + \"Beatles, The\" cluster.\nPure-Python pass over a fetched-once list \u2014 ~3.5k artists fits in\n<5MB Python overhead, sub-50ms group. Each suggestion ranks\nMBID-bearing candidates first (likely canonical winner); UI\nguards against merging two non-matching MBIDs.\n\nLong-tail rename cases (\"Antony\" \u2192 \"ANOHNI\", \"Ceephax\" \u2192 \"Ceephax\nAcid Crew\") aren't surfaced here \u2014 different canonical forms. The\nuser picks those manually via the merge UI's search panel.",
         "operationId": "artists_get_merge_suggestions",
@@ -10911,7 +10911,7 @@
         ]
       }
     },
-    "/api/v1/admin/artists/search": {
+    "/api/v1/artists/search": {
       "get": {
         "description": "Substring search across canonical artist names + sort_names.\n\nPowers the merge UI's manual-search panel \u2014 finds long-tail rename\nor abbreviation cases that the canonical-form-collision suggestions\ncan't see (e.g. \"Various\" vs \"Various Artists\", \"Se\u00f1or Coconut\"\nvs \"Se\u00f1or Coconut and His Orchestra\"). Trim/lower the query, ILIKE\nagainst name + sort_name, order by track count desc.",
         "operationId": "artists_search_artists",

--- a/backend/tests/test_compat_aliases.py
+++ b/backend/tests/test_compat_aliases.py
@@ -43,6 +43,10 @@ MOVED = [
         "/api/v1/playback/artifacts/00000000-0000-0000-0000-000000000000",
         "/api/v1/commands/artifacts/00000000-0000-0000-0000-000000000000",
     ),
+    # ADR-0076 point 5's deferred move.
+    ("POST", "/api/v1/admin/artists/merge", "/api/v1/artists/merge"),
+    ("GET", "/api/v1/admin/artists/merge-suggestions", "/api/v1/artists/merge-suggestions"),
+    ("GET", "/api/v1/admin/artists/search", "/api/v1/artists/search"),
 ]
 
 
@@ -110,7 +114,9 @@ def test_the_aliases_are_absent_from_the_schema(client: TestClient) -> None:
     leaked = [
         path
         for path in schema["paths"]
-        if path.startswith("/api/v1/queue/") or path.startswith("/api/v1/playback/")
+        if path.startswith("/api/v1/queue/")
+        or path.startswith("/api/v1/playback/")
+        or path.startswith("/api/v1/admin/")
     ]
     assert leaked == [], f"alias paths leaked into the published schema: {leaked}"
 

--- a/docs/decisions/ADR-0075-the-command-channel-is-not-playback.md
+++ b/docs/decisions/ADR-0075-the-command-channel-is-not-playback.md
@@ -119,9 +119,11 @@ not have to be renamed again when there is a second.
   used by an agent rather than watched by a person.
 - **Tradeoff** — point 4's removal check is a grep of another repository's shipped source, which is
   weaker than every other trigger in this set.
-- **Follow-up** — `PlaybackCommandClient` should move into `FamiliarKit` so the paths it builds can
-  be asserted by a test. It is in `App/Shared` today, which `swift test` cannot see, so the two
-  string literals this ADR changed are verified by nothing on the client side.
+- **Follow-up, now done (2026-08-28)** — the paths are asserted. Rather than move the whole
+  `ObservableObject` — it depends on `ServerConfiguration`, `FamiliarPlayer` and UIKit, all app-target
+  things — only the URL construction moved, to `FamiliarKit.PlaybackCommandEndpoints`, which is the
+  seam `PlaybackCommandClient`'s docstring already described. Five tests cover it, and they were
+  checked to *fail* on a reverted path rather than merely to pass.
 - **Follow-up** — the hand-written `PlaybackCommandClient` is the reason this is risky. Whether the
   command channel should be in the generated surface at all is a real question and not this ADR's:
   `ADR-0007` point 8 deliberately excludes SSE endpoints, so the answer today is no, and the artifact

--- a/docs/decisions/ADR-0076-server-operations-are-one-surface.md
+++ b/docs/decisions/ADR-0076-server-operations-are-one-surface.md
@@ -115,8 +115,10 @@ would qualify for and only this one uses.
    prefix misnames its resource is arguable in a way `/admin/` is not, and an arguable case does not
    clear `ADR-0072` point 4's bar.
 
-5. **`admin` becomes `artists`.** Three artist-merge operations named for what they act on. **The
-   `/admin/` prefix stays for now, and this is the one deferral that is a genuine loss**: unlike the
+5. **`admin` becomes `artists`, and so does the path.** Three artist-merge operations named for what
+   they act on. The tag moved with this ADR; **the `/admin/` prefix followed once `ADR-0079`'s alias
+   module existed** — see the Implementation note. It was the one deferral here that was a genuine
+   loss: unlike the
    others, `/admin/` really does misname its resource — under `ADR-0058` most of this API is
    administration, so a prefix claiming the word is worse than no prefix. It clears point 4's bar and
    is deferred only because `ADR-0079`'s mechanism is unbuilt and nine web-app call sites depend on
@@ -168,9 +170,10 @@ is displayed on the same screen as the worker status.
 - **Tradeoff** — merging four tags into `system` means a reader who knew where `/background/jobs` was
   has to look somewhere new. That is the point, but it is still a cost paid by the people most
   familiar with the codebase.
-- **Follow-up** — `/admin/artists/*` should still become `/artists/*`; point 5 explains why it is the
-  one path here that genuinely misnames its resource. It needs `ADR-0079`'s alias module built first,
-  and it moves nine web-app call sites.
+- **Follow-up, now done (2026-08-28)** — `/admin/artists/*` became `/artists/*` once `ADR-0074` built
+  `ADR-0079`'s alias module. Three operations, three web-app call sites — not the nine this bullet
+  estimated, which counted grep lines rather than distinct calls. `/artists` does not collide with
+  `/library/artists`: that one browses, this one merges.
 - **Follow-up** — **`ADR-0079` is accepted and unbuilt**, which this ADR discovered by depending on
   it. Every remaining path move in the restructure is blocked behind that module existing.
 - **Follow-up** — after this lands, `docs/REST-API.md` describes an API that no longer exists in any

--- a/packages/frontend/src/api/admin.ts
+++ b/packages/frontend/src/api/admin.ts
@@ -184,19 +184,19 @@ export interface ArtistSearchResponse {
 
 export const adminArtistsApi = {
   getMergeSuggestions: async (limit = 100): Promise<MergeSuggestionsResponse> => {
-    const { data } = await api.get('/admin/artists/merge-suggestions', {
+    const { data } = await api.get('/artists/merge-suggestions', {
       params: { limit },
     });
     return data;
   },
 
   mergeArtists: async (request: MergeArtistsRequest): Promise<MergeArtistsResponse> => {
-    const { data } = await api.post('/admin/artists/merge', request);
+    const { data } = await api.post('/artists/merge', request);
     return data;
   },
 
   searchArtists: async (q: string, limit = 20): Promise<ArtistSearchResponse> => {
-    const { data } = await api.get('/admin/artists/search', { params: { q, limit } });
+    const { data } = await api.get('/artists/search', { params: { q, limit } });
     return data;
   },
 };


### PR DESCRIPTION
Takes ADR-0076's deferred path move — the one it recorded as a genuine loss. **Stacked on #221**, the last of the ADR cluster.

## What moves

| before | after |
|---|---|
| `POST /admin/artists/merge` | `POST /artists/merge` |
| `GET /admin/artists/merge-suggestions` | `GET /artists/merge-suggestions` |
| `GET /admin/artists/search` | `GET /artists/search` |

With unschemad aliases, so anything that scripted the old spelling keeps working.

## Why it was deferred, and why it isn't now

`/admin/` promised a namespace two-thirds of this API would qualify for and only these three operations used. Under ADR-0058 most of Familiar's API **is** administration, so a prefix claiming the word is worse than no prefix. It is the one path in ADR-0076 that clears ADR-0072 point 4's "only when it misnames its resource" bar, which is why it was recorded as a follow-up rather than dropped.

It was blocked on ADR-0079's alias module not existing. **#220 built it**, so this is now three lines in `compat.py`.

## A correction to ADR-0076

It estimated **nine** web-app call sites. There are **three** — that figure counted grep lines rather than distinct calls. The ADR now says so rather than leaving the wrong number on the record.

`/artists` does not collide with `/library/artists`: that one browses, this one merges. Verified against the schema before moving.

## Verification

- Backend **1702 passed**, same four pre-existing failures.
- `tests/test_compat_aliases.py` now covers **eleven** aliases (35 tests) — routing, old-vs-new agreement, headers on the old path only, no schema leak, and the drift check between the test's table and `compat.py`'s.
- `ruff`, `mypy` (199 files), profile contracts, OpenAPI lint, schema freshness — clean.
- Frontend 372 passed; three call sites moved.
- Schema diff: three paths out, three in, 249 operations unchanged, **no `/admin/` left**.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01Emjrwedq7W1scadHdgiLfs