### PR TITLE
Make music video search actually work, and adopt the videos already on disk

### DIFF
--- a/backend/Makefile
+++ b/backend/Makefile
@@ -54,6 +54,11 @@ format:
 	uv run ruff format .
 	uv run ruff check --fix .
 
+# One-shot backfill: give already-downloaded video files a `track_videos` row.
+# ADR-0086 says the file on disk wins for existence; this is the half it did not build.
+adopt-videos:
+	uv run python -m app.cli.adopt_orphan_videos $(ARGS)
+
 # One-shot backfill: populate canonical artists/aliases from existing tracks.
 # Pass ARGS="--dry-run" or ARGS="--no-mb --limit 50" for variants.
 backfill-artists:

--- a/backend/app/api/routes/videos.py
+++ b/backend/app/api/routes/videos.py
@@ -9,13 +9,18 @@ from sqlalchemy import func, select
 from starlette.responses import FileResponse
 
 from app.api.deps import DbSession, release_connection
-from app.api.exceptions import NotFoundError, TrackNotFoundError, ValidationError
-from app.api.schemas.common import UTCDateTime
+from app.api.exceptions import (
+    NotFoundError,
+    ServiceUnavailableError,
+    TrackNotFoundError,
+    ValidationError,
+)
+from app.api.schemas.common import UTCDateTime, error_responses
 from app.api.schemas.tracks import TrackResponse
 from app.api.streaming import stream_file
 from app.db.models import Track
 from app.db.models.tracks import TrackVideo
-from app.services.video import get_video_service
+from app.services.video import VideoSearchUnavailable, get_video_service
 
 logger = logging.getLogger(__name__)
 
