### PR TITLE
Give tags one meaning and publish the areas (ADR-0072)

### DIFF
--- a/backend/app/api/routes/__init__.py
+++ b/backend/app/api/routes/__init__.py
@@ -22,7 +22,6 @@ from fastapi import APIRouter
 
 from app.api.routes import (
     admin_artists,
-    auth as auth_routes,
     analysis,
     artwork,
     background,
@@ -45,11 +44,16 @@ from app.api.routes import (
     proposed_changes,
     queue,
     s3_backup,
-    settings as settings_routes,
     smart_playlists,
     tracks,
     updates,
     videos,
+)
+from app.api.routes import (
+    auth as auth_routes,
+)
+from app.api.routes import (
+    settings as settings_routes,
 )
 from app.api.schemas.common import error_responses
 

--- a/backend/app/api/routes/__init__.py
+++ b/backend/app/api/routes/__init__.py
@@ -1,5 +1,95 @@
-"""API routes package."""
+"""API routes package — one aggregated router for the whole v1 surface.
 
-from app.api.routes import health, library, tracks
+**Everything is registered here, once** (ADR-0072 point 6). `main.py` mounts the result with a
+single `include_router`, so a concern shared by every route is expressed in one place instead of
+being repeated on a list of near-identical lines.
 
-__all__ = ["health", "library", "tracks"]
+That repetition was not hypothetical. `health.router` was the only one of the thirty-one registered
+without `DEFAULT_ERROR_RESPONSES`, so four operations documented a different error contract from the
+other 245 — not by decision, but because it was first in the list and the line above it was the one
+nobody copied. Applying the responses to `api_router` makes that class of defect unrepresentable:
+there is no longer a per-router place to forget it.
+
+**Order is preserved from the original registration and is load-bearing in one place.** The three
+`pending_review` routers must stay `group` → `bulk` → `router`, because the last one owns
+`/{pending_track_id}` and FastAPI matches in declaration order — registering it first would swallow
+`/group/...` and `/bulk/...` as ids. ADR-0077 deleted an endpoint that had been unreachable for
+exactly this reason (`GET /outputs/zones`, parsed as an output id), so it is worth stating rather
+than trusting to the diff.
+"""
+
+from fastapi import APIRouter
+
+from app.api.routes import (
+    admin_artists,
+    auth as auth_routes,
+    analysis,
+    artwork,
+    background,
+    diagnostics,
+    download,
+    export_import,
+    external_albums,
+    favorites,
+    health,
+    lastfm,
+    library,
+    mixtapes,
+    new_releases,
+    organizer,
+    outputs,
+    pending_review,
+    playback,
+    playlists,
+    profiles,
+    proposed_changes,
+    queue,
+    s3_backup,
+    settings as settings_routes,
+    smart_playlists,
+    tracks,
+    updates,
+    videos,
+)
+from app.api.schemas.common import error_responses
+
+# The error envelope every operation may return (ADR-0031's shape). Routes add their own statuses
+# on top where one is real control flow; this is the floor, applied to the aggregate router below.
+DEFAULT_ERROR_RESPONSES = error_responses(400, 401, 404, 422, 500)
+
+api_router = APIRouter(responses=DEFAULT_ERROR_RESPONSES)
+
+api_router.include_router(health.router)
+api_router.include_router(auth_routes.router)
+api_router.include_router(tracks.router)
+api_router.include_router(library.router)
+api_router.include_router(videos.router)
+api_router.include_router(lastfm.router)
+api_router.include_router(settings_routes.router)
+api_router.include_router(smart_playlists.router)
+api_router.include_router(playlists.router)
+api_router.include_router(mixtapes.router)
+api_router.include_router(profiles.router)
+api_router.include_router(favorites.router)
+api_router.include_router(organizer.router)
+api_router.include_router(proposed_changes.router)
+api_router.include_router(outputs.router)
+api_router.include_router(artwork.router)
+api_router.include_router(background.router)
+api_router.include_router(diagnostics.router)
+api_router.include_router(export_import.router)
+api_router.include_router(s3_backup.router)
+api_router.include_router(analysis.router)
+api_router.include_router(download.router)
+api_router.include_router(updates.router)
+api_router.include_router(playback.router)
+api_router.include_router(queue.router)
+api_router.include_router(external_albums.router)
+api_router.include_router(new_releases.router)
+api_router.include_router(admin_artists.router)
+# Order matters — see the module docstring.
+api_router.include_router(pending_review.group_router)
+api_router.include_router(pending_review.bulk_router)
+api_router.include_router(pending_review.router)
+
+__all__ = ["DEFAULT_ERROR_RESPONSES", "api_router"]

--- a/backend/app/api/routes/library.py
+++ b/backend/app/api/routes/library.py
@@ -22,7 +22,12 @@ from app.db.models import Track, TrackAnalysis
 
 logger = logging.getLogger(__name__)
 
-router = APIRouter(prefix="/library", tags=["library"])
+# No tag here. This router is an aggregator for the ten `library_*` leaf routers below, and
+# ADR-0072 point 2 puts the tag on the leaf that owns the operation: FastAPI *concatenates*
+# router tags rather than deduplicating them, so an aggregator that also tagged would give every
+# nested operation `["library", "library"]` — which is exactly what it used to do, for 32 of them.
+# The two operations declared directly on this router carry the tag on their own decorators.
+router = APIRouter(prefix="/library")
 
 
 class LibraryStats(BaseModel):
@@ -57,7 +62,7 @@ class LibraryFingerprint(BaseModel):
     max_updated_at: UTCDateTime | None = None
 
 
-@router.get("/fingerprint", response_model=LibraryFingerprint)
+@router.get("/fingerprint", response_model=LibraryFingerprint, tags=["library"])
 async def get_library_fingerprint(db: DbSession) -> LibraryFingerprint:
     """Cheap staleness check for an offline library cache.
 
@@ -89,7 +94,7 @@ async def get_library_fingerprint(db: DbSession) -> LibraryFingerprint:
     return LibraryFingerprint(track_count=track_count, max_updated_at=max_updated_at)
 
 
-@router.get("/stats", response_model=LibraryStats)
+@router.get("/stats", response_model=LibraryStats, tags=["library"])
 async def get_library_stats(db: DbSession) -> LibraryStats:
     """Get library statistics.
 

--- a/backend/app/api/routes/library_deduplicate.py
+++ b/backend/app/api/routes/library_deduplicate.py
@@ -16,7 +16,13 @@ from app.utils.time import to_rfc3339
 
 logger = logging.getLogger(__name__)
 
-router = APIRouter(prefix="/deduplicate", tags=["deduplicate"])
+# `library`, not `deduplicate`. This was the schema's only two-tag operation — the parent
+# aggregator's `library` plus this router's own — and therefore the only one whose generated name
+# depended on which tag happened to come first (ADR-0072 point 2). Resolving it toward `library`
+# rather than `deduplicate` is ADR-0072 point 7: a tag with one operation usually means a path
+# prefix was wanted, and `/library/deduplicate` is already that prefix. It also keeps the
+# operationId at `library_deduplicate_preview`, unchanged.
+router = APIRouter(prefix="/deduplicate", tags=["library"])
 
 
 # ── Response models ────────────────────────────────────────────

--- a/backend/app/api/routes/organizer.py
+++ b/backend/app/api/routes/organizer.py
@@ -17,7 +17,12 @@ from app.services.organizer import (
     get_available_templates,
 )
 
-router = APIRouter(prefix="/library/organize", tags=["Library Organization"])
+# `organizer`, lowercase kebab-case like every other tag (ADR-0072 point 3). It was
+# `Library Organization` — the schema's only tag with a space and capitals, which
+# `custom_generate_unique_id` then lowercased and hyphenated into
+# `library-organization_preview_organization`: 41 characters with "organization" in it twice.
+# ADR-0014 point 2 had asserted that class was empty; this tag had already been here seven months.
+router = APIRouter(prefix="/library/organize", tags=["organizer"])
 
 
 class TemplateInfo(BaseModel):

--- a/backend/app/main.py
+++ b/backend/app/main.py
@@ -29,40 +29,7 @@ from starlette.types import ASGIApp, Message, Receive, Scope, Send
 
 from app.api.exceptions import FamiliarError, NotFoundError
 from app.api.ratelimit import limiter
-from app.api.routes import (
-    admin_artists,
-    analysis,
-    artwork,
-    background,
-    diagnostics,
-    download,
-    export_import,
-    external_albums,
-    favorites,
-    health,
-    lastfm,
-    library,
-    mixtapes,
-    new_releases,
-    organizer,
-    outputs,
-    pending_review,
-    playback,
-    playlists,
-    profiles,
-    proposed_changes,
-    queue,
-    s3_backup,
-    smart_playlists,
-    tracks,
-    updates,
-    videos,
-)
-from app.api.routes import (
-    auth as auth_routes,
-)
-from app.api.routes import settings as settings_routes
-from app.api.schemas.common import error_responses
+from app.api.routes import api_router
 from app.config import AUDIO_EXTENSIONS, MUSIC_LIBRARY_PATH, get_app_version
 from app.config import settings as app_config
 from app.logging_config import get_logger, setup_logging
@@ -327,12 +294,117 @@ def custom_generate_unique_id(route: APIRoute) -> str:
     return f"{tag}_{route.name}"
 
 
+# ── The published index (ADR-0072 point 5) ────────────────────────────────────────────────────
+#
+# A newcomer's first read of this API should be the list of functional areas, not 249 operations
+# in alphabetical order. `openapi_tags` gives every tag an ordered position and a description;
+# `x-tagGroups` (added in `_openapi_with_global_security` below) gathers them into the seven areas
+# the product actually has. `/redoc` renders both and always could — `main.py` simply set neither.
+#
+# The order here is the order they render in. It runs from what a listener touches to what an
+# operator touches, which is also roughly most-used to least.
+#
+# **Every tag appears exactly once, and in exactly one group.** `scripts/lint_openapi.py` asserts
+# it, because a tag added without a description silently renders as a bare heading, which is the
+# failure this whole point exists to prevent.
+OPENAPI_TAGS = [
+    # Music — the collection itself.
+    {"name": "library", "description":
+        "The collection as a whole: artists, albums, aggregations, sync, import, duplicates and "
+        "the map. The largest tag in the API, and deliberately whole — ADR-0007 point 2 accepted "
+        "dead generated code rather than split it, and ADR-0073 is the proposal that revisits."},
+    {"name": "tracks", "description":
+        "Individual tracks: listing, detail, streaming, metadata and play/skip reporting. "
+        "`/tracks/{id}/played` belongs to the track, not to a reporting area (ADR-0072 point 4)."},
+    {"name": "analysis", "description":
+        "Audio analysis — features, embeddings and melodic data — over one track or the whole "
+        "library. Re-analysis happens only during a library sync; nothing is scheduled."},
+    {"name": "artwork", "description":
+        "Album and artist images: lookup, caching, regeneration and coverage reporting."},
+
+    # Collections — the ways a listener groups music.
+    {"name": "playlists", "description": "Hand-made playlists and their tracks."},
+    {"name": "smart-playlists", "description":
+        "Rule-driven playlists, evaluated server-side so every client sees the same result."},
+    {"name": "mixtapes", "description":
+        "Generated sequences with a stated shape, kept distinct from playlists because they are "
+        "authored by the server rather than by hand."},
+    {"name": "favorites", "description": "Per-profile favourites."},
+
+    # Playback — what is playing, and where.
+    {"name": "queue", "description":
+        "The server-owned playback queue and its radio suggestions (ADR-0003, ADR-0005). "
+        "ADR-0074 is the proposal that this tag names three different things."},
+    {"name": "playback", "description":
+        "Transport state reported by a client, so other surfaces can show what is playing."},
+    {"name": "outputs", "description":
+        "Network audio devices — Sonos, UPnP/DLNA, AirPlay, Chromecast — and casting to them "
+        "(ADR-0031). Zone grouping was removed by ADR-0077."},
+    {"name": "videos", "description":
+        "Music videos as a way of playing a track, not as a visualizer (ADR-0085, ADR-0086)."},
+
+    # Discovery — finding something that is not already in the collection.
+    {"name": "lastfm", "description": "Last.fm scrobbling and the metadata it supplies."},
+    {"name": "new-releases", "description": "New releases by artists in the library."},
+    {"name": "external-albums", "description":
+        "Albums found outside the library, offered as things to acquire."},
+
+    # Curation — deciding what the collection should become.
+    {"name": "pending-review", "description":
+        "Tracks awaiting a decision before they enter the library, in groups and in bulk."},
+    {"name": "proposed-changes", "description":
+        "Metadata changes proposed by analysis or by the LLM tools, awaiting approval."},
+    {"name": "organizer", "description":
+        "File-organisation previews. Preview only: no route moves a file, so there is nothing to "
+        "apply. Renamed from `Library Organization` by ADR-0072 point 3."},
+    {"name": "admin", "description":
+        "Artist-merge operations. The `admin` name is a misnomer under ADR-0058 — most of this API "
+        "is administration — and ADR-0076 point 5 is the proposal to rename it `artists`."},
+
+    # Transfer and backup — getting data out, and back.
+    {"name": "export-import", "description":
+        "Moving a profile or a library between servers."},
+    {"name": "s3-backup", "description":
+        "Scheduled backup to S3-compatible storage, and restore from it."},
+    {"name": "download", "description":
+        "ZIP exports of playlists, track sets and analysis reports."},
+
+    # Server — operating the thing.
+    {"name": "profiles", "description":
+        "Listener profiles. Familiar has no traditional auth; the profile id in the request header "
+        "is what scopes taste, history and favourites."},
+    {"name": "auth", "description": "Server-token administration (ADR-0045)."},
+    {"name": "settings", "description":
+        "Server configuration — library paths, API keys, provider choice."},
+    {"name": "health", "description":
+        "Liveness. `GET /api/v1/health` is a container probe, not a client-facing endpoint."},
+    {"name": "diagnostics", "description": "Logs and runtime introspection."},
+    {"name": "background", "description": "Background job state."},
+    {"name": "updates", "description": "Application update checks."},
+]
+
+# The seven areas, in render order. Point 5 says the areas are published rather than implied; this
+# is where they are stated. ADR-0073, ADR-0074 and ADR-0076 all move tags between these, so expect
+# to edit this list when they land — that is the intended cost, and it is cheap.
+OPENAPI_TAG_GROUPS = [
+    {"name": "Music", "tags": ["library", "tracks", "analysis", "artwork"]},
+    {"name": "Collections", "tags": ["playlists", "smart-playlists", "mixtapes", "favorites"]},
+    {"name": "Playback", "tags": ["queue", "playback", "outputs", "videos"]},
+    {"name": "Discovery", "tags": ["lastfm", "new-releases", "external-albums"]},
+    {"name": "Curation", "tags": ["pending-review", "proposed-changes", "organizer", "admin"]},
+    {"name": "Transfer and backup", "tags": ["export-import", "s3-backup", "download"]},
+    {"name": "Server", "tags": [
+        "profiles", "auth", "settings", "health", "diagnostics", "background", "updates"]},
+]
+
+
 app = FastAPI(
     title="Familiar",
     description="LLM-powered local music player API",
     version=get_app_version(),
     lifespan=lifespan,
     generate_unique_id_function=custom_generate_unique_id,
+    openapi_tags=OPENAPI_TAGS,
 )
 
 # MCP (ADR-0043). Mounted here rather than beside the API routers because the SPA catch-all is
@@ -496,46 +568,17 @@ async def generic_exception_handler(request: Request, exc: Exception) -> JSONRes
         request_id=request_id,
     )
 
