### PR TITLE
Ratify ADR-0053 and ADR-0054; supersede ADR-0065

### DIFF
--- a/docs/decisions/ADR-0053-the-command-channel-drives-and-observes-the-interface.md
+++ b/docs/decisions/ADR-0053-the-command-channel-drives-and-observes-the-interface.md
@@ -1,6 +1,34 @@
 # ADR-0053: The Command Channel Drives and Observes the Interface
 
-Status: proposed
+Status: accepted
+
+Implementation:
+- **Already built on both sides when ratified**, 2026-08-29, on `adr-0053-ratify-command-channel`.
+  Verified point by point rather than assumed.
+- Server: `navigate_app` and `capture_screenshot` are declared and dispatched in
+  `backend/app/mcp/playback.py` (`:105`, `:133`, `:223`, `:244`), the upload lands at
+  `POST /playback/artifacts/{request_id}` (`backend/app/api/routes/playback.py:138`), and
+  `ArtifactStore` in `services/playback_commands.py:254` holds captures in memory with `wait`
+  removing the entry once read — no table, no directory (points 1, 3, 8).
+- The request id is `uuid4().hex`, minted at issue (`mcp/playback.py:245`), and the tool waits
+  `_CAPTURE_TIMEOUT_SECONDS = 15.0` before answering with an error plus a note distinguishing "the
+  client is attached and declared the capability" from "unavailable" (`:261-272`). Nothing spins
+  (points 4, 5).
+- **Point 2's closed vocabulary was checked by comparing the two lists, not by reading either.**
+  `NAVIGATION_DESTINATIONS` and `SidebarItem`'s wire values are **15 entries that agree exactly** —
+  no server-only destination, no Swift-only one. That is the property the point is actually claiming.
+- Point 7 holds in all three directions: `_REQUIRES` gates both commands, `PlaybackCommand.supported`
+  omits `.screenshot` on iOS, and the web app declares no capabilities at all.
+- **Point 6's correction is in the code and absent from the comments around it.**
+  `WindowCapture.swift:80` renders through `layer.render(in:)` with `cacheDisplay` kept only as the
+  fallback at `:83` — the ADR's corrected form. But `WindowCapture.swift:13` still opens by
+  describing `cacheDisplay(in:to:)` as what the file does, and `PlaybackCommand.swift:92` explains
+  the iOS gate by saying "the capture is `cacheDisplay` over an `NSWindow`'s content view". Both
+  describe the mechanism this ADR *rejected*, and the second gives a correct conclusion a wrong
+  reason. Left as a follow-up rather than fixed in a docs-only change.
+- **One stale type name:** `mcp/playback.py:46` says the list "Mirrors `LibraryRoute` in
+  FamiliarKit". There is no `LibraryRoute`; it is `SidebarItem`, which is what point 2 says. Also a
+  follow-up.
 
 Date: 2026-08-12
 
@@ -128,6 +156,15 @@ render *its own* windows with no permission at all, and that is the only thing t
   or anything overlapping it — the title-bar strip comes back empty. For screenshots of the
   interface that is arguably better; for reproducing a visual bug involving a system control it is
   worse.
+- **Follow-up:** three comments describe the mechanism this ADR rejected. `WindowCapture.swift:13`
+  and `PlaybackCommand.swift:92` both call the capture `cacheDisplay` when it is
+  `CALayer.render(in:)`, and `mcp/playback.py:46` names a type, `LibraryRoute`, that does not exist.
+  Point 6 was corrected by running it; the prose around the correction was not. Cheap to fix and
+  worth doing, because the next person to touch the capture path will read the comment before the
+  code.
+- **Follow-up:** the ADR-0039 screenshot errand this unblocks has still not been run — the native
+  clients can now be photographed and have not been. That is the whole reason the capability was
+  built, and `docs/SITE-CLAIMS.md` will need the results before ADR-0055 can close.
 - **Tradeoff:** rendering a layer tree is not the same as what the compositor puts on screen.
   Anything the window server draws on top — a sheet from another process, a tooltip, the
   title bar — is absent by construction, and a capture is therefore evidence about the app's own

--- a/docs/decisions/ADR-0054-the-illustration-set-is-dark-theme-only.md
+++ b/docs/decisions/ADR-0054-the-illustration-set-is-dark-theme-only.md
@@ -1,8 +1,31 @@
 # ADR-0054: The Illustration Set Is Dark-Theme Only
 
-Status: proposed
+Status: accepted
 
 Date: 2026-08-13
