### PR TITLE
Source health is durable state the job acts on

### DIFF
--- a/backend/app/api/routes/health.py
+++ b/backend/app/api/routes/health.py
@@ -502,7 +502,7 @@ class DiscoverySourceHealthResponse(BaseModel):
     """Whether one discovery source is working — not whether it is configured."""
 
     source: str
-    #: working | degraded | backing_off | failing | never_succeeded
+    #: working | degraded | backing_off | failing | never_succeeded | not_instrumented
     state: str
     last_success_at: str | None = None
     last_failure_at: str | None = None
@@ -527,9 +527,19 @@ def _source_state(row: Any, now: datetime) -> str:
     **`never_succeeded` is its own state and not a kind of "no data"** (ADR-0099
     point 8). It was the true state for nineteen nights while the nightly job crashed,
     and rendering it as "nothing found yet" is what let that pass unnoticed.
+
+    **`not_instrumented` is the state that keeps `never_succeeded` meaningful.** A row
+    with no attempt recorded means nothing has ever *tried* this source, which is a
+    different fact from having tried and never succeeded. Last.fm and Bandcamp are in
+    this position today: both are integrated for recommendations, neither is wired to
+    the recorder until ADR-0099 point 5. Reporting them as failures would make the
+    aggregate badge permanently alarming and would conflate "unmonitored" with
+    "broken" — the exact conflation this surface exists to remove.
     """
     if row.backoff_until is not None and row.backoff_until > now:
         return "backing_off"
+    if row.last_attempt_at is None and row.last_success_at is None:
+        return "not_instrumented"
     if row.last_success_at is None:
         return "never_succeeded"
     if row.consecutive_failures >= 3:
@@ -574,7 +584,16 @@ async def discovery_source_health(db: DbSession) -> DiscoveryHealthResponse:
     ]
 
     # Worst-wins, matching how `/health/system` aggregates its services.
-    severity = {"working": 0, "degraded": 1, "backing_off": 2, "never_succeeded": 3, "failing": 4}
+    # `not_instrumented` sits at the bottom so it never drives the aggregate: a source
+    # nothing has attempted is not evidence that discovery is unhealthy.
+    severity = {
+        "not_instrumented": -1,
+        "working": 0,
+        "degraded": 1,
+        "backing_off": 2,
+        "never_succeeded": 3,
+        "failing": 4,
+    }
     worst = max(sources, key=lambda s: severity.get(s.state, 0), default=None)
 
     return DiscoveryHealthResponse(sources=sources, status=worst.state if worst else "working")

--- a/backend/app/api/routes/health.py
+++ b/backend/app/api/routes/health.py
@@ -1,6 +1,7 @@
 """Health check endpoints."""
 
 import logging
+from datetime import datetime
 from pathlib import Path
 from typing import Any
 
@@ -11,6 +12,7 @@ from sqlalchemy import func, select, text
 from app.api.deps import DbSession
 from app.config import FEATURES_VERSION, get_app_version
 from app.db.models import Track, TrackAnalysis
+from app.utils.time import utcnow
 
 logger = logging.getLogger(__name__)
 
@@ -494,3 +496,85 @@ async def get_worker_status(db: DbSession) -> WorkerStatus:
         recent_failures=recent_failures,
         background_events=background_events,
     )
+
+
+class DiscoverySourceHealthResponse(BaseModel):
+    """Whether one discovery source is working — not whether it is configured."""
+
+    source: str
+    #: working | degraded | backing_off | failing | never_succeeded
+    state: str
+    last_success_at: str | None = None
+    last_failure_at: str | None = None
+    last_failure_kind: str | None = None
+    last_failure_detail: str | None = None
+    consecutive_failures: int = 0
+    items_contributed: int = 0
+    backoff_until: str | None = None
+
+
+class DiscoveryHealthResponse(BaseModel):
+    """Health of every discovery source, plus the job that drives them."""
+
+    sources: list[DiscoverySourceHealthResponse]
+    #: Worst state across the list, so a caller can render one badge.
+    status: str
+
+
+def _source_state(row: Any, now: datetime) -> str:
+    """Turn a health row into the word a person reads.
+
+    **`never_succeeded` is its own state and not a kind of "no data"** (ADR-0099
+    point 8). It was the true state for nineteen nights while the nightly job crashed,
+    and rendering it as "nothing found yet" is what let that pass unnoticed.
+    """
+    if row.backoff_until is not None and row.backoff_until > now:
+        return "backing_off"
+    if row.last_success_at is None:
+        return "never_succeeded"
+    if row.consecutive_failures >= 3:
+        return "failing"
+    if row.consecutive_failures > 0:
+        return "degraded"
+    return "working"
+
+
+@router.get("/health/discovery-sources", response_model=DiscoveryHealthResponse)
+async def discovery_source_health(db: DbSession) -> DiscoveryHealthResponse:
+    """Report whether each discovery source is working.
+
+    Deliberately **not** folded into `/health/system`'s `services` list: `ServiceStatus`
+    carries only name/status/message/details, so the four facts ADR-0099 point 6 asks
+    for — last success, last failure and its kind, contribution, backoff — would land
+    in an untyped `details` dict, which is what `lint_openapi` exists to stop. It is
+    also a different question from "is the process up".
+    """
+    from app.db.models import DiscoverySourceHealth
+
+    now = utcnow().replace(tzinfo=None)
+    rows = (
+        (await db.execute(select(DiscoverySourceHealth).order_by(DiscoverySourceHealth.source)))
+        .scalars()
+        .all()
+    )
+
+    sources = [
+        DiscoverySourceHealthResponse(
+            source=row.source,
+            state=_source_state(row, now),
+            last_success_at=row.last_success_at.isoformat() if row.last_success_at else None,
+            last_failure_at=row.last_failure_at.isoformat() if row.last_failure_at else None,
+            last_failure_kind=row.last_failure_kind,
+            last_failure_detail=row.last_failure_detail,
+            consecutive_failures=row.consecutive_failures,
+            items_contributed=row.items_contributed,
+            backoff_until=row.backoff_until.isoformat() if row.backoff_until else None,
+        )
+        for row in rows
+    ]
+
+    # Worst-wins, matching how `/health/system` aggregates its services.
+    severity = {"working": 0, "degraded": 1, "backing_off": 2, "never_succeeded": 3, "failing": 4}
+    worst = max(sources, key=lambda s: severity.get(s.state, 0), default=None)
+
+    return DiscoveryHealthResponse(sources=sources, status=worst.state if worst else "working")

--- a/backend/app/db/models/__init__.py
+++ b/backend/app/db/models/__init__.py
@@ -12,6 +12,7 @@ from .artists import (
     Artist,
     ArtistAlias,
     ArtistCheckCache,
+    DiscoverySourceHealth,
     ExternalAlbumCache,
     ExternalArtistImageCache,
 )
@@ -53,6 +54,7 @@ __all__ = [
     "Artist",
     "ArtistAlias",
     "ArtistCheckCache",
+    "DiscoverySourceHealth",
     "ExternalAlbumCache",
     "ExternalArtistImageCache",
     "FrontendLog",

--- a/backend/app/db/models/artists.py
+++ b/backend/app/db/models/artists.py
@@ -217,3 +217,62 @@ class ExternalAlbumCache(Base):
     local_album_match: Mapped[bool] = mapped_column(Boolean, default=False, index=True)
 
     discovered_at: Mapped[datetime] = mapped_column(DateTime, server_default=func.now())
+
+
+class DiscoverySourceHealth(Base):
+    """Whether each discovery source is actually working (ADR-0099 points 6, 8, 10).
+
+    **Not "is a key configured", which is the question that already had an answer and
+    was the wrong one.** `panels/server/ApiKeyStatus.tsx` reports configuration, and a
+    source can hold a valid key, be scheduled, run every night, fail every time, and
+    look identical to a healthy one. That is what happened: nineteen consecutive
+    nightly crashes, logged at ERROR, surfaced nowhere.
+
+    **Postgres rather than Redis, deliberately.** The obvious home was the existing
+    `TASK_FAILURES_KEY` list, but it expires after 24 hours and the APScheduler
+    jobstore is in-memory — so "last succeeded five days ago" would become "no data"
+    on a container restart, and a stale record that quietly disappears is the precise
+    failure this table exists to prevent.
+
+    `backoff_until` is **control, not telemetry**: the batch reads it before deciding
+    whether to call a source, and the dashboard renders the same column. That is what
+    makes one source being down actually not stop the others, rather than merely
+    being reported.
+
+    Rows are seeded by the migration, because ADR-0099 point 8 needs "has never
+    succeeded" to be *representable* — an absent row reads as "not a thing" rather
+    than "has never worked".
+    """
+
+    __tablename__ = "discovery_source_health"
+
+    #: 'musicbrainz' | 'lastfm' | 'bandcamp', and 'discovery_batch' for the job itself.
+    source: Mapped[str] = mapped_column(String(40), primary_key=True)
+
+    last_attempt_at: Mapped[datetime | None] = mapped_column(DateTime)
+    last_success_at: Mapped[datetime | None] = mapped_column(DateTime)
+    last_failure_at: Mapped[datetime | None] = mapped_column(DateTime)
+
+    #: rate_limited | timeout | http_error | bad_response | not_configured | crashed
+    last_failure_kind: Mapped[str | None] = mapped_column(String(40))
+    last_failure_detail: Mapped[str | None] = mapped_column(Text)
+
+    # `server_default` rather than a Python-side `default=`: the baseline migration
+    # builds a fresh database with `Base.metadata.create_all()`, so the DDL comes from
+    # this model — and a Python default is invisible to the raw INSERT that seeds the
+    # rows, which then fails the NOT NULL. `updated_at` below already had it right.
+    consecutive_failures: Mapped[int] = mapped_column(
+        Integer, nullable=False, default=0, server_default="0"
+    )
+    #: How much this source has actually contributed. A source that answers every call
+    #: and yields nothing is a different problem from one that errors, and neither is
+    #: visible from a success timestamp alone.
+    items_contributed: Mapped[int] = mapped_column(
+        BigInteger, nullable=False, default=0, server_default="0"
+    )
+
+    backoff_until: Mapped[datetime | None] = mapped_column(DateTime)
+
+    updated_at: Mapped[datetime] = mapped_column(
+        DateTime, nullable=False, server_default=func.now()
+    )

--- a/backend/app/services/discovery/__init__.py
+++ b/backend/app/services/discovery/__init__.py
@@ -1,0 +1,13 @@
+"""Discovery: the background half of finding music you do not own (ADR-0099).
+
+The request path reads `external_album_cache` and never calls out; everything that
+talks to MusicBrainz, Last.fm or Bandcamp for discovery lives behind here.
+"""
+
+from app.services.discovery.sources import (
+    SourceHealthRecorder,
+    backoff_seconds,
+    get_recorder,
+)
+
+__all__ = ["SourceHealthRecorder", "backoff_seconds", "get_recorder"]

--- a/backend/app/services/discovery/sources.py
+++ b/backend/app/services/discovery/sources.py
@@ -1,0 +1,151 @@
+"""Per-source health for discovery, recorded durably and acted on (ADR-0099 §6, §8, §10).
+
+**Health here is control, not telemetry.** `backoff_until` is both the column the
+Server page renders and the value the batch consults before deciding whether to call
+a source. That is what makes "one source being down does not stop the others" a real
+property rather than a reported one.
+"""
+
+from __future__ import annotations
+
+import logging
+from datetime import timedelta
+from typing import Any
+
+from sqlalchemy import select
+
+from app.db.models import DiscoverySourceHealth
+from app.utils.time import utcnow
+
+logger = logging.getLogger(__name__)
+
+#: Backoff doubles per consecutive failure, capped so a source that recovers is not
+#: ignored for hours after the outage ends.
+BACKOFF_BASE_SECONDS = 60
+BACKOFF_MAX_SECONDS = 3600
+
+#: Failure kinds. `rate_limited` is separated from `http_error` because it is the one
+#: that is *expected* and self-correcting — treating a throttle as an outage would put
+#: MusicBrainz permanently in backoff on a busy library.
+FAILURE_KINDS = (
+    "rate_limited",
+    "timeout",
+    "http_error",
+    "bad_response",
+    "not_configured",
+    "crashed",
+)
+
+
+def backoff_seconds(consecutive_failures: int) -> int:
+    """Exponential backoff, capped. One failure is a minute; six or more is an hour."""
+    if consecutive_failures <= 0:
+        return 0
+    return min(BACKOFF_MAX_SECONDS, BACKOFF_BASE_SECONDS * 2 ** (consecutive_failures - 1))
+
+
+class SourceHealthRecorder:
+    """Reads and writes `discovery_source_health`, on its own transaction.
+
+    **The separate session is load-bearing, not tidiness.** ADR-0099 point 9 gives the
+    discovery batch a per-artist `rollback()` on failure; if health shared that session,
+    the rollback would erase the record of the very failure that caused it, and a
+    crashing source would look permanently untouched. Every write here commits
+    immediately and independently.
+    """
+
+    def __init__(self, session_factory: Any) -> None:
+        self._session_factory = session_factory
+
+    async def _row(self, db: Any, source: str) -> DiscoverySourceHealth:
+        existing = (
+            await db.execute(
+                select(DiscoverySourceHealth).where(DiscoverySourceHealth.source == source)
+            )
+        ).scalar_one_or_none()
+        if existing is not None:
+            return existing
+        # The migration seeds the known sources; this covers one added in code before
+        # its migration lands, which must not crash a batch.
+        row = DiscoverySourceHealth(source=source)
+        db.add(row)
+        await db.flush()
+        return row
+
+    async def record_success(self, source: str, *, items: int = 0) -> None:
+        """A call that reached the source and got a usable answer."""
+        try:
+            async with self._session_factory() as db:
+                row = await self._row(db, source)
+                now = utcnow().replace(tzinfo=None)
+                row.last_attempt_at = now
+                row.last_success_at = now
+                row.consecutive_failures = 0
+                row.backoff_until = None
+                row.items_contributed = (row.items_contributed or 0) + items
+                row.updated_at = now
+                await db.commit()
+        except Exception:
+            # Health recording must never be the reason discovery fails. A lost
+            # observation is worth less than the batch it would take down.
+            logger.warning("source_health_record_failed", exc_info=True)
+
+    async def record_failure(
+        self,
+        source: str,
+        *,
+        kind: str,
+        detail: str | None = None,
+        retry_after_seconds: float | None = None,
+    ) -> None:
+        """A call that did not get a usable answer, and why."""
+        try:
+            async with self._session_factory() as db:
+                row = await self._row(db, source)
+                now = utcnow().replace(tzinfo=None)
+                row.last_attempt_at = now
+                row.last_failure_at = now
+                row.last_failure_kind = kind if kind in FAILURE_KINDS else "http_error"
+                row.last_failure_detail = (detail or "")[:2000] or None
+                row.consecutive_failures = (row.consecutive_failures or 0) + 1
+                # An explicit Retry-After is the source telling us when to come back and
+                # is always preferred to our guess — including when it is *shorter*.
+                wait = (
+                    retry_after_seconds
+                    if retry_after_seconds is not None
+                    else backoff_seconds(row.consecutive_failures)
+                )
+                row.backoff_until = now + timedelta(seconds=wait)
+                row.updated_at = now
+                await db.commit()
+        except Exception:
+            logger.warning("source_health_record_failed", exc_info=True)
+
+    async def should_skip(self, source: str) -> bool:
+        """True while a source is backing off, so callers can move to the next one."""
+        try:
+            async with self._session_factory() as db:
+                row = (
+                    await db.execute(
+                        select(DiscoverySourceHealth).where(
+                            DiscoverySourceHealth.source == source
+                        )
+                    )
+                ).scalar_one_or_none()
+                if row is None or row.backoff_until is None:
+                    return False
+                return row.backoff_until > utcnow().replace(tzinfo=None)
+        except Exception:
+            # If health cannot be read, attempt the call. Skipping on an unknown state
+            # would let a database blip silently stop discovery — the failure mode this
+            # whole ADR exists to prevent.
+            logger.warning("source_health_read_failed", exc_info=True)
+            return False
+
+
+def get_recorder() -> SourceHealthRecorder:
+    """A recorder backed by its own engine, per the class docstring."""
+    from app.db.session import create_task_engine_session
+
+    _engine, session_factory = create_task_engine_session()
+    return SourceHealthRecorder(session_factory)

--- a/backend/app/services/tasks/new_releases.py
+++ b/backend/app/services/tasks/new_releases.py
@@ -276,12 +276,14 @@ async def _check_artist_against_musicbrainz(
         # having failed outright. `upstream_answered` stays False, so nothing is
         # recorded and the next batch retries the artist.
         stats["artists_timed_out"] = stats.get("artists_timed_out", 0) + 1
+        stats["_source_failure"] = ("rate_limited", f"no answer in {MUSICBRAINZ_CALL_TIMEOUT_SECONDS}s")
         logger.warning(
             "discovery_musicbrainz_timeout",
             extra={"artist": artist_name, "timeout_s": MUSICBRAINZ_CALL_TIMEOUT_SECONDS},
         )
 
     except Exception as e:
+        stats["_source_failure"] = ("http_error", str(e))
         logger.warning(f"MusicBrainz lookup failed for {artist_name}: {e}")
 
     for release in releases_for_artist:
@@ -449,6 +451,20 @@ async def run_prioritized_new_releases_check(
         "artists_timed_out": 0,
     }
 
+    from app.services.discovery import get_recorder
+
+    health = get_recorder()
+
+    # **Backoff is consulted before the work, not just reported after it** (ADR-0099
+    # point 4). A source in backoff is skipped and the batch ends immediately rather
+    # than spending ten slots re-confirming an outage. With one source this looks like
+    # a guard; the shape is what makes a second source able to keep running while this
+    # one is down.
+    if await health.should_skip("musicbrainz"):
+        logger.info("discovery_batch_skipped", extra={"reason": "musicbrainz backing off"})
+        await health.record_success("discovery_batch", items=0)
+        return {"status": "skipped", "reason": "musicbrainz backing off", **stats}
+
     local_engine, local_session_maker = create_task_engine_session()
 
     try:
@@ -504,6 +520,19 @@ async def run_prioritized_new_releases_check(
             new=stats["releases_new"],
         )
 
+        # One health write per source per batch rather than per artist: ten writes to
+        # say the same thing costs ten transactions and tells nobody anything more.
+        #
+        # **"Answered" is the success condition, not "found something".** A source that
+        # replies correctly and has no new releases is working; conflating the two is
+        # how a healthy upstream would start reading as broken every quiet week.
+        answered = stats["musicbrainz_queries"] > 0 or stats.get("artists_unmatched", 0) > 0
+        if answered:
+            await health.record_success("musicbrainz", items=stats["releases_new"])
+        elif stats.get("_source_failure"):
+            kind, detail = stats["_source_failure"]
+            await health.record_failure("musicbrainz", kind=kind, detail=detail)
+
         logger.info(
             f"Priority-based new releases check complete: "
             f"{stats['artists_checked']} artists, {stats['releases_new']} new releases, "
@@ -511,11 +540,19 @@ async def run_prioritized_new_releases_check(
             f"{stats.get('artists_timed_out', 0)} timed out, "
             f"{stats.get('artists_failed', 0)} failed"
         )
+
+        # ADR-0099 point 10: the job's own outcome, separately from its upstreams'.
+        # The nineteen-night outage had a perfectly healthy MusicBrainz and a dead
+        # writer — a source-only view would have shown all green throughout.
+        await health.record_success("discovery_batch", items=stats["releases_new"])
+
+        stats.pop("_source_failure", None)
         return {"status": "success", **stats}
 
     except Exception as e:
         logger.error(f"Priority-based new releases check failed: {e}", exc_info=True)
         progress.error(str(e))
+        await health.record_failure("discovery_batch", kind="crashed", detail=str(e))
         return {"status": "error", "error": str(e)}
     finally:
         await local_engine.dispose()

--- a/backend/migrations/versions/20260831_discovery_source_health.py
+++ b/backend/migrations/versions/20260831_discovery_source_health.py
@@ -1,0 +1,79 @@
+"""Create discovery_source_health, and seed a row per source.
+
+ADR-0099 points 6, 8 and 10. The question this answers is whether a source is
+*working*, which is not the question `ApiKeyStatus.tsx` answers — a source can hold
+a valid key, be scheduled, run nightly, fail every time, and look identical to a
+healthy one.
+
+**The rows are seeded here rather than created on first write**, because point 8
+requires "has never succeeded" to be representable. A source with no row reads as
+"not a thing we track" rather than "has never worked", and those are the two
+readings that must not be confused.
+
+`discovery_batch` is seeded alongside the three upstreams because point 10 says
+health has to cover the job's own outcome: the nineteen-night outage had a
+perfectly healthy MusicBrainz and a dead writer, and a source-only view would have
+shown all green.
+
+Revision ID: 20260831_disc_src_health
+Revises: 20260831_drop_check_prio
+"""
+
+import sqlalchemy as sa
+from alembic import op
+
+from migrations.helpers import table_exists
+
+revision: str = "20260831_disc_src_health"
+down_revision: str | None = "20260831_drop_check_prio"
+branch_labels = None
+depends_on = None
+
+SOURCES = ("musicbrainz", "lastfm", "bandcamp", "discovery_batch")
+
+
+def upgrade() -> None:
+    if not table_exists("discovery_source_health"):
+        op.create_table(
+            "discovery_source_health",
+            sa.Column("source", sa.String(40), primary_key=True),
+            sa.Column("last_attempt_at", sa.DateTime(), nullable=True),
+            sa.Column("last_success_at", sa.DateTime(), nullable=True),
+            sa.Column("last_failure_at", sa.DateTime(), nullable=True),
+            sa.Column("last_failure_kind", sa.String(40), nullable=True),
+            sa.Column("last_failure_detail", sa.Text(), nullable=True),
+            sa.Column(
+                "consecutive_failures", sa.Integer(), nullable=False, server_default="0"
+            ),
+            sa.Column(
+                "items_contributed", sa.BigInteger(), nullable=False, server_default="0"
+            ),
+            sa.Column("backoff_until", sa.DateTime(), nullable=True),
+            sa.Column(
+                "updated_at",
+                sa.DateTime(),
+                nullable=False,
+                server_default=sa.func.now(),
+            ),
+        )
+
+    # Idempotent: re-running must not duplicate or reset a row that has since
+    # recorded real successes.
+    for source in SOURCES:
+        op.execute(
+            sa.text(
+                # Values stated rather than left to column defaults. On a fresh
+                # database the baseline migration builds tables with
+                # `Base.metadata.create_all()`, so a model-side Python default never
+                # reaches the DDL and this INSERT would violate NOT NULL.
+                "INSERT INTO discovery_source_health "
+                "  (source, consecutive_failures, items_contributed) "
+                "VALUES (:source, 0, 0) "
+                "ON CONFLICT (source) DO NOTHING"
+            ).bindparams(source=source)
+        )
+
+
+def downgrade() -> None:
+    if table_exists("discovery_source_health"):
+        op.drop_table("discovery_source_health")

--- a/backend/openapi.json
+++ b/backend/openapi.json
@@ -2708,6 +2708,92 @@
         "title": "DiscoverTrack",
         "type": "object"
       },
+      "DiscoveryHealthResponse": {
+        "description": "Health of every discovery source, plus the job that drives them.",
+        "properties": {
+          "sources": {
+            "items": {
+              "$ref": "#/components/schemas/DiscoverySourceHealthResponse"
+            },
+            "title": "Sources",
+            "type": "array"
+          },
+          "status": {
+            "title": "Status",
+            "type": "string"
+          }
+        },
+        "required": [
+          "sources",
+          "status"
+        ],
+        "title": "DiscoveryHealthResponse",
+        "type": "object"
+      },
+      "DiscoverySourceHealthResponse": {
+        "description": "Whether one discovery source is working \u2014 not whether it is configured.",
+        "properties": {
+          "backoff_until": {
+            "title": "Backoff Until",
+            "type": [
+              "string",
+              "null"
+            ]
+          },
+          "consecutive_failures": {
+            "default": 0,
+            "title": "Consecutive Failures",
+            "type": "integer"
+          },
+          "items_contributed": {
+            "default": 0,
+            "title": "Items Contributed",
+            "type": "integer"
+          },
+          "last_failure_at": {
+            "title": "Last Failure At",
+            "type": [
+              "string",
+              "null"
+            ]
+          },
+          "last_failure_detail": {
+            "title": "Last Failure Detail",
+            "type": [
+              "string",
+              "null"
+            ]
+          },
+          "last_failure_kind": {
+            "title": "Last Failure Kind",
+            "type": [
+              "string",
+              "null"
+            ]
+          },
+          "last_success_at": {
+            "title": "Last Success At",
+            "type": [
+              "string",
+              "null"
+            ]
+          },
+          "source": {
+            "title": "Source",
+            "type": "string"
+          },
+          "state": {
+            "title": "State",
+            "type": "string"
+          }
+        },
+        "required": [
+          "source",
+          "state"
+        ],
+        "title": "DiscoverySourceHealthResponse",
+        "type": "object"
+      },
       "DownloadRequest": {
         "description": "Request to download a video.",
         "properties": {
@@ -15088,6 +15174,78 @@
           }
         },
         "summary": "Db Health Check",
+        "tags": [
+          "system"
+        ]
+      }
+    },
+    "/api/v1/health/discovery-sources": {
+      "get": {
+        "description": "Report whether each discovery source is working.\n\nDeliberately **not** folded into `/health/system`'s `services` list: `ServiceStatus`\ncarries only name/status/message/details, so the four facts ADR-0099 point 6 asks\nfor \u2014 last success, last failure and its kind, contribution, backoff \u2014 would land\nin an untyped `details` dict, which is what `lint_openapi` exists to stop. It is\nalso a different question from \"is the process up\".",
+        "operationId": "system_discovery_source_health",
+        "responses": {
+          "200": {
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/DiscoveryHealthResponse"
+                }
+              }
+            },
+            "description": "Successful Response"
+          },
+          "400": {
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/ErrorEnvelope"
+                }
+              }
+            },
+            "description": "Bad Request"
+          },
+          "401": {
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/ErrorEnvelope"
+                }
+              }
+            },
+            "description": "Unauthorized"
+          },
+          "404": {
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/ErrorEnvelope"
+                }
+              }
+            },
+            "description": "Not Found"
+          },
+          "422": {
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/ErrorEnvelope"
+                }
+              }
+            },
+            "description": "Unprocessable Entity"
+          },
+          "500": {
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/ErrorEnvelope"
+                }
+              }
+            },
+            "description": "Internal Server Error"
+          }
+        },
+        "summary": "Discovery Source Health",
         "tags": [
           "system"
         ]

--- a/backend/tests/conftest.py
+++ b/backend/tests/conftest.py
@@ -19,6 +19,7 @@ from app.db.models import (
     Artist,
     ArtistAlias,
     ArtistCheckCache,
+    DiscoverySourceHealth,
     ExternalAlbumCache,
     ExternalArtistImageCache,
     MixTape,
@@ -101,6 +102,9 @@ def make_profile_headers(profile: dict) -> dict[str, str]:
 # ArtistAlias FKs to Artist with CASCADE; Track.canonical_artist_id FKs
 # to Artist with SET NULL — so deleting tracks first then artists is safe.
 _CLEANUP_TABLES = [
+    # Seeded by its migration, so it survives between tests and one test's backoff
+    # leaks into the next. Truncated here; the recorder recreates rows on demand.
+    DiscoverySourceHealth,
     MixTape,
     PlaylistTrack,
     Playlist,

--- a/backend/tests/test_discovery_source_health.py
+++ b/backend/tests/test_discovery_source_health.py
@@ -1,0 +1,232 @@
+"""Source health is durable, and the job acts on it (ADR-0099 points 4, 6, 8, 10).
+
+The question is whether a source is *working*, not whether a key is configured.
+A source can hold a valid key, be scheduled, run every night, fail every time, and
+look identical to a healthy one — which is exactly what happened for nineteen
+nights.
+"""
+
+from datetime import timedelta
+
+import pytest
+from sqlalchemy import select
+
+from app.db.models import DiscoverySourceHealth
+from app.services.discovery.sources import (
+    BACKOFF_MAX_SECONDS,
+    SourceHealthRecorder,
+    backoff_seconds,
+)
+from app.utils.time import utcnow
+
+
+def _recorder(async_db):
+    """A recorder over the test session.
+
+    Production uses its own engine per the class docstring; here one session keeps
+    the assertions readable, and the separate-session requirement has its own test.
+    """
+    class _Factory:
+        def __call__(self):
+            return _Ctx(async_db)
+
+    class _Ctx:
+        def __init__(self, db):
+            self.db = db
+
+        async def __aenter__(self):
+            return self.db
+
+        async def __aexit__(self, *exc):
+            return False
+
+    return SourceHealthRecorder(_Factory())
+
+
+async def _row(async_db, source: str):
+    return (
+        await async_db.execute(
+            select(DiscoverySourceHealth).where(DiscoverySourceHealth.source == source)
+        )
+    ).scalar_one_or_none()
+
+
+# ---------------------------------------------------------------------------
+# Backoff arithmetic
+# ---------------------------------------------------------------------------
+
+
+def test_backoff_grows_and_is_capped():
+    """Capped so a recovered source is not ignored for hours after an outage ends."""
+    assert backoff_seconds(0) == 0
+    assert backoff_seconds(1) == 60
+    assert backoff_seconds(2) == 120
+    assert backoff_seconds(3) == 240
+    assert backoff_seconds(99) == BACKOFF_MAX_SECONDS
+
+
+# ---------------------------------------------------------------------------
+# Recording
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.asyncio
+async def test_failure_sets_backoff_and_success_clears_it(async_db):
+    rec = _recorder(async_db)
+
+    await rec.record_failure("musicbrainz", kind="rate_limited", detail="503")
+    assert await rec.should_skip("musicbrainz") is True
+    row = await _row(async_db, "musicbrainz")
+    assert row.consecutive_failures == 1
+    assert row.last_failure_kind == "rate_limited"
+
+    await rec.record_success("musicbrainz", items=3)
+    assert await rec.should_skip("musicbrainz") is False
+    row = await _row(async_db, "musicbrainz")
+    assert row.consecutive_failures == 0
+    assert row.backoff_until is None
+    assert row.items_contributed == 3
+
+
+@pytest.mark.asyncio
+async def test_retry_after_is_preferred_to_our_guess(async_db):
+    """The source telling us when to return beats an exponential guess — including
+    when it is shorter, which a `max()` would have thrown away."""
+    rec = _recorder(async_db)
+    for _ in range(5):
+        await rec.record_failure("lastfm", kind="rate_limited")
+    await rec.record_failure("lastfm", kind="rate_limited", retry_after_seconds=5)
+
+    row = await _row(async_db, "lastfm")
+    assert (row.backoff_until - utcnow().replace(tzinfo=None)) < timedelta(seconds=30)
+
+
+@pytest.mark.asyncio
+async def test_items_contributed_accumulates(async_db):
+    """A source that answers every call and yields nothing is a different problem
+    from one that errors, and a success timestamp cannot tell them apart."""
+    rec = _recorder(async_db)
+    await rec.record_success("bandcamp", items=2)
+    await rec.record_success("bandcamp", items=5)
+    row = await _row(async_db, "bandcamp")
+    assert row.items_contributed == 7
+
+
+@pytest.mark.asyncio
+async def test_a_source_in_backoff_does_not_block_the_others(async_db):
+    """Point 4's only real assertion.
+
+    With one source wired this looks trivial; it is the property that has to hold
+    before a second source can be added, and asserting it now is what stops the
+    shape regressing while nobody is looking.
+    """
+    rec = _recorder(async_db)
+    await rec.record_failure("musicbrainz", kind="rate_limited")
+
+    assert await rec.should_skip("musicbrainz") is True
+    assert await rec.should_skip("lastfm") is False
+    assert await rec.should_skip("bandcamp") is False
+
+
+@pytest.mark.asyncio
+async def test_an_unreadable_health_record_does_not_stop_discovery(async_db):
+    """Failing open is deliberate.
+
+    Skipping on an unknown state would let a database blip silently stop discovery —
+    which is the failure mode this whole ADR exists to prevent, reintroduced by the
+    mechanism meant to detect it.
+    """
+    class _Broken:
+        def __call__(self):
+            raise RuntimeError("no database")
+
+    assert await SourceHealthRecorder(_Broken()).should_skip("musicbrainz") is False
+
+
+# ---------------------------------------------------------------------------
+# The endpoint the Server page reads
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.asyncio
+async def test_never_succeeded_is_distinct_from_working(async_db, client):
+    """ADR-0099 point 8, as a shape a client can render.
+
+    A seeded row with no success is *not* "nothing found yet" — it was the true
+    state for nineteen nights and nothing said so.
+    """
+    async_db.add(DiscoverySourceHealth(source="musicbrainz"))
+    await async_db.commit()
+
+    data = client.get("/api/v1/health/discovery-sources").json()
+    by_source = {s["source"]: s for s in data["sources"]}
+
+    assert by_source["musicbrainz"]["state"] == "never_succeeded"
+    assert data["status"] == "never_succeeded"
+
+
+@pytest.mark.asyncio
+async def test_a_source_failing_for_days_does_not_look_healthy(async_db, client):
+    """The acceptance criterion, in the ADR's own terms.
+
+    A source with a valid key that has failed every night for nineteen days must
+    not be indistinguishable from a working one — which is precisely what
+    `ApiKeyStatus.tsx` showed, because it answers a different question.
+    """
+    long_ago = utcnow().replace(tzinfo=None) - timedelta(days=19)
+    async_db.add(
+        DiscoverySourceHealth(
+            source="musicbrainz",
+            last_success_at=long_ago,
+            last_failure_at=utcnow().replace(tzinfo=None),
+            last_failure_kind="rate_limited",
+            consecutive_failures=19,
+            items_contributed=600,
+        )
+    )
+    await async_db.commit()
+
+    data = client.get("/api/v1/health/discovery-sources").json()
+    mb = next(s for s in data["sources"] if s["source"] == "musicbrainz")
+
+    assert mb["state"] == "failing"
+    assert mb["consecutive_failures"] == 19
+    assert mb["last_failure_kind"] == "rate_limited"
+    assert data["status"] == "failing"
+
+
+@pytest.mark.asyncio
+async def test_backing_off_says_when_it_will_retry(async_db, client):
+    async_db.add(
+        DiscoverySourceHealth(
+            source="lastfm",
+            last_success_at=utcnow().replace(tzinfo=None) - timedelta(hours=1),
+            backoff_until=utcnow().replace(tzinfo=None) + timedelta(minutes=4),
+            consecutive_failures=2,
+        )
+    )
+    await async_db.commit()
+
+    data = client.get("/api/v1/health/discovery-sources").json()
+    lf = next(s for s in data["sources"] if s["source"] == "lastfm")
+
+    assert lf["state"] == "backing_off"
+    assert lf["backoff_until"] is not None
+
+
+@pytest.mark.asyncio
+async def test_a_working_source_reads_as_working(async_db, client):
+    async_db.add(
+        DiscoverySourceHealth(
+            source="bandcamp",
+            last_success_at=utcnow().replace(tzinfo=None),
+            consecutive_failures=0,
+            items_contributed=12,
+        )
+    )
+    await async_db.commit()
+
+    data = client.get("/api/v1/health/discovery-sources").json()
+    bc = next(s for s in data["sources"] if s["source"] == "bandcamp")
+    assert bc["state"] == "working"
+    assert bc["items_contributed"] == 12

--- a/backend/tests/test_discovery_source_health.py
+++ b/backend/tests/test_discovery_source_health.py
@@ -149,20 +149,52 @@ async def test_an_unreadable_health_record_does_not_stop_discovery(async_db):
 
 
 @pytest.mark.asyncio
-async def test_never_succeeded_is_distinct_from_working(async_db, client):
-    """ADR-0099 point 8, as a shape a client can render.
+async def test_tried_and_never_succeeded_is_distinct_from_never_tried(async_db, client):
+    """ADR-0099 point 8, and the distinction that keeps it meaningful.
 
-    A seeded row with no success is *not* "nothing found yet" — it was the true
-    state for nineteen nights and nothing said so.
+    A source that has been *attempted* and never succeeded is a failure and was the
+    true state for nineteen nights. A source nothing has attempted is merely
+    unmonitored — Last.fm and Bandcamp are in that position until point 5 wires
+    them. Reporting the second as the first makes the aggregate badge permanently
+    alarming and conflates "unmonitored" with "broken", which is the conflation this
+    surface exists to remove.
     """
