### PR TITLE
Ratify ADR-0049 — the Mac's Playlists section, verified against the app

### DIFF
--- a/docs/decisions/ADR-0049-playlists-are-a-top-level-destination-on-the-mac.md
+++ b/docs/decisions/ADR-0049-playlists-are-a-top-level-destination-on-the-mac.md
@@ -1,8 +1,38 @@
 # ADR-0049: Playlists Are a Top-Level Destination on the Mac
 
-Status: proposed
+Status: accepted
 
 Date: 2026-08-10
+
+Implementation:
+- **Already built when ratified.** Accepted 2026-08-29 on `adr-0049-ratify-playlists-section` after
+  checking all eight points against `familiar-apple` as it stands. Like ADR-0061, this had shipped
+  and the record had not caught up.
+- Verified point by point: the Playlists section sits between Library and Manage
+  (`LibrarySidebar.swift:111`, after Library ends at `:109` and before Manage at `:116`); "All
+  Playlists" heads the enumeration (`:153`) followed by one `ForEach` over every playlist with no
+  provenance grouping (`:156`); Smart Playlists live inside the section (`:160-175`); `SidebarItem`
+  has no `.playlist` case and `LibraryRouting.swift` and its tests are untouched (point 5's own
+  test, and it passes); the highlight is derived from `openPlaylist`, with
+  `isSelected = selection == item && openPlaylist == nil` (`:295`) so an open playlist takes the
+  highlight from the root it was reached through (point 6); both stores load in their own `.task` at
+  launch (`LibraryView.swift:1181`).
+- **Three things shipped beyond the Decision**, all improvements, none of them recorded until now:
+  the `+` is a *menu* offering "New Playlist" and "New Smart Playlist" rather than a bare button,
+  because moving smart playlists inside this section had pushed making one from two clicks to three
+  at the same moment it took making a regular one down to one (`:196-202`); playlist rows carry a
+  rename/delete context menu (`:221-224`); and smart playlist rows carry "Edit rules…" (`:236-238`),
+  which had no menu at all while the manual playlist beside it had two items.
+- **`PlaylistGrouping` no longer exists.** It was deleted with the quarantine when point 3 was
+  corrected, so the Tradeoff below that offered `PlaylistGrouping.split` as the one-line escape
+  hatch for ordering has been rewritten to name where that edit actually lives now.
+  `PlaylistRowKind.swift:9` records it as "the surviving half" of that file.
+- **The accumulation premise still holds, 19 days on.** Live against the NAS: 4 playlists, 3
+  auto-generated, and `generation_prompt like 'seed:%'` still matches **zero** — nothing has ever
+  been seeded-generated. Three of the six chat-era playlists named in the Context (*Neon Pulse
+  Drift*, *Echoes of Stillness*, *Binary Dreamscape*) have since been deleted, which the Mac can now
+  do; no claim is made about whether that is why. *Demo Analysis*, called a test artifact above, is
+  still there with 26 tracks.
 
 Extends [ADR-0013](ADR-0013-the-mac-is-a-management-surface-too.md), and follows
 [ADR-0048](ADR-0048-seeded-playlists-are-generated-from-analysis.md)
@@ -99,10 +129,25 @@ quarantine built on it hid the collection while leaving the scratch file on show
    separately from the column drifted out of agreement with it once already; a second flag here
    would be that defect returning by a different door.
 
-7. **Creating a playlist exists on macOS only.** Reachable from the `+` on the section header and
-   from a toolbar button on All Playlists, mirroring `SmartPlaylistsListView`. **iOS is unchanged**
-   and still cannot create one — ADR-0013 point 2 keeps the phone on the listening path, and its
-   root list is a different construction. This is a known gap, not an oversight.
+7. **Creating a playlist is reachable on both platforms.** On macOS from the `+` menu on the section
+   header and from the `PlaylistsListView` toolbar; on iOS from that same toolbar, reached through
+   the Library tab's Playlists row, plus a "New Playlist" button in the empty state.
+
+   **This point said "macOS only" and called iOS "a known gap, not an oversight".** The app now says
+   otherwise: `LibraryView.swift:670` constructs `PlaylistsListView` outside any `#if`, passing
+   `onCreate` on both platforms, and `BrowseViews.swift:453` renders a toolbar item whenever that
+   closure is non-nil. There is an iOS `PlaylistEditorSheet` presenter to match
+   (`LibraryView.swift:1360`, inside the `#else` branch). Corrected before acceptance rather than
+   after, which is the only reason it could be corrected at all.
+
+   **The ADR-0013 point 2 question was never actually answered** — the Follow-up below asked for a
+   decision about whether the phone should manage playlists, and the capability arrived without one.
+   Recorded rather than reverted, because on the evidence the shipped behaviour is coherent: the
+   phone can also *add* tracks to a playlist (`DownloadControls.swift:270`, outside that file's
+   macOS block), so a playlist created there is fillable rather than permanently empty. Creating a
+   playlist to listen to is the listening path; editing a smart playlist's rules is management, and
+   that stays on the Mac. The follow-up below now asks for the decision to be written down, not for
+   the feature to be built.
 
 8. **The playlist stores load at launch on macOS.** Previously they loaded only when their section
    was opened, which was correct when each was one row leading elsewhere and is wrong once the rows
