### PR TITLE
Discovery has crashed every night for nineteen nights, on one row

### DIFF
--- a/backend/app/services/external_albums_helpers.py
+++ b/backend/app/services/external_albums_helpers.py
@@ -9,10 +9,38 @@ logic. Living here so both features stay in sync.
 import unicodedata
 
 from rapidfuzz import fuzz
-from sqlalchemy import func, select
+from sqlalchemy import func, select, text
 from sqlalchemy.ext.asyncio import AsyncSession
+from sqlalchemy.sql.elements import TextClause
 
 from app.db.models import Track
+
+# The three values `ExternalAlbumCache.discovery_context` may take. They live here,
+# rather than in the service that writes each one, because the partial unique indexes
+# below are keyed on them and all three must agree.
+ARTIST_NEW_RELEASE_CONTEXT = "artist_new_release"
+PLAYLIST_REC_CONTEXT = "playlist_recommendation"
+LISTENING_PROFILE_CONTEXT = "listening_profile_recommendation"
+
+# Literal predicates that exactly mirror the partial-unique-index `postgresql_where`
+# clauses on ExternalAlbumCache (see `app/db/models/artists.py`). PostgreSQL needs
+# the ON CONFLICT inference predicate to imply the partial index predicate at plan
+# time; a parameterized comparison (`discovery_context = $param`) breaks inference,
+# so each context maps to a fixed text clause that matches the index definition.
+#
+# `artist_new_release` was missing here until 2026-08-30, and its absence is not why
+# it was added: `save_discovered_release` was deduping on `release_id` alone, without
+# any context predicate at all. Uniqueness in this table is *per context*, so one
+# release legitimately exists once per context, and `scalar_one_or_none()` raised
+# `MultipleResultsFound` on the single release that did. That killed the nightly
+# discovery job every night for nineteen nights. See ADR-0099.
+_INDEX_WHERE_BY_CONTEXT: dict[str, TextClause] = {
+    ARTIST_NEW_RELEASE_CONTEXT: text("discovery_context = 'artist_new_release'"),
+    PLAYLIST_REC_CONTEXT: text("discovery_context = 'playlist_recommendation'"),
+    LISTENING_PROFILE_CONTEXT: text(
+        "discovery_context = 'listening_profile_recommendation'"
+    ),
+}
 
 
 def normalize_artist_name(name: str) -> str:

--- a/backend/app/services/new_releases.py
+++ b/backend/app/services/new_releases.py
@@ -12,6 +12,7 @@ from typing import Any
 from uuid import UUID
 
 from sqlalchemy import Float, func, or_, select
+from sqlalchemy.dialects.postgresql import insert as pg_insert
 from sqlalchemy.ext.asyncio import AsyncSession
 
 from app.db.models import (
@@ -23,6 +24,8 @@ from app.db.models import (
     TrackStatus,
 )
 from app.services.external_albums_helpers import (
+    _INDEX_WHERE_BY_CONTEXT,
+    ARTIST_NEW_RELEASE_CONTEXT,
     check_user_has_release,
     normalize_artist_name,
 )
@@ -34,7 +37,7 @@ __all__ = ["DISCOVERY_CONTEXT", "NewReleasesService", "normalize_artist_name"]
 
 logger = logging.getLogger(__name__)
 
-DISCOVERY_CONTEXT = "artist_new_release"
+DISCOVERY_CONTEXT = ARTIST_NEW_RELEASE_CONTEXT
 
 
 
@@ -187,35 +190,56 @@ class NewReleasesService:
         extra_data: dict[str, Any] | None = None,
         musicbrainz_artist_id: str | None = None,
     ) -> ExternalAlbumCache | None:
-        """Save a discovered release if not already cached. Returns the row or None."""
-        existing = await self.db.execute(
-            select(ExternalAlbumCache).where(
-                ExternalAlbumCache.release_id == release_id,
-            )
-        )
-        if existing.scalar_one_or_none():
-            return None
+        """Save a discovered release if not already cached. Returns the row or None.
 
+        **The existence check is scoped to this discovery context, and that scoping is
+        load-bearing.** ``external_album_cache`` does not enforce uniqueness on
+        ``release_id`` globally — it carries three *partial* unique indexes, one per
+        ``discovery_context``, so the same release legitimately exists once per context.
+        This method used to select on ``release_id`` alone and call
+        ``scalar_one_or_none()``, which raises ``MultipleResultsFound`` the moment any
+        release appears in two contexts. Exactly one did, and it killed the nightly
+        discovery job every night for nineteen nights. See ADR-0099.
+
+        The insert is an upsert rather than check-then-write for a second reason: the
+        scheduled job and ``POST /new-releases/check/batch`` both start runs with no
+        lock between them, so two runs could pass the check and the loser would raise
+        ``IntegrityError`` — poisoning the session the same way.
+        """
         local_match = await self.check_if_user_has_release(artist_name, release_name)
 
