### PR TITLE
Owning an artist is enough to be discovered

### DIFF
--- a/backend/app/services/new_releases.py
+++ b/backend/app/services/new_releases.py
@@ -11,7 +11,7 @@ from datetime import datetime, timedelta
 from typing import Any
 from uuid import UUID
 
-from sqlalchemy import Float, func, or_, select
+from sqlalchemy import Float, and_, func, or_, select
 from sqlalchemy.dialects.postgresql import insert as pg_insert
 from sqlalchemy.ext.asyncio import AsyncSession
 
@@ -89,6 +89,24 @@ def plausible_release_date(
     if value - reference > MAX_RELEASE_DATE_LOOKAHEAD:
         return None
     return value
+
+
+#: Share of each discovery batch reserved for artists never checked at all.
+#:
+#: **Without a reserve, admitting unplayed artists to the pool accomplishes nothing.**
+#: They score zero on both recency and frequency, so they sort below every artist with
+#: any listening history — and measured on 2026-08-31 the played set alone oversubscribes
+#: the rotation: 706 played artists eligible at any moment against a capacity of 525 per
+#: seven-day cycle. A queue that refills faster than it drains never reaches its tail.
+#:
+#: One third rather than a half or a tenth, and the tension is real in both directions.
+#: Too small and the 2,932 never-checked artists take years; too large and new releases by
+#: the artists someone actually listens to go unnoticed while the backlog is walked. Two
+#: thirds keeps the listened-to set current, which is the thing a person notices.
+#:
+#: This is a backlog mechanism, not a permanent policy: once every artist has been checked
+#: once, no artist matches the reserve and the whole batch is priority-ordered again.
+NEVER_CHECKED_BATCH_SHARE = 1 / 3
 
 
 # Beyond this, the precompute is old enough that a caller should say so out loud.
@@ -460,14 +478,24 @@ class NewReleasesService:
         batch_size: int = 75,
         min_days_since_check: int = 7,
     ) -> list[dict[str, Any]]:
-        """Return artists prioritized by listening recency (60%) + frequency (40%).
+        """Return library artists prioritized by listening recency (60%) + frequency (40%).
 
