### PR TITLE
Bring the README and CLAUDE.md up to what shipped

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -172,6 +172,50 @@ the filter keys are a union, so the tag re-admits the stream the ADR deliberatel
 `String`**, so deleting `VisualizerChoice.musicVideo` leaves profiles holding `"music-video"`
 selecting nothing unless they are reset.
 
+**`ADR-0087`–`ADR-0089` make a visualizer a document, and the app bundle seed it.** A visualizer is
+now a folder with an `index.html`, sandboxed at an opaque origin and driven by `postMessage` — not a
+component the host supplies React to. `App/Shared/Visualizers.bundle/` ships five of them and
+`VisualizerPlugins.seed` copies them into the drop-in folder once. `ADR-0091`/`0092` moved the
+visualizers and plugin folders out of this repo entirely; the server no longer serves them.
+`ADR-0065`, which proposed seeding two examples the old way, is **superseded by `0089`** — its point
+2's "once, ever" reasoning survives and is cited in `VisualizerPlugins.swift`, but its examples were
+the `"main": "dist/index.js"` shape `0087` replaced.
+
+**`ADR-0072`–`ADR-0077` and `ADR-0079` restructure the API** (all accepted, merged 2026-08-30 as a
+nine-PR stack). Tags mean one thing, paths follow function rather than history, and endpoints
+nothing called were deleted. **Existing clients keep working**: the five `/queue/*` paths that moved
+are aliased, and `ADR-0079` point 5 requires that *every* alias in the API live in one module —
+`backend/app/api/routes/compat.py`. They are `include_in_schema=False`, delegate to the same function
+object rather than a copy, and answer with `Deprecation: true` and a `Sunset` date. The removal
+trigger is written down in that file: when no App Store build calling `/queue/*` is still offered.
+
+**`ADR-0093`–`ADR-0094` are shipped.** `0093` suggests tracks you already own for Favourites and any
+playlist, each explaining itself with a real pair of tracks rather than a generated label — three
+attempts at naming a cluster failed first. `0094` toggles the artists grid to a sortable table;
+**sorting is server-side**, because paging at 50 and sorting the loaded page repeats the
+library-shuffle defect on a surface where a wrong order looks like an order.
+
+**`ADR-0095`–`ADR-0097` are about the website, and two of them exist because the record was wrong.**
+`0095` makes the install section platform-first — five panels, one per machine you might install on —
+and supersedes `ADR-0055` point 1's reader, who was defined as "comfortable enough to run `docker
+compose up`". `0096` gives remote access its own section leading with the reason: **Familiar has no
+login**, because `ADR-0045` is accepted and unimplemented, so "don't port-forward 4400" is the
+difference between a private server and a public one.
+
+`0097` exists because **the live site served an April build for four months**. Cloudflare's
+`production_branch` was `master` against a repository on `main`, so every green deploy landed as a
+preview and the production alias never moved — while `check-claims.py` passed, because it audits the
+working tree. It now fetches the deployed site as well. **Both are fixed**, and the shape is the one
+this project keeps finding: a check whose subject is not the thing anyone uses.
+
+Three things established by running them rather than reading them, all of which had been asserted
+wrongly for months: **Docker Desktop on Windows genuinely rejects the `journald` driver** (exit 125),
+so `docker-compose.desktop.yml` — renamed from `.macos.yml`, since the content is "this host is not
+Linux" — is required there; **the first pull is ~7 GB**, not the 4 GB three docs claimed; and
+**disabling CLAP costs far more than "semantic search"**, since `TrackAnalysis.embedding` is read by
+eighteen modules including Find Similar and suggested tracks.
+
+
 ## Key Directories
 
 ```

--- a/README.md
+++ b/README.md
@@ -143,6 +143,8 @@ Three destinations — the library, the tools you run against it, and the server
 
 ## Quick Start
 
+On Linux:
+
 ```bash
 git clone https://github.com/seethroughlab/familiar.git
 cd familiar/docker
@@ -151,18 +153,39 @@ cp .env.example .env
 docker compose -f docker-compose.prod.yml up -d
 ```
 
-Access at http://localhost:4400. API keys are configured in your `.env` file — open **Library** in the top bar to manage your library and start a scan.
+**On macOS or Windows, add `-f docker-compose.desktop.yml`.** The production compose file logs to
+`journald`, which is Linux-only, and Docker Desktop's Linux VM does not have it — the run fails with
+*"failed to initialize logging driver: journald"*. On macOS `./start.sh` detects this and adds the
+override for you.
 
