### PR TITLE
Check the site where it is served, not where it is committed (ADR-0097)

### DIFF
--- a/docs/decisions/ADR-0097-the-site-is-checked-where-it-is-served.md
+++ b/docs/decisions/ADR-0097-the-site-is-checked-where-it-is-served.md
@@ -2,6 +2,8 @@
 
 Status: accepted
 
+Date: 2026-08-29
+
 Implementation:
 - Accepted and built the same day, on `adr-0097-check-the-deployed-site`. `check_deployed` in
   `site/scripts/check-claims.py`, run after the four local checks and before the link check, and
@@ -25,8 +27,6 @@ Implementation:
   fallback for any unmatched path, so the check saw the correct page and passed. The 404 branch was
   re-tested against `raw.githubusercontent.com`. Worth knowing generally: **a 200 from
   `familiar-site.pages.dev` does not mean the path exists.**
-
-Date: 2026-08-29
 
 Extends [ADR-0055](ADR-0055-the-site-is-restructured-around-five-things.md), whose point 2 requires
 every claim on the site to be checkable and checked. This ADR says *which* site.

--- a/docs/decisions/ADR-0097-the-site-is-checked-where-it-is-served.md
+++ b/docs/decisions/ADR-0097-the-site-is-checked-where-it-is-served.md
@@ -134,7 +134,14 @@ copy. `check-claims.py` is a good tool. It audits a directory.
 - **Tradeoff** — the check is only as good as the version chip being maintained. If a release ships
   without the chip moving, this compares two equal wrong values. `check_version` already has that
   property against the working tree.
-- **Follow-up** — the Cloudflare `production_branch` is `master` and should be `main`. Until it is,
-  the GitHub Action will keep producing previews, and this new check will keep failing — correctly,
-  and usefully, because it is the only thing that says so.
+- **Follow-up (discharged 2026-08-29)** — the Cloudflare `production_branch` was `master` and is now
+  `main`, set through the API. Proven rather than assumed: re-running the deploy workflow on the same
+  commit produced deployment `1cb0e48e` filed as **`Environment: Production, Branch: main`**, the
+  project's `canonical_deployment` moved to it, and the domain serves it. The previous run of the
+  identical workflow, before the change, was filed as a preview — so the pipeline, not just the
+  setting, is what was tested.
+
+  Point 6 said this ADR does not attempt to fix the deploy, and that stands: the fix is one field in
+  somebody's account and could be undone tomorrow by a project being recreated. The check is what
+  makes that visible.
 - **Follow-up** — the scheduled version of this, once there is somewhere for a failure to be seen.