-        Groups by canonical ``Artist.id`` so spelling variants share one
-        priority score. ``ArtistCheckCache`` is joined on a Python-side
-        normalized form of ``Artist.name`` — the cache table is legacy
-        string-keyed and stays that way; the join condition uses the same
-        ``lower(trim(Artist.name))`` normalization the resolver wrote
-        with.
+        **Every artist in the library is a candidate, whether or not you have played
+        them.** This used to select *from* ``ProfilePlayHistory``, which made play
+        history a gate rather than a priority: 2,614 of 3,453 owned artists had no row
+        there and were structurally invisible to new-release discovery. Nothing in
+        ADR-0099 asked for that — it was an implementation accident, recorded as a bug
+        in ADR-0101.
+
+        Play history is now an outer join and decides *order*, not membership. An
+        artist you have never played scores zero and sorts last, which is correct and,
+        on its own, still useless — see ``NEVER_CHECKED_BATCH_SHARE``.
+
+        Groups by canonical ``Artist.id`` so spelling variants share one priority
+        score. ``ArtistCheckCache`` is joined on a Python-side normalized form of
+        ``Artist.name`` — the cache table is legacy string-keyed and stays that way;
+        the join condition uses the same ``lower(trim(Artist.name))`` normalization the
+        resolver wrote with.
         """
         artist_stats = (
             select(
@@ -476,12 +504,21 @@ class NewReleasesService:
                 Artist.musicbrainz_id.label("musicbrainz_artist_id"),
                 func.lower(func.trim(Artist.name)).label("artist_normalized"),
                 func.max(ProfilePlayHistory.last_played_at).label("last_played"),
-                func.sum(ProfilePlayHistory.play_count).label("total_plays"),
+                # `coalesce` matters: an artist with no play history has a NULL sum,
+                # and NULL propagates through `ln()` to a NULL priority score, which
+                # sorts unpredictably rather than last.
+                func.coalesce(func.sum(ProfilePlayHistory.play_count), 0).label("total_plays"),
             )
-            .select_from(ProfilePlayHistory)
-            .join(Track, ProfilePlayHistory.track_id == Track.id)
-            .join(Artist, Artist.id == Track.canonical_artist_id)
-            .where(ProfilePlayHistory.profile_id == profile_id)
+            .select_from(Artist)
+            .join(Track, Track.canonical_artist_id == Artist.id)
+            .outerjoin(
+                ProfilePlayHistory,
+                and_(
+                    ProfilePlayHistory.track_id == Track.id,
+                    ProfilePlayHistory.profile_id == profile_id,
+                ),
+            )
+            .where(Track.status == TrackStatus.ACTIVE)
             .group_by(
                 Artist.id,
                 Artist.name,
@@ -509,32 +546,54 @@ class NewReleasesService:
 
         priority_score = (recency_score + frequency_score).label("priority_score")
 
-        query = (
-            select(
-                artist_stats.c.artist_normalized,
-                artist_stats.c.artist_name,
-                artist_stats.c.musicbrainz_artist_id,
-                artist_stats.c.last_played,
-                artist_stats.c.total_plays,
-                priority_score,
+        def eligible(*, never_checked_only: bool, limit: int, exclude: set[str]):
+            """Eligible artists in priority order, optionally only the unchecked ones."""
+            stale = or_(
+                ArtistCheckCache.last_checked_at.is_(None),
+                ArtistCheckCache.last_checked_at < cache_cutoff,
             )
-            .select_from(artist_stats)
-            .outerjoin(
-                ArtistCheckCache,
-                artist_stats.c.artist_normalized == ArtistCheckCache.artist_name_normalized,
-            )
-            .where(
-                or_(
-                    ArtistCheckCache.last_checked_at.is_(None),
-                    ArtistCheckCache.last_checked_at < cache_cutoff,
+            conditions = [ArtistCheckCache.last_checked_at.is_(None)] if never_checked_only else [stale]
+            if exclude:
+                conditions.append(artist_stats.c.artist_normalized.notin_(exclude))
+            return (
+                select(
+                    artist_stats.c.artist_normalized,
+                    artist_stats.c.artist_name,
+                    artist_stats.c.musicbrainz_artist_id,
+                    artist_stats.c.last_played,
+                    artist_stats.c.total_plays,
+                    priority_score,
+                    ArtistCheckCache.last_checked_at.label("last_checked_at"),
                 )
+                .select_from(artist_stats)
+                .outerjoin(
+                    ArtistCheckCache,
+                    artist_stats.c.artist_normalized == ArtistCheckCache.artist_name_normalized,
+                )
+                .where(*conditions)
+                .order_by(priority_score.desc())
+                .limit(limit)
             )
-            .order_by(priority_score.desc())
-            .limit(batch_size)
-        )
 
-        result = await self.db.execute(query)
-        rows = result.fetchall()
+        # **The reserved slots are the half of this fix that does the work.** Widening the
+        # pool alone changes nothing: measured 2026-08-31, 706 played artists are eligible
+        # at any moment against a capacity of 525 per seven-day cycle, so the played set
+        # oversubscribes on its own and anything scoring zero waits behind a queue that
+        # refills faster than it drains. A fix that is correct in the query and inert in
+        # effect is not a fix.
+        reserved = max(1, round(batch_size * NEVER_CHECKED_BATCH_SHARE))
+        first_pass = (await self.db.execute(
+            eligible(never_checked_only=True, limit=reserved, exclude=set())
+        )).fetchall()
+
+        seen = {row.artist_normalized for row in first_pass}
+        remainder = (await self.db.execute(
+            eligible(
+                never_checked_only=False,
+                limit=max(0, batch_size - len(first_pass)),
+                exclude=seen,
+            )
+        )).fetchall()
 
         return [
             {
@@ -544,8 +603,13 @@ class NewReleasesService:
                 "last_played": row.last_played.isoformat() if row.last_played else None,
                 "total_plays": row.total_plays,
                 "priority_score": float(row.priority_score) if row.priority_score else 0.0,
+                # Read off the row rather than from membership of the reserved slice:
+                # the remainder is filtered on "stale *or* never checked", so it can
+                # legitimately contain never-checked artists too once the reserve is
+                # smaller than the backlog.
+                "never_checked": row.last_checked_at is None,
             }
-            for row in rows
+            for row in [*first_pass, *remainder]
         ]
 
     async def get_rotation_status(self, profile_id: UUID) -> dict[str, Any]:

--- a/backend/app/services/new_releases.py
+++ b/backend/app/services/new_releases.py
@@ -14,6 +14,7 @@ from uuid import UUID
 from sqlalchemy import Float, and_, func, or_, select
 from sqlalchemy.dialects.postgresql import insert as pg_insert
 from sqlalchemy.ext.asyncio import AsyncSession
+from sqlalchemy.sql.elements import ColumnElement
 
 from app.db.models import (
     Artist,
@@ -552,7 +553,12 @@ class NewReleasesService:
                 ArtistCheckCache.last_checked_at.is_(None),
                 ArtistCheckCache.last_checked_at < cache_cutoff,
             )
-            conditions = [ArtistCheckCache.last_checked_at.is_(None)] if never_checked_only else [stale]
+            # Annotated because the two branches produce different SQLAlchemy types —
+            # `.is_()` gives a BinaryExpression and `or_()` a ColumnElement — and mypy
+            # infers the list from whichever branch it sees first.
+            conditions: list[ColumnElement[bool]] = (
+                [ArtistCheckCache.last_checked_at.is_(None)] if never_checked_only else [stale]
+            )
             if exclude:
                 conditions.append(artist_stats.c.artist_normalized.notin_(exclude))
             return (

--- a/backend/app/services/tasks/new_releases.py
+++ b/backend/app/services/tasks/new_releases.py
@@ -199,8 +199,10 @@ async def _check_artist_against_musicbrainz(
 ) -> None:
     """Resolve an artist's MB id, fetch recent releases, and persist them.
 
