### PR TITLE
Bound the new-release scan, and propose ADR-0099 for the real fix

### DIFF
--- a/backend/app/api/routes/library_artists.py
+++ b/backend/app/api/routes/library_artists.py
@@ -4,6 +4,7 @@ import asyncio
 import html
 import logging
 import re
+import time
 from pathlib import Path
 from typing import Any
 
@@ -142,9 +143,7 @@ async def list_artists(
     else:
         # No profile: keep the columns in the row shape, always null, so the response schema does
         # not change between requests.
-        base_query = base_query.outerjoin(
-            ProfilePlayHistory, literal_column("false")
-        )
+        base_query = base_query.outerjoin(ProfilePlayHistory, literal_column("false"))
 
     # Filter to only artists with embeddings if requested.
     if has_embeddings:
@@ -341,12 +340,30 @@ class NewRelease(BaseModel):
     in_library: bool
 
 
+#: How long the whole new-release scan may take before it returns what it has.
+#:
+#: Twenty seconds because an MCP host is a person waiting: the tool's own docstring promised
+#: "10-15 seconds", and this leaves headroom without turning a stalled upstream into a hung request.
+NEW_RELEASE_SCAN_BUDGET_SECONDS = 20.0
+
+#: How long any one artist may take. Stops a single stalled lookup from eating the whole budget and
+#: starving the artists behind it, which is what the retry backoff did.
+NEW_RELEASE_PER_ARTIST_TIMEOUT_SECONDS = 6.0
+
+
 class ArtistNewReleasesResponse(BaseModel):
     """New releases from artists in the user's library."""
 
     releases: list[NewRelease]
     artists_checked: int
     artists_skipped: int
+    #: True when the deadline stopped the scan early, so `releases` is partial.
+    #:
+    #: The caller has to be able to tell "nothing new" from "we ran out of time", because they look
+    #: identical in an empty list and lead to opposite conclusions.
+    partial: bool = False
+    #: Set when the scan stopped for a reason worth repeating to a person.
+    note: str | None = None
 
 
 @router.get("/artists/new-releases", tags=["discover"], response_model=ArtistNewReleasesResponse)
@@ -387,20 +404,56 @@ async def get_artist_new_releases(
     all_releases: list[NewRelease] = []
     artists_checked = 0
     artists_skipped = 0
+    partial = False
+    note: str | None = None
+
+    # **A deadline, because the upstream can stall indefinitely and used to.**
+    #
+    # `musicbrainzngs` answers a 503 by retrying with backoff, logging it at INFO and telling the
+    # caller nothing. MusicBrainz rate-limits at 1 req/sec per client, and when this endpoint runs
+    # alongside the background artist resolver it gets 503s — so fifteen artists, each retried a few
+    # times, turns a docstring promising "10-15 seconds" into a request that never returns. Observed
+    # 2026-08-30: 240 seconds with no response and no error, which an MCP host reports as a bare
+    # "Tool execution failed".
+    #
+    # Partial results beat a hang. The caller is told which it got.
+    deadline = time.monotonic() + NEW_RELEASE_SCAN_BUDGET_SECONDS
 
     for row in top_artists:
         if not row.musicbrainz_id:
             artists_skipped += 1
             continue
 
+        if time.monotonic() > deadline:
+            partial = True
+            note = (
+                f"Stopped after {artists_checked} of {len(top_artists)} artists — MusicBrainz was "
+                "too slow to finish. It rate-limits to one request a second and answers 503 when "
+                "that is exceeded. Results below are what arrived in time; try again shortly."
+            )
+            break
+
         artists_checked += 1
 
-        # MusicBrainz call (synchronous, rate-limited at 1 req/sec).
-        releases = await asyncio.to_thread(
-            get_artist_releases_recent,
-            row.musicbrainz_id,
-            days_back,
-        )
+        # MusicBrainz call (synchronous, rate-limited at 1 req/sec), bounded so one artist cannot
+        # consume the whole budget on retries.
+        try:
+            releases = await asyncio.wait_for(
+                asyncio.to_thread(get_artist_releases_recent, row.musicbrainz_id, days_back),
+                timeout=NEW_RELEASE_PER_ARTIST_TIMEOUT_SECONDS,
+            )
+        except TimeoutError:
+            # `asyncio.wait_for` cannot cancel a thread, so the worker keeps running to completion
+            # in the background. That is acceptable: it is one bounded HTTP call, and the
+            # alternative is holding the request open for it.
+            partial = True
+            note = (
+                "MusicBrainz did not answer in time for at least one artist. It rate-limits to one "
+                "request a second and answers 503 when that is exceeded, so this is usually "
+                "temporary."
+            )
+            logger.warning("new_releases_artist_timeout", extra={"artist": row.artist_name})
+            continue
 
         for r in releases:
             all_releases.append(
@@ -452,6 +505,8 @@ async def get_artist_new_releases(
         releases=all_releases,
         artists_checked=artists_checked,
         artists_skipped=artists_skipped,
+        partial=partial,
+        note=note,
     )
 
 

--- a/backend/app/services/llm/handlers/discovery.py
+++ b/backend/app/services/llm/handlers/discovery.py
@@ -4,6 +4,7 @@ from __future__ import annotations
 
 import asyncio
 import logging
+import time
 from datetime import timedelta
 from typing import TYPE_CHECKING, Any
 
@@ -212,7 +213,10 @@ class DiscoveryHandlersMixin:
         artists = [row[0] for row in result.all() if row[0]]
 
         if not artists:
-            return {"recommendations": [], "message": "No artists in library to base recommendations on"}
+            return {
+                "recommendations": [],
+                "message": "No artists in library to base recommendations on",
+            }
 
         bc = BandcampService()
         recommendations = []
@@ -226,13 +230,15 @@ class DiscoveryHandlersMixin:
                 results = await bc.search(artist, item_type="a", limit=2)
 
                 for r in results:
-                    recommendations.append({
-                        "type": r.result_type,
-                        "name": r.name,
-                        "artist": r.artist,
-                        "url": r.url,
-                        "genre": r.genre,
-                    })
+                    recommendations.append(
+                        {
+                            "type": r.result_type,
+                            "name": r.name,
+                            "artist": r.artist,
+                            "url": r.url,
+                            "genre": r.genre,
+                        }
+                    )
 
                 if len(recommendations) >= limit:
                     break
@@ -265,9 +271,8 @@ class DiscoveryHandlersMixin:
         lastfm = get_lastfm_service()
 
         # Check if the requested artist is in the library
-        artist_in_library_stmt = (
-            select(func.count(Track.id))
-            .where(Track.active_filter(), Track.artist.ilike(f"%{artist}%"))
+        artist_in_library_stmt = select(func.count(Track.id)).where(
+            Track.active_filter(), Track.artist.ilike(f"%{artist}%")
         )
         artist_count = await self.db.scalar(artist_in_library_stmt) or 0
         requested_artist_in_library = artist_count > 0
@@ -281,7 +286,9 @@ class DiscoveryHandlersMixin:
                 "requested_artist_in_library": requested_artist_in_library,
                 "similar_artists_in_library": [],
                 "count": 0,
-                "bandcamp_search_url": f"https://bandcamp.com/search?q={artist.replace(' ', '+')}" if not requested_artist_in_library else None,
+                "bandcamp_search_url": f"https://bandcamp.com/search?q={artist.replace(' ', '+')}"
+                if not requested_artist_in_library
+                else None,
                 "note": "Could not find similar artists via Last.fm. Try semantic_search instead.",
             }
 
@@ -301,15 +308,20 @@ class DiscoveryHandlersMixin:
             if row:
                 # Find the match score from Last.fm data
                 match_score = next(
-                    (float(a.get("match", 0)) for a in similar_artists
-                     if a.get("name", "").lower() == similar_name.lower()),
-                    0.0
+                    (
+                        float(a.get("match", 0))
+                        for a in similar_artists
+                        if a.get("name", "").lower() == similar_name.lower()
+                    ),
+                    0.0,
                 )
-                artists_in_library.append({
-                    "name": row.artist,
-                    "track_count": row.track_count,
-                    "similarity": round(match_score, 2),
-                })
+                artists_in_library.append(
+                    {
+                        "name": row.artist,
+                        "track_count": row.track_count,
+                        "similarity": round(match_score, 2),
+                    }
+                )
 
         # Sort by similarity score
         artists_in_library.sort(key=lambda x: x["similarity"], reverse=True)
@@ -320,8 +332,12 @@ class DiscoveryHandlersMixin:
             "requested_artist_in_library": requested_artist_in_library,
             "similar_artists_in_library": artists_in_library,
             "count": len(artists_in_library),
-            "bandcamp_search_url": f"https://bandcamp.com/search?q={artist.replace(' ', '+')}" if not requested_artist_in_library else None,
-            "note": f"Found {len(artists_in_library)} similar artists in your library. Search for their tracks to build a playlist." if artists_in_library else "No similar artists found in library.",
+            "bandcamp_search_url": f"https://bandcamp.com/search?q={artist.replace(' ', '+')}"
+            if not requested_artist_in_library
+            else None,
+            "note": f"Found {len(artists_in_library)} similar artists in your library. Search for their tracks to build a playlist."
+            if artists_in_library
+            else "No similar artists found in library.",
         }
 
     async def _get_new_releases(
@@ -368,26 +384,58 @@ class DiscoveryHandlersMixin:
         artists_checked = 0
         artists_skipped = 0
 
+        # **Bounded, because MusicBrainz stalls and `musicbrainzngs` hides it.**
+        #
+        # A 503 is answered by retrying with backoff, logged at INFO, and the caller is told
+        # nothing. MusicBrainz rate-limits to one request a second per client, so when this runs
+        # alongside the background artist resolver it gets 503s — and fifteen artists, each retried,
+        # turns a scan that should take fifteen seconds into one that never returns. Observed on
+        # 2026-08-30 at 240 seconds with no response, which an MCP host reports as a bare
+        # "Tool execution failed" pointing at the app rather than at the upstream.
+        #
+        # The budgets live in `library_artists` so the tool and the HTTP endpoint cannot drift into
+        # disagreeing about how long a person will wait.
+        from app.api.routes.library_artists import (
+            NEW_RELEASE_PER_ARTIST_TIMEOUT_SECONDS,
+            NEW_RELEASE_SCAN_BUDGET_SECONDS,
+        )
+
+        deadline = time.monotonic() + NEW_RELEASE_SCAN_BUDGET_SECONDS
+        partial = False
+        stalled = False
+
         for row in top_artists:
             if not row.musicbrainz_id:
                 artists_skipped += 1
                 continue
 
+            if time.monotonic() > deadline:
+                partial = True
+                break
+
             artists_checked += 1
-            releases = await asyncio.to_thread(
-                get_artist_releases_recent,
-                row.musicbrainz_id,
-                days_back,
-            )
+            try:
+                releases = await asyncio.wait_for(
+                    asyncio.to_thread(get_artist_releases_recent, row.musicbrainz_id, days_back),
+                    timeout=NEW_RELEASE_PER_ARTIST_TIMEOUT_SECONDS,
+                )
+            except TimeoutError:
+                # `wait_for` cannot cancel the thread; it finishes in the background. Acceptable —
+                # it is one bounded HTTP call, and the alternative is holding the tool open for it.
+                partial = True
+                stalled = True
+                continue
 
             for r in releases:
-                all_releases.append({
-                    "artist": row.artist_name,
-                    "title": r["title"],
-                    "type": r.get("release_type"),
-                    "date": r["release_date"],
-                    "in_library": False,
-                })
+                all_releases.append(
+                    {
+                        "artist": row.artist_name,
+                        "title": r["title"],
+                        "type": r.get("release_type"),
+                        "date": r["release_date"],
+                        "in_library": False,
+                    }
+                )
 
         # Cross-reference with the library by canonical artist + album.
         if all_releases:
@@ -405,8 +453,7 @@ class DiscoveryHandlersMixin:
             )
             album_result = await self.db.execute(album_pairs_query)
             library_albums = {
-                (row.artist_name.lower().strip(), row.album_lower)
-                for row in album_result.all()
+                (row.artist_name.lower().strip(), row.album_lower) for row in album_result.all()
             }
 
             for release in all_releases:
@@ -424,9 +471,18 @@ class DiscoveryHandlersMixin:
             "artists_skipped": artists_skipped,
             "count": len(all_releases),
             "new_releases_not_in_library": new_count,
-            "note": f"Found {len(all_releases)} recent releases ({new_count} not in library) from {artists_checked} artists (last {days_back} days)."
-            if all_releases
-            else f"No recent releases found in the last {days_back} days.",
+            "partial": partial,
+            # The note is what the host reads aloud, so it has to distinguish "nothing new" from
+            # "we ran out of time" — an empty list looks identical either way and leads to
+            # opposite conclusions.
+            "note": _new_release_note(
+                found=len(all_releases),
+                new_count=new_count,
+                artists_checked=artists_checked,
+                days_back=days_back,
+                partial=partial,
+                stalled=stalled,
+            ),
         }
 
     async def _get_discovery_recommendations(
@@ -469,7 +525,12 @@ class DiscoveryHandlersMixin:
         top_artist_ids = [row.artist_id for row in top_artists]
 
         if not top_artists:
-            return {"recommended_artists": [], "unheard_tracks": [], "deep_cuts": [], "note": "No play history found."}
+            return {
+                "recommended_artists": [],
+                "unheard_tracks": [],
+                "deep_cuts": [],
+                "note": "No play history found.",
+            }
 
         # Similar-artist candidates from the canonical artists' cached data.
         seen: set[str] = set()
@@ -533,14 +594,16 @@ class DiscoveryHandlersMixin:
             except (ValueError, TypeError):
                 match_score = 0.0
 
-            recommended.append({
-                "name": similar.get("name", ""),
-                "match_score": round(match_score, 2),
-                "in_library": in_library,
-                "track_count": tc if in_library else None,
-                "bandcamp_url": generate_artist_search_url("bandcamp", similar.get("name", "")),
-                "based_on": based_on,
-            })
+            recommended.append(
+                {
+                    "name": similar.get("name", ""),
+                    "match_score": round(match_score, 2),
+                    "in_library": in_library,
+                    "track_count": tc if in_library else None,
+                    "bandcamp_url": generate_artist_search_url("bandcamp", similar.get("name", "")),
+                    "based_on": based_on,
+                }
+            )
 
         recommended.sort(key=lambda a: a["match_score"], reverse=True)
         recommended = recommended[:limit]
@@ -550,9 +613,8 @@ class DiscoveryHandlersMixin:
         deep_cuts: list[dict[str, Any]] = []
 
         if top_artist_ids:
-            played_ids = (
-                select(ProfilePlayHistory.track_id)
-                .where(ProfilePlayHistory.profile_id == self.profile_id)
+            played_ids = select(ProfilePlayHistory.track_id).where(
+                ProfilePlayHistory.profile_id == self.profile_id
             )
 
             unheard_result = await self.db.execute(
@@ -568,15 +630,19 @@ class DiscoveryHandlersMixin:
             unheard_ids = set()
             for row in unheard_result.fetchall():
                 unheard_ids.add(row.id)
-                unheard_tracks.append({
-                    "id": str(row.id),
-                    "title": row.title,
-                    "artist": row.artist,
-                    "album": row.album,
-                })
+                unheard_tracks.append(
+                    {
+                        "id": str(row.id),
+                        "title": row.title,
+                        "artist": row.artist,
+                        "album": row.album,
+                    }
+                )
 
             deep_result = await self.db.execute(
-                select(Track.id, Track.title, Track.artist, Track.album, ProfilePlayHistory.play_count)
+                select(
+                    Track.id, Track.title, Track.artist, Track.album, ProfilePlayHistory.play_count
+                )
                 .join(ProfilePlayHistory, ProfilePlayHistory.track_id == Track.id)
                 .where(
                     Track.canonical_artist_id.in_(top_artist_ids),
@@ -589,13 +655,15 @@ class DiscoveryHandlersMixin:
             )
             for row in deep_result.fetchall():
                 if row.id not in unheard_ids:
-                    deep_cuts.append({
-                        "id": str(row.id),
-                        "title": row.title,
-                        "artist": row.artist,
-                        "album": row.album,
-                        "play_count": row.play_count,
-                    })
+                    deep_cuts.append(
+                        {
+                            "id": str(row.id),
+                            "title": row.title,
+                            "artist": row.artist,
+                            "album": row.album,
+                            "play_count": row.play_count,
+                        }
+                    )
 
         return {
             "recommended_artists": recommended,
@@ -626,11 +694,15 @@ class DiscoveryHandlersMixin:
             return {"error": "Both title and artist are required"}
 
         # Search local library for exact match first
-        stmt = select(Track).where(
-            Track.active_filter(),
-            func.lower(Track.title) == title.lower(),
-            func.lower(Track.artist) == artist.lower(),
-        ).limit(1)
+        stmt = (
+            select(Track)
+            .where(
+                Track.active_filter(),
+                func.lower(Track.title) == title.lower(),
+                func.lower(Track.artist) == artist.lower(),
+            )
+            .limit(1)
+        )
         result = await self.db.execute(stmt)
         track = result.scalar_one_or_none()
 
@@ -645,10 +717,14 @@ class DiscoveryHandlersMixin:
             }
 
         # Try fuzzy match on local library
-        stmt = select(Track).where(
-            Track.active_filter(),
-            func.lower(Track.artist).contains(artist.lower()),
-        ).limit(200)
+        stmt = (
+            select(Track)
+            .where(
+                Track.active_filter(),
+                func.lower(Track.artist).contains(artist.lower()),
+            )
+            .limit(200)
+        )
         result = await self.db.execute(stmt)
         candidates = list(result.scalars().all())
 
@@ -726,17 +802,25 @@ class DiscoveryHandlersMixin:
         for similar in similar_tracks[:limit]:
             similar_name = similar.get("name", "")
             similar_artist_data = similar.get("artist", {})
-            similar_artist = similar_artist_data.get("name", "") if isinstance(similar_artist_data, dict) else str(similar_artist_data)
+            similar_artist = (
+                similar_artist_data.get("name", "")
+                if isinstance(similar_artist_data, dict)
+                else str(similar_artist_data)
+            )
 
             if not similar_name or not similar_artist:
                 continue
 
             # Check if in local library
-            stmt = select(Track).where(
-                Track.active_filter(),
-                func.lower(Track.title) == similar_name.lower(),
-                func.lower(Track.artist) == similar_artist.lower(),
-            ).limit(1)
+            stmt = (
+                select(Track)
+                .where(
+                    Track.active_filter(),
+                    func.lower(Track.title) == similar_name.lower(),
+                    func.lower(Track.artist) == similar_artist.lower(),
+                )
+                .limit(1)
+            )
             result = await self.db.execute(stmt)
             local_track = result.scalar_one_or_none()
 
@@ -766,3 +850,38 @@ class DiscoveryHandlersMixin:
             "missing": len(tracks_with_status) - in_library_count,
             "note": f"Found {len(tracks_with_status)} similar tracks ({in_library_count} in library, {len(tracks_with_status) - in_library_count} not in library).",
         }
+
+
+def _new_release_note(
+    *,
+    found: int,
+    new_count: int,
+    artists_checked: int,
+    days_back: int,
+    partial: bool,
+    stalled: bool,
+) -> str:
+    """What to tell a person about a scan that may not have finished.
+
+    Separated from the handler because the interesting case is the unhappy one, and it was
+    previously unrepresentable: the old note could only say "found N" or "found none", so a scan cut
+    short by a rate-limited upstream reported "No recent releases found" — a confident wrong answer.
+    """
+    if stalled:
+        return (
+            f"MusicBrainz did not answer in time for some artists, so this is partial: "
+            f"{found} release(s) from {artists_checked} artist(s). It rate-limits to one request a "
+            "second and returns 503 when that is exceeded, which is usually temporary — try again "
+            "in a minute."
+        )
+    if partial:
+        return (
+            f"Stopped early to stay responsive: {found} release(s) from the first "
+            f"{artists_checked} artist(s). Ask again to continue where MusicBrainz left off."
+        )
+    if found:
+        return (
+            f"Found {found} recent releases ({new_count} not in library) from {artists_checked} "
+            f"artists (last {days_back} days)."
+        )
+    return f"No recent releases found in the last {days_back} days."

--- a/backend/openapi.json
+++ b/backend/openapi.json
@@ -680,6 +680,18 @@
             "title": "Artists Skipped",
             "type": "integer"
           },
+          "note": {
+            "title": "Note",
+            "type": [
+              "string",
+              "null"
+            ]
+          },
+          "partial": {
+            "default": false,
+            "title": "Partial",
+            "type": "boolean"
+          },
           "releases": {
             "items": {
               "$ref": "#/components/schemas/NewRelease"

--- a/backend/tests/test_new_release_budget.py
+++ b/backend/tests/test_new_release_budget.py
@@ -1,9 +1,16 @@
 """The scan must return within its budget even when MusicBrainz stalls."""
-import asyncio, time, pytest
+
+import asyncio
+import time
+
+import pytest
+
 from app.api.routes.library_artists import (
-    NEW_RELEASE_SCAN_BUDGET_SECONDS, NEW_RELEASE_PER_ARTIST_TIMEOUT_SECONDS,
+    NEW_RELEASE_PER_ARTIST_TIMEOUT_SECONDS,
+    NEW_RELEASE_SCAN_BUDGET_SECONDS,
 )
 from app.services.llm.handlers.discovery import _new_release_note
+
 
 def test_budgets_are_sane():
     # A person is waiting; per-artist must be well inside the whole-scan budget or one stalled
@@ -11,11 +18,14 @@ def test_budgets_are_sane():
     assert NEW_RELEASE_PER_ARTIST_TIMEOUT_SECONDS < NEW_RELEASE_SCAN_BUDGET_SECONDS / 2
     assert NEW_RELEASE_SCAN_BUDGET_SECONDS <= 30
 
+
 def test_note_distinguishes_empty_from_unfinished():
-    empty = _new_release_note(found=0, new_count=0, artists_checked=15, days_back=90,
-                              partial=False, stalled=False)
-    stalled = _new_release_note(found=0, new_count=0, artists_checked=3, days_back=90,
-                                partial=True, stalled=True)
+    empty = _new_release_note(
+        found=0, new_count=0, artists_checked=15, days_back=90, partial=False, stalled=False
+    )
+    stalled = _new_release_note(
+        found=0, new_count=0, artists_checked=3, days_back=90, partial=True, stalled=True
+    )
     assert "No recent releases" in empty
     # The bug this exists for: a rate-limited scan used to report "no recent releases", which is a
     # confident wrong answer rather than a failure.
@@ -23,11 +33,15 @@ def test_note_distinguishes_empty_from_unfinished():
     assert "503" in stalled or "did not answer" in stalled
     assert empty != stalled
 
+
 @pytest.mark.asyncio
 async def test_per_artist_timeout_actually_bounds_a_stalled_call():
-    def stalls(): time.sleep(30)
+    def stalls():
+        time.sleep(30)
+
     started = time.monotonic()
     with pytest.raises(TimeoutError):
-        await asyncio.wait_for(asyncio.to_thread(stalls),
-                               timeout=NEW_RELEASE_PER_ARTIST_TIMEOUT_SECONDS)
+        await asyncio.wait_for(
+            asyncio.to_thread(stalls), timeout=NEW_RELEASE_PER_ARTIST_TIMEOUT_SECONDS
+        )
     assert time.monotonic() - started < NEW_RELEASE_PER_ARTIST_TIMEOUT_SECONDS + 2

--- a/backend/tests/test_new_release_budget.py
+++ b/backend/tests/test_new_release_budget.py
@@ -1,0 +1,33 @@
+"""The scan must return within its budget even when MusicBrainz stalls."""
+import asyncio, time, pytest
+from app.api.routes.library_artists import (
+    NEW_RELEASE_SCAN_BUDGET_SECONDS, NEW_RELEASE_PER_ARTIST_TIMEOUT_SECONDS,
+)
+from app.services.llm.handlers.discovery import _new_release_note
+
+def test_budgets_are_sane():
+    # A person is waiting; per-artist must be well inside the whole-scan budget or one stalled
+    # lookup starves the rest.
+    assert NEW_RELEASE_PER_ARTIST_TIMEOUT_SECONDS < NEW_RELEASE_SCAN_BUDGET_SECONDS / 2
+    assert NEW_RELEASE_SCAN_BUDGET_SECONDS <= 30
+
+def test_note_distinguishes_empty_from_unfinished():
+    empty = _new_release_note(found=0, new_count=0, artists_checked=15, days_back=90,
+                              partial=False, stalled=False)
+    stalled = _new_release_note(found=0, new_count=0, artists_checked=3, days_back=90,
+                                partial=True, stalled=True)
+    assert "No recent releases" in empty
+    # The bug this exists for: a rate-limited scan used to report "no recent releases", which is a
+    # confident wrong answer rather than a failure.
+    assert "No recent releases" not in stalled
+    assert "503" in stalled or "did not answer" in stalled
+    assert empty != stalled
+
+@pytest.mark.asyncio
+async def test_per_artist_timeout_actually_bounds_a_stalled_call():
+    def stalls(): time.sleep(30)
+    started = time.monotonic()
+    with pytest.raises(TimeoutError):
+        await asyncio.wait_for(asyncio.to_thread(stalls),
+                               timeout=NEW_RELEASE_PER_ARTIST_TIMEOUT_SECONDS)
+    assert time.monotonic() - started < NEW_RELEASE_PER_ARTIST_TIMEOUT_SECONDS + 2

--- a/docs/decisions/ADR-0099-discovery-is-a-background-job-with-visible-sources.md
+++ b/docs/decisions/ADR-0099-discovery-is-a-background-job-with-visible-sources.md
@@ -1,0 +1,155 @@
+# ADR-0099: Discovery Is a Background Job, and Its Sources Are Visible
+
+Status: proposed
+
+Date: 2026-08-30
+
+Extends [ADR-0058](ADR-0058-the-web-app-is-an-administration-tool.md), whose point 2 makes the
+Server destination the place you find out whether the thing is working.
+
+## Context
+
+On 2026-08-30 an MCP host asked Familiar for new releases and the tool hung. Measured: **240 seconds
+with no response and no error**, which the host reports as a bare *"Tool execution failed"*.
+
+The cause is upstream and ordinary. MusicBrainz rate-limits to **one request a second per client**
+and answers **503** when that is exceeded, which happens whenever this runs alongside the background
+artist resolver. `musicbrainzngs` retries with backoff, logs the retry at `INFO`, and tells the
+caller nothing. Fifteen artists, each retried, turns a docstring promising "10–15 seconds" into a
+request that never returns. A single artist measures **0.6 s** when it gets through, so the
+arithmetic only fails under throttling — which is why it looked fine when it was written.
+
+That has been bounded already: a 20-second budget, a 6-second per-artist timeout, partial results,
+and a note that distinguishes "nothing new" from "we ran out of time". This ADR is about why the
+request was talking to MusicBrainz at all.
+
+### The precompute already exists, and nothing reads it
+
+Measured on the production database:
+
+| | |
+|---|---|
+| `external_album_cache`, `discovery_context = 'artist_new_release'` | **600 rows** |
+| `artist_check_cache` | **520 rows** |
+| a daily job at 03:00 (`daily_new_releases` in `background/manager.py:109`) | **runs** — eight log entries in 24 h |
+
+`backend/app/services/new_releases.py` is 446 lines whose docstring says it "reads/writes the shared
+`external_album_cache` table filtered to `discovery_context='artist_new_release'`".
+
+**And `GET /library/artists/new-releases` does not read any of it.** Nor does the MCP handler
+`_get_new_releases`, which duplicates the endpoint's logic rather than calling it. Both walk the top
+fifteen artists and hit MusicBrainz live, on the request path, while a populated cache sits beside
+them. This is the third capability-with-no-caller found in this codebase this week.
+
+### The freshness nobody could see
+
+The newest `artist_new_release` row is dated **2026-08-25** — five days old — while
+`listening_profile_recommendation`, written by the neighbouring job, is from today. So the daily
+new-release job is running and *not writing*, almost certainly hitting the same 503 wall the request
+path hit.
+
+Nothing surfaced that. `panels/server/ApiKeyStatus.tsx` is 55 lines and reports whether an API *key*
+is configured, which is not the same question as whether a source is *working*. A source can have a
+valid key, be scheduled, run daily, fail every time, and look identical to a healthy one.
+
+### What is actually being asked of these sources
+
+Discovery — finding music you do not own — currently uses:
+
+- **MusicBrainz**, for new releases, external album recommendations and artist resolution. No key.
+- **Last.fm**, for similar artists. Keyed.
+- **Bandcamp**, for purchase recommendations. No key; reads their JSON endpoint.
+
+Enrichment of music you *do* own additionally uses AcoustID, the Cover Art Archive, Wikipedia and the
+community analysis cache, and is out of scope here.
+
+**MusicBrainz is doing nearly all the discovery work alone**, which is why one upstream's rate limit
+stopped everything at once. Last.fm and Bandcamp are integrated and barely used for it.
+
+## Decision
+
+1. **The request path never calls an external service for discovery.** `GET
+   /library/artists/new-releases` and the `get_new_releases` MCP tool read `external_album_cache`
+   and return immediately. A request may return stale results or none; it may not return slowly.
+
+2. **The background job is the only thing that talks to MusicBrainz, Last.fm or Bandcamp for
+   discovery**, and it is the only place that has to care about rate limits, retries and backoff.
+   This is what `new_releases.py` was built for and what the 03:00 job already does.
+
+3. **Discovery runs continuously rather than once a night.** A single daily sweep is why a rate-limit
+   window costs a whole day: the job either wins the race at 03:00 or the library learns nothing for
+   twenty-four hours. Instead it works a small, prioritised batch on a short interval, so throttling
+   costs one batch and the next one picks up where it stopped. `artist_check_cache` already records
+   per-artist progress, which is what makes resumption possible.
+
+4. **Sources are polled independently, and one being down does not stop the others.** MusicBrainz
+   returning 503 must not prevent Last.fm from answering, and today it effectively does, because the
+   scan is a single sequential loop over one source.
+
+5. **Last.fm and Bandcamp become discovery sources, not just recommendation lookups.** Both are
+   already integrated. Using them widens what "new music" can mean beyond "a release group appeared
+   in MusicBrainz", and removes the single point of failure point 4 is about.
+
+6. **Every source reports health, and it is a first-class surface on the Server destination**
+   (ADR-0058 point 2). For each source: when it last succeeded, when it last failed and with what,
+   how many items it has contributed, and whether it is currently backing off. **Not whether a key is
+   configured** — that is what exists today and it is the question that let a five-day-stale table go
+   unnoticed.
+
+7. **Staleness is visible where the data is used, not only in the dashboard.** A discovery response
+   carries the age of what it is returning, so a host reading it aloud can say "as of five days ago"
+   rather than presenting stale results as current. The bounded-scan work already established that a
+   caller must be able to tell "nothing" from "we did not finish"; this is the same rule applied to
+   time.
+
+8. **A source that has never succeeded is reported as such, and is not silently skipped.** The
+   failure mode this ADR exists to prevent is a component that runs, fails, and looks like a
+   component that ran and found nothing.
+
+## Alternatives Considered
+
+- **Keep the request path as it is and rely on the timeouts already added.** Cheapest, and it fixes
+  the hang. Rejected because it makes every discovery request a network call to a rate-limited
+  third party: the best case is slow, the common case under throttling is partial, and the cache
+  that would answer instantly is right there. The timeouts are a floor, not a design.
+
+- **Cache the request-path call with a TTL instead of moving to a job.** Simpler than a scheduler,
+  and the first request warms it. Rejected because the first request still pays the full cost, and
+  under throttling the first request is the one that hangs — so the miss path is exactly the failure
+  being fixed. It also gives no place to put backoff state that outlives a request.
+
+- **Poll harder rather than continuously.** Increase the daily job to hourly and leave the rest
+  alone. Rejected as insufficient on its own: it narrows the window but keeps a single sequential
+  MusicBrainz loop, so point 4's problem — one source's outage stopping the others — is untouched.
+
+- **Add a "sources" page rather than integrating health into Server.** A dedicated screen has room
+  for detail. Rejected by ADR-0058 point 2: the Server destination is where you find out whether the
+  thing is working, and a second place to look is how a five-day-stale table stays unnoticed for
+  five days.
+
+- **Report health only in logs.** It is already there — the 503s were logged at `INFO` throughout.
+  Rejected because that is precisely what failed: the information existed, in the one place nobody
+  reads until something is already known to be wrong.
+
+## Consequences
+
+- **Positive** — discovery requests answer immediately, from data that is already there. The tool
+  that hung for 240 seconds becomes a database read.
+- **Positive** — the five-day-stale table becomes visible the day it happens rather than when
+  somebody investigates an unrelated hang.
+- **Positive** — Last.fm and Bandcamp start contributing to discovery, which is both more music and
+  less exposure to one upstream's rate limit.
+- **Tradeoff** — results are as fresh as the last successful run, not as fresh as the request. Point
+  7 makes that visible rather than pretending otherwise, but a user asking at 09:00 may be told
+  about a release found at 03:00.
+- **Tradeoff** — continuous polling is more total requests to services that rate-limit, and the
+  prioritised batch has to stay small enough to be a good citizen. `musicbrainzngs`'s 1 req/sec
+  limiter is per-process, so this needs care if the work is ever parallelised.
+- **Follow-up** — the endpoint and `_get_new_releases` duplicate each other's logic. Both were
+  bounded separately on 2026-08-30 because fixing one fixed nothing the user hit. Moving the read to
+  the cache is the moment to make one call the other.
+- **Follow-up** — `musicbrainzngs` retries 503s internally and reports nothing to its caller. Point 6
+  needs a real signal, which probably means wrapping the client rather than reading its logs.
+- **Follow-up** — nothing here decides how a *user* triggers a refresh when they know something is
+  new. Point 1 forbids a synchronous scan; an explicit "check now" that enqueues a job and returns is
+  the obvious shape, and is not decided.


### PR DESCRIPTION
Two things: the immediate fix for a tool that hung, and the ADR for why it was reaching the network at all.

## The hang

An MCP host asked for new releases and got nothing back for **240 seconds** — reported as a bare *"Tool execution failed."*

The cause is upstream and ordinary. MusicBrainz rate-limits to **one request/second per client** and returns **503** when exceeded, which happens when this runs alongside the background artist resolver. `musicbrainzngs` retries with backoff, **logs it at `INFO`, and tells the caller nothing.** Fifteen artists, each retried, turns a docstring promising "10–15 seconds" into a request that never returns. One artist measures **0.6s** when it gets through, so the arithmetic only fails under throttling — which is why it looked fine when written.

**Now bounded:** 20s for the scan, 6s per artist, partial results instead of a hang. Verified on the NAS — the endpoint that never returned now answers in **16.5s**, 15 artists checked, `partial: false`.

### The part that would have wasted the fix

**The MCP handler duplicates the endpoint.** `_get_new_releases` calls MusicBrainz directly rather than going through the route, so fixing the endpoint alone would have fixed nothing you hit. Both are bounded, sharing constants from one module so they can't drift on how long a person waits.

### And the note, which matters as much

The old note could only say "found N" or "found none" — so a scan cut short by throttling reported **"No recent releases found in the last 90 days."** A confident wrong answer, not a failure. It now distinguishes empty from unfinished and names the 503.

`tests/test_new_release_budget.py` asserts the budgets are ordered sanely, that the two notes differ, and that a stalled call is genuinely cut off — against a real 30-second sleep, not a mock.

---

## ADR-0099 (proposed): the real fix

**The precompute already exists and nothing reads it.**

| | |
|---|---|
| `external_album_cache` (`artist_new_release`) | **600 rows** |
| `artist_check_cache` | **520 rows** |
| daily job at 03:00 | **runs** — 8 log entries in 24h |
| `services/new_releases.py` | 446 lines, docstring describes reading/writing that table |
| endpoint referencing `ExternalAlbumCache` | **0** |
| MCP handler referencing it | **0** |

Both walk the top fifteen artists and hit MusicBrainz live while a populated cache sits beside them. Third capability-with-no-caller found in this codebase this week.

**And the staleness was invisible.** The newest `artist_new_release` row is **2026-08-25** — five days old — while the neighbouring job's rows are from today. So the daily job runs and doesn't write, almost certainly hitting the same 503 wall. `ApiKeyStatus.tsx` is 55 lines reporting whether a *key* is configured, which is not whether a source *works*: a source can have a valid key, be scheduled, run daily, fail every time, and look identical to a healthy one.

**Eight points, one direction.** The request path never calls an external service. The background job is the only thing that does, and the only place that cares about rate limits. It runs continuously in resumable batches rather than once nightly, so throttling costs one batch instead of a day. Sources are polled independently. **Last.fm and Bandcamp become discovery sources** rather than MusicBrainz carrying it alone. And source health becomes a first-class Server surface — last success, last failure, backoff state — per ADR-0058 point 2.

Point 7 applies the bounded-scan lesson to time: a response says how old its data is, so a host can say *"as of five days ago"* rather than presenting stale results as current.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01Emjrwedq7W1scadHdgiLfs