@@ -122,7 +127,14 @@ async def list_videos(
     return VideoListResponse(items=items, total=total, page=page, page_size=page_size)
 
 
-@router.get("/{track_id}/search")
+@router.get(
+    "/{track_id}/search",
+    # 503 is control flow, not a server fault: YouTube being unreachable is an ordinary answer a
+    # client must expect, and `videos_search_videos` is in the generated surface. Undeclared, a
+    # generated client has no case to branch on and reports an unexpected response — the reasoning
+    # `listening/session.py` records for its own 503.
+    responses=error_responses(503),
+)
 async def search_videos(
     db: DbSession,
     track_id: UUID,
@@ -148,7 +160,13 @@ async def search_videos(
     logger.info("Video search for track %s: '%s'", track_id, search_query)
 
     video_service = get_video_service()
-    results = await video_service.search(search_query, limit=limit)
+    try:
+        results = await video_service.search(search_query, limit=limit)
+    except VideoSearchUnavailable as exc:
+        # 503, not an empty list. "YouTube could not be asked" and "YouTube has nothing" are
+        # different answers, and only one of them is the listener's problem to shrug at. This is
+        # the distinction ADR-0077 records `search_bandcamp` losing for months.
+        raise ServiceUnavailableError(f"Could not search for videos: {exc}") from exc
 
     return [
         VideoSearchResultResponse(

--- a/backend/app/cli/adopt_orphan_videos.py
+++ b/backend/app/cli/adopt_orphan_videos.py
@@ -1,0 +1,120 @@
+"""One-shot backfill: give already-downloaded video files a `track_videos` row.
+
+Run via ``python -m app.cli.adopt_orphan_videos`` (or ``make adopt-videos`` from ``backend/``).
+Idempotent — a file that already has a row is skipped, so it is safe to re-run.
+
+Why this exists
+---------------
+`ADR-0086` moved "does this track have a video" from *a file exists on disk* to *a row exists in
+`track_videos`*. It says, in point 2, that where the two disagree **the file on disk wins for
+existence** — but it only built half of that: a row whose file is gone is deleted, while a file
+with no row is simply invisible. `GET /videos` lists from the table.
+
+The other half was never a hypothetical. The production library had **twelve videos, 136 MB,
+downloaded between February and June 2026** by the pre-ADR-0086 feature, every one of them
+matching a real track, and none of them visible anywhere in the app. Nobody would have found that
+by reading the code: the API answers "no videos", which is exactly what it would say if the
+directory were empty.
+
+What it cannot recover, and why that is acceptable
+--------------------------------------------------
+The old feature named files after the *track* id, not the video, so the YouTube id it came from is
+not in the filename and is nowhere else either — the row that would have held it is the row that
+does not exist. `source_id` is therefore recorded as ``adopted``, which is honest and searchable:
+these rows can be found later if the source id ever matters.
+
+Everything that makes the video *playable* — the path, the size, the track it belongs to — is
+recoverable, and playing it is the point. `downloaded_at` comes from the file's mtime, which is
+when it really was downloaded.
+"""
+
+from __future__ import annotations
+
+import argparse
+import asyncio
+import logging
+from datetime import UTC, datetime
+from uuid import UUID, uuid4
+
+from sqlalchemy import select
+
+from app.config import settings
+from app.db.models import Track, TrackVideo
+from app.db.session import async_session_maker
+from app.utils.time import to_naive_utc
+
+logger = logging.getLogger(__name__)
+
+
+async def adopt(dry_run: bool = False) -> tuple[int, int, int]:
+    """Return (adopted, already_had_a_row, no_matching_track)."""
+    videos_dir = settings.videos_path
+    if not videos_dir.exists():
+        print(f"No videos directory at {videos_dir} — nothing to do.")
+        return (0, 0, 0)
+
+    adopted = existing = unmatched = 0
+
+    async with async_session_maker() as session:
+        for path in sorted(videos_dir.glob("*.mp4")):
+            try:
+                track_id = UUID(path.stem)
+            except ValueError:
+                # Not named after a track id — not something this backfill can claim.
+                print(f"  skip   {path.name}  (filename is not a track id)")
+                unmatched += 1
+                continue
+
+            track = await session.scalar(select(Track).where(Track.id == track_id))
+            if track is None:
+                print(f"  skip   {path.name}  (no such track)")
+                unmatched += 1
+                continue
+
+            already = await session.scalar(
+                select(TrackVideo).where(TrackVideo.track_id == track_id)
+            )
+            if already is not None:
+                existing += 1
+                continue
+
+            stat = path.stat()
+            print(f"  adopt  {track.artist} — {track.title}  ({stat.st_size // 1_000_000} MB)")
+            if not dry_run:
+                session.add(
+                    TrackVideo(
+                        id=uuid4(),
+                        track_id=track_id,
+                        source="youtube",
+                        # Not knowable from the file — see the module docstring.
+                        source_id="adopted",
+                        source_url=None,
+                        file_path=str(path),
+                        is_audio_only=False,
+                        file_size_bytes=stat.st_size,
+                        # `downloaded_at` is TIMESTAMP WITHOUT TIME ZONE, so a tz-aware value is
+                        # rejected by asyncpg outright — the whole insert fails rather than
+                        # silently storing the wrong instant, which is the better failure.
+                        downloaded_at=to_naive_utc(datetime.fromtimestamp(stat.st_mtime, tz=UTC)),
+                    )
+                )
+            adopted += 1
+
+        if not dry_run:
+            await session.commit()
+
+    return (adopted, existing, unmatched)
+
+
+def main() -> None:
+    parser = argparse.ArgumentParser(description=__doc__)
+    parser.add_argument("--dry-run", action="store_true", help="report without writing")
+    args = parser.parse_args()
+
+    adopted, existing, unmatched = asyncio.run(adopt(dry_run=args.dry_run))
+    verb = "would adopt" if args.dry_run else "adopted"
+    print(f"\n{verb} {adopted}; {existing} already had a row; {unmatched} unmatched")
+
+
+if __name__ == "__main__":
+    main()

--- a/backend/app/services/video.py
+++ b/backend/app/services/video.py
@@ -1,5 +1,6 @@
 """Music video service using yt-dlp for YouTube video download."""
 
+
 import asyncio
 import json
 import logging
@@ -17,6 +18,13 @@ from app.db.session import async_session_maker
 from app.utils.time import utcnow
 
 logger = logging.getLogger(__name__)
+class VideoSearchUnavailable(Exception):
+    """YouTube could not be searched — as distinct from having nothing to return.
+
+    The two must not look alike to a caller. An empty list means "no videos match"; this means
+    "the question could not be asked", and only one of them is worth telling somebody about.
+    """
+
 
 
 @dataclass
@@ -51,10 +59,23 @@ class VideoService:
 
     @staticmethod
     def _base_ytdlp_args() -> list[str]:
-        """Common yt-dlp args for YouTube compatibility."""
-        return [
-            "--extractor-args", "youtube:player_client=web",
-        ]
+        """Common yt-dlp args.
+
+        **Deliberately empty, and that is the fix.** This used to pin
+        `--extractor-args youtube:player_client=web`. YouTube now answers that client with
+        storyboard images only, so every search failed with *"Only images are available for
+        download"* → *"Requested format is not available"* — measured on 2026-08-29 against
+        yt-dlp 2026.08.19, where `web` and `web_safari` both failed and no argument at all
+        returned 32 playable formats up to 1080p.
+
+        Pinning a client is a standing bet that YouTube will not change, against a project whose
+        entire job is tracking those changes — `docker/entrypoint.sh` already updates yt-dlp on
+        every boot for exactly that reason. Letting it choose is what makes that update useful.
+
+        Kept as a method rather than inlined so a future argument has an obvious home and this
+        note stays attached to the decision not to have one.
+        """
+        return []
 
     async def search(
         self,
@@ -91,16 +112,20 @@ class VideoService:
                 logger.error("Video search timed out after 30s for query: %r", query)
                 process.kill()
                 await process.wait()
-                return []
+                raise VideoSearchUnavailable("search timed out after 30s") from None
 
             stderr_text = stderr.decode().strip() if stderr else ""
 
             if process.returncode != 0:
+                # Raised, not swallowed. Returning `[]` here made a broken search look exactly
+                # like an empty one — the defect ADR-0077 records for `search_bandcamp`, which
+                # "answered 'no results' for every query, for however long it had been". A
+                # listener seeing "no videos found" has no reason to report anything.
                 logger.error(
                     "yt-dlp search failed (rc=%d) for query %r: %s",
                     process.returncode, query, stderr_text[:500]
                 )
-                return []
+                raise VideoSearchUnavailable(stderr_text[:300] or "yt-dlp failed")
 
             if stderr_text:
                 logger.debug("yt-dlp search warnings for %r: %s", query, stderr_text[:500])
@@ -129,9 +154,13 @@ class VideoService:
 
             logger.info("Video search returned %d results for query: %r", len(results), query)
             return results
-        except Exception:
+        except VideoSearchUnavailable:
+            # Already the honest answer — do not let the catch-all below turn it back into "no
+            # results", which is what this handler did to every failure before.
+            raise
+        except Exception as exc:
             logger.exception("Video search failed for query: %r", query)
-            return []
+            raise VideoSearchUnavailable(str(exc)) from exc
 
     def get_video_path(self, track_id: str) -> Path | None:
         """Get the path to a downloaded video for a track."""

--- a/backend/openapi.json
+++ b/backend/openapi.json
@@ -33082,6 +33082,16 @@
               }
             },
             "description": "Internal Server Error"
+          },
+          "503": {
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/ErrorEnvelope"
+                }
+              }
+            },
+            "description": "Service Unavailable"
           }
         },
         "summary": "Search Videos",