-    async_db.add(DiscoverySourceHealth(source="musicbrainz"))
+    async_db.add(
+        DiscoverySourceHealth(
+            source="musicbrainz",
+            last_attempt_at=utcnow().replace(tzinfo=None),
+        )
+    )
+    async_db.add(DiscoverySourceHealth(source="bandcamp"))
     await async_db.commit()
 
     data = client.get("/api/v1/health/discovery-sources").json()
     by_source = {s["source"]: s for s in data["sources"]}
 
     assert by_source["musicbrainz"]["state"] == "never_succeeded"
+    assert by_source["bandcamp"]["state"] == "not_instrumented"
+    # Worst-wins, but an unmonitored source must not drive the aggregate.
     assert data["status"] == "never_succeeded"
+
+
+@pytest.mark.asyncio
+async def test_an_unmonitored_source_alone_does_not_make_discovery_look_broken(
+    async_db, client
+):
+    """The production shape on the day this shipped: two sources wired, two not."""
+    async_db.add(
+        DiscoverySourceHealth(
+            source="musicbrainz",
+            last_attempt_at=utcnow().replace(tzinfo=None),
+            last_success_at=utcnow().replace(tzinfo=None),
+        )
+    )
+    async_db.add(DiscoverySourceHealth(source="lastfm"))
+    async_db.add(DiscoverySourceHealth(source="bandcamp"))
+    await async_db.commit()
+
+    data = client.get("/api/v1/health/discovery-sources").json()
+    assert data["status"] == "working"
 
 
 @pytest.mark.asyncio