+
+Implementation:
+- **Already built when ratified**, 2026-08-29, on `adr-0054-ratify-illustrations`. Fourteen marks
+  live in `site/assets/marks/` as `.webp`, and `site/ILLUSTRATIONS.md` holds the prompts.
+- Point 1 holds: the marks are full-colour raster on the site's single dark palette, with no
+  `currentColor` and no light variants. Point 3's transparency was checked in the files themselves
+  rather than assumed — every one is RGBA with a fully transparent corner and `alpha-min = 0`.
+  Sizes are 2×-scale (479×689, 1024×510), and SVG is still what `icon.svg` and the App Store badge
+  use.
+- **Point 3 is honoured by a route the ADR did not anticipate, and `ILLUSTRATIONS.md` reads like it
+  contradicts it.** That file says in bold: *"Ask for a pure black background, and never for a
+  transparent one."* The reason is in `site/scripts/extract-marks.py` — **Gemini returns JPEG, which
+  has no alpha channel**, so asked for transparency it *draws* the grey checkerboard, because that
+  is the visual signifier it has seen. Those squares are real pixels and no prompt removes them. The
+  prompt therefore asks for a ground the script can key, and the script produces the transparency
+  the decision requires. The instruction that looks like a contradiction is what makes the point
+  achievable.
+- **Nine of the fourteen marks are unreferenced.** In use: `cat-and-crow` (hero), `crow-record`,
+  `lantern`, `cat-curled`, `cat-sitting`. Unused: `cat-stretching`, `cat-walking`, `cauldron`,
+  `constellation`, `crow-calling`, `crow-flight`, `crow-hopping`, `moon-phases`, `tuning-fork`.
+  Recorded so nobody prunes them as dead assets — ADR-0055 point 5 turns features into five or six
+  illustrated sections, and this is the reserve that pays for it. If `0055` is withdrawn, they
+  become genuinely unused and the question is worth reopening.
 
 Supersedes the theme-awareness clause of
 [ADR-0039](ADR-0039-the-website-is-rebuilt-in-place.md) point 4. The rest of that point — one set,

--- a/docs/decisions/ADR-0065-the-app-seeds-the-drop-in-folder-with-worked-examples.md
+++ b/docs/decisions/ADR-0065-the-app-seeds-the-drop-in-folder-with-worked-examples.md
@@ -1,8 +1,34 @@
 # ADR-0065: The App Seeds the Drop-In Folder With Worked Examples
 
-Status: proposed
+Status: superseded by [ADR-0089](ADR-0089-the-app-bundle-seeds-the-folder-and-is-not-a-source.md)
 
 Date: 2026-08-18
+
+Superseded 2026-08-29. **The idea shipped; this ADR's version of it did not, and should not.**
+
+`ADR-0089` decided the same thing in a stronger form two days after this was written, and points 1
+through 4 of it are built: `App/Shared/Visualizers.bundle/` ships **five** visualizers as real
+folders — `beat-tiles`, `lyric-storm`, `lyrics`, `reactive-terrain`, `spectrum` — and
+`VisualizerPlugins.seed(marker:)` copies them into the drop-in folder once, with `restore` beside
+it. This ADR is not discarded so much as absorbed: `VisualizerPlugins.swift:167` cites **"`ADR-0065`
+point 2's reasoning, inherited"** for seeding once, ever. That point was right and is why the code
+reads the way it does.
+
+What did not survive is the *shape*, and it could not have. `ADR-0087` had already redefined a
+visualizer as **a folder with an `index.html`**, sandboxed at an opaque origin and driven by
+`postMessage`. Both examples here are the form that replaced: `"main": "dist/index.js"`, built from
+JSX, requiring the host to supply `React` and a `jsx`/`jsxs` shim. **There is no host-provided React
+in a document.** So point 6's vendoring of `non-places`, point 4's choice of which two examples, and
+point 5's `affinity` corrections are all answers to a question `0087` stopped asking.
+
+The implementation branch `adr/ship-example-visualizers` (`familiar-apple`, PR #129, closed
+2026-08-25) is two commits of dead code carrying `ExampleVisualizer-non-places.js`/`.json` as flat
+pairs reconstructed at runtime, plus a second "Restore" button duplicating `0089`'s. **It should be
+deleted along with its worktree at `/Users/jeff/Developer/familiar-apple-examples`.**
+
+The lesson worth keeping: this sat `proposed` for eleven days while the ground moved under it twice
+(`0087`, then `0088`/`0089`). A proposal that is not executed promptly is not held in amber — and
+nothing flagged the conflict. The PR review caught it, which is late but not too late.
 
 Extends [ADR-0034](ADR-0034-visualizers-are-drop-in-bundles.md) and supersedes the last sentence of
 its point 4 — "There is no third source in this ADR." There still is not: what follows is not a new