--- a/backend/tests/test_videos.py
+++ b/backend/tests/test_videos.py
@@ -247,3 +247,70 @@ class TestDelete:
         assert not (settings.videos_path / f"{track_id}.mp4").exists()
         listed = client.get("/api/v1/videos").json()["items"]
         assert all(i["id"] != track_id for i in listed)
+
+
+class TestSearchFailureIsNotAnEmptyResult:
+    """A broken search must not look like a search that found nothing.
+
+    This is the defect ADR-0077 records for `search_bandcamp` — it "answered 'no results' for every
+    query, for however long it had been" — and video search had it too: every `yt-dlp` failure was
+    caught and returned as `[]`. It was found the same way, by asking for a video that certainly
+    exists and being told there were none.
+    """
+
+    @pytest.mark.asyncio
+    async def test_a_failed_search_raises_rather_than_returning_empty(self, monkeypatch):
+        from app.services.video import VideoSearchUnavailable, VideoService
+
+        async def fake_exec(*args, **kwargs):
+            class Proc:
+                returncode = 1
+
+                async def communicate(self):
+                    return b"", b"ERROR: Requested format is not available"
+
+                def kill(self):
+                    pass
+
+                async def wait(self):
+                    pass
+
+            return Proc()
+
+        monkeypatch.setattr("asyncio.create_subprocess_exec", fake_exec)
+        with pytest.raises(VideoSearchUnavailable):
+            await VideoService().search("anything")
+
+    @pytest.mark.asyncio
+    async def test_a_genuinely_empty_search_still_returns_empty(self, monkeypatch):
+        """The other half: success with no matches is an empty list, not an error."""
+        from app.services.video import VideoService
+
+        async def fake_exec(*args, **kwargs):
+            class Proc:
+                returncode = 0
+
+                async def communicate(self):
+                    return b"", b""
+
+                def kill(self):
+                    pass
+
+                async def wait(self):
+                    pass
+
+            return Proc()
+
+        monkeypatch.setattr("asyncio.create_subprocess_exec", fake_exec)
+        assert await VideoService().search("nothing matches this") == []
+
+    def test_no_player_client_is_pinned(self):
+        """yt-dlp chooses its own client.
+
+        Pinning `player_client=web` is what broke every search: YouTube answered it with
+        storyboard images only. `docker/entrypoint.sh` updates yt-dlp on every boot precisely so
+        it can track these changes — a pin here makes that update useless.
+        """
+        from app.services.video import VideoService
+
+        assert VideoService._base_ytdlp_args() == []