-# Include routers.
+# Include routers — every one of them, in a single call (ADR-0072 point 6). The list lives in
+# `app/api/routes/__init__.py`; see that module for why it is there and which part of its order is
+# load-bearing.
 #
-# `DEFAULT_ERROR_RESPONSES` is attached to every router rather than to 260 individual routes
-# (ADR-0007). Without it the schema documents only 200 and FastAPI's automatic 422 — and that 422
-# is the wrong shape, since `validation_exception_handler` below emits the Familiar envelope
-# instead. Declaring 422 explicitly replaces FastAPI's `HTTPValidationError` with the shape the
-# server actually sends. Routes add their own statuses on top where one is real control flow.
-DEFAULT_ERROR_RESPONSES = error_responses(400, 401, 404, 422, 500)
-
-app.include_router(health.router, prefix="/api/v1")
-app.include_router(auth_routes.router, prefix="/api/v1", responses=DEFAULT_ERROR_RESPONSES)
-app.include_router(tracks.router, prefix="/api/v1", responses=DEFAULT_ERROR_RESPONSES)
-app.include_router(library.router, prefix="/api/v1", responses=DEFAULT_ERROR_RESPONSES)
-app.include_router(videos.router, prefix="/api/v1", responses=DEFAULT_ERROR_RESPONSES)
-app.include_router(lastfm.router, prefix="/api/v1", responses=DEFAULT_ERROR_RESPONSES)
-app.include_router(settings_routes.router, prefix="/api/v1", responses=DEFAULT_ERROR_RESPONSES)
-app.include_router(smart_playlists.router, prefix="/api/v1", responses=DEFAULT_ERROR_RESPONSES)
-app.include_router(playlists.router, prefix="/api/v1", responses=DEFAULT_ERROR_RESPONSES)
-app.include_router(mixtapes.router, prefix="/api/v1", responses=DEFAULT_ERROR_RESPONSES)
-app.include_router(profiles.router, prefix="/api/v1", responses=DEFAULT_ERROR_RESPONSES)
-app.include_router(favorites.router, prefix="/api/v1", responses=DEFAULT_ERROR_RESPONSES)
-app.include_router(organizer.router, prefix="/api/v1", responses=DEFAULT_ERROR_RESPONSES)
-app.include_router(proposed_changes.router, prefix="/api/v1", responses=DEFAULT_ERROR_RESPONSES)
-app.include_router(outputs.router, prefix="/api/v1", responses=DEFAULT_ERROR_RESPONSES)
-app.include_router(artwork.router, prefix="/api/v1", responses=DEFAULT_ERROR_RESPONSES)
-app.include_router(background.router, prefix="/api/v1", responses=DEFAULT_ERROR_RESPONSES)
-app.include_router(diagnostics.router, prefix="/api/v1", responses=DEFAULT_ERROR_RESPONSES)
-app.include_router(export_import.router, prefix="/api/v1", responses=DEFAULT_ERROR_RESPONSES)
-app.include_router(s3_backup.router, prefix="/api/v1", responses=DEFAULT_ERROR_RESPONSES)
-app.include_router(analysis.router, prefix="/api/v1", responses=DEFAULT_ERROR_RESPONSES)
-app.include_router(download.router, prefix="/api/v1", responses=DEFAULT_ERROR_RESPONSES)
-app.include_router(updates.router, prefix="/api/v1", responses=DEFAULT_ERROR_RESPONSES)
-app.include_router(playback.router, prefix="/api/v1", responses=DEFAULT_ERROR_RESPONSES)
-app.include_router(queue.router, prefix="/api/v1", responses=DEFAULT_ERROR_RESPONSES)
-app.include_router(external_albums.router, prefix="/api/v1", responses=DEFAULT_ERROR_RESPONSES)
-app.include_router(new_releases.router, prefix="/api/v1", responses=DEFAULT_ERROR_RESPONSES)
-app.include_router(admin_artists.router, prefix="/api/v1", responses=DEFAULT_ERROR_RESPONSES)
-app.include_router(pending_review.group_router, prefix="/api/v1", responses=DEFAULT_ERROR_RESPONSES)
-app.include_router(pending_review.bulk_router, prefix="/api/v1", responses=DEFAULT_ERROR_RESPONSES)
-app.include_router(pending_review.router, prefix="/api/v1", responses=DEFAULT_ERROR_RESPONSES)
+# `DEFAULT_ERROR_RESPONSES` is attached to the aggregate router rather than to 249 individual
+# routes (ADR-0007). Without it the schema documents only 200 and FastAPI's automatic 422 — and
+# that 422 is the wrong shape, since `validation_exception_handler` below emits the Familiar
+# envelope instead. Declaring 422 explicitly replaces FastAPI's `HTTPValidationError` with the
+# shape the server actually sends. Routes add their own statuses on top where one is real control
+# flow.
+app.include_router(api_router, prefix="/api/v1")
 
 
 def _openapi_with_global_security() -> dict[str, Any]:
@@ -564,11 +607,15 @@ def _openapi_with_global_security() -> dict[str, Any]:
 
     from app.api.auth import TOKEN_HEADER
 
+    # `tags=` must be passed explicitly. `get_openapi` does not read it off the app, so the
+    # `openapi_tags` given to `FastAPI(...)` is silently dropped by any custom `openapi` hook that
+    # forgets it — the descriptions render as nothing and no error is raised anywhere.
     schema = get_openapi(
         title=app.title,
         version=app.version,
         description=app.description,
         routes=app.routes,
+        tags=app.openapi_tags,
     )
     components = schema.setdefault("components", {})
     schemes = components.setdefault("securitySchemes", {})
@@ -585,6 +632,12 @@ def _openapi_with_global_security() -> dict[str, Any]:
     # Applies to every operation, including the ones that declare `ProfileHeader`: the two are
     # different questions, and an operation can require both.
     schema["security"] = [{"FamiliarToken": []}]
+
+    # The functional areas, grouped (ADR-0072 point 5). `x-tagGroups` is a ReDoc extension rather
+    # than core OpenAPI, which is why it is set here instead of on the `FastAPI(...)` call — there
+    # is no constructor argument for it. `/redoc` renders it as the left-hand navigation; a
+    # generator that does not understand the key ignores it, which is the intended failure mode.
+    schema["x-tagGroups"] = OPENAPI_TAG_GROUPS
 
     app.openapi_schema = schema
     return schema