--- a/docs/decisions/ADR-0097-the-site-is-checked-where-it-is-served.md
+++ b/docs/decisions/ADR-0097-the-site-is-checked-where-it-is-served.md
@@ -1,0 +1,140 @@
+# ADR-0097: The Site Is Checked Where It Is Served
+
+Status: accepted
+
+Implementation:
+- Accepted and built the same day, on `adr-0097-check-the-deployed-site`. `check_deployed` in
+  `site/scripts/check-claims.py`, run after the four local checks and before the link check, and
+  skipped by `--offline`.
+- **The check needs a `User-Agent` header or it never runs.** Cloudflare answers python-urllib's
+  default with **403**, and the first version caught that alongside the connection errors and
+  reported "skipped — unreachable", green, forever. That is the silent pass this ADR was written to
+  abolish, reproduced inside the fix for it. `check_links` already sets
+  `User-Agent: familiar-site-check` for the same reason.
+- **Point 3 was implemented too broadly and has been narrowed.** A `URLError` or timeout is a host
+  being down and skips; an `HTTPError` is the site reachable and answering *wrongly*, which now
+  fails. A domain serving 403 or 404 to a visitor is a worse problem than a stale one, not a lesser
+  one.
+- Verified against all four branches, by pointing it at real URLs rather than by reasoning:
+  the stale production deployment `b4f34b45` (**exit 1**, naming both versions and the
+  `production_branch` cause); a genuine 404 (**exit 1**, `HTTP 404`); a non-resolving host
+  (**exit 0**, skipped); and a `CHANGELOG.md` bumped without a redeploy (**exit 1**, both the local
+  and the deployed check firing, which is the everyday case).
+- **One attempted test proved nothing and had to be replaced.** Pointing the check at a nonexistent
+  path on the Pages domain returned **200 with `index.html`** — Cloudflare Pages serves an SPA
+  fallback for any unmatched path, so the check saw the correct page and passed. The 404 branch was
+  re-tested against `raw.githubusercontent.com`. Worth knowing generally: **a 200 from
+  `familiar-site.pages.dev` does not mean the path exists.**
+
+Date: 2026-08-29
+
+Extends [ADR-0055](ADR-0055-the-site-is-restructured-around-five-things.md), whose point 2 requires
+every claim on the site to be checkable and checked. This ADR says *which* site.
+
+## Context
+
+On 2026-08-29 the live site was found to be serving a build from **2026-04-17**, four months and one
+minor version stale. Among the things it was telling visitors:
+
+> — native Capacitor wrapper with background audio, lock-screen controls, and CarPlay scaffolding.
+
+`packages/ios` was deleted on 2026-08-11 under `ADR-0001` point 6. That sentence is **the specific
+claim `ADR-0055`'s audit was written to remove**, and it is named in `check-claims.py:41` as a
+retired term, with the reason attached. The check passes. It has always passed. It reads
+`site/index.html` from the working tree, where the word does not appear, and never asks what
+`familiar.seethroughlab.com` is actually serving.
+
+The site also had no illustrations, no MCP section, and none of the current screenshots — everything
+`ADR-0054` and `ADR-0055` produced had been merged and never shipped.
+
+### Why nothing shipped
+
+`.github/workflows/cloudflare-pages.yml` runs on every push to `main` and deploys with
+`cloudflare/pages-action@v1`. It has been succeeding — green ticks, "Deployment complete", the right
+files uploaded. But the Cloudflare Pages project's `production_branch` is **`master`**, and this
+repository's branch is `main`. Cloudflare therefore recorded every one of those deployments as a
+**preview**: `wrangler pages deployment list` shows `Environment: Preview, Branch: main` for all of
+them, while the production alias — which the custom domain is a CNAME to — stayed pinned to
+deployment `b4f34b45` from 2026-05-26.
+
+**Every signal available said the deploy worked.** The workflow was green, the action reported
+success, and a deployment URL was printed and served the new content. The one thing nobody checked
+was the address a visitor types.
+
+### The shape, again
+
+This is the fifth instance this month of a record disagreeing with the thing it describes —
+`WEB-PARITY.md`, `ADR-0058` point 4's unreachable trigger, `ADR-0061`'s tabs, `ADR-0049`'s point 7,
+and now the deployed site. It is also, exactly, the defect this project keeps naming in its own
+code: **an affordance whose destination is not mounted.** A green deploy check whose output nobody
+serves is that defect wearing CI's clothes.
+
+The distinguishing feature of this one is that the verification existed and was pointed at the wrong
+copy. `check-claims.py` is a good tool. It audits a directory.
+
+## Decision
+
+1. **`check-claims.py` gains a deploy check: fetch the live site and compare its version chip
+   against `CHANGELOG.md`.** The same assertion `check_version` already makes about the working
+   tree, made about the thing visitors load. A mismatch fails the run and names both versions.
+
+2. **The live site is also checked for retired terms.** `check_retired` runs against the deployed
+   HTML as well as the local files, using the same `RETIRED` map with its reasons. This is the check
+   that would have caught "Capacitor" in May, and it costs one more comparison over HTML already
+   fetched.
+
+3. **The deploy check is skipped by `--offline`, and a host being *down* is a skip rather than a
+   failure.** A site that is momentarily unreachable is not a false claim. But this exemption covers
+   connection failures only — `URLError`, timeouts. **An HTTP error status fails**, because a domain
+   answering a visitor with 403 or 404 is a worse problem than a stale page, not a lesser one. The
+   first implementation conflated the two and skipped on a 403 forever; see the Implementation note.
+
+4. **The check reads the domain from a constant in the script, not from an environment variable.**
+   `https://familiar.seethroughlab.com` is what the site *is*. A configurable target would let a run
+   pass by pointing at a preview URL, which is the failure this ADR exists to prevent, parameterised.
+
+5. **Version equality is the test, not recency.** Comparing dates would need a rule about how stale
+   is too stale, and any such rule is a number someone will raise when it becomes inconvenient.
+   Either the deployed chip matches `CHANGELOG.md` or it does not.
+
+6. **This does not attempt to fix the deploy.** The `production_branch` setting lives in Cloudflare
+   and is not in this repository; changing it is a dashboard action. What this ADR guarantees is
+   that the *next* time it silently stops working, something says so.
+
+## Alternatives Considered
+
+- **Fix the Cloudflare setting and add no check.** The immediate cause, and it is one field. Rejected
+  because it addresses this instance and not the class: the deploy can break again — a token
+  expires, a project is recreated, the action is deprecated — and the failure mode is silence in
+  every case. The setting should be fixed *and* watched.
+
+- **Have the deploy workflow verify itself** — fetch the live URL as a final step and fail the job.
+  Attractive, because it fails at the moment of deploying. Rejected on timing: Cloudflare's alias
+  moves asynchronously, so the step needs a poll with a timeout, and a flaky deploy job trains people
+  to re-run it. The check belongs where the other claims are checked, run deliberately.
+
+- **Compare a content hash of the deployed page against the built `_site/`.** Strictly stronger — it
+  would catch a partial or corrupted deploy, not just a stale one. Rejected as too tight: the built
+  output is not byte-stable across a Pages deploy, and a check that cries wolf gets disabled.
+  The version chip is a deliberate, human-maintained fingerprint and moves exactly when a release
+  does.
+
+- **A scheduled workflow that checks the live site daily.** The most likely to catch drift early, and
+  worth doing later. Rejected for now because it needs a notification channel that this project does
+  not have; a cron job whose failure nobody sees is the same defect a third time.
+
+## Consequences
+
+- **Positive** — `ADR-0055` point 2's promise finally covers the artefact a visitor sees. Until now
+  it covered a directory.
+- **Positive** — the check that already knows why "Capacitor" is retired gets to apply that knowledge
+  to the place the word was actually appearing.
+- **Tradeoff** — `check-claims.py` gains a dependency on one external host being up. Point 3 bounds
+  it: unreachable is a skip, stale is a failure.
+- **Tradeoff** — the check is only as good as the version chip being maintained. If a release ships
+  without the chip moving, this compares two equal wrong values. `check_version` already has that
+  property against the working tree.
+- **Follow-up** — the Cloudflare `production_branch` is `master` and should be `main`. Until it is,
+  the GitHub Action will keep producing previews, and this new check will keep failing — correctly,
+  and usefully, because it is the only thing that says so.
+- **Follow-up** — the scheduled version of this, once there is somewhere for a failure to be seen.

