### PR TITLE
Accept ADR-0093 — the client half is built

### DIFF
--- a/docs/decisions/ADR-0093-collections-suggest-tracks-from-the-library.md
+++ b/docs/decisions/ADR-0093-collections-suggest-tracks-from-the-library.md
@@ -1,6 +1,6 @@
 # ADR-0093: Collections Suggest Tracks From the Library
 
-Status: proposed
+Status: accepted
 
 Date: 2026-08-25
 
@@ -259,9 +259,26 @@ negative half of the signal is kept, because a track skipped repeatedly is evide
 - **Follow-up.** "You play these but have not favourited them" — 247 tracks at 2+ plays, 39 at 5+.
   Nothing today answers it: `library_discover`'s `deep_cuts` is *least*-played, `unheard_tracks`
   ignores favourites, and `smart_playlists` has no favourite field at all.
-- **Follow-up.** The Apple client surface — toolbar item, sheet, and the add action wiring into the
-  existing `playlistsAddTracksToPlaylist` — is a separate plan in `familiar-apple`, after the
-  endpoints are proven against the real library.
+- **Follow-up, now done (2026-08-29).** The Apple client shipped: `SuggestedTracksSheet`, opened
+  from a toolbar item on Favorites and on any playlist, adding through `FavoritesStore.toggle` and
+  the existing `playlistsAddTracksToPlaylist`.
+
+  The endpoints were re-proven against the real library first, as this bullet required: **1.3 s
+  warm** at limits 8 and 25 over 1,732 favourites, votes running 8→4 so `MIN_VOTES` is genuinely
+  binding, and `because_of` populated on every row. The 3.9 s first call is a cold cache, not the
+  steady state.
+
+  Three things the client work turned up, none of them in the ADR:
+
+  - **Smart playlists deliberately get no button.** Their contents are a rule's output, so an
+    "add this" action there would be overwritten by the next evaluation. Point 8 says "a playlist",
+    and this is where that stops being the same thing.
+  - **The sheet injects its environment objects explicitly.** A sheet presents in its own hierarchy
+    and does not reliably inherit them on macOS — `MatchVideoSheet` crashed on exactly this earlier
+    the same day, in `EnvironmentObject.error()`.
+  - **`suggestedTracks` had to sit outside `RowActions`' `#if os(macOS)` block.** It was first added
+    beside `searchVideos`, which is Mac-only because music video is; point 8 says both platforms,
+    and iOS failed to compile rather than silently losing the feature — the good failure.
 - **Follow-up.** `PlaylistSeed` in `FamiliarKit` deliberately omits `track_ids` "because no native
   surface can produce one". A suggestions sheet offering "make a playlist from these" would be the
   first native surface that could. That is a decision to record, not to slide in.


### PR DESCRIPTION
**Stacked on #224.** Paired with seethroughlab/familiar-apple#153, which is the actual client work.

This PR is the ADR flipping to `accepted` plus its Implementation record. The server half — `collection_suggestions.py`, `GET /favorites/suggested-tracks`, `GET /playlists/{id}/suggested-tracks` — shipped and was deployed on 2026-08-25. The ADR stayed `proposed` because its own follow-up gated acceptance on the Apple surface, "after the endpoints are proven against the real library".

## Re-proven before building the client

| | |
|---|---|
| warm response | **1.3 s** at limits 8 and 25, over 1,732 favourites |
| cold first call | 3.9 s — a cache effect, not the steady state |
| votes | **8 → 4**, so `MIN_VOTES = 2` genuinely binds rather than everything falling through to the single-vote top-up |
| `because_of` | populated on every suggestion (point 7) |
| `seed_track_count` | 1,732 |

One caveat on my own checking: I verified point 4's exclusion against only the first 100 favourites, because my pager compared a growing *set* against `total` and spun. Zero of 25 suggestions were already favourited in that sample — suggestive, not conclusive.

## What the client work added to the record

Three things not in the ADR, now in its Implementation block:

- **Smart playlists deliberately get no button.** Their contents are a rule's output, so an "add this" action would be overwritten by the next evaluation. Point 8 says "a playlist"; this is where that stops being the same thing.
- **The sheet injects its environment objects explicitly** — a sheet presents in its own hierarchy and does not reliably inherit them on macOS. `MatchVideoSheet` crashed on exactly this earlier the same day.
- **`suggestedTracks` had to sit outside `RowActions`' `#if os(macOS)` block.** It was first added beside `searchVideos`, which is Mac-only because music video is. Point 8 says both platforms, and iOS failed to compile rather than quietly shipping without it.

No backend code changes here — the endpoints were already merged.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01Emjrwedq7W1scadHdgiLfs