--- a/backend/openapi.json
+++ b/backend/openapi.json
@@ -14664,6 +14664,56 @@
               }
             },
             "description": "Successful Response"
+          },
+          "400": {
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/ErrorEnvelope"
+                }
+              }
+            },
+            "description": "Bad Request"
+          },
+          "401": {
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/ErrorEnvelope"
+                }
+              }
+            },
+            "description": "Unauthorized"
+          },
+          "404": {
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/ErrorEnvelope"
+                }
+              }
+            },
+            "description": "Not Found"
+          },
+          "422": {
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/ErrorEnvelope"
+                }
+              }
+            },
+            "description": "Unprocessable Entity"
+          },
+          "500": {
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/ErrorEnvelope"
+                }
+              }
+            },
+            "description": "Internal Server Error"
           }
         },
         "summary": "Health Check",
@@ -14686,6 +14736,56 @@
               }
             },
             "description": "Successful Response"
+          },
+          "400": {
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/ErrorEnvelope"
+                }
+              }
+            },
+            "description": "Bad Request"
+          },
+          "401": {
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/ErrorEnvelope"
+                }
+              }
+            },
+            "description": "Unauthorized"
+          },
+          "404": {
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/ErrorEnvelope"
+                }
+              }
+            },
+            "description": "Not Found"
+          },
+          "422": {
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/ErrorEnvelope"
+                }
+              }
+            },
+            "description": "Unprocessable Entity"
+          },
+          "500": {
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/ErrorEnvelope"
+                }
+              }
+            },
+            "description": "Internal Server Error"
           }
         },
         "summary": "Db Health Check",
@@ -14708,6 +14808,56 @@
               }
             },
             "description": "Successful Response"
+          },
+          "400": {
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/ErrorEnvelope"
+                }
+              }
+            },
+            "description": "Bad Request"
+          },
+          "401": {
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/ErrorEnvelope"
+                }
+              }
+            },
+            "description": "Unauthorized"
+          },
+          "404": {
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/ErrorEnvelope"
+                }
+              }
+            },
+            "description": "Not Found"
+          },
+          "422": {
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/ErrorEnvelope"
+                }
+              }
+            },
+            "description": "Unprocessable Entity"
+          },
+          "500": {
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/ErrorEnvelope"
+                }
+              }
+            },
+            "description": "Internal Server Error"
           }
         },
         "summary": "System Health Check",
