### PR TITLE
The artists grid toggles to a sortable table (ADR-0094)

### DIFF
--- a/backend/app/api/routes/library_artists.py
+++ b/backend/app/api/routes/library_artists.py
@@ -11,10 +11,11 @@ from fastapi.responses import RedirectResponse, StreamingResponse
 from pydantic import BaseModel
 from sqlalchemy import func, select
 
-from app.api.deps import DbSession, RequiredProfile
+from app.api.deps import CurrentProfile, DbSession, RequiredProfile
 from app.api.exceptions import NotFoundError
 from app.api.schemas.artists import SimilarArtistInfo
-from app.db.models import Artist, ArtistAlias, Track, TrackAnalysis, TrackStatus
+from app.api.schemas.common import UTCDateTime
+from app.db.models import Artist, ArtistAlias, ProfilePlayHistory, Track, TrackAnalysis, TrackStatus
 from app.services.external_albums_helpers import normalize_artist_name
 from app.utils.time import utcnow
 
@@ -34,6 +35,19 @@ class ArtistSummary(BaseModel):
     first_album: str | None = None
     image_url: str | None = None  # Resolved Wikipedia/Wikidata/Spotify thumbnail
 
+    # Columns for the Mac's artists table (ADR-0094). All are aggregates over the same grouped
+    # query the counts already use, so they cost no extra round trip.
+    total_duration_seconds: float | None = None
+    year_min: int | None = None
+    year_max: int | None = None
+    #: When this artist first appeared in the library — `min(Track.created_at)`.
+    date_added: UTCDateTime | None = None
+    #: Per-profile, and null when the request carries no profile. "How often have you played this"
+    #: has no answer when there is no you — the same reasoning `PROFILE_SORT_FIELDS` uses on the
+    #: tracks list.
+    play_count: int | None = None
+    last_played_at: UTCDateTime | None = None
+
 
 class ArtistListResponse(BaseModel):
     """Paginated list of artists."""
