### PR TITLE
Discovery runs every twenty minutes instead of once a night

### DIFF
--- a/backend/app/db/models/artists.py
+++ b/backend/app/db/models/artists.py
@@ -6,7 +6,6 @@ from sqlalchemy import (
     BigInteger,
     Boolean,
     DateTime,
-    Float,
     ForeignKey,
     Index,
     Integer,
@@ -132,9 +131,10 @@ class ArtistCheckCache(Base):
     musicbrainz_artist_id: Mapped[str | None] = mapped_column(String(36))
     last_checked_at: Mapped[datetime] = mapped_column(DateTime, server_default=func.now())
 
-    # Priority-based checking
-    check_priority: Mapped[float] = mapped_column(Float, default=0.0)
-    priority_updated_at: Mapped[datetime | None] = mapped_column(DateTime, nullable=True)
+    # No `check_priority` column: the score is profile-relative and this table is
+    # keyed per artist for the whole installation, so a stored value would be one
+    # listener's opinion imposed on everyone. Recomputed per run in
+    # `get_prioritized_artists_batch`. Dropped 2026-08-31, see ADR-0101.
 
 
 class ExternalAlbumCache(Base):

--- a/backend/app/services/background/manager.py
+++ b/backend/app/services/background/manager.py
@@ -13,6 +13,16 @@ from .sync import SyncMixin
 
 logger = logging.getLogger(__name__)
 
+#: How often a discovery batch runs, and how many artists it checks (ADR-0099 point 3).
+#:
+#: The pair is the decision, not either number alone: ten per twenty minutes is 720 a
+#: day against a library of 3,453 artists on a seven-day re-check window, which needs
+#: 493 a day to keep up. Raising the batch without lengthening the interval is what
+#: would make this a bad citizen of a public, unauthenticated, one-request-per-second
+#: service — so change them together and recompute the duty cycle.
+DISCOVERY_INTERVAL_MINUTES = 20
+DISCOVERY_BATCH_SIZE = 10
+
 
 class BackgroundManager(ExecutorMixin, AnalysisMixin, SyncMixin, BackupMixin):
     """Manages background tasks in the API process.
@@ -104,11 +114,33 @@ class BackgroundManager(ExecutorMixin, AnalysisMixin, SyncMixin, BackupMixin):
                 replace_existing=True,
             )
 
-            # Daily new-releases check (prioritized batch) at 3:00 AM
+            # Discovery runs continuously, in small prioritised batches (ADR-0099 point 3).
+            #
+            # **A single nightly sweep is why one bad window cost a whole day.** The job
+            # either won the race at 03:00 or the library learned nothing for
+            # twenty-four hours — and when it crashed, it crashed on the same artist at
+            # the same time every night for nineteen nights. On a short interval a
+            # rate-limited window costs one batch and the next picks up where it
+            # stopped, because `ArtistCheckCache.last_checked_at` is the resumption
+            # state.
+            #
+            # Ten artists per twenty minutes is 720 a day. The library has 3,453 artists
+            # and a seven-day re-check window, so keeping up needs 493 a day — this has
+            # headroom without being greedy. MusicBrainz allows one request a second, so
+            # a batch is roughly 10-20 seconds of upstream time out of 1,200: a duty
+            # cycle near 1%, which is what "small enough to be a good citizen" has to
+            # mean for an unauthenticated public service.
             self._scheduler.add_job(
-                self._daily_new_releases_check,
-                CronTrigger(hour=3, minute=0),
-                id="daily_new_releases",
+                self._discovery_batch,
+                IntervalTrigger(minutes=DISCOVERY_INTERVAL_MINUTES),
+                id="discovery_batch",
+                # None of the daily jobs needed these, because a run could not overlap
+                # its own next trigger. At twenty minutes it can: a batch stalled behind
+                # a rate-limited upstream must not have a second copy started on top of
+                # it, and a container restart must not replay every tick it missed.
+                max_instances=1,
+                coalesce=True,
+                misfire_grace_time=300,
                 replace_existing=True,
             )
 

--- a/backend/app/services/background/sync.py
+++ b/backend/app/services/background/sync.py
@@ -8,6 +8,7 @@ import logging
 from typing import TYPE_CHECKING, Any
 
 from app.services.background.events import record_background_event
+from app.services.redis_client import get_redis
 from app.utils.time import utcnow
 
 if TYPE_CHECKING:
@@ -369,8 +370,19 @@ class SyncMixin(_SyncBase):
             logger.error(f"prioritized new_releases check failed: {e}", exc_info=True)
             return {"status": "error", "error": str(e)}
 
-    async def _daily_new_releases_check(self) -> None:
-        """APScheduler entry: pick the first profile and run a prioritized batch."""
+    async def _discovery_batch(self) -> None:
+        """APScheduler entry: one small prioritised batch, for one profile in turn.
+
+        **Profiles take turns rather than the first one always winning.** This used to
+        `select(Profile.id).limit(1)`, so on a shared library one listener's play
+        history decided what the whole household discovered — while the rows it writes
+        are not profile-scoped at all, so everyone saw the result of one person's taste.
+        `_daily_external_albums_refresh` directly below already made the opposite choice
+        for its own case.
+
+        The cursor lives in Redis because it is a hint, not state worth a table: if it
+        is lost the rotation restarts at the first profile, which costs one batch.
+        """
         from sqlalchemy import select
         from sqlalchemy.ext.asyncio import (
             AsyncSession,
@@ -380,26 +392,48 @@ class SyncMixin(_SyncBase):
 
         from app.config import settings
         from app.db.models import Profile
+        from app.services.background.manager import DISCOVERY_BATCH_SIZE
+
+        cursor_key = "familiar:discovery:profile_cursor"
 
         try:
             engine = create_async_engine(settings.database_url)
             async_session = async_sessionmaker(engine, class_=AsyncSession)
             try:
                 async with async_session() as db:
-                    result = await db.execute(select(Profile.id).limit(1))
-                    profile_row = result.first()
-                    if not profile_row:
-                        logger.info(
-                            "Daily new releases check: no profiles, skipping"
-                        )
-                        return
-                    profile_id = str(profile_row[0])
+                    # Ordered by id so the rotation is stable across restarts — without
+                    # an ORDER BY the cursor indexes into an arbitrary order and can
+                    # revisit one profile while skipping another indefinitely.
+                    result = await db.execute(select(Profile.id).order_by(Profile.id))
+                    profile_ids = [str(row[0]) for row in result.all()]
             finally:
                 await engine.dispose()
 
-            await self.run_prioritized_new_releases_check(profile_id=profile_id)
+            if not profile_ids:
+                logger.info("discovery_batch_skipped", extra={"reason": "no profiles"})
+                return
+
+            index = 0
+            try:
+                raw = get_redis().get(cursor_key)
+                if raw is not None:
+                    index = int(raw) % len(profile_ids)
+            except Exception:
+                # A missing or unreadable cursor costs one batch, not a failure.
+                index = 0
+
+            profile_id = profile_ids[index]
+            try:
+                get_redis().set(cursor_key, (index + 1) % len(profile_ids))
+            except Exception:
+                logger.debug("discovery cursor not persisted", exc_info=True)
+
+            await self.run_prioritized_new_releases_check(
+                profile_id=profile_id,
+                batch_size=DISCOVERY_BATCH_SIZE,
+            )
         except Exception as e:
-            logger.warning(f"Daily new releases check failed: {e}")
+            logger.warning(f"Discovery batch failed: {e}")
 
     async def _daily_external_albums_refresh(self) -> None:
         """APScheduler entry: recompute "Albums you might want" for every profile.

--- a/backend/app/services/tasks/new_releases.py
+++ b/backend/app/services/tasks/new_releases.py
@@ -31,6 +31,19 @@ def _artist_names_match(searched: str, found: str) -> bool:
 
 NEW_RELEASES_PROGRESS_KEY = "familiar:new_releases:progress"
 
+#: How long any one MusicBrainz call may take before the artist is skipped.
+#:
+#: Inherited from the request path that ADR-0099 Phase 1 deleted, where it existed to
+#: stop a person waiting. Here the reason is different and better: `musicbrainzngs`
+#: answers a 503 by retrying with backoff, silently, so one throttled artist could
+#: otherwise absorb an entire batch's wall-clock and starve the nine behind it. A
+#: stalled artist now costs one slot out of ten.
+#:
+#: `asyncio.wait_for` cannot cancel the thread — the call finishes in the background
+#: pool regardless. That is accepted: it is one bounded HTTP request, and the artist is
+#: left unrecorded so the next batch retries it.
+MUSICBRAINZ_CALL_TIMEOUT_SECONDS = 6.0
+
 
 async def _check_one_artist_isolated(
     db: Any,
@@ -219,7 +232,10 @@ async def _check_artist_against_musicbrainz(
 
     try:
         if not mb_id_to_use:
-            mb_result = await asyncio.to_thread(search_artist, artist_name)
+            mb_result = await asyncio.wait_for(
+                asyncio.to_thread(search_artist, artist_name),
+                timeout=MUSICBRAINZ_CALL_TIMEOUT_SECONDS,
+            )
             if mb_result and mb_result.get("score", 0) >= 80:
                 if _artist_names_match(artist_name, mb_result.get("name", "")):
                     mb_id_to_use = mb_result["musicbrainz_artist_id"]
@@ -230,8 +246,11 @@ async def _check_artist_against_musicbrainz(
                     )
 
         if mb_id_to_use:
-            recent = await asyncio.to_thread(
-                get_artist_releases_recent, mb_id_to_use, days_back=days_back
+            recent = await asyncio.wait_for(
+                asyncio.to_thread(
+                    get_artist_releases_recent, mb_id_to_use, days_back=days_back
+                ),
+                timeout=MUSICBRAINZ_CALL_TIMEOUT_SECONDS,
             )
             stats["musicbrainz_queries"] += 1
 
@@ -249,6 +268,18 @@ async def _check_artist_against_musicbrainz(
                 )
 
         upstream_answered = True
+
+    except TimeoutError:
+        # Logged apart from other failures because this is the *rate-limit signature*:
+        # `musicbrainzngs` retries a 503 with backoff and reports nothing, so a call
+        # that runs past the bound has almost certainly been throttled rather than
+        # having failed outright. `upstream_answered` stays False, so nothing is
+        # recorded and the next batch retries the artist.
+        stats["artists_timed_out"] = stats.get("artists_timed_out", 0) + 1
+        logger.warning(
+            "discovery_musicbrainz_timeout",
+            extra={"artist": artist_name, "timeout_s": MUSICBRAINZ_CALL_TIMEOUT_SECONDS},
+        )
 
     except Exception as e:
         logger.warning(f"MusicBrainz lookup failed for {artist_name}: {e}")
@@ -333,6 +364,7 @@ async def run_new_releases_check(
         "musicbrainz_queries": 0,
         "artists_failed": 0,
         "artists_unmatched": 0,
+        "artists_timed_out": 0,
     }
 
     local_engine, local_session_maker = create_task_engine_session()
@@ -414,6 +446,7 @@ async def run_prioritized_new_releases_check(
         "musicbrainz_queries": 0,
         "artists_failed": 0,
         "artists_unmatched": 0,
+        "artists_timed_out": 0,
     }
 
     local_engine, local_session_maker = create_task_engine_session()
@@ -475,6 +508,7 @@ async def run_prioritized_new_releases_check(
             f"Priority-based new releases check complete: "
             f"{stats['artists_checked']} artists, {stats['releases_new']} new releases, "
             f"{stats.get('artists_unmatched', 0)} unmatched, "
+            f"{stats.get('artists_timed_out', 0)} timed out, "
             f"{stats.get('artists_failed', 0)} failed"
         )
         return {"status": "success", **stats}

--- a/backend/migrations/versions/20260831_drop_check_priority.py
+++ b/backend/migrations/versions/20260831_drop_check_priority.py
@@ -1,0 +1,56 @@
+"""Drop artist_check_cache.check_priority and priority_updated_at.
+
+Not merely unused, though they are: `check_priority` was 0.0 on all 520 production
+rows and read by no code, because `get_prioritized_artists_batch` recomputes the
+score in SQL on every run.
+
+**The reason they should not be wired up instead is that the value is
+profile-relative and the table is not.** `ArtistCheckCache`'s primary key is
+`artist_name_normalized` — one row per artist, for the whole installation — while
+the priority is computed against one profile's `ProfilePlayHistory`. Any stored
+number is one listener's opinion imposed on everyone else sharing the library,
+which is the same defect as the first-profile pick that ADR-0099's Phase 2 replaced
+with a round-robin. Recomputing per run is both correct and cheap at this size.
+
+ADR-0101 records the audit that found them.
+
+Revision ID: 20260831_drop_check_prio
+Revises: 20260825_track_videos
+"""
+
+import sqlalchemy as sa
+from alembic import op
+
+from migrations.helpers import column_exists
+
+revision: str = "20260831_drop_check_prio"
+down_revision: str | None = "20260825_track_videos"
+branch_labels = None
+depends_on = None
+
+
+def upgrade() -> None:
+    if column_exists("artist_check_cache", "check_priority"):
+        op.drop_column("artist_check_cache", "check_priority")
+    if column_exists("artist_check_cache", "priority_updated_at"):
+        op.drop_column("artist_check_cache", "priority_updated_at")
+
+
+def downgrade() -> None:
+    # Restores the columns, not their meaning: they held 0.0 for every row, and
+    # nothing has ever written anything else.
+    if not column_exists("artist_check_cache", "check_priority"):
+        op.add_column(
+            "artist_check_cache",
+            sa.Column(
+                "check_priority",
+                sa.Float(),
+                nullable=False,
+                server_default="0",
+            ),
+        )
+    if not column_exists("artist_check_cache", "priority_updated_at"):
+        op.add_column(
+            "artist_check_cache",
+            sa.Column("priority_updated_at", sa.DateTime(), nullable=True),
+        )

--- a/backend/tests/test_discovery_schedule.py
+++ b/backend/tests/test_discovery_schedule.py
@@ -1,0 +1,126 @@
+"""Discovery runs continuously, in small batches, taking profiles in turn.
+
+ADR-0099 point 3. A single nightly sweep is why one bad window cost a whole day:
+the job either won the race at 03:00 or the library learned nothing for
+twenty-four hours — and when it crashed it crashed on the same artist at the same
+time, nineteen nights running.
+"""
+
+from app.services.background.manager import (
+    DISCOVERY_BATCH_SIZE,
+    DISCOVERY_INTERVAL_MINUTES,
+)
+from app.services.tasks.new_releases import MUSICBRAINZ_CALL_TIMEOUT_SECONDS
+
+# The library this was sized against, so the arithmetic below can be rechecked
+# rather than trusted.
+LIBRARY_ARTISTS = 3453
+RECHECK_WINDOW_DAYS = 7
+
+
+def _checks_per_day() -> float:
+    return DISCOVERY_BATCH_SIZE * (60 / DISCOVERY_INTERVAL_MINUTES) * 24
+
+
+def test_the_rotation_can_keep_up_with_the_library():
+    """Capacity must exceed what the re-check window demands.
+
+    The defect this replaces was the opposite: 75 a day against a seven-day window
+    is 525 slots for 839 eligible artists, so the tail was never reached. Any change
+    to the interval or batch size has to keep this true.
+    """
+    needed_per_day = LIBRARY_ARTISTS / RECHECK_WINDOW_DAYS
+    assert _checks_per_day() > needed_per_day, (
+        f"{_checks_per_day():.0f}/day cannot sustain {LIBRARY_ARTISTS} artists "
+        f"on a {RECHECK_WINDOW_DAYS}-day window ({needed_per_day:.0f}/day needed)"
+    )
+
+
+def test_the_upstream_duty_cycle_stays_polite():
+    """MusicBrainz allows one request a second and is unauthenticated and free.
+
+    A batch is at most `DISCOVERY_BATCH_SIZE` seconds of upstream time — two calls
+    per artist in the worst case — against an interval measured in minutes. Raising
+    the batch without lengthening the interval is the way to make this a bad
+    neighbour, so the ratio is asserted rather than left to judgement.
+    """
+    worst_case_upstream_seconds = DISCOVERY_BATCH_SIZE * 2
+    interval_seconds = DISCOVERY_INTERVAL_MINUTES * 60
+    duty_cycle = worst_case_upstream_seconds / interval_seconds
+    assert duty_cycle < 0.05, f"duty cycle {duty_cycle:.1%} is not a good citizen"
+
+
+def test_one_stalled_artist_cannot_absorb_the_batch():
+    """The per-call bound has to be small relative to the batch it protects."""
+    worst_case_batch_seconds = DISCOVERY_BATCH_SIZE * MUSICBRAINZ_CALL_TIMEOUT_SECONDS * 2
+    assert worst_case_batch_seconds < DISCOVERY_INTERVAL_MINUTES * 60, (
+        "a fully stalled batch must still finish before its next trigger, or "
+        "max_instances=1 silently drops ticks"
+    )
+
+
+# ---------------------------------------------------------------------------
+# Profiles take turns (ADR-0099 point 3, the shared-library half)
+# ---------------------------------------------------------------------------
+
+
+class _FakeRedis:
+    def __init__(self) -> None:
+        self.store: dict[str, str] = {}
+
+    def get(self, key):
+        return self.store.get(key)
+
+    def set(self, key, value):
+        self.store[key] = str(value)
+
+
+class _CursorHarness:
+    """The cursor arithmetic from `_discovery_batch`, exercised on its own.
+
+    Extracted rather than driving the real job because the job builds its own
+    engine and session; the part that can silently regress is the indexing.
+    """
+
+    def __init__(self, profile_ids, redis):
+        self.profile_ids = profile_ids
+        self.redis = redis
+        self.key = "familiar:discovery:profile_cursor"
+
+    def next_profile(self):
+        index = 0
+        raw = self.redis.get(self.key)
+        if raw is not None:
+            index = int(raw) % len(self.profile_ids)
+        self.redis.set(self.key, (index + 1) % len(self.profile_ids))
+        return self.profile_ids[index]
+
+
+def test_profiles_take_turns_rather_than_the_first_always_winning():
+    """On a shared library one listener must not decide what everyone discovers.
+
+    `_discovery_batch` used to `select(Profile.id).limit(1)`, so the first profile's
+    play history drove every batch — while the rows it writes are not profile-scoped,
+    so the whole household saw one person's taste.
+    """
+    harness = _CursorHarness(["a", "b", "c"], _FakeRedis())
+    picked = [harness.next_profile() for _ in range(7)]
+    assert picked == ["a", "b", "c", "a", "b", "c", "a"]
+
+
+def test_a_lost_cursor_costs_one_batch_not_the_rotation():
+    """The cursor is a hint in Redis, not state worth a table."""
+    redis = _FakeRedis()
+    harness = _CursorHarness(["a", "b", "c"], redis)
+    harness.next_profile()
+    harness.next_profile()
+    redis.store.clear()
+    assert harness.next_profile() == "a"
+
+
+def test_the_cursor_survives_a_profile_being_removed():
+    """A stale index must wrap rather than raise IndexError."""
+    redis = _FakeRedis()
+    redis.store["familiar:discovery:profile_cursor"] = "9"
+    harness = _CursorHarness(["a", "b"], redis)
+    assert harness.next_profile() == "b"  # 9 % 2 == 1


### PR DESCRIPTION
ADR-0099 point 3. A single nightly sweep is why one bad window cost a whole day: the job either won the race at 03:00 or the library learned nothing for twenty-four hours — and when it crashed, it crashed on the same artist at the same time for **nineteen consecutive nights**. On a short interval a rate-limited window costs one batch, and the next picks up where it stopped, because `ArtistCheckCache.last_checked_at` is the resumption state and always was.

### Ten artists per twenty minutes

The pair is the decision, not either number. 720 a day against 3,453 artists on a seven-day re-check window, which needs 493 a day to keep up. Upstream cost is at most 20 seconds out of 1,200 — a duty cycle near **1%**, which is what "good citizen" has to mean for a free, unauthenticated, one-request-per-second service.

Both numbers are asserted in tests rather than left as comments, because raising the batch without lengthening the interval is exactly how this becomes a bad neighbour.

`max_instances=1`, `coalesce=True` and `misfire_grace_time` are new, and needed now rather than before: at twenty minutes a run can overlap its own next trigger, so a batch stalled behind a throttled upstream must not get a second copy started on top of it, and a restart must not replay every missed tick. No daily job needed these, because a daily run cannot overlap itself.

### Profiles take turns

`_daily_new_releases_check` picked `Profile.id LIMIT 1`, so on a shared library **one listener's play history decided what the whole household discovered** — while the rows it writes aren't profile-scoped, so everyone saw one person's taste. A Redis cursor now advances each tick, ordered by id so the rotation is stable across restarts; an unordered query would let the cursor revisit one profile while skipping another indefinitely.

### The per-call bound moves into the job

On the request path it stopped a person waiting. Here it stops one throttled artist absorbing a whole batch's wall-clock and starving the nine behind it. A timeout is logged separately because it's the **rate-limit signature** — `musicbrainzngs` retries a 503 with backoff and reports nothing, so a call that runs past the bound has almost certainly been throttled rather than failed. Nothing is recorded for it, so the next batch retries.

### Two dead columns dropped

`check_priority` was 0.0 on all 520 production rows, but "unused" isn't the reason to drop rather than wire up. The score is **profile-relative** and the table is keyed per artist for the whole installation, so a stored value would be one listener's opinion imposed on everyone — the same defect as the first-profile pick this change replaces. The downgrade restores the columns but not their meaning, and says so.

### The full sweep stays

ADR-0101 named its deletion as what would have made the coverage gap permanent. That gap is now closed from the other side, so removing it would no longer be harmful — but it isn't required here either, and dropping a fallback in the same change that alters the cadence isn't a trade worth making.

Migration verified up → down → up. 1,739 tests pass; the 4 failures are pre-existing on `main`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01Emjrwedq7W1scadHdgiLfs