@@ -14730,6 +14880,56 @@
               }
             },
             "description": "Successful Response"
+          },
+          "400": {
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/ErrorEnvelope"
+                }
+              }
+            },
+            "description": "Bad Request"
+          },
+          "401": {
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/ErrorEnvelope"
+                }
+              }
+            },
+            "description": "Unauthorized"
+          },
+          "404": {
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/ErrorEnvelope"
+                }
+              }
+            },
+            "description": "Not Found"
+          },
+          "422": {
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/ErrorEnvelope"
+                }
+              }
+            },
+            "description": "Unprocessable Entity"
+          },
+          "500": {
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/ErrorEnvelope"
+                }
+              }
+            },
+            "description": "Internal Server Error"
           }
         },
         "summary": "Get Worker Status",
@@ -15355,7 +15555,6 @@
         },
         "summary": "List Albums",
         "tags": [
-          "library",
           "library"
         ]
       }
@@ -15474,7 +15673,6 @@
         },
         "summary": "Get Album Detail",
         "tags": [
-          "library",
           "library"
         ]
       }
@@ -15547,7 +15745,6 @@
         },
         "summary": "Cancel Analysis",
         "tags": [
-          "library",
           "library"
         ]
       }
@@ -15620,7 +15817,6 @@
         },
         "summary": "Get Executor Status",
         "tags": [
-          "library",
           "library"
         ]
       }
@@ -15693,7 +15889,6 @@
         },
         "summary": "Reset Executor",
         "tags": [
-          "library",
           "library"
         ]
       }
@@ -15778,7 +15973,6 @@
         },
         "summary": "Start Analysis",
         "tags": [
-          "library",
           "library"
         ]
       }
@@ -15851,7 +16045,6 @@
         },
         "summary": "Get Analysis Status",
         "tags": [
-          "library",
           "library"
         ]
       }
@@ -15978,7 +16171,6 @@
         },
         "summary": "List Artists",
         "tags": [
-          "library",
           "library"
         ]
       }
@@ -16082,7 +16274,6 @@
         ],
         "summary": "Get Artist New Releases",
         "tags": [
-          "library",
           "library"
         ]
       }
@@ -16176,7 +16367,6 @@
         },
         "summary": "Get Artist Detail",
         "tags": [
-          "library",
           "library"
         ]
       }
@@ -16263,7 +16453,6 @@
         },
         "summary": "Get Artist Image",
         "tags": [
-          "library",
           "library"
         ]
       }
@@ -16374,8 +16563,7 @@
         },
         "summary": "Deduplicate Preview",
         "tags": [
-          "library",
-          "deduplicate"
+          "library"
         ]
       }
     },
@@ -16512,7 +16700,6 @@
         ],
         "summary": "Get Discover Dashboard",
         "tags": [
-          "library",
           "library"
         ]
       }
@@ -16614,7 +16801,6 @@
         ],
         "summary": "Get Listening Profile External Albums",
         "tags": [
-          "library",
           "library"
         ]
       }
@@ -16769,7 +16955,6 @@
         },
         "summary": "Import Preview",
         "tags": [
-          "library",
           "library"
         ]
       }
@@ -16852,7 +17037,6 @@
         },
         "summary": "Import Preview From Path",
         "tags": [
-          "library",
           "library"
         ]
       }
@@ -16940,7 +17124,6 @@
         },
         "summary": "Scan Path",
         "tags": [
-          "library",
           "library"
         ]
       }
@@ -17076,7 +17259,6 @@
         },
         "summary": "Get Letter Index",
         "tags": [
-          "library",
           "library"
         ]
       }
@@ -17175,7 +17357,6 @@
         },
         "summary": "Get Music Map",
         "tags": [
-          "library",
           "library"
         ]
       }
@@ -17264,7 +17445,6 @@
         },
         "summary": "Get 3D Music Map",
         "tags": [
-          "library",
           "library"
         ]
       }
@@ -17349,7 +17529,6 @@
         },
         "summary": "Get 3D Music Map Stream",
         "tags": [
-          "library",
           "library"
         ]
       }
@@ -17462,7 +17641,6 @@
         },
         "summary": "Get Ego Centric Map",
         "tags": [
-          "library",
           "library"
         ]
       }
@@ -17557,7 +17735,6 @@
         },
         "summary": "Get Music Map Stream",
         "tags": [
-          "library",
           "library"
         ]
       }
@@ -17630,7 +17807,6 @@
         },
         "summary": "Get Missing Tracks",
         "tags": [
-          "library",
           "library"
         ]
       }
@@ -17713,7 +17889,6 @@
         },
         "summary": "Delete Missing Tracks Batch",
         "tags": [
-          "library",
           "library"
         ]
       }
@@ -17796,7 +17971,6 @@
         },
         "summary": "Relocate Missing Tracks",
         "tags": [
-          "library",
           "library"
         ]
       }
@@ -17880,7 +18054,6 @@
         },
         "summary": "Delete Missing Track",
         "tags": [
-          "library",
           "library"
         ]
       }
@@ -17974,7 +18147,6 @@
         },
         "summary": "Locate Single Track",
         "tags": [
-          "library",
           "library"
         ]
       }
@@ -18083,7 +18255,6 @@
         },
         "summary": "Get Mood Distribution",
         "tags": [
-          "library",
           "library"
         ]
       }