@@ -47,23 +61,29 @@ class ArtistListResponse(BaseModel):
 @router.get("/artists", tags=["library"], response_model=ArtistListResponse)
 async def list_artists(
     db: DbSession,
+    profile: CurrentProfile = None,
     search: str | None = None,
-    sort_by: str = "name",  # name, track_count, album_count
+    sort_by: str = "name",
     page: int = 1,
     page_size: int = 100,
     has_embeddings: bool = False,
-    min_track_count: int = 1,
 ) -> ArtistListResponse:
     """Get distinct artists with aggregated stats.
 
-    Returns artists sorted by name (default), track count, or album count.
     Includes first_track_id for artwork lookup.
 
-    ``min_track_count`` hides the long tail — an artist with one track is usually a compilation
-    straggler rather than someone in the library (ADR-0094 point 5). It is the one filter here,
-    and it earns that because **sorting cannot express it**: ascending order shows those artists
-    first and descending merely buries them, and neither removes them. Everything else the browse
-    surface needs is a sort, which ``sort_by`` already answers.
+    **The aggregates are all over the one grouped query**, so the extra columns the Mac's table
+    shows (ADR-0094) cost no second round trip: duration, year range and date-added come from the
+    `Track` join that already computes the counts.
+
+    ``play_count`` and ``last_played_at`` are **per profile** and null without one, via an outer
+    join to ``ProfilePlayHistory``. That mirrors ``PROFILE_SORT_FIELDS`` on the tracks list: "how
+    often have you played this" has no answer when there is no you, and ordering by it anyway
+    would leave the database to invent a cross join.
+
+    ``sort_by`` accepts ``name``, ``track_count``, ``album_count``, ``duration``, ``date_added``,
+    ``year``, ``play_count`` and ``last_played`` — the last two only with a profile, falling back
+    to name without one rather than erroring.
 
     Args:
         has_embeddings: If True, only include artists that have at least one
@@ -89,11 +109,35 @@ async def list_artists(
             func.count(func.distinct(Track.album)).label("album_count"),
             func.min(cast(Track.id, TEXT)).label("first_track_id"),
             func.min(Track.album).label("first_album"),
+            # ADR-0094's columns, aggregated over the join that is already here.
+            func.sum(Track.duration_seconds).label("total_duration_seconds"),
+            func.min(Track.year).label("year_min"),
+            func.max(Track.year).label("year_max"),
+            func.min(Track.created_at).label("date_added"),
+            # Per profile, and null without one — see the docstring.
+            func.sum(ProfilePlayHistory.play_count).label("play_count"),
+            func.max(ProfilePlayHistory.last_played_at).label("last_played_at"),
         )
         .join(Track, Track.canonical_artist_id == Artist.id)
         .where(Track.status == TrackStatus.ACTIVE)
         .group_by(Artist.id, Artist.name, Artist.sort_name, Artist.image_url)
     )
+
+    # **Outer** join, and scoped to this profile in the ON clause rather than in `WHERE`. In
+    # `WHERE` it would become an inner join and silently drop every artist the listener has never
+    # played — which is exactly the set "last played" is most useful for finding.
+    if profile is not None:
+        base_query = base_query.outerjoin(
+            ProfilePlayHistory,
+            (ProfilePlayHistory.track_id == Track.id)
+            & (ProfilePlayHistory.profile_id == profile.id),
+        )
+    else:
+        # No profile: keep the columns in the row shape, always null, so the response schema does
+        # not change between requests.
+        base_query = base_query.outerjoin(
+            ProfilePlayHistory, literal_column("false")
+        )
 
     # Filter to only artists with embeddings if requested.
     if has_embeddings:
@@ -113,22 +157,34 @@ async def list_artists(
             func.lower(Artist.name).contains(s) | func.lower(Artist.sort_name).contains(s)
         )
 
-    # The long-tail filter, applied *before* the count (ADR-0094 point 5). `HAVING` rather than
-    # `WHERE` because it tests the aggregate this query groups by. Counting after filtering is
-    # what keeps `total` agreeing with the rows — count it first and the last page is short of
-    # what the client was told to expect.
-    if min_track_count > 1:
-        base_query = base_query.having(func.count(Track.id) >= min_track_count)
-
     # Total count.
     count_query = select(func.count()).select_from(base_query.subquery())
     total = await db.scalar(count_query) or 0
 
     # Sorting — prefer ``Artist.sort_name`` so "The Beatles" sorts under B.
-    if sort_by == "track_count":
-        base_query = base_query.order_by(desc(literal_column("track_count")), Artist.sort_name)
-    elif sort_by == "album_count":
-        base_query = base_query.order_by(desc(literal_column("album_count")), Artist.sort_name)
+    # Counts and dates descend; the name ascends. "Sort by tracks" means the biggest first, and
+    # "sort by name" means A first — one direction for both would make one of them useless.
+    #
+    # `Artist.sort_name` is the tiebreaker on every branch so the order is total: without it, rows
+    # tied on an aggregate have no defined order and OFFSET paging may repeat or skip them between
+    # pages, which is the defect `apply_track_sort` records on the tracks list.
+    descending = {
+        "track_count": "track_count",
+        "album_count": "album_count",
+        "duration": "total_duration_seconds",
+        "date_added": "date_added",
+        "year": "year_max",
+    }
+    # Per-profile sorts need a profile, for the reason `PROFILE_SORT_FIELDS` gives: ordering by a
+    # column from a table that was never joined is a wrong answer served slowly. Fall back to name.
+    if profile is not None:
+        descending["play_count"] = "play_count"
+        descending["last_played"] = "last_played_at"
+
+    if column := descending.get(sort_by):
+        base_query = base_query.order_by(
+            desc(literal_column(column)).nullslast(), Artist.sort_name
+        )
     else:
         base_query = base_query.order_by(Artist.sort_name)
 
@@ -146,6 +202,12 @@ async def list_artists(
             album_count=row.album_count,
             first_track_id=str(row.first_track_id),
             first_album=row.first_album,
+            total_duration_seconds=row.total_duration_seconds,
+            year_min=row.year_min,
+            year_max=row.year_max,
+            date_added=row.date_added,
+            play_count=row.play_count,
+            last_played_at=row.last_played_at,
             image_url=row.image_url,
         )
         for row in rows

--- a/backend/app/api/routes/library_artists.py
+++ b/backend/app/api/routes/library_artists.py
@@ -5,11 +5,13 @@ import html
 import logging
 import re
 from pathlib import Path
+from typing import Any
 
 from fastapi import APIRouter, Query, Request
 from fastapi.responses import RedirectResponse, StreamingResponse
 from pydantic import BaseModel
 from sqlalchemy import func, select
+from sqlalchemy.sql import ColumnElement
 
 from app.api.deps import CurrentProfile, DbSession, RequiredProfile
 from app.api.exceptions import NotFoundError
@@ -64,6 +66,7 @@ async def list_artists(
     profile: CurrentProfile = None,
     search: str | None = None,
     sort_by: str = "name",
+    sort_order: str | None = None,
     page: int = 1,
     page_size: int = 100,
     has_embeddings: bool = False,
@@ -84,6 +87,10 @@ async def list_artists(
     ``sort_by`` accepts ``name``, ``track_count``, ``album_count``, ``duration``, ``date_added``,
     ``year``, ``play_count`` and ``last_played`` — the last two only with a profile, falling back
     to name without one rather than erroring.
+
+    ``sort_order`` is ``asc``/``desc``, and defaults to whichever way the column is usually read:
+    A-first for a name, biggest-first for a count or a date. A client that offers a direction
+    control must send one, or the arrow it draws will disagree with the rows it gets.
 
     Args:
         has_embeddings: If True, only include artists that have at least one
@@ -182,11 +189,17 @@ async def list_artists(
         descending["last_played"] = "last_played_at"
 
     if column := descending.get(sort_by):
+        # Natural direction unless the caller says otherwise.
+        ascending = sort_order == "asc"
+        ordering: ColumnElement[Any] = literal_column(column)
         base_query = base_query.order_by(
-            desc(literal_column(column)).nullslast(), Artist.sort_name
+            ordering.asc().nullslast() if ascending else desc(ordering).nullslast(),
+            Artist.sort_name,
         )
     else:
-        base_query = base_query.order_by(Artist.sort_name)
+        base_query = base_query.order_by(
+            Artist.sort_name.desc() if sort_order == "desc" else Artist.sort_name
+        )
 
     offset = (page - 1) * page_size
     base_query = base_query.offset(offset).limit(page_size)

--- a/backend/app/api/routes/library_artists.py
+++ b/backend/app/api/routes/library_artists.py
@@ -52,11 +52,18 @@ async def list_artists(
     page: int = 1,
     page_size: int = 100,
     has_embeddings: bool = False,
+    min_track_count: int = 1,
 ) -> ArtistListResponse:
     """Get distinct artists with aggregated stats.
 
     Returns artists sorted by name (default), track count, or album count.
     Includes first_track_id for artwork lookup.