### PR DESCRIPTION
**No code.** Docs-only, off `main`. Independent of #226 and #227, which do the same for ADR-0061 and ADR-0049.

Outcome of sweeping the eight remaining `proposed` ADRs. Of the eight: two were fully built, one was superseded and nobody had said so, two are partly built, and three are genuinely unstarted.

---

## ADR-0053 → accepted

Built on both sides. `navigate_app` and `capture_screenshot` are declared and dispatched (`mcp/playback.py:105,133,223,244`), the upload lands at `POST /playback/artifacts/{request_id}` (`routes/playback.py:138`), and `ArtifactStore` (`services/playback_commands.py:254`) holds captures in memory with `wait` removing the entry once read — no table, no directory. Request id is `uuid4().hex`; the tool waits 15 s and then **answers**, distinguishing "attached and declared the capability, so it failed" from "unavailable".

**Point 2 was checked by comparing the two lists, not by reading either.** `NAVIGATION_DESTINATIONS` and `SidebarItem`'s wire values are **15 entries that agree exactly** — no server-only destination, no Swift-only one. That agreement *is* the claim; reading either file alone would have proved nothing.

**Point 6's correction is in the code and absent from the prose around it.** `WindowCapture.swift:80` renders through `layer.render(in:)` with `cacheDisplay` kept only as the fallback at `:83` — the corrected form. But `WindowCapture.swift:13` still opens by describing `cacheDisplay(in:to:)` as what the file does, and `PlaybackCommand.swift:92` justifies the iOS gate with "the capture is `cacheDisplay` over an `NSWindow`'s content view" — a correct conclusion with a wrong reason. A third comment, `mcp/playback.py:46`, says the list mirrors `LibraryRoute`; there is no such type, it is `SidebarItem`.

Recorded as a follow-up rather than fixed, to keep this docs-only. Worth doing, because the next person to touch the capture path reads the comment before the code.

## ADR-0054 → accepted

Fourteen marks in `site/assets/marks/`, verified transparent **in the files** rather than assumed: RGBA, `alpha-min = 0`, transparent corners, 2× (479×689, 1024×510).

**Point 3 looked contradicted and is not.** `ILLUSTRATIONS.md` says in bold: *"Ask for a pure black background, and never for a transparent one."* The reason is in `extract-marks.py` — **Gemini returns JPEG, which has no alpha channel**, so asked for transparency it *draws* the grey checkerboard, because that is the visual signifier of transparency it has seen. Those squares are real pixels and no prompt removes them. So the prompt asks for a ground the script can key, and the script produces the transparency the decision requires. The instruction that reads as a contradiction is what makes the point achievable.

**Nine of the fourteen marks are unreferenced** — in use are `cat-and-crow`, `crow-record`, `lantern`, `cat-curled`, `cat-sitting`. Recorded so nobody prunes them as dead assets: ADR-0055 point 5 turns features into five or six illustrated sections, and this is the reserve that pays for it.

## ADR-0065 → superseded by ADR-0089

**The idea shipped; this ADR's version of it did not, and should not.** `App/Shared/Visualizers.bundle/` ships five visualizers as real folders — `beat-tiles`, `lyric-storm`, `lyrics`, `reactive-terrain`, `spectrum` — with `VisualizerPlugins.seed(marker:)` and `restore`. It is absorbed rather than discarded: `VisualizerPlugins.swift:167` cites **"`ADR-0065` point 2's reasoning, inherited"** for seeding once, ever.

The shape could not survive. `ADR-0087` had already made a visualizer **a folder with an `index.html`**, sandboxed at an opaque origin and driven by `postMessage`. Both examples here are the `"main": "dist/index.js"` form, built from JSX, needing the host to supply `React` and a `jsx`/`jsxs` shim — and there is no host-provided React in a document. So point 6's vendoring of `non-places`, point 4's choice of examples and point 5's `affinity` corrections all answer a question `0087` stopped asking.

It sat `proposed` for eleven days while the ground moved under it twice, and nothing flagged the conflict — PR review caught it. **`familiar-apple`'s `adr/ship-example-visualizers` branch and its worktree are now dead code and should be deleted;** that is not done here.

---

Remaining: `0055` and `0082` partly built, `0063`, `0069` and `0081` unstarted.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01Emjrwedq7W1scadHdgiLfs