@@ -18091,7 +18262,7 @@
     "/api/v1/library/organize/preview": {
       "post": {
         "description": "Preview what organization would do without moving files.\n\nReturns a list of tracks and their proposed new paths.\nLimited to first N tracks for performance.",
-        "operationId": "library-organization_preview_organization",
+        "operationId": "organizer_preview_organization",
         "requestBody": {
           "content": {
             "application/json": {
@@ -18166,14 +18337,14 @@
         },
         "summary": "Preview Organization",
         "tags": [
-          "Library Organization"
+          "organizer"
         ]
       }
     },
     "/api/v1/library/organize/templates": {
       "get": {
         "description": "List available organization templates.",
-        "operationId": "library-organization_list_templates",
+        "operationId": "organizer_list_templates",
         "responses": {
           "200": {
             "content": {
@@ -18238,14 +18409,14 @@
         },
         "summary": "List Templates",
         "tags": [
-          "Library Organization"
+          "organizer"
         ]
       }
     },
     "/api/v1/library/organize/track/{track_id}/preview": {
       "get": {
         "description": "Preview organization for a single track.",
-        "operationId": "library-organization_preview_track",
+        "operationId": "organizer_preview_track",
         "parameters": [
           {
             "in": "path",
@@ -18332,7 +18503,7 @@
         },
         "summary": "Preview Track",
         "tags": [
-          "Library Organization"
+          "organizer"
         ]
       }
     },
@@ -18488,7 +18659,6 @@
         },
         "summary": "Start Sync",
         "tags": [
-          "library",
           "library"
         ]
       }
@@ -18561,7 +18731,6 @@
         },
         "summary": "Cancel Sync",
         "tags": [
-          "library",
           "library"
         ]
       }
@@ -18634,7 +18803,6 @@
         },
         "summary": "Get Sync Status Endpoint",
         "tags": [
-          "library",
           "library"
         ]
       }
@@ -18707,7 +18875,6 @@
         },
         "summary": "Get Year Distribution",
         "tags": [
-          "library",
           "library"
         ]
       }
@@ -33039,6 +33206,190 @@
   "security": [
     {
       "FamiliarToken": []
+    }
+  ],
+  "tags": [
+    {
+      "description": "The collection as a whole: artists, albums, aggregations, sync, import, duplicates and the map. The largest tag in the API, and deliberately whole \u2014 ADR-0007 point 2 accepted dead generated code rather than split it, and ADR-0073 is the proposal that revisits.",
+      "name": "library"
+    },
+    {
+      "description": "Individual tracks: listing, detail, streaming, metadata and play/skip reporting. `/tracks/{id}/played` belongs to the track, not to a reporting area (ADR-0072 point 4).",
+      "name": "tracks"
+    },
+    {
+      "description": "Audio analysis \u2014 features, embeddings and melodic data \u2014 over one track or the whole library. Re-analysis happens only during a library sync; nothing is scheduled.",
+      "name": "analysis"
+    },
+    {
+      "description": "Album and artist images: lookup, caching, regeneration and coverage reporting.",
+      "name": "artwork"
+    },
+    {
+      "description": "Hand-made playlists and their tracks.",
+      "name": "playlists"
+    },
+    {
+      "description": "Rule-driven playlists, evaluated server-side so every client sees the same result.",
+      "name": "smart-playlists"
+    },
+    {
+      "description": "Generated sequences with a stated shape, kept distinct from playlists because they are authored by the server rather than by hand.",
+      "name": "mixtapes"
+    },
+    {
+      "description": "Per-profile favourites.",
+      "name": "favorites"
+    },
+    {
+      "description": "The server-owned playback queue and its radio suggestions (ADR-0003, ADR-0005). ADR-0074 is the proposal that this tag names three different things.",
+      "name": "queue"
+    },
+    {
+      "description": "Transport state reported by a client, so other surfaces can show what is playing.",
+      "name": "playback"
+    },
+    {
+      "description": "Network audio devices \u2014 Sonos, UPnP/DLNA, AirPlay, Chromecast \u2014 and casting to them (ADR-0031). Zone grouping was removed by ADR-0077.",
+      "name": "outputs"
+    },
+    {
+      "description": "Music videos as a way of playing a track, not as a visualizer (ADR-0085, ADR-0086).",
+      "name": "videos"
+    },
+    {
+      "description": "Last.fm scrobbling and the metadata it supplies.",
+      "name": "lastfm"
+    },
+    {
+      "description": "New releases by artists in the library.",
+      "name": "new-releases"
+    },
+    {
+      "description": "Albums found outside the library, offered as things to acquire.",
+      "name": "external-albums"
+    },
+    {
+      "description": "Tracks awaiting a decision before they enter the library, in groups and in bulk.",
+      "name": "pending-review"
+    },
+    {
+      "description": "Metadata changes proposed by analysis or by the LLM tools, awaiting approval.",
+      "name": "proposed-changes"
+    },
+    {
+      "description": "File-organisation previews. Preview only: no route moves a file, so there is nothing to apply. Renamed from `Library Organization` by ADR-0072 point 3.",
+      "name": "organizer"
+    },
+    {
+      "description": "Artist-merge operations. The `admin` name is a misnomer under ADR-0058 \u2014 most of this API is administration \u2014 and ADR-0076 point 5 is the proposal to rename it `artists`.",
+      "name": "admin"
+    },
+    {
+      "description": "Moving a profile or a library between servers.",
+      "name": "export-import"
+    },
+    {
+      "description": "Scheduled backup to S3-compatible storage, and restore from it.",
+      "name": "s3-backup"
+    },
+    {
+      "description": "ZIP exports of playlists, track sets and analysis reports.",
+      "name": "download"
+    },
+    {
+      "description": "Listener profiles. Familiar has no traditional auth; the profile id in the request header is what scopes taste, history and favourites.",
+      "name": "profiles"
+    },
+    {
+      "description": "Server-token administration (ADR-0045).",
+      "name": "auth"
+    },
+    {
+      "description": "Server configuration \u2014 library paths, API keys, provider choice.",
+      "name": "settings"
+    },
+    {
+      "description": "Liveness. `GET /api/v1/health` is a container probe, not a client-facing endpoint.",
+      "name": "health"
+    },
+    {
+      "description": "Logs and runtime introspection.",
+      "name": "diagnostics"
+    },
+    {
+      "description": "Background job state.",
+      "name": "background"
+    },
+    {
+      "description": "Application update checks.",
+      "name": "updates"
+    }
+  ],
+  "x-tagGroups": [
+    {
+      "name": "Music",
+      "tags": [
+        "library",
+        "tracks",
+        "analysis",
+        "artwork"
+      ]
+    },
+    {
+      "name": "Collections",
+      "tags": [
+        "playlists",
+        "smart-playlists",
+        "mixtapes",
+        "favorites"
+      ]
+    },
+    {
+      "name": "Playback",
+      "tags": [
+        "queue",
+        "playback",
+        "outputs",
+        "videos"
+      ]
+    },
+    {
+      "name": "Discovery",
+      "tags": [
+        "lastfm",
+        "new-releases",
+        "external-albums"
+      ]
+    },
+    {
+      "name": "Curation",
+      "tags": [
+        "pending-review",
+        "proposed-changes",
+        "organizer",
+        "admin"
+      ]
+    },
+    {
+      "name": "Transfer and backup",
+      "tags": [
+        "export-import",
+        "s3-backup",
+        "download"
+      ]
+    },
+    {
+      "name": "Server",
+      "tags": [
+        "profiles",
+        "auth",
+        "settings",
+        "health",
+        "diagnostics",
+        "background",
+        "updates"
+      ]
     }
   ]
 }