+
+    ``min_track_count`` hides the long tail — an artist with one track is usually a compilation
+    straggler rather than someone in the library (ADR-0094 point 5). It is the one filter here,
+    and it earns that because **sorting cannot express it**: ascending order shows those artists
+    first and descending merely buries them, and neither removes them. Everything else the browse
+    surface needs is a sort, which ``sort_by`` already answers.
 
     Args:
         has_embeddings: If True, only include artists that have at least one
@@ -105,6 +112,13 @@ async def list_artists(
         base_query = base_query.where(
             func.lower(Artist.name).contains(s) | func.lower(Artist.sort_name).contains(s)
         )
+
+    # The long-tail filter, applied *before* the count (ADR-0094 point 5). `HAVING` rather than
+    # `WHERE` because it tests the aggregate this query groups by. Counting after filtering is
+    # what keeps `total` agreeing with the rows — count it first and the last page is short of
+    # what the client was told to expect.
+    if min_track_count > 1:
+        base_query = base_query.having(func.count(Track.id) >= min_track_count)
 
     # Total count.
     count_query = select(func.count()).select_from(base_query.subquery())

--- a/backend/openapi.json
+++ b/backend/openapi.json
@@ -16253,7 +16253,7 @@
     },
     "/api/v1/library/artists": {
       "get": {
-        "description": "Get distinct artists with aggregated stats.\n\nReturns artists sorted by name (default), track count, or album count.\nIncludes first_track_id for artwork lookup.\n\nArgs:\n    has_embeddings: If True, only include artists that have at least one\n        track with an embedding (for use in similarity-based features).",
+        "description": "Get distinct artists with aggregated stats.\n\nReturns artists sorted by name (default), track count, or album count.\nIncludes first_track_id for artwork lookup.\n\n``min_track_count`` hides the long tail \u2014 an artist with one track is usually a compilation\nstraggler rather than someone in the library (ADR-0094 point 5). It is the one filter here,\nand it earns that because **sorting cannot express it**: ascending order shows those artists\nfirst and descending merely buries them, and neither removes them. Everything else the browse\nsurface needs is a sort, which ``sort_by`` already answers.\n\nArgs:\n    has_embeddings: If True, only include artists that have at least one\n        track with an embedding (for use in similarity-based features).",
         "operationId": "library_list_artists",
         "parameters": [
           {
@@ -16306,6 +16306,16 @@
               "default": false,
               "title": "Has Embeddings",
               "type": "boolean"
+            }
+          },
+          {
+            "in": "query",
+            "name": "min_track_count",
+            "required": false,
+            "schema": {
+              "default": 1,
+              "title": "Min Track Count",
+              "type": "integer"
             }
           }
         ],

--- a/backend/openapi.json
+++ b/backend/openapi.json
@@ -755,6 +755,14 @@
             "title": "Album Count",
             "type": "integer"
           },
+          "date_added": {
+            "format": "date-time",
+            "title": "Date Added",
+            "type": [
+              "string",
+              "null"
+            ]
+          },
           "first_album": {
             "title": "First Album",
             "type": [
@@ -780,13 +788,49 @@
               "null"
             ]
           },
+          "last_played_at": {
+            "format": "date-time",
+            "title": "Last Played At",
+            "type": [
+              "string",
+              "null"
+            ]
+          },
           "name": {
             "title": "Name",
             "type": "string"
           },
+          "play_count": {
+            "title": "Play Count",
+            "type": [
+              "integer",
+              "null"
+            ]
+          },
+          "total_duration_seconds": {
+            "title": "Total Duration Seconds",
+            "type": [
+              "number",
+              "null"
+            ]
+          },
           "track_count": {
             "title": "Track Count",
             "type": "integer"
+          },
+          "year_max": {
+            "title": "Year Max",
+            "type": [
+              "integer",
+              "null"
+            ]
+          },
+          "year_min": {
+            "title": "Year Min",
+            "type": [
+              "integer",
+              "null"
+            ]
           }
         },
         "required": [
@@ -16253,7 +16297,7 @@
     },
     "/api/v1/library/artists": {
       "get": {
-        "description": "Get distinct artists with aggregated stats.\n\nReturns artists sorted by name (default), track count, or album count.\nIncludes first_track_id for artwork lookup.\n\n``min_track_count`` hides the long tail \u2014 an artist with one track is usually a compilation\nstraggler rather than someone in the library (ADR-0094 point 5). It is the one filter here,\nand it earns that because **sorting cannot express it**: ascending order shows those artists\nfirst and descending merely buries them, and neither removes them. Everything else the browse\nsurface needs is a sort, which ``sort_by`` already answers.\n\nArgs:\n    has_embeddings: If True, only include artists that have at least one\n        track with an embedding (for use in similarity-based features).",
+        "description": "Get distinct artists with aggregated stats.\n\nIncludes first_track_id for artwork lookup.\n\n**The aggregates are all over the one grouped query**, so the extra columns the Mac's table\nshows (ADR-0094) cost no second round trip: duration, year range and date-added come from the\n`Track` join that already computes the counts.\n\n``play_count`` and ``last_played_at`` are **per profile** and null without one, via an outer\njoin to ``ProfilePlayHistory``. That mirrors ``PROFILE_SORT_FIELDS`` on the tracks list: \"how\noften have you played this\" has no answer when there is no you, and ordering by it anyway\nwould leave the database to invent a cross join.\n\n``sort_by`` accepts ``name``, ``track_count``, ``album_count``, ``duration``, ``date_added``,\n``year``, ``play_count`` and ``last_played`` \u2014 the last two only with a profile, falling back\nto name without one rather than erroring.\n\nArgs:\n    has_embeddings: If True, only include artists that have at least one\n        track with an embedding (for use in similarity-based features).",
         "operationId": "library_list_artists",
         "parameters": [
           {
@@ -16306,16 +16350,6 @@
               "default": false,
               "title": "Has Embeddings",
               "type": "boolean"
-            }
-          },
-          {
-            "in": "query",
-            "name": "min_track_count",
-            "required": false,
-            "schema": {
-              "default": 1,
-              "title": "Min Track Count",
-              "type": "integer"
             }
           }
         ],
@@ -16381,6 +16415,11 @@
             "description": "Internal Server Error"
           }
         },