-**Running on macOS?** See the **[macOS Installation Guide](docs/MACOS.md)** — covers Docker Desktop setup, Apple Silicon, and music library paths.
+Access at http://localhost:4400. API keys are configured in your `.env` file — open **Library** in the top bar to manage your library and start a scan. The first run downloads about 7 GB.
 
-See the **[Installation Guide](docs/INSTALLATION.md)** for other platforms (OpenMediaVault, Synology NAS, development setup).
+Step-by-step guides, no prior Docker experience assumed:
+
+| | |
+|---|---|
+| **macOS** | [Installing Familiar on your Mac](docs/MACOS_BEGINNER.md) · [reference guide](docs/MACOS.md) |
+| **Synology** | [Container Manager, DSM 7.2+](docs/INSTALLATION.md#synology-nas) |
+| **OpenMediaVault** | [Services → Compose](docs/INSTALLATION.md#openmediavault) |
+| **Windows, Linux, other NAS** | [Installation Guide](docs/INSTALLATION.md) |
+
+Or use [the install page](https://familiar.seethroughlab.com/#install), which asks which machine you are installing on and shows only that path.
 
 ## Requirements
 
 - Docker Engine 24.0+ / Docker Compose v2
-- 2 GB RAM minimum (4 GB recommended for large libraries)
-- x86_64 or ARM64 (ARM64: CLAP embeddings can be disabled if needed)
+- x86_64 or ARM64
 - Music library accessible via filesystem mount
+- Tested on macOS, Windows, Linux, OpenMediaVault and Synology
+
+**Memory is the thing to check.** Familiar itself runs in 2–4 GB, but the CLAP model that listens to
+your music peaks at about 4 GB while analysing, so a machine with 8 GB or less — most NAS boxes, and
+a Raspberry Pi — wants `DISABLE_CLAP_EMBEDDINGS=true`. You keep the library, the tags, BPM, key,
+energy and mood, and smart playlists; you lose the features that compare how tracks *sound*, which
+includes Find Similar and suggested tracks. It can be enabled later on a bigger machine.
+
+This used to be documented as an ARM64 caveat and as "4 GB recommended". Both were wrong: the
+constraint is memory rather than architecture, and 4 GB is what the model alone needs.
 
 ## Keyboard Shortcuts
 


### PR DESCRIPTION
Documentation only. Both files had drifted; the README had drifted into being **wrong**, not just incomplete.

## README: two errors, both load-bearing

**The Quick Start could not work on macOS or Windows.** It gave the Linux command with no mention of `-f docker-compose.desktop.yml`. The production compose logs to `journald`, Docker Desktop's VM has none, and the run fails with *"failed to initialize logging driver: journald"* — **exit 125**, measured on Windows 11 yesterday rather than inferred. The site's install section was fixed in #229 and #232; the README was not.

**The Requirements were wrong twice.** *"2 GB RAM minimum (4 GB recommended)"* and *"ARM64: CLAP embeddings can be disabled if needed"*. The constraint is **memory, not architecture**, and `MACOS.md:17` records that the model alone peaks at ~4 GB — so the recommended figure could not run the analysis the README is selling. And disabling CLAP does not cost "semantic search": `TrackAnalysis.embedding` is read by **eighteen modules**, including Find Similar and suggested tracks.

Also corrected: the first pull is **~7 GB**, not the 4 GB three documents had been repeating with nobody having pulled the image to check.

## CLAUDE.md was eleven ADRs behind

It stopped at **ADR-0086** while **0097** exists — in the file every session loads first. Extended with:

- **0087–0089** — a visualizer is a document, not a component; the bundle seeds the folder; and why **0065 is superseded** (its "once, ever" reasoning survives and is cited in the code, its examples were the shape 0087 replaced)
- **0072–0077, 0079** — the API restructure, and that **every alias lives in `compat.py`**, `include_in_schema=False`, delegating to the same function object, with `Deprecation`/`Sunset` headers and a written removal trigger
- **0093–0094** — suggested tracks, and that the artists table sorts **server-side**, because sorting the loaded page repeats the library-shuffle defect
- **0095–0097** — the install rewrite, remote access leading with "Familiar has no login", and why the live site served an **April build for four months** while `check-claims.py` passed

## Checked, not recalled

Every claim in the new text was verified against the tree: `compat.py` present with its headers, `Visualizers.bundle` at five, ADR-0065's status line, **zero** auth-token references in `deps.py`/`config.py`, and the embedding count at **exactly eighteen**. All four README links and both `INSTALLATION.md` anchors resolve. `check-claims.py` green.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01Emjrwedq7W1scadHdgiLfs