-        release = ExternalAlbumCache(
-            discovery_context=DISCOVERY_CONTEXT,
-            artist_name=artist_name,
-            artist_name_normalized=normalize_artist_name(artist_name),
-            musicbrainz_artist_id=musicbrainz_artist_id,
-            release_id=release_id,
-            release_name=release_name,
-            release_type=release_type,
-            release_date=release_date,
-            artwork_url=artwork_url,
-            external_url=external_url,
-            track_count=track_count,
-            extra_data=extra_data or {},
-            local_album_match=local_match,
+        result = await self.db.execute(
+            pg_insert(ExternalAlbumCache)
+            .values(
+                discovery_context=DISCOVERY_CONTEXT,
+                # Stamped from the application clock, not `server_default=func.now()`:
+                # in PostgreSQL `now()` is the *transaction* timestamp. The neighbouring
+                # writer in `recommendations.py` records what that cost when it was got
+                # wrong.
+                discovered_at=utcnow(),
+                artist_name=artist_name,
+                artist_name_normalized=normalize_artist_name(artist_name),
+                musicbrainz_artist_id=musicbrainz_artist_id,
+                release_id=release_id,
+                release_name=release_name,
+                release_type=release_type,
+                release_date=release_date,
+                artwork_url=artwork_url,
+                external_url=external_url,
+                track_count=track_count,
+                extra_data=extra_data or {},
+                local_album_match=local_match,
+            )
+            .on_conflict_do_nothing(
+                index_elements=["release_id"],
+                index_where=_INDEX_WHERE_BY_CONTEXT[DISCOVERY_CONTEXT],
+            )
+            .returning(ExternalAlbumCache)
         )
-        self.db.add(release)
-        await self.db.flush()
-        return release
+        # `RETURNING` yields no row when the conflict clause suppressed the insert, so
+        # `None` still means "already had this one" and callers counting new releases
+        # keep counting the same thing.
+        return result.scalar_one_or_none()
 
     async def get_cached_releases(
         self,

--- a/backend/app/services/recommendations.py
+++ b/backend/app/services/recommendations.py
@@ -7,10 +7,9 @@ from datetime import datetime, timedelta
 from typing import Any
 from uuid import UUID
 
-from sqlalchemy import Float, delete, func, select, text
+from sqlalchemy import Float, delete, func, select
 from sqlalchemy.dialects.postgresql import insert as pg_insert
 from sqlalchemy.ext.asyncio import AsyncSession
-from sqlalchemy.sql.elements import TextClause
 
 from app.db.models import (
     ArtistCheckCache,
@@ -22,6 +21,9 @@ from app.db.models import (
 )
 from app.services.bandcamp import BandcampService
 from app.services.external_albums_helpers import (
+    _INDEX_WHERE_BY_CONTEXT,
+    LISTENING_PROFILE_CONTEXT,
+    PLAYLIST_REC_CONTEXT,
     check_user_has_release,
     normalize_artist_name,
 )
@@ -31,20 +33,8 @@ from app.utils.time import utcnow
 
 logger = logging.getLogger(__name__)
 
-PLAYLIST_REC_CONTEXT = "playlist_recommendation"
-LISTENING_PROFILE_CONTEXT = "listening_profile_recommendation"
-
-# Literal predicates that exactly mirror the partial-unique-index `postgresql_where`
-# clauses on ExternalAlbumCache (see `app/db/models/artists.py`). PostgreSQL needs
-# the ON CONFLICT inference predicate to imply the partial index predicate at plan
-# time; a parameterized comparison (`discovery_context = $param`) breaks inference,
-# so each context maps to a fixed text clause that matches the index definition.
-_INDEX_WHERE_BY_CONTEXT: dict[str, TextClause] = {
-    PLAYLIST_REC_CONTEXT: text("discovery_context = 'playlist_recommendation'"),
-    LISTENING_PROFILE_CONTEXT: text(
-        "discovery_context = 'listening_profile_recommendation'"
-    ),
-}
+# Re-exported from `external_albums_helpers`, which owns the discovery contexts and
+# the index predicates keyed on them, so the three writers cannot disagree.
 
 PLAYLIST_REC_TTL_HOURS = 24
 PLAYLIST_REC_MB_RELEASE_TYPES = ["album", "ep"]

--- a/backend/app/services/tasks/new_releases.py
+++ b/backend/app/services/tasks/new_releases.py
@@ -32,6 +32,56 @@ def _artist_names_match(searched: str, found: str) -> bool:
 NEW_RELEASES_PROGRESS_KEY = "familiar:new_releases:progress"
 
 
+async def _check_one_artist_isolated(
+    db: Any,
+    service: Any,
+    artist_name: str,
+    normalized: str,
+    mb_artist_id: str | None,
+    days_back: int,
+    stats: dict[str, Any],
+) -> bool:
+    """Check one artist, containing any failure to that artist. Returns success.
+
+    **One artist's failure must cost one artist.** Before this existed, the only
+    ``try`` in the path was inside ``_check_artist_against_musicbrainz``, around the
+    MusicBrainz call and nothing else — so a database error raised while saving a
+    release escaped to the caller's outer handler and ended the whole run. That is
+    how a single duplicated release row stopped nineteen consecutive nights of
+    discovery (ADR-0099).
+
+    The ``rollback()`` is the part that actually does the work. Catching without it
+    leaves the ``AsyncSession`` in a failed transaction, so every subsequent artist
+    raises ``PendingRollbackError`` and the batch is just as dead — a fix that looks
+    right and changes nothing.
+    """
+    from app.services.tasks.common import _record_task_failure
+
+    try:
+        await _check_artist_against_musicbrainz(
+            service=service,
+            artist_name=artist_name,
+            normalized=normalized,
+            mb_artist_id=mb_artist_id,
+            days_back=days_back,
+            stats=stats,
+        )
+        # Commit per artist rather than every 25: a rollback must not discard up to
+        # twenty-four artists' worth of successful work alongside the one that failed.
+        await db.commit()
+        return True
+    except Exception as e:
+        await db.rollback()
+        stats["artists_failed"] = stats.get("artists_failed", 0) + 1
+        _record_task_failure("new_releases", str(e), track_info=artist_name)
+        logger.warning(
+            "discovery_artist_failed",
+            extra={"artist": artist_name, "error": str(e)},
+            exc_info=True,
+        )
+        return False
+
+
 class NewReleasesProgressReporter:
     """Reports new releases check progress to Redis for API consumption."""
 
@@ -251,6 +301,7 @@ async def run_new_releases_check(
         "releases_found": 0,
         "releases_new": 0,
         "musicbrainz_queries": 0,
+        "artists_failed": 0,
     }
 
     local_engine, local_session_maker = create_task_engine_session()
@@ -286,7 +337,8 @@ async def run_new_releases_check(
 
                 stats["artists_checked"] += 1
 
-                await _check_artist_against_musicbrainz(
+                await _check_one_artist_isolated(
+                    db=db,
                     service=service,
                     artist_name=artist_name,
                     normalized=normalized,
@@ -294,11 +346,6 @@ async def run_new_releases_check(
                     days_back=days_back,
                     stats=stats,
                 )
-
-                if (i + 1) % 25 == 0:
-                    await db.commit()
-
-            await db.commit()
 
         progress.complete(
             checked=stats["artists_checked"],
@@ -334,6 +381,7 @@ async def run_prioritized_new_releases_check(
         "releases_found": 0,
         "releases_new": 0,
         "musicbrainz_queries": 0,
+        "artists_failed": 0,
     }
 
     local_engine, local_session_maker = create_task_engine_session()
@@ -375,7 +423,8 @@ async def run_prioritized_new_releases_check(
 
                 stats["artists_checked"] += 1
 
-                await _check_artist_against_musicbrainz(
+                await _check_one_artist_isolated(
+                    db=db,
                     service=service,
                     artist_name=artist_name,
                     normalized=normalized,
@@ -383,11 +432,6 @@ async def run_prioritized_new_releases_check(
                     days_back=days_back,
                     stats=stats,
                 )
-
-                if (i + 1) % 25 == 0:
-                    await db.commit()
-
-            await db.commit()
 
         progress.complete(
             checked=stats["artists_checked"],
@@ -397,7 +441,8 @@ async def run_prioritized_new_releases_check(
 
         logger.info(
             f"Priority-based new releases check complete: "
-            f"{stats['artists_checked']} artists, {stats['releases_new']} new releases"
+            f"{stats['artists_checked']} artists, {stats['releases_new']} new releases, "
+            f"{stats.get('artists_failed', 0)} failed"
         )
         return {"status": "success", **stats}
 

--- a/backend/tests/test_new_releases_service.py
+++ b/backend/tests/test_new_releases_service.py
@@ -397,3 +397,154 @@ async def test_get_check_status_aggregates(async_db):
     assert status["new_releases_available"] == 1
     assert status["last_check_at"] is not None
     assert isinstance(datetime.fromisoformat(status["last_check_at"]), datetime)
+
+
+# ---------------------------------------------------------------------------
+# ADR-0099: the dedup must be scoped to its own discovery context
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.asyncio
+async def test_save_discovered_release_is_scoped_to_its_own_discovery_context(async_db):
+    """A release already cached under a *different* context must not block this one.
+
+    This is the nineteen-night outage, in one test. ``external_album_cache`` does not
+    enforce uniqueness on ``release_id`` globally — it carries three *partial* unique
+    indexes, one per ``discovery_context`` — so the same release legitimately exists
+    once per context. ``save_discovered_release`` deduped on ``release_id`` alone and
+    called ``scalar_one_or_none()``, which raises ``MultipleResultsFound`` the moment
+    two rows come back.
+
+    In production exactly one release did this: ``b9df3445-4699-4221-9994-734c1c912468``
+    ("Reality Awaits"), present as both ``artist_new_release`` and
+    ``listening_profile_recommendation``. That single row crashed the nightly discovery
+    job every night from 2026-08-11 to 2026-08-30.
+
+    Against the old code this test raises rather than fails.
+    """
+    shared_release_id = "b9df3445-4699-4221-9994-734c1c912468"
+
+    async_db.add(
+        ExternalAlbumCache(
+            release_id=shared_release_id,
+            discovery_context="listening_profile_recommendation",
+            artist_name="Bruised Sky",
+            artist_name_normalized=normalize_artist_name("Bruised Sky"),
+            release_name="Reality Awaits",
+        )
+    )
+    await async_db.flush()
+
+    service = NewReleasesService(async_db)
+    saved = await service.save_discovered_release(
+        artist_name="Bruised Sky",
+        release_id=shared_release_id,
+        release_name="Reality Awaits",
+    )
+
+    assert saved is not None, "a new context is a new row, not a duplicate"
+
+    result = await async_db.execute(
+        select(ExternalAlbumCache).where(
+            ExternalAlbumCache.release_id == shared_release_id
+        )
+    )
+    contexts = sorted(row.discovery_context for row in result.scalars().all())
+    assert contexts == ["artist_new_release", "listening_profile_recommendation"]
+
+
+@pytest.mark.asyncio
+async def test_save_discovered_release_second_call_is_a_no_op_not_an_error(async_db):
+    """Re-saving within the same context returns None and does not raise.
+
+    The upsert replaced a check-then-write, so this pins the contract that the
+    conflict path is silent: ``None`` means "already had it", which is what the
+    ``releases_new`` counter is built on.
+    """
+    service = NewReleasesService(async_db)
+
+    first = await service.save_discovered_release(
+        artist_name="Boards of Canada",
+        release_id="rg-same-context",
+        release_name="Tomorrow's Harvest",
+    )
+    second = await service.save_discovered_release(
+        artist_name="Boards of Canada",
+        release_id="rg-same-context",
+        release_name="Tomorrow's Harvest",
+    )
+
+    assert first is not None
+    assert second is None
+
+    result = await async_db.execute(
+        select(ExternalAlbumCache).where(
+            ExternalAlbumCache.release_id == "rg-same-context"
+        )
+    )
+    assert len(result.scalars().all()) == 1
+
+
+def test_index_predicates_match_the_model():
+    """The literal ON CONFLICT predicates must equal the model's index predicates.
+
+    ``_INDEX_WHERE_BY_CONTEXT`` restates each partial index's ``postgresql_where`` as a
+    literal, because PostgreSQL cannot infer a partial index from a parameterised
+    predicate. That makes it a second source of truth, and this asserts the two agree —
+    the first copy of this knowledge is what drifted.
+    """
+    from app.db.models import ExternalAlbumCache as EAC
+    from app.services.external_albums_helpers import _INDEX_WHERE_BY_CONTEXT
+
+    model_predicates = {
+        str(idx.dialect_options["postgresql"]["where"])
+        for idx in EAC.__table__.indexes
+        if idx.unique and idx.dialect_options["postgresql"].get("where") is not None
+    }
+    mapped_predicates = {str(clause) for clause in _INDEX_WHERE_BY_CONTEXT.values()}
+
+    assert mapped_predicates == model_predicates, (
+        "every partial unique index needs an entry, and every entry an index — "
+        "artist_new_release was missing from the map, which is ADR-0099"
+    )
+
+
+@pytest.mark.asyncio
+async def test_save_does_not_raise_when_a_release_already_exists_in_two_contexts(
+    async_db,
+):
+    """The crash itself: two pre-existing rows for one release_id.
+
+    This is the state production reached and the one that actually took the job
+    down. The recommendations writer upserts scoped to its own context, so it will
+    happily add a ``listening_profile_recommendation`` row for a release that
+    already has an ``artist_new_release`` row. Once both exist, the next discovery
+    run selected on ``release_id`` alone, got two rows back, and
+    ``scalar_one_or_none()`` raised ``MultipleResultsFound`` — aborting the batch.
+
+    Nineteen consecutive nights, from one release.
+    """
+    release_id = "b9df3445-4699-4221-9994-734c1c912468"
+
+    for context in ("artist_new_release", "listening_profile_recommendation"):
+        async_db.add(
+            ExternalAlbumCache(
+                release_id=release_id,
+                discovery_context=context,
+                artist_name="Bruised Sky",
+                artist_name_normalized=normalize_artist_name("Bruised Sky"),
+                release_name="Reality Awaits",
+            )
+        )
+    await async_db.flush()
+
+    service = NewReleasesService(async_db)
+
+    # Must not raise. The release is already cached in this context, so this is a
+    # no-op — but a no-op, not an exception that ends the run.
+    result = await service.save_discovered_release(
+        artist_name="Bruised Sky",
+        release_id=release_id,
+        release_name="Reality Awaits",
+    )
+    assert result is None

--- a/backend/tests/test_new_releases_task.py
+++ b/backend/tests/test_new_releases_task.py
@@ -1,0 +1,148 @@
+"""Fault isolation in the discovery batch (ADR-0099 point 9).
+
+One artist's failure must cost one artist. Before `_check_one_artist_isolated`
+existed, the only `try` in the path wrapped the MusicBrainz call, so a database
+error raised while *saving* a release escaped to the run's outer handler and
+ended the batch — which is how one duplicated row stopped nineteen consecutive
+nights of discovery.
+"""
+
+from typing import Any
+
+import pytest
+
+from app.services.tasks.new_releases import _check_one_artist_isolated
+
+
+class _RecordingSession:
+    """Minimal stand-in that records commit/rollback ordering."""
+
+    def __init__(self) -> None:
+        self.calls: list[str] = []
+
+    async def commit(self) -> None:
+        self.calls.append("commit")
+
+    async def rollback(self) -> None:
+        self.calls.append("rollback")
+
+
+def _stats() -> dict[str, Any]:
+    return {
+        "artists_checked": 0,
+        "releases_found": 0,
+        "releases_new": 0,
+        "musicbrainz_queries": 0,
+        "artists_failed": 0,
+    }
+
+
+@pytest.mark.asyncio
+async def test_a_failing_artist_is_contained_and_rolled_back(monkeypatch):
+    """A raise is caught, counted, and the session is rolled back.
+
+    The rollback is the load-bearing half: catching without it leaves the
+    AsyncSession in a failed transaction, so every later artist raises
+    PendingRollbackError and the batch is just as dead.
+    """
+    async def _boom(**kwargs: Any) -> None:
+        raise RuntimeError("Multiple rows were found when one or none was required")
+
+    monkeypatch.setattr(
+        "app.services.tasks.new_releases._check_artist_against_musicbrainz", _boom
+    )
+    monkeypatch.setattr(
+        "app.services.tasks.common._record_task_failure", lambda *a, **k: None
+    )
+
+    db = _RecordingSession()
+    stats = _stats()
+
+    ok = await _check_one_artist_isolated(
+        db=db,
+        service=object(),
+        artist_name="Bruised Sky",
+        normalized="bruised sky",
+        mb_artist_id=None,
+        days_back=90,
+        stats=stats,
+    )
+
+    assert ok is False
+    assert stats["artists_failed"] == 1
+    assert db.calls == ["rollback"], "must roll back, and must not commit"
+
+
+@pytest.mark.asyncio
+async def test_a_successful_artist_commits_on_its_own(monkeypatch):
+    """Commit is per artist, so a later rollback cannot discard earlier work."""
+    async def _ok(**kwargs: Any) -> None:
+        kwargs["stats"]["releases_new"] += 1
+
+    monkeypatch.setattr(
+        "app.services.tasks.new_releases._check_artist_against_musicbrainz", _ok
+    )
+
+    db = _RecordingSession()
+    stats = _stats()
+
+    ok = await _check_one_artist_isolated(
+        db=db,
+        service=object(),
+        artist_name="Boards of Canada",
+        normalized="boards of canada",
+        mb_artist_id=None,
+        days_back=90,
+        stats=stats,
+    )
+
+    assert ok is True
+    assert stats["artists_failed"] == 0
+    assert stats["releases_new"] == 1
+    assert db.calls == ["commit"]
+
+
+@pytest.mark.asyncio
+async def test_one_failing_artist_does_not_abort_the_batch(monkeypatch):
+    """The whole point: artist 2 fails, artists 1 and 3 still get checked.
+
+    Against the pre-ADR-0099 code the raise on artist 2 propagated out of the
+    loop and artist 3 was never reached.
+    """
+    seen: list[str] = []
+
+    async def _fail_on_second(**kwargs: Any) -> None:
+        name = kwargs["artist_name"]
+        seen.append(name)
+        if name == "artist-2":
+            raise RuntimeError("boom")
+        kwargs["stats"]["releases_new"] += 1
+
+    monkeypatch.setattr(
+        "app.services.tasks.new_releases._check_artist_against_musicbrainz",
+        _fail_on_second,
+    )
+    monkeypatch.setattr(
+        "app.services.tasks.common._record_task_failure", lambda *a, **k: None
+    )
+
+    db = _RecordingSession()
+    stats = _stats()
+
+    for name in ("artist-1", "artist-2", "artist-3"):
+        stats["artists_checked"] += 1
+        await _check_one_artist_isolated(
+            db=db,
+            service=object(),
+            artist_name=name,
+            normalized=name,
+            mb_artist_id=None,
+            days_back=90,
+            stats=stats,
+        )
+
+    assert seen == ["artist-1", "artist-2", "artist-3"]
+    assert stats["artists_checked"] == 3
+    assert stats["artists_failed"] == 1
+    assert stats["releases_new"] == 2
+    assert db.calls == ["commit", "rollback", "commit"]

--- a/docs/decisions/ADR-0099-discovery-is-a-background-job-with-visible-sources.md
+++ b/docs/decisions/ADR-0099-discovery-is-a-background-job-with-visible-sources.md
@@ -30,8 +30,8 @@ Measured on the production database:
 | | |
 |---|---|
 | `external_album_cache`, `discovery_context = 'artist_new_release'` | **600 rows** |
-| `artist_check_cache` | **520 rows** |
-| a daily job at 03:00 (`daily_new_releases` in `background/manager.py:109`) | **runs** — eight log entries in 24 h |
+| `artist_check_cache` | **520 rows**, **0 checked in the last 24 h**, `check_priority` **0.0 on all of them** |
+| a daily job at 03:00 (`daily_new_releases` in `background/manager.py:109`) | **runs and crashes** — every night since 2026-08-11 |
 
 `backend/app/services/new_releases.py` is 446 lines whose docstring says it "reads/writes the shared
 `external_album_cache` table filtered to `discovery_context='artist_new_release'`".
@@ -44,11 +44,46 @@ them. This is the third capability-with-no-caller found in this codebase this we
 ### The freshness nobody could see
 
 The newest `artist_new_release` row is dated **2026-08-25** — five days old — while
-`listening_profile_recommendation`, written by the neighbouring job, is from today. So the daily
-new-release job is running and *not writing*, almost certainly hitting the same 503 wall the request
-path hit.
+`listening_profile_recommendation`, written by the neighbouring job, is from today.
 
-Nothing surfaced that. `panels/server/ApiKeyStatus.tsx` is 55 lines and reports whether an API *key*
+#### The premise that was wrong: it is not the rate limit, it is us
+
+This ADR was first drafted saying the daily job was "almost certainly hitting the same 503 wall the
+request path hit". **That is false, and checking it before implementing is what found the real
+defect.**
+
+The job has not been throttled. It has *crashed*, every night since at least 2026-08-11 — nineteen
+consecutive nights — with `sqlalchemy.exc.MultipleResultsFound`, raised at
+`services/new_releases.py:196` inside `save_discovered_release` and reached from
+`tasks/new_releases.py:216`.
+
+`save_discovered_release` deduped on `release_id` alone. `external_album_cache` does not enforce
+uniqueness that way: it carries **three partial unique indexes**, one per `discovery_context`
+(`ix_eac_artist_new_release_unique`, `ix_eac_listening_profile_unique`, `ix_eac_playlist_rec_unique`),
+so the same release legitimately exists once per context. Production held exactly **one** such
+release — `b9df3445-4699-4221-9994-734c1c912468`, "Reality Awaits", in both `artist_new_release` and
+`listening_profile_recommendation` — and `scalar_one_or_none()` raises on two rows.
+
+**One row stopped nineteen nights of discovery**, because the exception escaped the only `try` in the
+path — `_check_artist_against_musicbrainz` guarded the MusicBrainz call and nothing else — into a
+batch loop with no per-artist guard.
+
+Two consequences for what this ADR decides. First, **source health as originally argued would not
+have caught this**: the failure was ours, not an upstream's, and MusicBrainz answered fine throughout
+— which is why point 10 below now exists. Second, point 8's "runs, fails, and looks like a component
+that ran and found nothing" stops being a hypothesis; it is a literal description of nineteen logged
+crashes nobody read. Points 1–8 otherwise stand.
+
+Two further corrections to this ADR's own framing, found the same way. **`GET
+/library/artists/new-releases` has no callers in either repository** — the Discover page the Mac and
+iPhone display is the embedded web surface, whose `NewReleasesSection.tsx` calls the *cached*
+`GET /new-releases`. So the user-facing read path already satisfies point 1 and has all along; it was
+serving a cache the crash had frozen. The 240-second hang came through the MCP tool
+`get_new_releases`, which carries its own copy of the live-scan logic. And **`get_check_status`
+derives `last_check_at` from `max(ArtistCheckCache.last_checked_at)`**, which read 2026-08-28 while
+every run since 08-11 crashed — a freshness signal computed from a side effect of partial work.
+
+Nothing surfaced any of it. `panels/server/ApiKeyStatus.tsx` is 55 lines and reports whether an API *key*
 is configured, which is not the same question as whether a source is *working*. A source can have a
 valid key, be scheduled, run daily, fail every time, and look identical to a healthy one.
 
@@ -106,6 +141,18 @@ stopped everything at once. Last.fm and Bandcamp are integrated and barely used 
    failure mode this ADR exists to prevent is a component that runs, fails, and looks like a
    component that ran and found nothing.
 
+9. **One artist's failure costs one artist.** A discovery batch is fault-isolated per item: an
+   exception on one artist is recorded, the transaction rolled back to the last commit, and the batch
+   continues. The nineteen-night outage was one bad row taking a whole run with it, and no amount of
+   source health would have prevented that — only the isolation would. The rollback is the
+   load-bearing half: catching without it leaves the session in a failed transaction, so every later
+   artist fails too and the fix changes nothing.
+
+10. **Health covers the job's own outcome, not only its upstreams'.** Did the batch run, did it
+    finish, did it write. A source that answered perfectly while our own writer crashed must not read
+    as healthy — which is exactly the state that held for nineteen nights, and which points 6 and 8
+    as originally written would have rendered green.
+
 ## Alternatives Considered
 
 - **Keep the request path as it is and rely on the timeouts already added.** Cheapest, and it fixes
@@ -146,8 +193,9 @@ stopped everything at once. Last.fm and Bandcamp are integrated and barely used 
   prioritised batch has to stay small enough to be a good citizen. `musicbrainzngs`'s 1 req/sec
   limiter is per-process, so this needs care if the work is ever parallelised.
 - **Follow-up** — the endpoint and `_get_new_releases` duplicate each other's logic. Both were
-  bounded separately on 2026-08-30 because fixing one fixed nothing the user hit. Moving the read to
-  the cache is the moment to make one call the other.
+  bounded separately on 2026-08-30 because fixing one fixed nothing the user hit. Since the endpoint
+  turned out to have no callers, the resolution is to **delete it** (ADR-0077's precedent) and have
+  the MCP tool read the cache through `NewReleasesService`, rather than to make one call the other.
 - **Follow-up** — `musicbrainzngs` retries 503s internally and reports nothing to its caller. Point 6
   needs a real signal, which probably means wrapping the client rather than reading its logs.
 - **Follow-up** — nothing here decides how a *user* triggers a refresh when they know something is


### PR DESCRIPTION
The nightly new-releases job has not completed since **2026-08-11**. It raises `sqlalchemy.exc.MultipleResultsFound` and aborts, every night, and the `artist_new_release` cache has been frozen at 2026-08-25 ever since.

### ADR-0099 blamed MusicBrainz's rate limit. That was wrong.

Checking the premise before implementing the ADR is what found the real defect. The job was never throttled — MusicBrainz answered fine throughout.

`save_discovered_release` deduped on `release_id` **alone**. `external_album_cache` does not enforce uniqueness that way: it carries three *partial* unique indexes, one per `discovery_context`. So one release legitimately exists once per context, and `scalar_one_or_none()` raises on two rows.

Production holds exactly one such release — `b9df3445…`, "Reality Awaits", present as both `artist_new_release` and `listening_profile_recommendation`. **One row stopped nineteen nights of discovery**, because the only `try` in the path wrapped the MusicBrainz call and nothing else, so a database error escaped into a batch loop with no per-artist guard.

### Two defects, two fixes

**The dedup is scoped to its context**, written as an upsert rather than check-then-write — `on_conflict_do_nothing` with the partial index's literal predicate. Not just for tidiness: the scheduled job and `POST /check/batch` both start runs with no lock, so check-then-write leaves a live TOCTOU race whose loser raises `IntegrityError` and poisons the session exactly as `MultipleResultsFound` did. `RETURNING` yields no row on conflict, so `None` still means "already had it".

**A batch is fault-isolated per artist.** The `rollback()` is the load-bearing half — catching without it leaves the session in a failed transaction, so every later artist raises `PendingRollbackError` and the batch is just as dead. Commit moves to per-artist from every-25, so a rollback cannot discard twenty-four artists' good work.

### The tests were verified to fail against the committed code

Not assumed to. One reproduces the `MultipleResultsFound` crash from two pre-existing rows; another pins a subtler symptom of the same bug — a release already cached under another context was silently **skipped**, which is why "Reality Awaits" never got its `artist_new_release` row. Plus a test that the literal `ON CONFLICT` predicates still equal the model's index predicates, since that map is a second source of truth and the first copy already drifted.

94 related tests pass. The four failures in the full run are pre-existing and reproduce on unmodified `HEAD`.

### ADR-0099 amended

Per CLAUDE.md rule 5 the contradicted premise is recorded, with two new decision points the crash showed 1–8 do not cover: **one artist's failure costs one artist**, and **health must cover the job's own outcome**, not only its upstreams' — a source answering perfectly while our writer crashed read green for nineteen nights.

Two further corrections found the same way: `GET /library/artists/new-releases` has **no callers in either repo** (the embedded Discover page reads the *cached* endpoint, so the user-facing path already satisfied point 1 — the 240s hang came through the MCP tool), and `get_check_status` infers freshness from `max(last_checked_at)`, which showed 08-28 while every run crashed.

This is Phase 0 of five. It ships alone and unfreezes the data tonight.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01Emjrwedq7W1scadHdgiLfs