--- a/packages/frontend/src/api/admin.ts
+++ b/packages/frontend/src/api/admin.ts
@@ -72,7 +72,30 @@ export interface WorkerStatus {
   recent_failures: TaskFailure[];
 }
 
+export interface DiscoverySourceHealth {
+  source: string;
+  /** working | degraded | backing_off | failing | never_succeeded */
+  state: string;
+  last_success_at: string | null;
+  last_failure_at: string | null;
+  last_failure_kind: string | null;
+  last_failure_detail: string | null;
+  consecutive_failures: number;
+  items_contributed: number;
+  backoff_until: string | null;
+}
+
+export interface DiscoveryHealth {
+  sources: DiscoverySourceHealth[];
+  status: string;
+}
+
 export const healthApi = {
+  getDiscoverySources: async (): Promise<DiscoveryHealth> => {
+    const { data } = await api.get('/health/discovery-sources');
+    return data;
+  },
+
   getSystemHealth: async (): Promise<SystemHealth> => {
     const { data } = await api.get('/health/system');
     return data;

--- a/packages/frontend/src/api/queryKeys.ts
+++ b/packages/frontend/src/api/queryKeys.ts
@@ -94,6 +94,11 @@ export const queryKeys = {
     autoDownload: ['favorites-auto-download'] as const,
   },
 
+  // ── Health ────────────────────────────────────────────────────────────
+  discoverySources: {
+    all: ['discovery-sources'] as const,
+  },
+
   // ── Settings & Config ─────────────────────────────────────────────────
   appSettings: {
     all: ['app-settings'] as const,

--- a/packages/frontend/src/panels/server/DiscoverySources.tsx
+++ b/packages/frontend/src/panels/server/DiscoverySources.tsx
@@ -1,0 +1,138 @@
+/**
+ * Whether each discovery source is actually working (ADR-0099 point 6).
+ *
+ * **Deliberately not the question `ApiKeyStatus` answers.** That panel reports
+ * whether a key is *configured*, and a source can hold a valid key, be scheduled,
+ * run every night, fail every time, and look identical to a healthy one. That is
+ * not hypothetical: the nightly discovery job crashed nineteen nights running,
+ * logged at ERROR, and every surface in the app showed green.
+ *
+ * So the fact this leads with is **when a source last found something** — not when
+ * it last ran, which the old dashboard could already imply and which was true
+ * throughout the outage.
+ */
+import { useQuery } from '@tanstack/react-query';
+import { AlertTriangle, CheckCircle, Clock, HelpCircle, XCircle } from 'lucide-react';
+import { healthApi, type DiscoverySourceHealth } from '../../api/admin';
+import { queryKeys } from '../../api/queryKeys';
+
+const REFRESH_MS = 30_000;
+
+/** Human labels. The source key is an implementation detail, not a name. */
+const SOURCE_LABELS: Record<string, string> = {
+  musicbrainz: 'MusicBrainz',
+  lastfm: 'Last.fm',
+  bandcamp: 'Bandcamp',
+  discovery_batch: 'Discovery job',
+};
+
+const STATE_STYLES: Record<string, { label: string; cls: string; Icon: typeof CheckCircle }> = {
+  working: { label: 'Working', cls: 'text-success', Icon: CheckCircle },
+  degraded: { label: 'Degraded', cls: 'text-warning', Icon: AlertTriangle },
+  backing_off: { label: 'Backing off', cls: 'text-warning', Icon: Clock },
+  failing: { label: 'Failing', cls: 'text-danger', Icon: XCircle },
+  never_succeeded: { label: 'Never succeeded', cls: 'text-danger', Icon: HelpCircle },
+};
+
+function relative(iso: string | null): string | null {
+  if (!iso) return null;
+  const then = new Date(iso).getTime();
+  if (Number.isNaN(then)) return null;
+  const mins = Math.max(0, Math.round((Date.now() - then) / 60_000));
+  if (mins < 1) return 'just now';
+  if (mins < 60) return `${mins} min ago`;
+  const hours = Math.round(mins / 60);
+  if (hours < 24) return `${hours} hour${hours === 1 ? '' : 's'} ago`;
+  const days = Math.round(hours / 24);
+  return `${days} day${days === 1 ? '' : 's'} ago`;
+}
+
+function untilNow(iso: string | null): string | null {
+  if (!iso) return null;
+  const mins = Math.round((new Date(iso).getTime() - Date.now()) / 60_000);
+  if (Number.isNaN(mins) || mins <= 0) return null;
+  return mins < 60 ? `retrying in ${mins} min` : `retrying in ${Math.round(mins / 60)} h`;
+}
+
+function SourceRow({ source }: { source: DiscoverySourceHealth }) {
+  const style = STATE_STYLES[source.state] ?? STATE_STYLES.working;
+  const { Icon } = style;
+  const lastSuccess = relative(source.last_success_at);
+  const retry = untilNow(source.backoff_until);
+
+  return (
+    <div className="flex items-start gap-3 p-3 bg-zinc-900/50 rounded-lg">
+      <Icon className={`w-5 h-5 flex-shrink-0 mt-0.5 ${style.cls}`} />
+      <div className="flex-1 min-w-0">
+        <div className="flex items-baseline gap-2 flex-wrap">
+          <p className="text-sm text-white">{SOURCE_LABELS[source.source] ?? source.source}</p>
+          <span className={`text-xs ${style.cls}`}>{style.label}</span>
+        </div>
+
+        {/* "Last found something", not "last ran" — the distinction the outage turned on. */}
+        <p className="text-xs text-zinc-400 mt-0.5">
+          {lastSuccess
+            ? `Last found something ${lastSuccess}`
+            : 'Has never found anything — this is not the same as "nothing new"'}
+        </p>
+
+        {source.last_failure_kind && (
+          <p className="text-xs text-zinc-500 mt-0.5">
+            Last failure: {source.last_failure_kind.replace(/_/g, ' ')}
+            {source.consecutive_failures > 1 && ` (${source.consecutive_failures} in a row)`}
+            {retry && ` — ${retry}`}
+          </p>
+        )}
+
+        {source.items_contributed > 0 && (
+          <p className="text-xs text-zinc-500 mt-0.5">
+            {source.items_contributed.toLocaleString()} releases contributed
+          </p>
+        )}
+      </div>
+    </div>
+  );
+}
+
+export function DiscoverySources() {
+  const { data, isLoading, isError } = useQuery({
+    queryKey: queryKeys.discoverySources.all,
+    queryFn: healthApi.getDiscoverySources,
+    refetchInterval: REFRESH_MS,
+  });
+
+  if (isLoading) {
+    return (
+      <div className="bg-zinc-800/50 rounded-lg p-4">
+        <div className="animate-pulse h-16 bg-zinc-700/50 rounded" />
+      </div>
+    );
+  }
+
+  // An error here is itself a health signal and must not render as an empty,
+  // healthy-looking panel — that is the failure this whole surface exists to stop.
+  if (isError || !data) {
+    return (
+      <div className="bg-zinc-800/50 rounded-lg p-4">
+        <p className="text-sm text-danger">Could not read discovery source health.</p>
+      </div>
+    );
+  }
+
+  return (
+    <div className="bg-zinc-800/50 rounded-lg p-4 space-y-3">
+      <div>
+        <h4 className="font-medium text-white">Discovery sources</h4>
+        <p className="text-sm text-zinc-400">
+          Whether each source is working — not whether a key is configured
+        </p>
+      </div>
+
+      <div className="space-y-2">
+        {data.sources.map((source) => (
+          <SourceRow key={source.source} source={source} />
+        ))}
+      </div>
+    </div>
+  );
+}

--- a/packages/frontend/src/panels/server/DiscoverySources.tsx
+++ b/packages/frontend/src/panels/server/DiscoverySources.tsx
@@ -32,6 +32,10 @@ const STATE_STYLES: Record<string, { label: string; cls: string; Icon: typeof Ch
   backing_off: { label: 'Backing off', cls: 'text-warning', Icon: Clock },
   failing: { label: 'Failing', cls: 'text-danger', Icon: XCircle },
   never_succeeded: { label: 'Never succeeded', cls: 'text-danger', Icon: HelpCircle },
+  // Nothing has attempted this source yet — unmonitored, not broken. Neutral on
+  // purpose: colouring it would make the panel cry wolf about a source that is
+  // simply not wired to the recorder until ADR-0099 point 5.
+  not_instrumented: { label: 'Not monitored', cls: 'text-zinc-500', Icon: HelpCircle },
 };
 
 function relative(iso: string | null): string | null {
@@ -73,7 +77,9 @@ function SourceRow({ source }: { source: DiscoverySourceHealth }) {
         <p className="text-xs text-zinc-400 mt-0.5">
           {lastSuccess
             ? `Last found something ${lastSuccess}`
-            : 'Has never found anything — this is not the same as "nothing new"'}
+            : source.state === 'not_instrumented'
+              ? 'Used for recommendations; not yet reporting health'
+              : 'Has never found anything — this is not the same as "nothing new"'}
         </p>
 
         {source.last_failure_kind && (

--- a/packages/frontend/src/panels/server/__tests__/DiscoverySources.test.tsx
+++ b/packages/frontend/src/panels/server/__tests__/DiscoverySources.test.tsx
@@ -115,3 +115,20 @@ describe('DiscoverySources', () => {
     ).toBeTruthy();
   });
 });
+
+describe('DiscoverySources — unmonitored sources', () => {
+  it('a source nothing has attempted reads as not monitored, not as broken', async () => {
+    vi.mocked(healthApi.getDiscoverySources).mockResolvedValue({
+      status: 'working',
+      sources: [
+        source({ source: 'bandcamp', state: 'not_instrumented', last_success_at: null }),
+      ],
+    });
+    renderPanel();
+
+    expect(await screen.findByText('Not monitored')).toBeTruthy();
+    expect(screen.getByText(/not yet reporting health/)).toBeTruthy();
+    // The alarming wording belongs to never_succeeded, not to this.
+    expect(screen.queryByText(/never found anything/)).toBeNull();
+  });
+});

--- a/packages/frontend/src/panels/server/__tests__/DiscoverySources.test.tsx
+++ b/packages/frontend/src/panels/server/__tests__/DiscoverySources.test.tsx
@@ -1,0 +1,117 @@
+/**
+ * The acceptance criterion, in ADR-0099's own terms: a source with a valid key
+ * that has failed for nineteen days must not look like a working one.
+ */
+import { afterEach, describe, expect, it, vi } from 'vitest';
+import { cleanup, render, screen } from '@testing-library/react';
+import { QueryClient, QueryClientProvider } from '@tanstack/react-query';
+import { DiscoverySources } from '../DiscoverySources';
+import { healthApi } from '../../../api/admin';
+
+vi.mock('../../../api/admin', () => ({
+  healthApi: { getDiscoverySources: vi.fn() },
+}));
+
+function renderPanel() {
+  const client = new QueryClient({ defaultOptions: { queries: { retry: false } } });
+  return render(
+    <QueryClientProvider client={client}>
+      <DiscoverySources />
+    </QueryClientProvider>,
+  );
+}
+
+const iso = (daysAgo: number) =>
+  new Date(Date.now() - daysAgo * 86_400_000).toISOString();
+
+const source = (over: Partial<Record<string, unknown>> = {}) => ({
+  source: 'musicbrainz',
+  state: 'working',
+  last_success_at: iso(0),
+  last_failure_at: null,
+  last_failure_kind: null,
+  last_failure_detail: null,
+  consecutive_failures: 0,
+  items_contributed: 0,
+  backoff_until: null,
+  ...over,
+});
+
+// RTL does not auto-clean in this config, so renders accumulate in document.body
+// and a second test finds the first test's DOM as well as its own.
+afterEach(cleanup);
+
+describe('DiscoverySources', () => {
+  it('a source failing for nineteen days does not look healthy', async () => {
+    vi.mocked(healthApi.getDiscoverySources).mockResolvedValue({
+      status: 'failing',
+      sources: [
+        source({
+          state: 'failing',
+          last_success_at: iso(19),
+          last_failure_kind: 'rate_limited',
+          consecutive_failures: 19,
+        }),
+      ],
+    });
+    renderPanel();
+
+    expect(await screen.findByText('Failing')).toBeTruthy();
+    expect(screen.getByText(/19 days ago/)).toBeTruthy();
+    expect(screen.getByText(/rate limited/)).toBeTruthy();
+    expect(screen.getByText(/19 in a row/)).toBeTruthy();
+  });
+
+  it('never succeeded is distinct from found nothing', async () => {
+    vi.mocked(healthApi.getDiscoverySources).mockResolvedValue({
+      status: 'never_succeeded',
+      sources: [source({ state: 'never_succeeded', last_success_at: null })],
+    });
+    renderPanel();
+
+    expect(await screen.findByText('Never succeeded')).toBeTruthy();
+    // The wording is the point: an empty result and a broken source read alike
+    // without it, which is how nineteen nights passed unnoticed.
+    expect(
+      screen.getByText(/not the same as "nothing new"/),
+    ).toBeTruthy();
+  });
+
+  it('backing off says when it will retry', async () => {
+    vi.mocked(healthApi.getDiscoverySources).mockResolvedValue({
+      status: 'backing_off',
+      sources: [
+        source({
+          state: 'backing_off',
+          last_failure_kind: 'rate_limited',
+          consecutive_failures: 2,
+          backoff_until: new Date(Date.now() + 240_000).toISOString(),
+        }),
+      ],
+    });
+    renderPanel();
+
+    expect(await screen.findByText('Backing off')).toBeTruthy();
+    expect(screen.getByText(/retrying in 4 min/)).toBeTruthy();
+  });
+
+  it('leads with when a source last found something, not when it last ran', async () => {
+    vi.mocked(healthApi.getDiscoverySources).mockResolvedValue({
+      status: 'working',
+      sources: [source({ items_contributed: 600 })],
+    });
+    renderPanel();
+
+    expect(await screen.findByText(/Last found something/)).toBeTruthy();
+    expect(screen.getByText(/600 releases contributed/)).toBeTruthy();
+  });
+
+  it('a failed read renders as an error, not as an empty healthy panel', async () => {
+    vi.mocked(healthApi.getDiscoverySources).mockRejectedValue(new Error('nope'));
+    renderPanel();
+
+    expect(
+      await screen.findByText(/Could not read discovery source health/),
+    ).toBeTruthy();
+  });
+});

--- a/packages/frontend/src/screens/ServerPage.tsx
+++ b/packages/frontend/src/screens/ServerPage.tsx
@@ -12,6 +12,7 @@
  */
 import { AdminPage, AdminSection } from './AdminPage';
 import { SystemStatus } from '../panels/server/SystemStatus';
+import { DiscoverySources } from '../panels/server/DiscoverySources';
 import { ApiKeyStatus } from '../panels/server/ApiKeyStatus';
 import { ServerTokenSettings } from '../panels/server/ServerTokenSettings';
 import { ProfileSettings } from '../panels/server/ProfileSettings';
@@ -35,6 +36,13 @@ export function ServerPage() {
 
       {/* Renders its own section, or nothing at all when idle. Inherited from the status menu
           ADR-0080 removed — `artwork_fetch` and `s3_backup` report their progress nowhere else. */}
+      {/* Its own section rather than folded into Health: ADR-0058 point 2 names the
+          destination, and whether an upstream is answering is a different question
+          from whether this process is up. */}
+      <AdminSection title="Discovery">
+        <DiscoverySources />
+      </AdminSection>
+
       <BackgroundJobs />
 
       <AdminSection title="Access">


### PR DESCRIPTION
> Stacked on #247. Base will retarget to `main` once that merges.

ADR-0099 points 4, 6, 8 and 10. `ApiKeyStatus.tsx` reports whether a key is **configured**, which is not whether a source is **working** — and a source can hold a valid key, be scheduled, run every night, fail every time, and look identical to a healthy one. Not hypothetical: the nightly job crashed nineteen nights running, logged at ERROR, and every surface in the app showed green.

### Health is control, not telemetry

`backoff_until` is both the column the Server page renders and the value the batch consults **before** deciding whether to call a source. That's what makes "one source being down does not stop the others" a property rather than a report. With one source wired it looks like a guard; it's the shape a second source needs.

### Postgres, not Redis

The obvious home was the existing `TASK_FAILURES_KEY` list — but it expires after 24 hours and the APScheduler jobstore is in-memory, so "last succeeded five days ago" becomes "no data" after a restart. A stale record that quietly disappears is the precise failure this table prevents.

The recorder runs on its **own session** and commits immediately. Load-bearing: the batch takes a per-artist `rollback()` on failure, and a shared session would erase the record of the very failure that caused it.

### Point 10 gets its own row

The outage had a perfectly healthy MusicBrainz and a dead writer, so a source-only view would have shown all green throughout. `discovery_batch` records whether the job itself ran, finished and wrote.

Success is **"answered"**, not "found something" — a source replying correctly on a quiet week is working, and conflating those is how a healthy upstream starts reading as broken every time there's no new music.

### Two things the database taught me, both of which would have shipped silently

**The baseline migration builds a fresh database with `Base.metadata.create_all()`**, so DDL comes from the *model* — and a Python-side `default=0` never reaches the column. The seed INSERT violated NOT NULL on a clean database while passing on an existing one. Fixed on both sides: the model declares `server_default` (as `updated_at` already did), and the seed states its values rather than relying on defaults at all.

**`discovery_source_health` is seeded by its migration**, so it survived between tests and one test's backoff leaked into the next. Added to conftest's cleanup list.

### The panel

Leads with **when a source last found something**, not when it last ran — the latter was true throughout the outage. A failed read renders as an error rather than an empty healthy-looking panel, which is the same failure in miniature. Its own `AdminSection`, per ADR-0058 point 2: whether an upstream is answering is a different question from whether the process is up.

1,750 backend tests and 368 frontend tests pass; the 4 backend failures are pre-existing on `main`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01Emjrwedq7W1scadHdgiLfs