### PR DESCRIPTION
**ADR-0085/0086 merged in August and the feature had never worked.** Confirmed working end to end on 2026-08-29 — search, download, playback. **Stacked on #223.**

Paired with seethroughlab/familiar-apple#152 (the Mac half).

## Search returned nothing, for every query

Asking for Interpol's *Obstacle 1* — which plainly has a video — returned `[]`. That is how it was found.

**Cause: `--extractor-args youtube:player_client=web`.** YouTube answers that client with storyboard images only, so yt-dlp reported *"Only images are available for download"* then *"Requested format is not available"* for every result it found. Measured on the NAS against yt-dlp 2026.08.19:

| client | result |
|---|---|
| `web`, `web_safari` | fail — images only |
| **no argument at all** | **32 playable formats, up to 1080p** |

Pinning a player client is a standing bet that YouTube will not change, against a project whose whole job is tracking those changes — and `docker/entrypoint.sh` already updates yt-dlp on every boot, which the pin made pointless.

## The failure was invisible, which is why it lasted

**Three paths returned `[]`**: non-zero exit, timeout, and a catch-all `except Exception`. A broken search was indistinguishable from one that found nothing, and the Mac app faithfully reported *"No videos found for this track."*

That is the defect ADR-0077 records for `search_bandcamp` — *"answered 'no results' for every query, for however long it had been"* — repeated exactly.

Search now raises `VideoSearchUnavailable`; the route returns **503**, declared on the operation because `videos_search_videos` is in the generated surface and an undeclared status leaves a generated client with no case to branch on.

## 136 MB of videos were already on disk and invisible

ADR-0086 moved "does this track have a video" from *a file exists* to *a row exists*. Its point 2 says **the file on disk wins for existence** — but only the row-without-file half was built (delete the row). A file with no row is simply unlistable, because `GET /videos` reads the table.

The production library had **twelve videos, 136 MB, downloaded February–June 2026**, every one matching a real track, none visible anywhere. `make adopt-videos` (`app/cli/adopt_orphan_videos.py`) claims them. Idempotent, with `--dry-run`.

Those rows carry `source_id = "adopted"`: the old feature named files after the *track* id, so the YouTube id is unrecoverable — it lived in the row that never existed. Everything that makes the video playable is recoverable, and that is the point.

## Verification

- Backend **1709 passed**; the four failures are pre-existing.
- Three new tests assert the distinction that was lost: a failed search raises, a genuinely empty one still returns `[]`, and no player client is pinned.
- Deployed to the NAS and exercised: **112 videos, 4.07 GB**, ~90% of first-result matches correct across a 100-track batch.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01Emjrwedq7W1scadHdgiLfs