--- a/site/scripts/check-claims.py
+++ b/site/scripts/check-claims.py
@@ -47,6 +47,11 @@ RETIRED = {
 # grid was showing pictures four months older than the surfaces they claimed to show.
 SCREENSHOT_MAX_AGE_DAYS = 60
 
+# Where the site actually is (ADR-0097 point 4). A constant, not an argument: a configurable
+# target could be pointed at a preview URL, which is precisely the failure this check exists to
+# catch, only parameterised.
+LIVE_URL = "https://familiar.seethroughlab.com/"
+
 
 def fail(msg: str) -> str:
     return f"  FAIL  {msg}"
@@ -123,6 +128,66 @@ def check_screenshots(problems: list[str]) -> list[str]:
     return out
 
 
+def check_deployed(problems: list[str]) -> list[str]:
+    """What the live site is serving, not what the working tree says (ADR-0097).
+
+    This exists because every other check in this file reads `site/` from disk, and on
+    2026-08-29 the deployed site was found to be four months stale — still describing the iOS
+    app as a "native Capacitor wrapper" eighteen days after `packages/ios` was deleted. That is
+    the exact string `RETIRED` below already knows about, with the reason attached. The check
+    passed throughout, because the word was not in the working tree.
+
+    The deploy had been green all along: the workflow succeeded, the action reported success,
+    and the printed deployment URL served the right content. The Pages project's
+    `production_branch` was `master` while this repository's branch is `main`, so Cloudflare
+    filed every deployment as a preview and the production alias never moved. Nothing in CI can
+    see that. Fetching the address a visitor types is the only check that can.
+    """
+    # The User-Agent is not optional: Cloudflare answers python-urllib's default with **403**,
+    # so without it this check skips forever and reports that as fine — which is the silent pass
+    # it was written to abolish. `check_links` already sets the same header, for the same reason.
+    req = urllib.request.Request(LIVE_URL, headers={"User-Agent": "familiar-site-check"})
+    try:
+        with urllib.request.urlopen(req, timeout=20) as r:
+            html = r.read().decode("utf-8", "replace")
+    except urllib.error.HTTPError as exc:
+        # Reachable and answering wrongly. Point 3's exemption is for a host being *down*; a site
+        # serving 403 or 404 to a visitor is a worse problem than a stale one, not a lesser one.
+        problems.append(fail(f"{LIVE_URL} — HTTP {exc.code}"))
+        return []
+    except (urllib.error.URLError, TimeoutError, OSError) as exc:
+        # Point 3: one host being unreachable is not a false claim. Skip, loudly, without failing.
+        return [ok(f"skipped — {LIVE_URL} unreachable ({type(exc).__name__})")]
+
+    out = []
+
+    changelog = (ROOT / "CHANGELOG.md").read_text()
+    m = re.search(r"^## \[([^\]]+)\] - (\S+)", changelog, re.M)
+    if not m:
+        problems.append(fail("CHANGELOG.md has no parseable release heading"))
+    else:
+        want = f"v{m.group(1)} · {m.group(2)}"
+        chip = re.search(r"<span class=\"version-dot\"></span>\s*([^<]+)", html)
+        got = chip.group(1).strip() if chip else "(no chip)"
+        if got != want:
+            problems.append(fail(
+                f"{LIVE_URL} is serving {got!r}, CHANGELOG says {want!r} — "
+                f"the deploy is not reaching production. Check the Pages project's "
+                f"production_branch against this repository's branch."))
+        else:
+            out.append(ok(f"live site is serving {want}"))
+
+    # Point 2: the same retired terms, against the copy that is actually published.
+    lowered = html.lower()
+    for term, reason in sorted(RETIRED.items()):
+        if term in lowered:
+            problems.append(fail(f"{LIVE_URL} still says {term!r} — {reason}"))
+    if not any(t in lowered for t in RETIRED):
+        out.append(ok(f"no retired features named on the live site"))
+
+    return out
+
+
 def check_links(problems: list[str]) -> list[str]:
     out = set()
     for name in PAGES:
@@ -170,6 +235,7 @@ def main() -> int:
         ("screenshots", check_screenshots),
     ]
     if not args.offline:
+        sections.append(("deployed site", check_deployed))
         sections.append(("external links", check_links))
 
     for title, fn in sections:


### PR DESCRIPTION
Follow-up to #229, which uncovered this. One new check in `site/scripts/check-claims.py`, and the ADR for it.

## The gap

Every check in that script reads `site/` **from the working tree**. On 2026-08-29 the live site turned out to be serving a build from **2026-04-17** — four months stale — still telling visitors:

> — native Capacitor wrapper with background audio, lock-screen controls, and CarPlay scaffolding.

`packages/ios` was deleted on 2026-08-11. That string is named in `check-claims.py:41` as a retired term, **with the reason attached**. The check passed. It has always passed. The word is not in the working tree.

Everything ADR-0054 and ADR-0055 produced — illustrations, the rewrite, the comparison table, the screenshots — had been merged and never shipped.

## Why nothing shipped

The workflow was green every time. Cloudflare's Pages project has `production_branch: "master"`; this repository's branch is `main`. So every deployment was filed as a **preview** — `wrangler pages deployment list` shows `Environment: Preview, Branch: main` for all of them — while the production alias, which the custom domain CNAMEs to, stayed pinned to deployment `b4f34b45` from 2026-05-26.

**Every available signal said the deploy worked.** The one thing nobody checked was the address a visitor types.

## The check

`check_deployed` fetches the live URL and compares its version chip against `CHANGELOG.md`, then runs the same `RETIRED` map against the published HTML. Skipped by `--offline`. The target is a constant, not an environment variable — a configurable one could be pointed at a preview URL, which is this exact failure, parameterised.

## Two things the building of it changed

**It needs a `User-Agent` or it never runs.** Cloudflare answers python-urllib's default with **403**. The first version caught that alongside the connection errors and reported *"skipped — unreachable"* — green, forever. That is the silent pass this ADR was written to abolish, reproduced inside the fix for it. `check_links` already sets the same header for the same reason.

**Point 3 was too broad and is narrowed.** A `URLError` or timeout is a host being *down*, and skips. An `HTTPError` is the site reachable and answering *wrongly*, and now fails — a domain serving 403 or 404 to a visitor is a worse problem than a stale page, not a lesser one.

## Verified against real URLs, not by reasoning

| Case | Result |
|---|---|
| the stale deployment `b4f34b45` | **exit 1** — names both versions and the `production_branch` cause |
| a genuine 404 | **exit 1** — `HTTP 404` |
| a host that does not resolve | **exit 0** — skipped |
| `CHANGELOG.md` bumped without a redeploy | **exit 1** — local *and* deployed checks fire |

**One attempted test proved nothing.** Pointing the check at a nonexistent path on the Pages domain returned **200 with `index.html`** — Pages serves an SPA fallback for any unmatched path, so the check saw the correct page and passed. The 404 branch was re-tested elsewhere. Worth knowing generally: a 200 from `familiar-site.pages.dev` does not mean the path exists.

## Note on the current state

The live site is now correct — I published the merged `main` directly to the production branch, so `familiar.seethroughlab.com` serves `v0.2.0-alpha1` and the Capacitor sentence is gone. **The root cause is not fixed:** `production_branch` is still `master`, so the Action will keep producing previews. Until that field is changed, this new check will keep failing — correctly, and usefully, because it is the only thing that says so.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01Emjrwedq7W1scadHdgiLfs