@@ -155,29 +200,34 @@ quarantine built on it hid the collection while leaving the scratch file on show
   accepted for the same reason: a 200pt column and a 393pt phone are not the same surface.
 - **Tradeoff** — sidebar rows follow the server's `updated_at DESC` ordering, so a row can move when
   a playlist is edited. Alphabetical would be steadier for muscle memory; consistency with All
-  Playlists was chosen instead, and this is one line in `PlaylistGrouping.split` if that proves
-  wrong.
+  Playlists was chosen instead. This originally offered `PlaylistGrouping.split` as the one-line fix
+  if that proved wrong; that type was deleted along with the quarantine when point 3 was corrected,
+  so the edit is now a sort on `playlists.playlists` at `LibrarySidebar.swift:156`.
 - **Tradeoff** — the disclosure state is `@State` and resets each launch rather than persisting.
-- **Follow-up** — the phone still cannot create a playlist. Whether it should is an ADR-0013 point 2
-  question, not an oversight to be quietly patched.
+- **Follow-up** — this asked whether the phone *should* create a playlist, as an ADR-0013 point 2
+  question rather than an oversight to be quietly patched. It was then quietly patched: the phone can
+  create one, and no ADR says so. Point 7 above now describes the behaviour and argues it is
+  coherent; what is still owed is the ADR-0013 reading, which should also say where the line falls
+  for the phone's other playlist actions rather than settling this one case.
 - **Follow-up** — the accumulation ADR-0048 makes possible is still unaddressed, and is a real risk
   once seeded generation is actually used. The lever should be recency, pinning, or an expiry — not
-  provenance, and not a group the listener cannot get out of.
-- **Follow-up** — `is_auto_generated` is read as a *capability* in two places, which nothing defends:
-  `GET /playlists/{id}/recommendations` answers **400** for a hand-made playlist
-  (`recommendations.py:69`), while its sibling `/recommendations/external-albums` documents at
-  `:121-123` that it deliberately works for any playlist; and the web "Add to playlist" picker passes
-  `include_auto=false` (`PlaylistPickerModal.tsx:28`), so on the web a track cannot be added to any
-  of the six playlists above — while the Mac's equivalent menu offers all of them.
-- **Follow-up** — nothing parses `generation_prompt`, and both surfaces that display it
-  (`PlaylistDetail.tsx:526`, `DetailStore.swift:192`) print it raw, so an ADR-0048 playlist shows the
-  listener `seed:album:OK Computer`. The structured form was introduced without updating the two
-  renderers that assumed a sentence.
-- **Follow-up** — two unrelated web defects found while investigating: mobile web filters its
-  playlist list to `is_auto_generated`, so a hand-made playlist never appears there
-  (`MobileMoreSheet.tsx:49-56`); and the entire "Unsaved" ephemeral-playlist system is unreachable,
-  since `ephemeralPlaylistStore.addPlaylist` has zero callers and nothing dispatches the
-  `show-ephemeral-playlist` event `useAppBootstrap.ts:83` listens for.
-- **Follow-up** — renaming and deleting a regular playlist are still not possible on the Mac, though
-  `playlistsUpdatePlaylist` and `playlistsDeletePlaylist` are generated and unused. Same shape as the
-  gap this ADR closes.
+  provenance, and not a group the listener cannot get out of. **Still entirely hypothetical at
+  acceptance**: `seed:%` matches zero playlists 19 days after this was written.
+- **Follow-up (discharged)** — `is_auto_generated` was read as a *capability* in two places, which
+  nothing defended: `GET /playlists/{id}/recommendations` answered **400** for a hand-made playlist,
+  and the web "Add to playlist" picker passed `include_auto=false`. Both are gone —
+  `recommendations.py` no longer mentions the flag at all, and `PlaylistPickerModal.tsx:36` now calls
+  `playlistsApi.list(true)` explicitly. The Mac and the web finally offer the same playlists.
+- **Follow-up (discharged)** — `generation_prompt` was printed raw by both surfaces that displayed
+  it, so an ADR-0048 playlist would have shown the listener `seed:album:OK Computer`. The web
+  renderer was deleted with the player, and the Mac routes through
+  `Self.blurb(prompt:description:)` (`DetailStore.swift:204`), whose comment names that exact string
+  as what it exists to suppress.
+- **Follow-up (discharged by deletion)** — two unrelated web defects found while investigating:
+  mobile web filtered its playlist list to `is_auto_generated`, and the "Unsaved"
+  ephemeral-playlist system was unreachable. `MobileMoreSheet.tsx` and `ephemeralPlaylistStore` no
+  longer exist; ADR-0058's narrowing of the web app removed both. Neither was fixed, which is worth
+  distinguishing from being solved.
+- **Follow-up (discharged)** — renaming and deleting a regular playlist are now possible on the Mac,
+  from a context menu on the sidebar row (`LibrarySidebar.swift:221-224`) through
+  `PlaylistEditorSheet`. `playlistsUpdatePlaylist` and `playlistsDeletePlaylist` have callers.