--- a/backend/scripts/lint_openapi.py
+++ b/backend/scripts/lint_openapi.py
@@ -320,6 +320,66 @@ def lint_openapi(schema: dict[str, Any]) -> list[str]:
         errors.append(disagreement)
     components = schema.get("components", {}).get("schemas", {})
 
+    # ── ADR-0072: paths name resources, tags name functions ───────────────────────────────────
+    #
+    # Points 2, 3 and 5 are the machine-checkable half of that ADR (points 1 and 4 are judgement,
+    # and a reviewer applies them). Each of these three had already been violated once before it
+    # was a rule — 32 operations tagged `["library", "library"]`, one tag with a space and
+    # capitals that a prior audit missed, and an index nothing set — so they are asserted rather
+    # than trusted.
+    schema_tags: set[str] = set()
+    for path, methods in schema.get("paths", {}).items():
+        for method, operation in methods.items():
+            if not isinstance(operation, dict):
+                continue
+            tags = operation.get("tags") or []
+            # `GET /` is the app root, registered outside `api_router` and outside `/api/v1`. It
+            # has never carried a tag and is not part of any functional area.
+            if path == "/":
+                continue
+            if len(tags) != 1:
+                errors.append(
+                    f"{method.upper()} {path} has {len(tags)} tags ({tags!r}) — ADR-0072 point 2 "
+                    f"requires exactly one. Tag the leaf router that owns the operation, and make "
+                    f"sure no aggregator above it also tags: FastAPI concatenates rather than "
+                    f"deduplicating."
+                )
+            for tag in tags:
+                schema_tags.add(tag)
+                if tag != tag.lower() or " " in tag:
+                    errors.append(
+                        f"tag {tag!r} on {method.upper()} {path} is not lowercase kebab-case — "
+                        f"ADR-0072 point 3. The tag is half of the generated operationId, so this "
+                        f"reaches the Swift method name."
+                    )
+
+    # Point 5: every tag is described, and sits in exactly one group. An undescribed tag renders in
+    # /redoc as a bare heading, which is precisely the illegibility the point exists to remove.
+    described = {t["name"]: t.get("description") for t in schema.get("tags", [])}
+    if not described:
+        errors.append(
+            "schema has no top-level `tags` array — ADR-0072 point 5. Note that `get_openapi()` "
+            "ignores the app's `openapi_tags` unless it is passed `tags=` explicitly, so a custom "
+            "`app.openapi` hook drops the index silently."
+        )
+    grouped: list[str] = [t for g in schema.get("x-tagGroups", []) for t in g.get("tags", [])]
+    if not grouped:
+        errors.append("schema has no `x-tagGroups` — ADR-0072 point 5.")
+    for tag in sorted(schema_tags):
+        if tag not in described:
+            errors.append(f"tag {tag!r} is used but has no description — ADR-0072 point 5.")
+        elif not described[tag]:
+            errors.append(f"tag {tag!r} has an empty description — ADR-0072 point 5.")
+        if grouped.count(tag) != 1:
+            errors.append(
+                f"tag {tag!r} appears in {grouped.count(tag)} x-tagGroups entries — ADR-0072 "
+                f"point 5 requires exactly one."
+            )
+    for tag in sorted(set(described) - schema_tags):
+        errors.append(
+            f"tag {tag!r} is described but no operation carries it — a stale index entry."
+        )
+
     # The profile header must reach the schema. It is the only authentication there is, and it is
     # supplied by a dependency rather than a route signature — so deleting `Depends(profile_header)`
     # in deps.py would silently strip every security requirement and leave a generated client with

--- a/docs/decisions/ADR-0072-paths-name-resources-tags-name-functions.md
+++ b/docs/decisions/ADR-0072-paths-name-resources-tags-name-functions.md
@@ -8,6 +8,46 @@ Extends [ADR-0007](ADR-0007-clients-are-generated-from-openapi.md), which made t
 and the tag the unit that defines the generated surface. This says what a tag and a path each mean,
 so that the contract can be reorganized without guessing.
 