+        "security": [
+          {
+            "ProfileHeader": []
+          }
+        ],
         "summary": "List Artists",
         "tags": [
           "library"

--- a/backend/openapi.json
+++ b/backend/openapi.json
@@ -16297,7 +16297,7 @@
     },
     "/api/v1/library/artists": {
       "get": {
-        "description": "Get distinct artists with aggregated stats.\n\nIncludes first_track_id for artwork lookup.\n\n**The aggregates are all over the one grouped query**, so the extra columns the Mac's table\nshows (ADR-0094) cost no second round trip: duration, year range and date-added come from the\n`Track` join that already computes the counts.\n\n``play_count`` and ``last_played_at`` are **per profile** and null without one, via an outer\njoin to ``ProfilePlayHistory``. That mirrors ``PROFILE_SORT_FIELDS`` on the tracks list: \"how\noften have you played this\" has no answer when there is no you, and ordering by it anyway\nwould leave the database to invent a cross join.\n\n``sort_by`` accepts ``name``, ``track_count``, ``album_count``, ``duration``, ``date_added``,\n``year``, ``play_count`` and ``last_played`` \u2014 the last two only with a profile, falling back\nto name without one rather than erroring.\n\nArgs:\n    has_embeddings: If True, only include artists that have at least one\n        track with an embedding (for use in similarity-based features).",
+        "description": "Get distinct artists with aggregated stats.\n\nIncludes first_track_id for artwork lookup.\n\n**The aggregates are all over the one grouped query**, so the extra columns the Mac's table\nshows (ADR-0094) cost no second round trip: duration, year range and date-added come from the\n`Track` join that already computes the counts.\n\n``play_count`` and ``last_played_at`` are **per profile** and null without one, via an outer\njoin to ``ProfilePlayHistory``. That mirrors ``PROFILE_SORT_FIELDS`` on the tracks list: \"how\noften have you played this\" has no answer when there is no you, and ordering by it anyway\nwould leave the database to invent a cross join.\n\n``sort_by`` accepts ``name``, ``track_count``, ``album_count``, ``duration``, ``date_added``,\n``year``, ``play_count`` and ``last_played`` \u2014 the last two only with a profile, falling back\nto name without one rather than erroring.\n\n``sort_order`` is ``asc``/``desc``, and defaults to whichever way the column is usually read:\nA-first for a name, biggest-first for a count or a date. A client that offers a direction\ncontrol must send one, or the arrow it draws will disagree with the rows it gets.\n\nArgs:\n    has_embeddings: If True, only include artists that have at least one\n        track with an embedding (for use in similarity-based features).",
         "operationId": "library_list_artists",
         "parameters": [
           {
@@ -16320,6 +16320,18 @@
               "default": "name",
               "title": "Sort By",
               "type": "string"
+            }
+          },
+          {
+            "in": "query",
+            "name": "sort_order",
+            "required": false,
+            "schema": {
+              "title": "Sort Order",
+              "type": [
+                "string",
+                "null"
+              ]
             }
           },
           {

--- a/backend/tests/test_library_artists_canonical.py
+++ b/backend/tests/test_library_artists_canonical.py
@@ -204,43 +204,78 @@ async def test_resolve_artist_via_alias_diacritic_fallback(async_db):
 
 
 @pytest.mark.asyncio
-async def test_min_track_count_hides_the_long_tail(async_db):
-    """`min_track_count` removes artists sorting cannot (ADR-0094 point 5).
+async def test_summary_carries_the_table_columns(async_db):
+    """Duration, year range and date-added come back on the list (ADR-0094).
 
-    An artist with one track is usually a compilation straggler. Sorting ascending puts those
-    first and descending buries them; neither takes them out of the list, which is why this is the
-    one filter the browse surface has.
+    All three are aggregates over the join that already computes the counts, so the point of this
+    test is that they are actually selected and mapped — a column that is computed and dropped on
+    the floor is the defect ADR-0094 was written about in the first place.
     """
-    prolific = await ar.resolve_canonical_artist(async_db, "Prolific", do_mb_lookup=False)
-    straggler = await ar.resolve_canonical_artist(async_db, "Straggler", do_mb_lookup=False)
-    for i in range(3):
-        async_db.add(_new_track(file=f"p{i}", artist_id=prolific.id, artist_str="Prolific"))
-    async_db.add(_new_track(file="s0", artist_id=straggler.id, artist_str="Straggler"))
+    artist = await ar.resolve_canonical_artist(async_db, "Aggregates", do_mb_lookup=False)
+    early = _new_track(file="a0", artist_id=artist.id, artist_str="Aggregates")
+    early.duration_seconds = 100.0
+    early.year = 1994
+    late = _new_track(file="a1", artist_id=artist.id, artist_str="Aggregates", album="Later")
+    late.duration_seconds = 50.0
+    late.year = 2003
+    async_db.add_all([early, late])
     await async_db.commit()
 
-    unfiltered = await list_artists(async_db)
-    assert {a.name for a in unfiltered.items} >= {"Prolific", "Straggler"}
-
-    filtered = await list_artists(async_db, min_track_count=2)
-    names = {a.name for a in filtered.items}
-    assert "Prolific" in names
-    assert "Straggler" not in names
+    listed = await list_artists(async_db)
+    row = next(a for a in listed.items if a.name == "Aggregates")
+    assert row.total_duration_seconds == 150.0
+    assert row.year_min == 1994
+    assert row.year_max == 2003
+    assert row.date_added is not None
 
 
 @pytest.mark.asyncio
-async def test_min_track_count_is_counted_before_the_total(async_db):
-    """`total` must describe the filtered set, not the whole one.
+async def test_play_columns_are_null_without_a_profile(async_db):
+    """Per-profile columns have no answer when there is no profile.
 
-    The filter is a `HAVING` on the same grouped query the count runs over. Count first and the
-    client is told there are more artists than it can ever page to — a last page that is short
-    for no visible reason, which is the kind of paging defect nothing surfaces as an error.
+    Null rather than 0: "never played" and "no listener to ask about" are different, and reporting
+    0 for the second would make an unplayed artist and an unknown one indistinguishable in a column
+    people will sort by.
     """
-    keep = await ar.resolve_canonical_artist(async_db, "Keep", do_mb_lookup=False)
-    drop = await ar.resolve_canonical_artist(async_db, "Drop", do_mb_lookup=False)
-    for i in range(2):
-        async_db.add(_new_track(file=f"k{i}", artist_id=keep.id, artist_str="Keep"))
-    async_db.add(_new_track(file="d0", artist_id=drop.id, artist_str="Drop"))
+    artist = await ar.resolve_canonical_artist(async_db, "Unknown Listener", do_mb_lookup=False)
+    async_db.add(_new_track(file="u0", artist_id=artist.id, artist_str="Unknown Listener"))
     await async_db.commit()
 
-    filtered = await list_artists(async_db, min_track_count=2)
-    assert filtered.total == len(filtered.items)
+    listed = await list_artists(async_db)
+    row = next(a for a in listed.items if a.name == "Unknown Listener")
+    assert row.play_count is None
+    assert row.last_played_at is None
+
+
+@pytest.mark.asyncio
+async def test_sorting_by_duration_puts_the_longest_first(async_db):
+    """`sort_by=duration` orders by total listening time, biggest first."""
+    short = await ar.resolve_canonical_artist(async_db, "Short", do_mb_lookup=False)
+    long = await ar.resolve_canonical_artist(async_db, "Long", do_mb_lookup=False)
+    s0 = _new_track(file="s0", artist_id=short.id, artist_str="Short")
+    s0.duration_seconds = 10.0
+    l0 = _new_track(file="l0", artist_id=long.id, artist_str="Long")
+    l0.duration_seconds = 900.0
+    async_db.add_all([s0, l0])
+    await async_db.commit()
+
+    listed = await list_artists(async_db, sort_by="duration")
+    names = [a.name for a in listed.items]
+    assert names.index("Long") < names.index("Short")
+
+
+@pytest.mark.asyncio
+async def test_an_unknown_sort_falls_back_to_name_rather_than_erroring(async_db):
+    """A sort the server does not know orders by name instead of failing.
+
+    This is what makes a client typo survivable — and also why `ArtistSort.wireValue` is asserted
+    on the Swift side: the fallback means a wrong value is silently ignored rather than reported.
+    """
+    for who in ("Zed", "Alpha"):
+        a = await ar.resolve_canonical_artist(async_db, who, do_mb_lookup=False)
+        async_db.add(_new_track(file=f"{who}0", artist_id=a.id, artist_str=who))
+    await async_db.commit()
+
+    listed = await list_artists(async_db, sort_by="not_a_column")
+    names = [a.name for a in listed.items if a.name in {"Zed", "Alpha"}]
+    assert names == ["Alpha", "Zed"]

--- a/backend/tests/test_library_artists_canonical.py
+++ b/backend/tests/test_library_artists_canonical.py
@@ -201,3 +201,46 @@ async def test_resolve_artist_via_alias_diacritic_fallback(async_db):
     found2 = await _resolve_artist_via_alias(async_db, "Bjork")
     assert found2 is not None
     assert found2.id == canonical.id
+
+
+@pytest.mark.asyncio
+async def test_min_track_count_hides_the_long_tail(async_db):
+    """`min_track_count` removes artists sorting cannot (ADR-0094 point 5).
+
+    An artist with one track is usually a compilation straggler. Sorting ascending puts those
+    first and descending buries them; neither takes them out of the list, which is why this is the
+    one filter the browse surface has.
+    """
+    prolific = await ar.resolve_canonical_artist(async_db, "Prolific", do_mb_lookup=False)
+    straggler = await ar.resolve_canonical_artist(async_db, "Straggler", do_mb_lookup=False)
+    for i in range(3):
+        async_db.add(_new_track(file=f"p{i}", artist_id=prolific.id, artist_str="Prolific"))
+    async_db.add(_new_track(file="s0", artist_id=straggler.id, artist_str="Straggler"))
+    await async_db.commit()
+
+    unfiltered = await list_artists(async_db)
+    assert {a.name for a in unfiltered.items} >= {"Prolific", "Straggler"}
+
+    filtered = await list_artists(async_db, min_track_count=2)
+    names = {a.name for a in filtered.items}
+    assert "Prolific" in names
+    assert "Straggler" not in names
+
+
+@pytest.mark.asyncio
+async def test_min_track_count_is_counted_before_the_total(async_db):
+    """`total` must describe the filtered set, not the whole one.
+
+    The filter is a `HAVING` on the same grouped query the count runs over. Count first and the
+    client is told there are more artists than it can ever page to — a last page that is short
+    for no visible reason, which is the kind of paging defect nothing surfaces as an error.
+    """
+    keep = await ar.resolve_canonical_artist(async_db, "Keep", do_mb_lookup=False)
+    drop = await ar.resolve_canonical_artist(async_db, "Drop", do_mb_lookup=False)
+    for i in range(2):
+        async_db.add(_new_track(file=f"k{i}", artist_id=keep.id, artist_str="Keep"))
+    async_db.add(_new_track(file="d0", artist_id=drop.id, artist_str="Drop"))
+    await async_db.commit()
+
+    filtered = await list_artists(async_db, min_track_count=2)
+    assert filtered.total == len(filtered.items)

--- a/docs/decisions/ADR-0094-the-artists-grid-toggles-to-a-sortable-table.md
+++ b/docs/decisions/ADR-0094-the-artists-grid-toggles-to-a-sortable-table.md
@@ -33,8 +33,28 @@ Implementation:
 - One wrinkle the schema forced: `ArtistSummary.id` is `String?` and so cannot satisfy
   `Identifiable`, which `Table` requires. A small `ArtistRow` wrapper keys on `name` — the same key
   the grid's `ForEach` already used, so both views agree what one row is.
-- Sorting is a toolbar picker, not column headers. A header that reordered the loaded page would
-  order the accident of what has been scrolled to, which is what point 2 forbids.
+- **Points 3, 4 and 5 were revised after first use, and the ADR is wrong about all three.** Built
+  as written, the toolbar carried a view toggle, a sort picker and a minimum-tracks stepper; three
+  controls for one list read as clutter, and the answer was not the one this ADR reasoned its way
+  to:
+  - **Sorting moved to the column headers** — point 2's mechanism, not its placement, was the part
+    that mattered. `ArtistSortComparator.compare` returns `.orderedSame` always, so `Table` never
+    reorders the loaded page; the binding is a signal and the store refetches. The ADR argued
+    headers would be misleading; they are only misleading if they sort *locally*.
+  - **Point 5's `min_track_count` was removed entirely**, UI and server parameter both. It is a
+    good filter and nobody wanted it in the toolbar, and an unhooked parameter is exactly the
+    surface-with-no-caller `ADR-0077` deletes.
+  - **Point 3 held for about a day.** Five columns were added — duration, year range, date added,
+    play count, last played — which point 3 anticipated as "a separate change with its own cost".
+    The cost was smaller than expected: all five are aggregates over the join `list_artists`
+    already had, and only the two per-profile ones needed anything new.
+- The per-profile join is scoped in the **ON clause**, not `WHERE`. In `WHERE` it silently becomes
+  an inner join and drops every artist the listener has never played — the set "last played" is
+  most useful for finding.
+- **A latent bug surfaced in the store**, unrelated to this ADR but found by it:
+  `isServingCachedCopy` was set on a fallback to the offline cache and never cleared, so one
+  transient failure pinned the store to disk for the session and every later sort silently
+  re-served the cached order.
 
 ## Context
 

--- a/docs/decisions/ADR-0094-the-artists-grid-toggles-to-a-sortable-table.md
+++ b/docs/decisions/ADR-0094-the-artists-grid-toggles-to-a-sortable-table.md
@@ -1,0 +1,152 @@
+# ADR-0094: The Artists Grid Toggles To A Sortable Table
+
+Status: accepted
+
+Date: 2026-08-28
+
+Extends [ADR-0021](ADR-0021-track-lists-on-the-mac-are-sortable-tables.md), which made track lists
+sortable tables on the Mac and scoped itself, in point 7, to lists *of tracks*. This applies the same
+rule to a list of artists, which is a different question only because the row is not a track.
+
+Implementation:
+
+- **Shipped 2026-08-28**, `familiar` on `adr-0094-artists-table-impl` and `familiar-apple` on
+  `adr-0094-artists-table`, stacked on the API cluster because `ADR-0073` had already edited
+  `library_artists.py` and a branch from `main` would have conflicted.
+- **`min_track_count` is applied as a `HAVING`, before the count** — the only subtle part of the
+  server change. Counting first would tell a client there are more artists than it can ever page
+  to, and a last page short for no visible reason is the kind of paging defect nothing raises. A
+  test asserts `total == len(items)` and was checked to *fail* when the filter moves after the
+  count.
+- Point 2 landed on the store rather than per call: `ArtistsStore` holds `sort` and
+  `minTrackCount`, and `apply(sort:minTrackCount:)` refetches from page one. Paging must ask for
+  the ordering the first page used, or two slices are spliced from different sorts.
+- **The offline cache sorts locally, and that is not an inconsistency.** `ADR-0021` point 3 puts
+  sorting with whoever holds the whole list; offline, the store does. Server-side sorting is
+  required for the *paged* path because 100 of ~3,500 rows is not the list.
+- `ArtistSort` lives in `FamiliarKit` so `wireValue` can be asserted. It is a string the server
+  branches on and **falls through to name-ordering for anything it does not recognise** — so a typo
+  is not an error, it is the control silently doing nothing. Both the literal values and a
+  "every case is recognised" check were verified to fail on a deliberate typo.
+- Point 3 held: no new server field. The columns are `name`, `track_count` and `album_count`, all
+  of which `ArtistSummary` already returned and rendered nowhere.
+- One wrinkle the schema forced: `ArtistSummary.id` is `String?` and so cannot satisfy
+  `Identifiable`, which `Table` requires. A small `ArtistRow` wrapper keys on `name` — the same key
+  the grid's `ForEach` already used, so both views agree what one row is.
+- Sorting is a toolbar picker, not column headers. A header that reordered the loaded page would
+  order the accident of what has been scrolled to, which is what point 2 forbids.
+
+## Context
+
+The Mac and phone browse artists through `ArtistsGridView` (`App/Shared/BrowseViews.swift:117`) — a
+`LazyVGrid` of circular artwork tiles, paged at 100, with a search field. It is the surface this ADR
+is about, and **it works**: the circles are a good way to find an artist you can picture.
+
+Three facts make the case that it should not be the *only* way.
+
+**Half the tiles have no picture.** The view's own comment records the measurement: *1,703 of 3,475
+artists carry a Last.fm `image_url`*. For the other 1,772 the grid renders a placeholder, so a
+surface whose organising idea is recognition falls back to reading names in a layout optimised for
+pictures.
+
+**The data the grid does not show is already in the response.** `ArtistSummary` carries `id`, `name`,
+`image_url`, `first_track_id`, `first_album`, **`track_count` and `album_count`**. The last two are
+computed per artist on every request and rendered nowhere.
+
+**The server can already sort by them, and nothing has ever asked it to.** `list_artists`
+(`backend/app/api/routes/library_artists.py:51`) takes `sort_by` with `name`, `track_count` and
+`album_count`, implemented at lines 114–116. The only Swift caller
+(`App/Shared/BrowseStores.swift:218`) passes `search`, `page` and `pageSize` — never `sort_by`. This
+is a capability with no caller, which `ADR-0077` would ordinarily delete; the reason it is being
+wired up instead of removed is that there is a want for it, which is this ADR.
+
+**The question this ADR was asked was "filters or a sortable list?"** — with "total number of tracks"
+as the example. Those two examples pull apart under examination, and the distinction is the whole
+decision: *number of tracks* is an attribute of each artist and belongs in a column, while *number of
+artists* is a property of the whole list and is already returned as `total`. A filter panel built to
+hold both would be answering two unrelated questions with one control.
+
+`ADR-0021` point 3 is the constraint that shapes any answer here: **"Sorting is done by whoever holds
+the whole list… A list must never sort the pages it happens to have."** The artists list holds 100
+rows of roughly 3,500, so it is in exactly the position that point was written about.
+
+## Decision
+
+1. **The grid gains a table view, toggled. It is not replaced.** The circles stay the default. The
+   missing-artwork measurement is an argument for offering an alternative, not for removing the
+   thing that works for the 1,703 artists that do have a picture.
+
+2. **The table sorts server-side, through the `sort_by` the endpoint already has.** Changing the sort
+   refetches from page 1, exactly as `ADR-0021` point 3 requires and for the same reason: with 100 of
+   3,500 rows loaded, sorting locally would order the accident of what has been scrolled to, and a
+   wrong order looks like an order.
+
+3. **The columns are the fields `ArtistSummary` already returns** — name, track count, album count.
+   No new server field, no new aggregate, no new join. A column that needs one is a separate change
+   with its own cost.
+
+4. **Sorting answers the question; a filter panel is not added.** "Which are my biggest artists" is a
+   sort, not a filter, and the three sorts the server offers already answer it. Adding a filter panel
+   as well would be two mechanisms for one question — the conflation `ADR-0072` point 1 exists to
+   stop, in the interface rather than in the schema.
+
+5. **One filter earns its place, and it is a single control: a minimum track count.** The long tail
+   is real — an artist with one track is usually a compilation straggler rather than someone in the
+   library — and sorting cannot answer it, because ascending order shows those artists first and
+   descending merely buries them. Neither removes them. This adds one query parameter,
+   `min_track_count`, and one stepper. It is the only new server surface in this ADR.
+
+6. **The toggle and the sort are Mac-only; the phone keeps the circles.** `TrackTable.swift` is
+   `#if os(macOS)` and `ADR-0021` point 2 took only the Mac to macOS 14 for
+   `TableColumnCustomization`. A multi-column table on a phone is a worse grid, not a better list.
+
+7. **The chosen view and sort are per-device and not synced**, following `ADR-0021` point 5 and
+   `ADR-0015` points 5 and 6: a display preference belongs to the screen it is displayed on.
+
+## Alternatives Considered
+
+**A filter panel, as the question proposed.** Rejected as the primary answer under point 4, but not
+because filtering is wrong — point 5 keeps the one filter that sorting genuinely cannot express. What
+it will not do is build a panel: every filter needs a control, a piece of state, a server parameter
+and a way to see what is currently applied, and for "which artists have the most tracks" all of that
+is bought by a column header that already has a server implementation waiting.
+
+**Replace the grid with the table.** Cheaper — one view instead of two, no toggle, no per-device
+preference. Rejected because it is a regression for the half of the library that has artwork, and
+because the grid is the surface the request explicitly said it liked. The measurement cuts both ways:
+1,703 artists are well served by circles.
+
+**Sort the loaded page on the device and skip the server work.** Rejected under `ADR-0021` point 3,
+which was written about precisely this and is cited in point 2. Worth restating because it is the
+tempting option: it looks correct while scrolling and is wrong at every page boundary.
+
+**Add the columns to the grid instead — track and album counts under each tile.** Genuinely
+considered, and it is the smallest possible change. Rejected because a grid cannot be sorted by
+something it merely displays; the counts would be visible and still not answer "which are the
+biggest", which is the question being asked.
+
+**Do albums at the same time.** `AlbumsGridView` is the same component with the same shape, and
+`list_albums` already takes `sort_by` with `name`, `year`, `track_count` and `artist` — so the second
+one is nearly free once the first exists. Rejected only to keep this to one decision, per the
+convention; it is recorded as a follow-up rather than as a future ADR, because it introduces nothing
+new.
+
+## Consequences
+
+- **Positive** — two `ArtistSummary` fields that are computed on every request start being shown, and
+  a `sort_by` parameter that has never had a caller starts having one.
+- **Positive** — the artists with no artwork become browsable by something other than a placeholder.
+- **Positive** — the pattern generalises to albums for almost nothing, since the endpoint is already
+  there.
+- **Tradeoff** — two views of one list is more code than one, and the toggle is a preference that has
+  to live somewhere. Point 7 puts it on the device, which is the cheap answer and the right one.
+- **Tradeoff** — `min_track_count` is a new server parameter, and the first filter is the one that
+  makes the second easy to argue for. Point 4 is what should be cited when that argument is made.
+- **Tradeoff** — sorting refetches from page 1, so changing sort on a long-scrolled list loses the
+  scroll position. That is inherent to server-side sorting of a paged list and is the cost `ADR-0021`
+  point 3 already accepted for tracks.
+- **Follow-up** — `AlbumsGridView` takes the same toggle, with `name`, `year`, `track_count` and
+  `artist` as its columns.
+- **Follow-up** — `has_embeddings`, an existing parameter on the same endpoint, is also uncalled from
+  Swift. It is a similarity-search filter rather than a browse control, so it is out of scope here,
+  but it is on the list `ADR-0077` point 1 governs and should be either used or removed.


### PR DESCRIPTION
Implements **ADR-0094**, and revises three of its points after using what it specified. **Stacked on #222.**

Paired with seethroughlab/familiar-apple#151.

## What the artists list gets

`ArtistSummary` gains **total time, year range, date added, play count and last played**. All are aggregates over the join `list_artists` already had, so the four non-profile ones cost no extra round trip.

`sort_by` gains `duration`, `date_added`, `year`, `play_count`, `last_played`, and a new `sort_order` (`asc`/`desc`) defaulting to how each column is normally read — A-first for a name, biggest-first for a count or date.

## Three of the ADR's points were wrong, and it now says so

Built as written, the toolbar carried a view toggle, a sort dropdown and a minimum-tracks stepper. Three controls for one list read as clutter, and using it produced better answers than the ADR reasoned to:

- **Point 2's placement was wrong.** Sorting moved to the column headers. The ADR argued headers would be misleading — they are, but only if they sort *locally*. `ArtistSortComparator.compare` returns `.orderedSame` always, so `Table` never reorders the loaded page and the store refetches. The *mechanism* (server-side) was the part that mattered, not the placement.
- **Point 5 is gone.** `min_track_count` shipped, wasn't wanted in the toolbar, and was removed from the **server too** — an unhooked query parameter is precisely the surface-with-no-caller ADR-0077 spent this cluster deleting fourteen of.
- **Point 3 held for about a day.** It said new columns would be "a separate change with its own cost". The cost turned out small: all five are aggregates over an existing join.

## The per-profile join is scoped in ON, not WHERE

`play_count` and `last_played_at` come from an outer join to `ProfilePlayHistory`. Scoped in the `ON` clause deliberately — in `WHERE` it silently becomes an inner join and drops **every artist the listener has never played**, which is the set "last played" is most useful for finding.

Verified there is no fan-out: counts and durations are identical with and without a profile header.

Nulls stay null rather than becoming 0. "Never played" and "no profile on the request" are different, and a column people sort by must not confuse them.

## Verification

- Backend **1706 passed**; the four failures are pre-existing.
- `ruff`, `mypy` (199 files), profile contracts, OpenAPI lint, schema freshness — clean.
- Every sort exercised against the real 26k library, both directions: `duration desc` → Joe Frank 321,989s; `play_count desc` → Boards of Canada 718 plays; `name desc` → 憂鬱 & Voyage. An unrecognised `sort_by` falls back to name rather than erroring, which is asserted.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01Emjrwedq7W1scadHdgiLfs