### PR DESCRIPTION
**No code.** Docs-only, off `main`, independent of the open stack and of #226.

All eight decisions were already built. This is the second ADR today that shipped while its record sat `proposed` — which is precisely what ADR-0061 point 5 is about.

## Verified point by point

| Point | Where |
|---|---|
| 1 — section between Library and Manage | `LibrarySidebar.swift:111` (Library ends `:109`, Manage `:116`) |
| 2 — enumerated, "All Playlists" above | `:153`, then one `ForEach` at `:156` |
| 3 — no grouping by provenance | that single `ForEach` — no `is_auto_generated` branch |
| 4 — Smart Playlists inside the section | `:160-175` |
| 5 — a pushed route, routing model untouched | `SidebarItem` has no `.playlist` case; `LibraryRouting.swift` and its tests unchanged. The ADR made this its own test, and it passes |
| 6 — highlight derived from the route | `isSelected = selection == item && openPlaylist == nil` (`:295`) |
| 8 — stores load at launch | `LibraryView.swift:1181` |

## Point 7 is corrected, because the app contradicts it

It said creation was **macOS only** and called iOS *"a known gap, not an oversight"*. But `LibraryView.swift:670` constructs `PlaylistsListView` outside any `#if` and passes `onCreate` on both platforms; `BrowseViews.swift:453` renders the toolbar item whenever that closure is non-nil; and there is an iOS `PlaylistEditorSheet` presenter at `LibraryView.swift:1360`, inside the `#else` branch.

The follow-up that asked for this to be an **ADR-0013 point 2 decision, not an oversight to be quietly patched**, got a quiet patch.

**Recorded rather than reverted.** On the evidence the shipped behaviour is coherent: the phone can also *add* tracks to a playlist (`DownloadControls.swift:270`, outside that file's macOS block), so a playlist made there is fillable rather than permanently empty. Creating a playlist to listen to is the listening path; editing a smart playlist's rules is management, and that stays on the Mac. What is still owed is the ADR-0013 reading — and it should say where the line falls generally, not settle this one case.

Corrected in `Decision` rather than noted below it because the ADR is still `proposed`. That is the only reason it could be corrected at all; point 3 sets the precedent, and rule 6 would forbid it a day later.

## Three things shipped beyond the Decision

The `+` is a **menu** offering both kinds of playlist, not a bare button — moving smart playlists into this section had pushed making one from two clicks to three at the same moment it took making a regular one down to one. Playlist rows gained a rename/delete context menu; smart playlist rows gained "Edit rules…", having had no menu at all while the row beside them had two items.

## Follow-ups: four discharged, one contradicted, one still open

- **Discharged** — the `recommendations` **400** for hand-made playlists and the web picker's `include_auto=false` are both gone (`PlaylistPickerModal.tsx:36` now passes `true`). The Mac and the web finally offer the same playlists.
- **Discharged** — `generation_prompt` is no longer printed raw. The Mac routes through `Self.blurb(prompt:description:)`, whose comment names `seed:album:OK Computer` as the exact string it suppresses.
- **Discharged** — rename and delete exist on the Mac; `playlistsUpdatePlaylist` and `playlistsDeletePlaylist` have callers.
- **Discharged by deletion** — `MobileMoreSheet.tsx` and `ephemeralPlaylistStore` no longer exist. ADR-0058 removed them. Flagged as *deleted, not fixed*, because those are different things.
- **Still open** — accumulation. Live against the NAS: **4 playlists, 3 auto-generated, and `seed:%` matches zero.** Nothing has ever been seeded-generated, 19 days on, so the risk stays hypothetical.

`PlaylistGrouping` was deleted along with the quarantine when point 3 was corrected — so a Tradeoff offering `PlaylistGrouping.split` as its one-line escape hatch named a type that no longer exists. Rewritten to point at the line that would actually change.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01Emjrwedq7W1scadHdgiLfs