-    Mutates ``stats`` in place. Updates artist check cache only when an MB id
-    was successfully resolved (so retries on unmatched artists aren't suppressed).
+    Mutates ``stats`` in place. Records the check whenever MusicBrainz *answered* —
+    matched or not — so an artist with no MusicBrainz entry leaves the never-checked
+    backlog instead of being re-selected on every batch. Only a call that genuinely
+    failed leaves no record, and is retried next batch. See the comment at the write.
     """
     from app.services.metadata.musicbrainz import (
         get_artist_releases_recent,
@@ -210,6 +212,10 @@ async def _check_artist_against_musicbrainz(
 
     mb_id_to_use = mb_artist_id
     releases_for_artist: list[dict[str, Any]] = []
+    # Whether MusicBrainz was actually reached and answered. Distinct from whether it
+    # *matched*: "asked, no such artist" and "could not ask" have to be told apart, or
+    # the artist either churns forever or is written off on a network blip.
+    upstream_answered = False
 
     try:
         if not mb_id_to_use:
@@ -241,6 +247,8 @@ async def _check_artist_against_musicbrainz(
                         "musicbrainz_artist_id": mb_id_to_use,
                     }
                 )
+
+        upstream_answered = True
 
     except Exception as e:
         logger.warning(f"MusicBrainz lookup failed for {artist_name}: {e}")
@@ -275,11 +283,33 @@ async def _check_artist_against_musicbrainz(
         if saved:
             stats["releases_new"] += 1
 
-    if mb_id_to_use:
+    # **Record the check whenever MusicBrainz answered, matched or not.**
+    #
+    # This used to write only when an id resolved, so that an unmatched artist would be
+    # retried rather than cached-out. That reasoning optimised for a rare transient at
+    # the cost of the common structural case, and once ADR-0101 admitted unplayed
+    # artists to the rotation the cost stopped being bounded: an artist MusicBrainz has
+    # no entry for would be re-selected by the never-checked reserve on *every* batch,
+    # forever, displacing artists that have never been looked at even once. Measured on
+    # the live library — a 20-artist batch touched six cache rows and inserted none,
+    # while 2,937 artists had no row at all.
+    #
+    # A row without a `musicbrainz_artist_id` is the honest record of "asked, nothing
+    # matched": the artist leaves the backlog and rejoins the normal staleness rotation
+    # rather than churning. If the call *failed*, nothing is written and it is retried
+    # next batch.
+    #
+    # The imperfection worth naming: `search_artist` swallows a 503 and returns `None`,
+    # so a rate-limited window is indistinguishable here from a genuine no-match and
+    # costs one rotation. ADR-0099 point 6 is where that becomes visible; it is not
+    # fixable from this side today.
+    if mb_id_to_use or upstream_answered:
         await service.update_artist_cache(
             artist_normalized=normalized,
             musicbrainz_id=mb_id_to_use,
         )
+        if not mb_id_to_use:
+            stats["artists_unmatched"] = stats.get("artists_unmatched", 0) + 1
 
 
 async def run_new_releases_check(
@@ -302,6 +332,7 @@ async def run_new_releases_check(
         "releases_new": 0,
         "musicbrainz_queries": 0,
         "artists_failed": 0,
+        "artists_unmatched": 0,
     }
 
     local_engine, local_session_maker = create_task_engine_session()
@@ -382,6 +413,7 @@ async def run_prioritized_new_releases_check(
         "releases_new": 0,
         "musicbrainz_queries": 0,
         "artists_failed": 0,
+        "artists_unmatched": 0,
     }
 
     local_engine, local_session_maker = create_task_engine_session()
@@ -442,6 +474,7 @@ async def run_prioritized_new_releases_check(
         logger.info(
             f"Priority-based new releases check complete: "
             f"{stats['artists_checked']} artists, {stats['releases_new']} new releases, "
+            f"{stats.get('artists_unmatched', 0)} unmatched, "
             f"{stats.get('artists_failed', 0)} failed"
         )
         return {"status": "success", **stats}

--- a/backend/tests/test_new_releases_service.py
+++ b/backend/tests/test_new_releases_service.py
@@ -672,3 +672,142 @@ async def test_new_releases_view_in_library_comes_from_the_precompute(async_db):
     view = await NewReleasesService(async_db).get_new_releases_view()
     assert view["releases"][0]["in_library"] is True
     assert view["new_releases_not_in_library"] == 0
+
+
+# ---------------------------------------------------------------------------
+# ADR-0101: play history is a priority, not a gate
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.asyncio
+async def test_an_artist_you_own_but_never_played_is_a_candidate(async_db):
+    """The bug, in one test.
+
+    ``get_prioritized_artists_batch`` used to select *from* ``ProfilePlayHistory``,
+    which made a play row a condition of membership rather than a source of order.
+    On the production library that hid **2,614 of 3,453 owned artists** from
+    new-release discovery entirely — they could never be checked, however long the
+    rotation ran.
+    """
+    profile = await insert_test_profile(async_db)
+    played = await insert_test_track(async_db, artist="Played Artist", album="A")
+    await insert_test_track(async_db, artist="Never Played Artist", album="B")
+    await insert_test_play_history(
+        async_db, profile.id, played.id, play_count=10, last_played_at=utcnow()
+    )
+    await async_db.commit()
+
+    batch = await NewReleasesService(async_db).get_prioritized_artists_batch(
+        profile_id=profile.id, batch_size=10
+    )
+
+    names = {a["name"] for a in batch}
+    assert "Never Played Artist" in names, "owning it is enough to be a candidate"
+    assert "Played Artist" in names
+
+
+@pytest.mark.asyncio
+async def test_play_history_still_decides_order(async_db):
+    """Widening the pool must not flatten the priority it replaced."""
+    profile = await insert_test_profile(async_db)
+    played = await insert_test_track(async_db, artist="Zzz Played", album="A")
+    await insert_test_track(async_db, artist="Aaa Never Played", album="B")
+    await insert_test_play_history(
+        async_db, profile.id, played.id, play_count=50, last_played_at=utcnow()
+    )
+    await async_db.commit()
+
+    batch = await NewReleasesService(async_db).get_prioritized_artists_batch(
+        profile_id=profile.id, batch_size=10
+    )
+
+    by_name = {a["name"]: a for a in batch}
+    assert by_name["Zzz Played"]["priority_score"] > by_name["Aaa Never Played"]["priority_score"]
+    assert by_name["Aaa Never Played"]["priority_score"] == 0.0
+
+
+@pytest.mark.asyncio
+async def test_never_checked_artists_get_reserved_slots(async_db):
+    """The half of the fix that stops it being inert.
+
+    Reproduces the production shape: the played artists have all been checked before
+    and are merely *stale*, while the owned-but-unplayed ones have never been checked
+    at all. Priority alone would spend every slot on the stale played set, which
+    regenerates faster than the rotation drains it — so widening the pool would change
+    nothing observable. The reserve is what guarantees forward progress.
+    """
+    profile = await insert_test_profile(async_db)
+    now = utcnow()
+
+    for i in range(6):
+        t = await insert_test_track(async_db, artist=f"Played {i}", album=f"P{i}")
+        await insert_test_play_history(
+            async_db, profile.id, t.id, play_count=100 - i, last_played_at=now
+        )
+        async_db.add(
+            ArtistCheckCache(
+                artist_name_normalized=f"played {i}",
+                last_checked_at=now - timedelta(days=30),
+            )
+        )
+    for i in range(3):
+        await insert_test_track(async_db, artist=f"Unplayed {i}", album=f"U{i}")
+    await async_db.commit()
+
+    batch = await NewReleasesService(async_db).get_prioritized_artists_batch(
+        profile_id=profile.id, batch_size=3
+    )
+
+    assert len(batch) == 3
+    unplayed = [a for a in batch if a["name"].startswith("Unplayed")]
+    assert unplayed, (
+        "without the reserve the six stale played artists take every slot and the "
+        "unplayed ones are never reached — the bug wearing a different hat"
+    )
+    assert all(a["never_checked"] for a in unplayed)
+
+
+@pytest.mark.asyncio
+async def test_a_played_artist_never_checked_outranks_an_unplayed_one(async_db):
+    """The reserve is ordered by priority, not by how little you listen.
+
+    "Never checked" is the backlog, and a played artist can be in it too. When one is,
+    it should take the reserved slot ahead of an artist you have never played — the
+    reserve exists to guarantee progress through the backlog, not to invert taste.
+    """
+    profile = await insert_test_profile(async_db)
+    t = await insert_test_track(async_db, artist="Played Unchecked", album="A")
+    await insert_test_play_history(
+        async_db, profile.id, t.id, play_count=40, last_played_at=utcnow()
+    )
+    await insert_test_track(async_db, artist="Unplayed Unchecked", album="B")
+    await async_db.commit()
+
+    batch = await NewReleasesService(async_db).get_prioritized_artists_batch(
+        profile_id=profile.id, batch_size=1
+    )
+
+    assert [a["name"] for a in batch] == ["Played Unchecked"]
+
+
+@pytest.mark.asyncio
+async def test_a_recently_checked_artist_is_still_skipped(async_db):
+    """Widening the pool must not defeat the staleness filter."""
+    profile = await insert_test_profile(async_db)
+    t = await insert_test_track(async_db, artist="Checked Yesterday", album="A")
+    await insert_test_play_history(
+        async_db, profile.id, t.id, play_count=5, last_played_at=utcnow()
+    )
+    async_db.add(
+        ArtistCheckCache(
+            artist_name_normalized="checked yesterday",
+            last_checked_at=utcnow() - timedelta(days=1),
+        )
+    )
+    await async_db.commit()
+
+    batch = await NewReleasesService(async_db).get_prioritized_artists_batch(
+        profile_id=profile.id, batch_size=10, min_days_since_check=7
+    )
+
+    assert "Checked Yesterday" not in {a["name"] for a in batch}

--- a/backend/tests/test_new_releases_task.py
+++ b/backend/tests/test_new_releases_task.py
@@ -11,7 +11,10 @@ from typing import Any
 
 import pytest
 
-from app.services.tasks.new_releases import _check_one_artist_isolated
+from app.services.tasks.new_releases import (
+    _check_artist_against_musicbrainz,
+    _check_one_artist_isolated,
+)
 
 
 class _RecordingSession:
@@ -146,3 +149,82 @@ async def test_one_failing_artist_does_not_abort_the_batch(monkeypatch):
     assert stats["artists_failed"] == 1
     assert stats["releases_new"] == 2
     assert db.calls == ["commit", "rollback", "commit"]
+
+
+# ---------------------------------------------------------------------------
+# The backlog must actually drain (ADR-0101 follow-through)
+# ---------------------------------------------------------------------------
+
+
+class _RecordingService:
+    """Captures update_artist_cache calls without touching a database."""
+
+    def __init__(self) -> None:
+        self.cached: list[tuple[str, str | None]] = []
+
+    async def save_discovered_release(self, **kwargs: Any):
+        return None
+
+    async def update_artist_cache(self, *, artist_normalized: str, musicbrainz_id=None):
+        self.cached.append((artist_normalized, musicbrainz_id))
+
+
+@pytest.mark.asyncio
+async def test_an_artist_musicbrainz_cannot_match_is_still_recorded_as_checked(
+    monkeypatch,
+):
+    """Otherwise the never-checked reserve re-picks it forever.
+
+    Found on the live library: with unplayed artists admitted to the rotation, a
+    20-artist batch touched six cache rows and inserted none, while 2,937 artists
+    had no row at all. Artists MusicBrainz has no entry for were being re-selected
+    every batch and displacing artists never looked at even once — so widening the
+    pool drained nothing.
+
+    "Asked, nothing matched" is recorded with a NULL musicbrainz id: the artist
+    leaves the backlog and rejoins the ordinary staleness rotation.
+    """
+    monkeypatch.setattr(
+        "app.services.metadata.musicbrainz.search_artist", lambda *a, **k: None
+    )
+    service = _RecordingService()
+    stats: dict[str, Any] = {"releases_found": 0, "releases_new": 0, "musicbrainz_queries": 0}
+
+    await _check_artist_against_musicbrainz(
+        service=service,
+        artist_name="Obscure Local Band",
+        normalized="obscure local band",
+        mb_artist_id=None,
+        days_back=90,
+        stats=stats,
+    )
+
+    assert service.cached == [("obscure local band", None)]
+    assert stats["artists_unmatched"] == 1
+
+
+@pytest.mark.asyncio
+async def test_an_artist_whose_lookup_errored_is_not_recorded(monkeypatch):
+    """The other half: a failed call must be retried, not written off.
+
+    Distinguishing these is the whole point. Recording a network blip as "checked"
+    would silently drop the artist for a full rotation.
+    """
+    def _boom(*a: Any, **k: Any):
+        raise ConnectionError("musicbrainz unreachable")
+
+    monkeypatch.setattr("app.services.metadata.musicbrainz.search_artist", _boom)
+    service = _RecordingService()
+    stats: dict[str, Any] = {"releases_found": 0, "releases_new": 0, "musicbrainz_queries": 0}
+
+    await _check_artist_against_musicbrainz(
+        service=service,
+        artist_name="Unreachable Artist",
+        normalized="unreachable artist",
+        mb_artist_id=None,
+        days_back=90,
+        stats=stats,
+    )
+
+    assert service.cached == [], "a failed lookup leaves no record, so it retries"
+    assert stats.get("artists_unmatched", 0) == 0


### PR DESCRIPTION
`get_prioritized_artists_batch` selected **from** `ProfilePlayHistory`, which made a play row a condition of membership rather than a source of order. On the production library that hid **2,614 of 3,453 owned artists** from new-release discovery — not deprioritised, structurally unreachable, however long the rotation ran. Nothing in ADR-0099 asked for that; ADR-0101 names it as a bug.

Play history is now an outer join over every library artist with an active track. It decides order, not membership.

### Widening the pool alone would have fixed nothing

That's the more interesting half. An unplayed artist scores zero, so it sorts below everything with any listening history — and the played set already oversubscribes the rotation: **706 played artists eligible at any moment against a capacity of 525 per seven-day cycle.** A queue that refills faster than it drains never reaches its tail.

So each batch reserves a third of its slots for artists never checked at all. One third rather than a half or a tenth, and the tension is real both ways: too small and 2,932 never-checked artists take years; too large and new releases by the artists you actually play go unnoticed while the backlog is walked. It's a backlog mechanism, not a permanent policy — once everything has been checked once, nothing matches the reserve.

The reserve is ordered by priority, so a *played* artist never checked takes a reserved slot ahead of an unplayed one. Deliberate, and tested: the reserve guarantees progress through the backlog, it doesn't invert taste.

### The second commit exists because the first one's claim was false

I claimed the backlog "strictly decreases". Deployed, it didn't: a 20-artist batch touched six existing rows and **inserted none**, while 2,937 artists had no row at all.

`_check_artist_against_musicbrainz` wrote the cache row only when an MBID resolved — deliberately, so unmatched artists would be retried. That was survivable only while play history gated the rotation, because the artists in the pool mostly had ids already. **The reserve made a latent defect load-bearing:** an artist MusicBrainz has no entry for was re-selected on every batch, forever, displacing artists never looked at once.

Now a check is recorded whenever MusicBrainz *answered*. A NULL id is the honest record of "asked, nothing matched" — the artist leaves the backlog and rejoins the staleness rotation. A call that genuinely *failed* still writes nothing and retries.

**Verified on the live library across two batches:** `521 → 531 → 538` cache rows, reporting `20 artists, 0 new releases, 5 unmatched, 0 failed`, with 14 rows now carrying a NULL id. The same batch size moved the count by zero beforehand.

### Named, not hidden

`search_artist` swallows a 503 and returns `None`, so a rate-limited window is indistinguishable from a genuine no-match and costs one rotation. Real 503s appeared during verification — the library sync competes for the same one-request-per-second budget. ADR-0099 point 6 is where that becomes visible.

Seven tests. Two fail against `main` — the gate and the reserve — verified by reverting with `git show origin/main:` rather than by hand. My first draft of the reserve test failed for the wrong reason and was itself wrong: it gave the played artists no cache rows either, so they were *also* never-checked and correctly won the reserved slot. Rewritten to the production shape, it fails for the right reason.

1,732 pass; the 4 failures are pre-existing on `main`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01Emjrwedq7W1scadHdgiLfs