### PR TITLE
Centre the admin destinations, the way a Mac settings pane does

### DIFF
--- a/packages/frontend/src/app/TopBar.tsx
+++ b/packages/frontend/src/app/TopBar.tsx
@@ -49,10 +49,18 @@ export function TopBar() {
 
   return (
     <header className="shrink-0 border-b border-zinc-800 bg-zinc-950">
-      <div className="flex items-center gap-3 px-3 sm:px-4 py-1.5">
-        <span className="hidden sm:block text-sm font-semibold text-white pr-1">Familiar</span>
+      {/* Three columns so the destinations sit in the centre of the window, the way a Mac
+          settings pane arranges its panes — not packed against the left edge after the wordmark.
+          The empty third column is what does it: `1fr` on both sides means the middle is centred
+          on the *window*, not on the space left over after the brand. Dropping it and using
+          `justify-between` would centre the nav between the brand and the right edge, which drifts
+          as the wordmark shows and hides at the `sm` breakpoint. */}
+      <div className="grid grid-cols-[1fr_auto_1fr] items-center gap-3 px-3 sm:px-4 py-1.5">
+        <span className="hidden sm:block text-sm font-semibold text-white justify-self-start">Familiar</span>
+        {/* Holds the first column open on small screens, where the wordmark is hidden. */}
+        <span className="sm:hidden" aria-hidden="true" />
 
-        <nav className="flex items-center gap-1">
+        <nav className="flex items-center justify-center gap-1">
           {DESTINATION_ITEMS.map((item) => (
             <Link
               key={item.path}
@@ -71,6 +79,10 @@ export function TopBar() {
             </Link>
           ))}
         </nav>
+
+        {/* Balances the brand column. Empty on purpose: the centring is the point, and anything
+            put here has to be weighed against pushing the destinations off-centre. */}
+        <span aria-hidden="true" />
       </div>
     </header>
   );


### PR DESCRIPTION
One commit, one file. The destinations sat packed against the left edge after the wordmark; a Mac settings pane centres them.

## The change

```
- flex items-center gap-3 …
+ grid grid-cols-[1fr_auto_1fr] items-center gap-3 …
```

**The empty third column is what does it.** `justify-between` would centre the nav between the brand and the right edge — which *drifts* as the wordmark shows and hides at the `sm` breakpoint. Equal `1fr` on both sides centres on the window instead.

## Measured, not eyeballed

Against a harness built from the component's own class strings, so it cannot drift from the component:

| width | before (flex) | after (grid) |
|---|---|---|
| 1440px | **515px off** | **0.0px** |
| 900px | 245px off | 0.0px |
| 600px | 152px off | 0.0px |

600px matters because the wordmark is `hidden sm:block` — the column has to hold itself open when the brand is gone, which is what the second `<span class="sm:hidden">` is for.

## The first measurement was worthless

It passed under **both** layouts. The harness referenced the stylesheet as `/dist/assets/…` while being served *from* `dist/`, so the CSS 404'd, every element fell back to block-level, and a full-width `<nav>` measured as perfectly centred either way.

It only became evidence once the old layout failed by 515px. Recorded because a green result that cannot go red is the recurring defect in this codebase, and this is the fourth instance today.

## Verified

`tsc` at 6 errors — identical to `main` — 364 tests passing, build clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01Emjrwedq7W1scadHdgiLfs