+Implementation:
+
+- **Shipped 2026-08-28**, `familiar` on `adr-0072-paths-and-tags` and `familiar-apple` on the branch
+  of the same name, both stacked on `ADR-0077`'s. Counts at the time: **249 operations, 219 paths,
+  29 tags** — the ADR's 260/228/32 was measured before `ADR-0077` deleted fourteen operations and
+  the `bandcamp` and `ambient` tags.
+- **It cost nothing in the generated surface.** Only three operationIds moved, all `organizer`
+  (`library-organization_preview_organization` → `organizer_preview_organization`, and two more),
+  and `organizer` is not in `filter.tags` — so the Swift client came back **byte-identical** for the
+  second ADR running. Point 4 held exactly: **no path moved.**
+- Point 2 was applied as the ADR words it — the aggregator stops tagging, the leaf keeps it.
+  `library.router` now carries no tag and its two own operations tag themselves; the ten leaf
+  routers already tagged. That is what made `["library", "library"]` unrepresentable rather than
+  fixed.
+- **Point 2 needed a tie-break the Decision does not give**, for the schema's one two-tag
+  operation. `library_deduplicate_preview` resolved to `library`, not `deduplicate`, under point 7:
+  a one-operation tag usually means a path prefix was wanted, and `/library/deduplicate` is already
+  that prefix. It also keeps the operationId and keeps the operation inside the generated surface,
+  which `deduplicate` would have removed it from. **`ADR-0073` point 6 assumes this is still
+  unresolved and moves it to `duplicates`** — it should now read as `library` → `duplicates`, one
+  move inside its own six-way split rather than two.
+- **Point 5 was silently inert before it was written, which is worth knowing.** `get_openapi()`
+  does not read `openapi_tags` off the app; it must be passed `tags=` explicitly. `main.py` has a
+  custom `app.openapi` hook (for `ADR-0045`'s global security block) that did not, so setting
+  `openapi_tags` on the constructor produced **no `tags` array at all** and raised nothing. The same
+  shape of defect the ADR is about: a value set in one place and ignored in another.
+- `x-tagGroups` is a ReDoc extension with no `FastAPI(...)` argument, so it is set in that same
+  hook. The seven areas are Music, Collections, Playback, Discovery, Curation, Transfer and backup,
+  and Server. **`ADR-0073`, `ADR-0074` and `ADR-0076` all move tags between them**, so this list is
+  expected to be edited when they land.
+- The final follow-up is built: `scripts/lint_openapi.py` now asserts points 2, 3 and 5 — one
+  lowercase kebab-case tag per operation, every tag described, every tag in exactly one group, and
+  no stale index entry. Each of the eight checks was verified to fire against a deliberately broken
+  schema, not merely to pass against the real one.
+- Point 6's aggregation went in as `routes/__init__.py:api_router`, and `health` gained the shared
+  error responses as a result: four operations that documented only `200` now document the same
+  envelope as the other 245. **The `pending_review` registration order is load-bearing** and is
+  called out in that module — `group` → `bulk` → `router`, because the last owns
+  `/{pending_track_id}`. That is the defect `ADR-0077` deleted an endpoint over.
+
 ## Context
 
 The API is 260 operations across 228 paths and 32 tags. Six independent defects were found while


### PR DESCRIPTION
Implements **ADR-0072**, the second of the API cluster. **Stacked on #216** — based on `adr-0077-delete-uncalled-surfaces` so this diff is only the 0072 work. Merge #216 first.

Points 2, 3, 5 and 6, plus the ADR's own final follow-up.

## It costs nothing in the generated surface

Only three operationIds move, all `organizer`, and `organizer` is not in `filter.tags`. The Swift client comes back **byte-identical** for the second ADR running. **No path moved**, so point 4 held exactly and nothing an installed build calls has shifted. Zero frontend files changed.

## Point 2 — exactly one tag per operation

`library.router` was an aggregator that *also* tagged, and FastAPI **concatenates** router tags rather than deduplicating them, so 32 operations carried `["library", "library"]`. The aggregator stops tagging and the ten leaf routers keep it — which makes the duplicate unrepresentable rather than fixed.

**The one two-tag operation needed a tie-break the Decision does not give.** `library_deduplicate_preview` resolves to `library`, not `deduplicate`, under **point 7**: a one-operation tag usually means a path prefix was wanted, and `/library/deduplicate` is already that prefix. It also keeps the operationId and keeps the operation *inside* the generated surface, which `deduplicate` would have removed it from.

⚠️ **This makes ADR-0073 point 6 slightly stale.** It assumes the resolution has not happened and moves `deduplicate` → `duplicates`; it should now read `library` → `duplicates`, one move inside its own six-way split rather than two. Noted in the Implementation block.

## Point 3 — the malformed tag

`Library Organization` → `organizer`. The schema's only tag with a space and capitals, which `custom_generate_unique_id` then lowercased and hyphenated into `library-organization_preview_organization` — 41 characters with "organization" in it twice. ADR-0014 point 2 asserted this class was empty; the tag had been there seven months.

## Point 5 — the published index, which was silently inert

29 tags now have an ordered position and a description, grouped into seven areas by `x-tagGroups`: Music, Collections, Playback, Discovery, Curation, Transfer and backup, Server.

**Worth reading even if you skip the rest:** setting `openapi_tags` on the `FastAPI(...)` constructor did nothing. `get_openapi()` does not read it off the app — it must be passed `tags=` explicitly — and `main.py` has a custom `app.openapi` hook (ADR-0045's global security block) that did not. The result was **no `tags` array at all**, and no error anywhere. That is the same defect shape this ADR is about, sitting inside its own implementation; it is now the lint's error message.

`x-tagGroups` is a ReDoc extension with no constructor argument, so it is set in that same hook.

## Point 6 — one aggregated router

`routes/__init__.py` exports a single `api_router`; `main.py` mounts it once. `health.router` had been the only one of thirty-one registered without `DEFAULT_ERROR_RESPONSES`, so four operations documented a different error contract — not by decision, but because it was first in the list. It now documents the same envelope as the other 245, and there is no per-router place left to forget it.

**The `pending_review` registration order is load-bearing** and now says so in the module: `group` → `bulk` → `router`, because the last owns `/{pending_track_id}` and FastAPI matches in declaration order. That is exactly the defect ADR-0077 deleted an endpoint over.

## The follow-up lint

`scripts/lint_openapi.py` now asserts points 2, 3 and 5: one lowercase kebab-case tag per operation, every tag described, every tag in exactly one group, no stale index entry.

**Each of the eight checks was verified to fire against a deliberately broken schema**, not merely to pass against the real one — a lint that has only ever been green proves nothing.

## Verification

- Backend **1667 passed**. The same four failures as `main` (`test_api_mixtapes` byline, three `test_scanner` sync-lock) are **pre-existing** — confirmed earlier against an unmodified baseline.
- `swift build` + `swift test` pass; generated sources unchanged. Paired with seethroughlab/familiar-apple#144.
- Counts at implementation time: **249 operations, 219 paths, 29 tags**. The ADR's 260/228/32 predates ADR-0077's deletions.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01Emjrwedq7W1scadHdgiLfs


---

*Recreated from #217, which GitHub closed when its base branch was deleted after #216 merged. Rebased onto `main`; git dropped the already-squashed ADR-0077 commit by patch-id, leaving the two commits that are actually this PR.*