### PR TITLE
Rediscovery: rank the library you own against what you actually play

### DIFF
--- a/backend/app/api/routes/library_discover.py
+++ b/backend/app/api/routes/library_discover.py
@@ -1,6 +1,7 @@
 """Discovery dashboard endpoints."""
 
 import logging
+from datetime import timedelta
 
 from fastapi import APIRouter, Query
 from pydantic import BaseModel
@@ -45,12 +46,33 @@ class DiscoverRecommendedArtist(BaseModel):
     based_on_artist: str  # Which library artist triggered this recommendation
 
 
+class RediscoverySuggestion(BaseModel):
+    """An unheard library track, and the played track that reached it."""
+
+    track: DiscoverTrack
+    #: **The reason, as a real pair of tracks.** ADR-0093 tried three times to name a
+    #: cluster and failed each time; "because you play X" is both true and checkable
+    #: where a generated label is neither. ADR-0101 point 3 keeps that rule here.
+    because_of_title: str | None
+    because_of_artist: str | None
+    similarity: float
+    #: How many of your played tracks independently reached this one. Agreement, not
+    #: an average — see `collection_suggestions` for why the average was abandoned.
+    votes: int
+
+
 class DiscoverResponse(BaseModel):
     """Aggregated discovery data for the dashboard."""
 
-    # Track-based discovery
-    unheard_tracks: list[DiscoverTrack]
-    deep_cuts: list[DiscoverTrack]
+    #: Owned, unheard, ranked against what you actually listen to (ADR-0101).
+    #:
+    #: Replaces `unheard_tracks` and `deep_cuts`, which were `ORDER BY random()` over
+    #: tracks by artists already played — not a ranking, and unable to reach an artist
+    #: the listener had never played however well it matched.
+    rediscovery: list[RediscoverySuggestion]
+    #: Seeds behind the list, so an empty result can say *why*. No listening history
+    #: and nothing similar found are different answers (ADR-0101 point 7).
+    rediscovery_seed_count: int
 
     # Recommended artists based on top-played artists (external only)
     recommended_artists: list[DiscoverRecommendedArtist]
@@ -76,7 +98,6 @@ async def get_discover_dashboard(
     - Recommended artists based on most-played
     - Recently added track count
     """
-    from datetime import timedelta
 
     from app.db.models import ProfilePlayHistory
     from app.services.lastfm import get_lastfm_service
@@ -101,7 +122,6 @@ async def get_discover_dashboard(
     )
     play_result = await db.execute(play_history_query)
     top_artists = play_result.fetchall()
-    top_artist_ids = [row.artist_id for row in top_artists]
 
     seen_recommendations: set[str] = set()
     similar_candidates: list[tuple[str, str, dict, str]] = []  # (name, normalized, similar_data, based_on)
@@ -232,87 +252,35 @@ async def get_discover_dashboard(
     schedule_background_resolve(unresolved)
 
     # 2. Track-based discovery using top canonical artist ids.
-    unheard_tracks: list[DiscoverTrack] = []
-    deep_cuts: list[DiscoverTrack] = []
+    # **Ranked against listening, not ordered at random** (ADR-0101 point 2).
+    #
+    # The engine is ADR-0093's: each played track's nearest neighbours, counted by how
+    # many seeds independently reach a candidate. Crucially the candidate pool is the
+    # whole library, so an unheard record by an artist never played can surface if it
+    # sounds like what this listener loves — which the previous top-artist filter made
+    # impossible by construction.
+    from app.services.rediscovery import suggest_rediscovery
 
-    if top_artist_ids:
-        # Subquery: track IDs this profile has played.
-        played_track_ids = (
-            select(ProfilePlayHistory.track_id)
-            .where(ProfilePlayHistory.profile_id == profile.id)
+    suggestions, seed_count = await suggest_rediscovery(
+        db, profile_id=profile.id, limit=15
+    )
+    rediscovery = [
+        RediscoverySuggestion(
+            track=DiscoverTrack(
+                id=str(s.track.id),
+                title=s.track.title,
+                artist=s.track.artist,
+                album=s.track.album,
+                duration_seconds=s.track.duration_seconds,
+                play_count=0,
+            ),
+            because_of_title=s.because_of.title,
+            because_of_artist=s.because_of.artist,
+            similarity=round(s.similarity, 4),
+            votes=s.votes,
         )
-
-        # Unheard tracks: by top canonical artists, never played by this profile.
-        unheard_query = (
-            select(
-                Track.id,
-                Track.title,
-                Track.artist,
-                Track.album,
-                Track.duration_seconds,
-            )
-            .where(
-                Track.canonical_artist_id.in_(top_artist_ids),
-                Track.status == TrackStatus.ACTIVE,
-                Track.id.notin_(played_track_ids),
-            )
-            .order_by(func.random())
-            .limit(15)
-        )
-        unheard_result = await db.execute(unheard_query)
-        unheard_rows = unheard_result.fetchall()
-        unheard_track_ids = set()
-
-        for row in unheard_rows:
-            unheard_track_ids.add(row.id)
-            unheard_tracks.append(
-                DiscoverTrack(
-                    id=str(row.id),
-                    title=row.title,
-                    artist=row.artist,
-                    album=row.album,
-                    duration_seconds=row.duration_seconds,
-                    play_count=0,
-                )
-            )
-
-        # Deep cuts: by top canonical artists, played but low play count.
-        deep_cuts_query = (
-            select(
-                Track.id,
-                Track.title,
-                Track.artist,
-                Track.album,
-                Track.duration_seconds,
-                ProfilePlayHistory.play_count,
-            )
-            .join(ProfilePlayHistory, ProfilePlayHistory.track_id == Track.id)
-            .where(
-                Track.canonical_artist_id.in_(top_artist_ids),
-                Track.status == TrackStatus.ACTIVE,
-                ProfilePlayHistory.profile_id == profile.id,
-                ProfilePlayHistory.play_count > 0,
-            )
-            .order_by(ProfilePlayHistory.play_count.asc())
-            .limit(20)  # Fetch extra to filter out unheard overlap
-        )
-        deep_cuts_result = await db.execute(deep_cuts_query)
-
-        for row in deep_cuts_result.fetchall():
-            if row.id in unheard_track_ids:
-                continue
-            deep_cuts.append(
-                DiscoverTrack(
-                    id=str(row.id),
-                    title=row.title,
-                    artist=row.artist,
-                    album=row.album,
-                    duration_seconds=row.duration_seconds,
-                    play_count=row.play_count,
-                )
-            )
-            if len(deep_cuts) >= 15:
-                break
+        for s in suggestions
+    ]
 
     # 3. Get recently added count (last 30 days)
     thirty_days_ago = utcnow() - timedelta(days=30)
@@ -326,8 +294,8 @@ async def get_discover_dashboard(
     recently_added_count = await db.scalar(recent_query) or 0
 
     return DiscoverResponse(
-        unheard_tracks=unheard_tracks,
-        deep_cuts=deep_cuts,
+        rediscovery=rediscovery,
+        rediscovery_seed_count=seed_count,
         recommended_artists=recommended_artists,
         recently_added_count=recently_added_count,
     )

--- a/backend/app/api/routes/library_discover.py
+++ b/backend/app/api/routes/library_discover.py
@@ -53,8 +53,12 @@ class RediscoverySuggestion(BaseModel):
     #: **The reason, as a real pair of tracks.** ADR-0093 tried three times to name a
     #: cluster and failed each time; "because you play X" is both true and checkable
     #: where a generated label is neither. ADR-0101 point 3 keeps that rule here.
+    #: ``null`` when the track reached itself — a deep cut, played once and forgotten.
+    #: The client says "played once" rather than borrowing a reason that is not one.
     because_of_title: str | None
     because_of_artist: str | None
+    #: This profile's plays of the suggested track. Zero for genuinely unheard music.
+    play_count: int
     similarity: float
     #: How many of your played tracks independently reached this one. Agreement, not
     #: an average — see `collection_suggestions` for why the average was abandoned.
@@ -267,19 +271,20 @@ async def get_discover_dashboard(
     rediscovery = [
         RediscoverySuggestion(
             track=DiscoverTrack(
-                id=str(s.track.id),
-                title=s.track.title,
-                artist=s.track.artist,
-                album=s.track.album,
-                duration_seconds=s.track.duration_seconds,
-                play_count=0,
+                id=str(r.suggestion.track.id),
+                title=r.suggestion.track.title,
+                artist=r.suggestion.track.artist,
+                album=r.suggestion.track.album,
+                duration_seconds=r.suggestion.track.duration_seconds,
+                play_count=r.play_count,
             ),
-            because_of_title=s.because_of.title,
-            because_of_artist=s.because_of.artist,
-            similarity=round(s.similarity, 4),
-            votes=s.votes,
+            because_of_title=r.because_of.title if r.because_of else None,
+            because_of_artist=r.because_of.artist if r.because_of else None,
+            play_count=r.play_count,
+            similarity=round(r.suggestion.similarity, 4),
+            votes=r.suggestion.votes,
         )
-        for s in suggestions
+        for r in suggestions
     ]
 
     # 3. Get recently added count (last 30 days)

--- a/backend/app/services/collection_suggestions.py
+++ b/backend/app/services/collection_suggestions.py
@@ -121,6 +121,7 @@ async def suggest_for_collection(
     ]
 
     candidates = _drop_duplicate_recordings(candidates)
+    candidates = await _drop_recordings_already_in_the_collection(db, candidates, excluded)
     candidates = await _demote_rejected(db, candidates, profile_id)
 
     # Agreement first; single votes only to fill. A three-track playlist cannot produce two votes for
@@ -255,6 +256,60 @@ def _drop_duplicate_recordings(candidates: list[Suggestion]) -> list[Suggestion]
         if key in seen:
             continue
         seen.add(key)
+        kept.append(candidate)
+    return kept
+
+
+async def _drop_recordings_already_in_the_collection(
+    db: AsyncSession,
+    candidates: list[Suggestion],
+    excluded: set[UUID],
+) -> list[Suggestion]:
+    """Drop candidates that are another *file* of a track already in the collection.
+
+    `exclude_track_ids` works on ids, so a library holding the same recording twice —
+    an album cut and a single, two rips of one release — has one copy excluded and the
+    other free to be suggested. It comes back with similarity 1.0 and its own seed as
+    the reason, which reads as "listen to this thing you already play".
+
+    Seen on the live library the day rediscovery shipped: four of ten suggestions were
+    a track recommended because of itself. `_drop_duplicate_recordings` cannot catch it
+    — that folds duplicates among *candidates*, and here the duplicate is on the other
+    side of the comparison.
+
+    **Keyed on the *excluded* set, not the seeds**, and the difference is not
+    cosmetic. For rediscovery the seeds are everything ever played, which includes the
+    barely-played tracks the feature most wants to resurface — filtering against those
+    drops exactly the deep-cut case it exists to serve. The excluded set is "what the
+    listener already has", which is the question being asked.
+    """
+    from app.services.normalize import normalize_for_duplicate_matching
+
+    if not candidates or not excluded:
+        return candidates
+
+    rows = (
+        await db.execute(
+            select(Track.artist, Track.title).where(Track.id.in_(list(excluded)))
+        )
+    ).all()
+    seed_keys = {
+        (
+            normalize_for_duplicate_matching(artist, strip_articles=True),
+            normalize_for_duplicate_matching(title),
+        )
+        for artist, title in rows
+    }
+    seed_keys.discard(("", ""))
+
+    kept = []
+    for candidate in candidates:
+        key = (
+            normalize_for_duplicate_matching(candidate.track.artist, strip_articles=True),
+            normalize_for_duplicate_matching(candidate.track.title),
+        )
+        if key in seed_keys:
+            continue
         kept.append(candidate)
     return kept
 

--- a/backend/app/services/collection_suggestions.py
+++ b/backend/app/services/collection_suggestions.py
@@ -84,6 +84,12 @@ async def suggest_for_collection(
     *,
     seed_track_ids: Sequence[UUID],
     exclude_track_ids: set[UUID] | None = None,
+    #: Tracks whose *metadata* marks a recording as already known, when that is a
+    #: wider set than the ids being excluded. Rediscovery excludes by id at three
+    #: plays but considers anything played at all "already heard" for the purpose of
+    #: spotting a duplicate file. Defaults to `exclude_track_ids`, which is right when
+    #: the two sets are the same — favourites, playlists.
+    duplicate_key_ids: set[UUID] | None = None,
     profile_id: UUID | None = None,
     limit: int = 10,
 ) -> list[Suggestion]:
@@ -121,7 +127,9 @@ async def suggest_for_collection(
     ]
 
     candidates = _drop_duplicate_recordings(candidates)
-    candidates = await _drop_recordings_already_in_the_collection(db, candidates, excluded)
+    candidates = await _drop_recordings_already_in_the_collection(
+        db, candidates, duplicate_key_ids if duplicate_key_ids is not None else excluded
+    )
     candidates = await _demote_rejected(db, candidates, profile_id)
 
     # Agreement first; single votes only to fill. A three-track playlist cannot produce two votes for
@@ -277,11 +285,14 @@ async def _drop_recordings_already_in_the_collection(
     — that folds duplicates among *candidates*, and here the duplicate is on the other
     side of the comparison.
 
-    **Keyed on the *excluded* set, not the seeds**, and the difference is not
-    cosmetic. For rediscovery the seeds are everything ever played, which includes the
-    barely-played tracks the feature most wants to resurface — filtering against those
-    drops exactly the deep-cut case it exists to serve. The excluded set is "what the
-    listener already has", which is the question being asked.
+    **The candidate is exempt from its own key**, and that exemption is the whole
+    subtlety. A track played twice and offered back *as itself* is the deep cut this
+    feature exists to resurface. The same metadata on a *different row* is a second
+    file of something already heard, and useless. Two earlier versions of this filter
+    got it wrong in opposite directions — one keyed on seeds and killed deep cuts, one
+    keyed on the heard set and let duplicates of barely-played tracks through, which
+    is how Interpol's "Anywhere" was still being suggested because you play Interpol's
+    "Anywhere".
     """
     from app.services.normalize import normalize_for_duplicate_matching
 
@@ -293,14 +304,14 @@ async def _drop_recordings_already_in_the_collection(
             select(Track.artist, Track.title).where(Track.id.in_(list(excluded)))
         )
     ).all()
-    seed_keys = {
+    collection_keys = {
         (
             normalize_for_duplicate_matching(artist, strip_articles=True),
             normalize_for_duplicate_matching(title),
         )
         for artist, title in rows
     }
-    seed_keys.discard(("", ""))
+    collection_keys.discard(("", ""))
 
     kept = []
     for candidate in candidates:
@@ -308,7 +319,7 @@ async def _drop_recordings_already_in_the_collection(
             normalize_for_duplicate_matching(candidate.track.artist, strip_articles=True),
             normalize_for_duplicate_matching(candidate.track.title),
         )
-        if key in seed_keys:
+        if key in collection_keys and candidate.track.id not in excluded:
             continue
         kept.append(candidate)
     return kept

--- a/backend/app/services/rediscovery.py
+++ b/backend/app/services/rediscovery.py
@@ -24,6 +24,7 @@ scales and returned the library's most generically average music both times.
 from __future__ import annotations
 
 import logging
+from dataclasses import dataclass
 from uuid import UUID
 
 from sqlalchemy import select
@@ -55,12 +56,28 @@ HEARD_THRESHOLD = 3
 #: the symptom is a track that never appears and no error anywhere.
 
 
+@dataclass
+class Rediscovery:
+    """A suggestion, and enough context to explain itself honestly.
+
+    ``because_of`` is ``None`` when the track reached *itself* — which happens for a
+    track played once and long forgotten, the deep-cut case. Saying "because you play
+    Anywhere" about Anywhere is not a reason, it is a bug wearing a reason's clothes,
+    and it is what four of the first fifteen live suggestions did.
+    """
+
+    suggestion: Suggestion
+    #: ``None`` for a self-reached track; the caller says "played once" instead.
+    because_of: Track | None
+    play_count: int
+
+
 async def suggest_rediscovery(
     db: AsyncSession,
     *,
     profile_id: UUID,
     limit: int = 15,
-) -> tuple[list[Suggestion], int]:
+) -> tuple[list[Rediscovery], int]:
     """Unheard library tracks ranked against recent listening.
 
     Returns the suggestions and the number of seeds behind them, because a caller
@@ -118,4 +135,26 @@ async def suggest_rediscovery(
         profile_id=profile_id,
         limit=limit,
     )
-    return suggestions, len(seed_ids)
+
+    # Play counts for what came back, so a self-reached track can say "played once"
+    # rather than borrowing a reason it does not have. Fifteen ids, one query.
+    counts: dict[UUID, int] = {}
+    if suggestions:
+        rows = (
+            await db.execute(
+                select(ProfilePlayHistory.track_id, ProfilePlayHistory.play_count).where(
+                    ProfilePlayHistory.profile_id == profile_id,
+                    ProfilePlayHistory.track_id.in_([s.track.id for s in suggestions]),
+                )
+            )
+        ).all()
+        counts = {track_id: play_count for track_id, play_count in rows}
+
+    return [
+        Rediscovery(
+            suggestion=s,
+            because_of=None if s.because_of.id == s.track.id else s.because_of,
+            play_count=counts.get(s.track.id, 0),
+        )
+        for s in suggestions
+    ], len(seed_ids)

--- a/backend/app/services/rediscovery.py
+++ b/backend/app/services/rediscovery.py
@@ -1,0 +1,116 @@
+"""Music you own and have not heard, ranked by what you actually listen to (ADR-0101).
+
+**The single largest discovery opportunity Familiar has, and the one a streaming
+service structurally cannot compete on.** Measured on the production library:
+23,683 of 26,434 tracks — 90% — have never been played. Spotify cannot recommend
+from a collection it cannot see, and cannot know you bought something in 2014 and
+never played it.
+
+This replaces the Discover dashboard's `unheard_tracks` and `deep_cuts`, which were
+`ORDER BY random()` over tracks by artists you already play. Two limits there, and
+the second is the interesting one: the ordering was not ranking at all, and the
+candidate set could never contain an artist you had not already listened to. A
+record that sounds exactly like your favourite album was unreachable if you had
+never played that artist.
+
+**The mechanism is ADR-0093's, pointed at a different collection**, and this module
+is deliberately thin because of that. Seeds are what you play; the exclusion set is
+what you have heard; the result is agreement between seeds, never their average.
+That last point is load-bearing and was learned the hard way — see
+`collection_suggestions`, which records that averaging embeddings was tried at two
+scales and returned the library's most generically average music both times.
+"""
+
+from __future__ import annotations
+
+import logging
+from uuid import UUID
+
+from sqlalchemy import select
+from sqlalchemy.ext.asyncio import AsyncSession
+
+from app.db.models import ProfilePlayHistory, Track
+from app.services.collection_suggestions import (
+    SEED_SAMPLE_CAP,
+    Suggestion,
+    suggest_for_collection,
+)
+
+logger = logging.getLogger(__name__)
+
+#: Plays above which a track counts as "heard" and stops being a candidate.
+#:
+#: Not 1. Excluding everything with any play history would drop the case the old
+#: `deep_cuts` list existed for — a track played once, years ago, and forgotten — and
+#: this section replaces that list rather than joining it. Three is low enough that
+#: anything genuinely in rotation is excluded, and high enough that a track you
+#: sampled once can still come back.
+HEARD_THRESHOLD = 3
+
+#: **A candidate needs features, not just an embedding.** `collection_suggestions`
+#: requires `TrackAnalysis.energy` to be present — a track with no features cannot be
+#: scored — so a track analysed for embeddings but not features is invisible here.
+#: Measured on the production library 2026-08-31: 736 of 26,471 embedded tracks, or
+#: 2.8%. Small enough to accept and specific enough to be worth writing down, because
+#: the symptom is a track that never appears and no error anywhere.
+
+
+async def suggest_rediscovery(
+    db: AsyncSession,
+    *,
+    profile_id: UUID,
+    limit: int = 15,
+) -> tuple[list[Suggestion], int]:
+    """Unheard library tracks ranked against recent listening.
+
+    Returns the suggestions and the number of seeds behind them, because a caller
+    showing an empty list has to be able to say *why* — no listening history and
+    nothing similar found are different answers, and ADR-0101 point 7 says a surface
+    returning nothing is a defect rather than a silence.
+    """
+    # Most-recent-first: `suggest_for_collection` samples from the head, so this is
+    # what makes the suggestions track current taste rather than all-time taste.
+    seed_rows = (
+        await db.execute(
+            select(ProfilePlayHistory.track_id)
+            .join(Track, ProfilePlayHistory.track_id == Track.id)
+            .where(
+                ProfilePlayHistory.profile_id == profile_id,
+                Track.active_filter(),
+            )
+            .order_by(ProfilePlayHistory.last_played_at.desc().nullslast())
+        )
+    ).scalars().all()
+    seed_ids = list(seed_rows)
+
+    if not seed_ids:
+        return [], 0
+
+    # Exclude what has been heard, which is a wider set than the seeds — ADR-0093
+    # point 4: once the seed is a sample, "exclude the seed" and "exclude what you
+    # already have" stop being the same set, and the difference shows up as a
+    # suggestion the listener plays every week.
+    heard_ids = set(
+        (
+            await db.execute(
+                select(ProfilePlayHistory.track_id).where(
+                    ProfilePlayHistory.profile_id == profile_id,
+                    ProfilePlayHistory.play_count >= HEARD_THRESHOLD,
+                )
+            )
+        )
+        .scalars()
+        .all()
+    )
+
+    suggestions = await suggest_for_collection(
+        db,
+        seed_track_ids=seed_ids[:SEED_SAMPLE_CAP],
+        exclude_track_ids=heard_ids,
+        # Carries ADR-0004's rejection signal into discovery (ADR-0101 point 4):
+        # `_demote_rejected` reads it, so a track the listener has already dismissed
+        # does not come back at the top of the list.
+        profile_id=profile_id,
+        limit=limit,
+    )
+    return suggestions, len(seed_ids)

--- a/backend/app/services/rediscovery.py
+++ b/backend/app/services/rediscovery.py
@@ -107,6 +107,11 @@ async def suggest_rediscovery(
         db,
         seed_track_ids=seed_ids[:SEED_SAMPLE_CAP],
         exclude_track_ids=heard_ids,
+        # Excluded by id at three plays, but *any* play makes a recording known well
+        # enough that a second file of it is not a discovery. Keeping these separate
+        # is what lets a track played twice come back as itself — a deep cut — while
+        # its duplicate does not.
+        duplicate_key_ids=set(seed_ids),
         # Carries ADR-0004's rejection signal into discovery (ADR-0101 point 4):
         # `_demote_rejected` reads it, so a track the listener has already dismissed
         # does not come back at the top of the list.

--- a/backend/openapi.json
+++ b/backend/openapi.json
@@ -7489,6 +7489,10 @@
               "null"
             ]
           },
+          "play_count": {
+            "title": "Play Count",
+            "type": "integer"
+          },
           "similarity": {
             "title": "Similarity",
             "type": "number"
@@ -7505,6 +7509,7 @@
           "track",
           "because_of_title",
           "because_of_artist",
+          "play_count",
           "similarity",
           "votes"
         ],

--- a/backend/openapi.json
+++ b/backend/openapi.json
@@ -2622,13 +2622,6 @@
       "DiscoverResponse": {
         "description": "Aggregated discovery data for the dashboard.",
         "properties": {
-          "deep_cuts": {
-            "items": {
-              "$ref": "#/components/schemas/DiscoverTrack"
-            },
-            "title": "Deep Cuts",
-            "type": "array"
-          },
           "recently_added_count": {
             "title": "Recently Added Count",
             "type": "integer"
@@ -2640,17 +2633,21 @@
             "title": "Recommended Artists",
             "type": "array"
           },
-          "unheard_tracks": {
+          "rediscovery": {
             "items": {
-              "$ref": "#/components/schemas/DiscoverTrack"
+              "$ref": "#/components/schemas/RediscoverySuggestion"
             },
-            "title": "Unheard Tracks",
+            "title": "Rediscovery",
             "type": "array"
+          },
+          "rediscovery_seed_count": {
+            "title": "Rediscovery Seed Count",
+            "type": "integer"
           }
         },
         "required": [
-          "unheard_tracks",
-          "deep_cuts",
+          "rediscovery",
+          "rediscovery_seed_count",
           "recommended_artists",
           "recently_added_count"
         ],
@@ -7473,6 +7470,45 @@
           "local_track_id"
         ],
         "title": "RecommendedTrackResponse",
+        "type": "object"
+      },
+      "RediscoverySuggestion": {
+        "description": "An unheard library track, and the played track that reached it.",
+        "properties": {
+          "because_of_artist": {
+            "title": "Because Of Artist",
+            "type": [
+              "string",
+              "null"
+            ]
+          },
+          "because_of_title": {
+            "title": "Because Of Title",
+            "type": [
+              "string",
+              "null"
+            ]
+          },
+          "similarity": {
+            "title": "Similarity",
+            "type": "number"
+          },
+          "track": {
+            "$ref": "#/components/schemas/DiscoverTrack"
+          },
+          "votes": {
+            "title": "Votes",
+            "type": "integer"
+          }
+        },
+        "required": [
+          "track",
+          "because_of_title",
+          "because_of_artist",
+          "similarity",
+          "votes"
+        ],
+        "title": "RediscoverySuggestion",
         "type": "object"
       },
       "RefetchGeneratedResponse": {

--- a/backend/tests/test_rediscovery.py
+++ b/backend/tests/test_rediscovery.py
@@ -76,7 +76,7 @@ async def test_an_unheard_track_by_an_artist_never_played_can_surface(async_db):
     suggestions, seed_count = await suggest_rediscovery(async_db, profile_id=profile.id)
 
     assert seed_count == 1
-    names = {s.track.artist for s in suggestions}
+    names = {r.suggestion.track.artist for r in suggestions}
     assert "Never Played Artist" in names, (
         "the candidate pool must not be limited to artists already played"
     )
@@ -104,10 +104,10 @@ async def test_every_suggestion_carries_a_real_played_track_as_its_reason(async_
     suggestions, _ = await suggest_rediscovery(async_db, profile_id=profile.id)
 
     assert suggestions
-    for s in suggestions:
-        assert s.because_of is not None
-        assert s.because_of.id == seed.id
-        assert s.similarity > 0
+    for r in suggestions:
+        assert r.because_of is not None
+        assert r.because_of.id == seed.id
+        assert r.suggestion.similarity > 0
 
 
 @pytest.mark.asyncio
@@ -134,7 +134,7 @@ async def test_a_track_in_rotation_is_not_suggested_back(async_db):
 
     suggestions, _ = await suggest_rediscovery(async_db, profile_id=profile.id)
 
-    assert in_rotation.id not in {s.track.id for s in suggestions}
+    assert in_rotation.id not in {r.suggestion.track.id for r in suggestions}
 
 
 @pytest.mark.asyncio
@@ -165,7 +165,7 @@ async def test_a_track_played_once_long_ago_can_still_come_back(async_db):
 
     suggestions, _ = await suggest_rediscovery(async_db, profile_id=profile.id)
 
-    assert forgotten.id in {s.track.id for s in suggestions}, (
+    assert forgotten.id in {r.suggestion.track.id for r in suggestions}, (
         "a track sampled once years ago is exactly what rediscovery is for"
     )
 
@@ -200,7 +200,39 @@ async def test_a_second_file_of_a_played_track_is_not_suggested(async_db):
 
     suggestions, _ = await suggest_rediscovery(async_db, profile_id=profile.id)
 
-    dupes = [s for s in suggestions if s.track.title == "Anywhere" and s.track.id != played.id]
+    dupes = [
+        r for r in suggestions
+        if r.suggestion.track.title == "Anywhere" and r.suggestion.track.id != played.id
+    ]
     assert not dupes, "a duplicate file of a played track is not a discovery"
-    titles = {s.track.title for s in suggestions}
+    titles = {r.suggestion.track.title for r in suggestions}
     assert "Genuinely New" in titles, "and the real suggestion still comes through"
+
+
+@pytest.mark.asyncio
+async def test_a_track_that_reaches_itself_does_not_borrow_a_reason(async_db):
+    """"Because you play Anywhere" — about Anywhere — is not a reason.
+
+    A track played once is below `HEARD_THRESHOLD`, so it is both a seed and a
+    candidate, and it reaches itself at similarity 1.0. That is the deep-cut case
+    working correctly; the defect was presentational. Four of the first fifteen live
+    suggestions read this way, and I spent three commits fixing a duplicate-file bug
+    that was not the cause before checking the database and finding one row, not two.
+
+    `because_of` is `None` for these, and the caller says "played once" instead.
+    """
+    profile = await insert_test_profile(async_db)
+    once = await _track_with_embedding(
+        async_db, title="Anywhere", artist="Interpol", embedding=_vec(1.0)
+    )
+    await insert_test_play_history(
+        async_db, profile.id, once.id, play_count=1, last_played_at=utcnow()
+    )
+    await async_db.commit()
+
+    suggestions, _ = await suggest_rediscovery(async_db, profile_id=profile.id)
+
+    self_reached = [r for r in suggestions if r.suggestion.track.id == once.id]
+    assert self_reached, "a track played once should still be resurfaced"
+    assert self_reached[0].because_of is None, "it cannot be its own reason"
+    assert self_reached[0].play_count == 1, "so the caller can say 'played once'"

--- a/backend/tests/test_rediscovery.py
+++ b/backend/tests/test_rediscovery.py
@@ -190,13 +190,17 @@ async def test_a_second_file_of_a_played_track_is_not_suggested(async_db):
     await _track_with_embedding(
         async_db, title="Genuinely New", artist="Someone Else", embedding=_vec(0.97)
     )
+    # Played *twice* — below HEARD_THRESHOLD, so not excluded by id. This is the
+    # production shape: the duplicate slipped through two earlier versions of the
+    # filter precisely because the played copy was not in the excluded set.
     await insert_test_play_history(
-        async_db, profile.id, played.id, play_count=10, last_played_at=utcnow()
+        async_db, profile.id, played.id, play_count=2, last_played_at=utcnow()
     )
     await async_db.commit()
 
     suggestions, _ = await suggest_rediscovery(async_db, profile_id=profile.id)
 
+    dupes = [s for s in suggestions if s.track.title == "Anywhere" and s.track.id != played.id]
+    assert not dupes, "a duplicate file of a played track is not a discovery"
     titles = {s.track.title for s in suggestions}
-    assert "Anywhere" not in titles, "a duplicate file of a played track is not a discovery"
     assert "Genuinely New" in titles, "and the real suggestion still comes through"

--- a/backend/tests/test_rediscovery.py
+++ b/backend/tests/test_rediscovery.py
@@ -168,3 +168,35 @@ async def test_a_track_played_once_long_ago_can_still_come_back(async_db):
     assert forgotten.id in {s.track.id for s in suggestions}, (
         "a track sampled once years ago is exactly what rediscovery is for"
     )
+
+
+@pytest.mark.asyncio
+async def test_a_second_file_of_a_played_track_is_not_suggested(async_db):
+    """"Listen to this thing you already play" is worse than no suggestion.
+
+    `exclude_track_ids` works on ids, so a library holding the same recording twice
+    has one copy excluded and the other free to come back — with similarity 1.0 and
+    its own seed as the reason. Four of ten suggestions did exactly this on the live
+    library the day rediscovery shipped.
+    """
+    profile = await insert_test_profile(async_db)
+    played = await _track_with_embedding(
+        async_db, title="Anywhere", artist="Interpol", embedding=_vec(1.0)
+    )
+    # A second file of the same recording: different row, identical metadata.
+    await _track_with_embedding(
+        async_db, title="Anywhere", artist="Interpol", embedding=_vec(1.0)
+    )
+    await _track_with_embedding(
+        async_db, title="Genuinely New", artist="Someone Else", embedding=_vec(0.97)
+    )
+    await insert_test_play_history(
+        async_db, profile.id, played.id, play_count=10, last_played_at=utcnow()
+    )
+    await async_db.commit()
+
+    suggestions, _ = await suggest_rediscovery(async_db, profile_id=profile.id)
+
+    titles = {s.track.title for s in suggestions}
+    assert "Anywhere" not in titles, "a duplicate file of a played track is not a discovery"
+    assert "Genuinely New" in titles, "and the real suggestion still comes through"

--- a/backend/tests/test_rediscovery.py
+++ b/backend/tests/test_rediscovery.py
@@ -1,0 +1,170 @@
+"""Owned, unheard, ranked against real listening (ADR-0101).
+
+The largest discovery opportunity in the product: 23,683 of 26,434 tracks on the
+production library have never been played, and a streaming service cannot compete
+on a collection it cannot see.
+"""
+
+from datetime import timedelta
+
+import pytest
+
+from app.services.rediscovery import HEARD_THRESHOLD, suggest_rediscovery
+from app.utils.time import utcnow
+from tests.factories import (
+    insert_test_analysis,
+    insert_test_play_history,
+    insert_test_profile,
+    insert_test_track,
+)
+
+
+async def _track_with_embedding(async_db, *, title, artist, embedding):
+    """A track carrying an embedding, which is what the ranker needs to see it."""
+    track = await insert_test_track(async_db, title=title, artist=artist, album=artist)
+    # `energy` as well as the embedding: the vote query requires it, because a
+    # candidate with no features cannot be scored. A track analysed for embeddings but
+    # not features is invisible to rediscovery — see the note in `suggest_rediscovery`.
+    await insert_test_analysis(
+        async_db, track.id, {"embedding": embedding, "energy": 0.5}
+    )
+    return track
+
+
+def _vec(lead: float) -> list[float]:
+    """A 512-dim vector whose first component dominates, so similarity is controllable."""
+    return [lead] + [0.0] * 511
+
+
+@pytest.mark.asyncio
+async def test_no_listening_history_returns_nothing_and_says_so(async_db):
+    """An empty result must be able to explain itself (ADR-0101 point 7).
+
+    Zero seeds and "nothing similar found" are different answers, and a surface that
+    renders both as an empty list is the defect this ADR is about.
+    """
+    profile = await insert_test_profile(async_db)
+    await insert_test_track(async_db, artist="Unplayed", album="A")
+    await async_db.commit()
+
+    suggestions, seed_count = await suggest_rediscovery(async_db, profile_id=profile.id)
+
+    assert suggestions == []
+    assert seed_count == 0
+
+
+@pytest.mark.asyncio
+async def test_an_unheard_track_by_an_artist_never_played_can_surface(async_db):
+    """The limit that made the old list useless, removed.
+
+    `unheard_tracks` filtered candidates to `Track.canonical_artist_id.in_(top_artists)`,
+    so a record that sounds exactly like a favourite was unreachable if its artist had
+    never been played. The candidate pool is now the whole library.
+    """
+    profile = await insert_test_profile(async_db)
+    seed = await _track_with_embedding(
+        async_db, title="Played", artist="Known Artist", embedding=_vec(1.0)
+    )
+    await _track_with_embedding(
+        async_db, title="Sounds Alike", artist="Never Played Artist", embedding=_vec(0.99)
+    )
+    await insert_test_play_history(
+        async_db, profile.id, seed.id, play_count=10, last_played_at=utcnow()
+    )
+    await async_db.commit()
+
+    suggestions, seed_count = await suggest_rediscovery(async_db, profile_id=profile.id)
+
+    assert seed_count == 1
+    names = {s.track.artist for s in suggestions}
+    assert "Never Played Artist" in names, (
+        "the candidate pool must not be limited to artists already played"
+    )
+
+
+@pytest.mark.asyncio
+async def test_every_suggestion_carries_a_real_played_track_as_its_reason(async_db):
+    """ADR-0101 point 3, inherited from ADR-0093.
+
+    Three attempts at naming a cluster failed; "because you play X" is true and
+    checkable where a generated label is neither.
+    """
+    profile = await insert_test_profile(async_db)
+    seed = await _track_with_embedding(
+        async_db, title="The Seed", artist="Seed Artist", embedding=_vec(1.0)
+    )
+    await _track_with_embedding(
+        async_db, title="Candidate", artist="Other", embedding=_vec(0.98)
+    )
+    await insert_test_play_history(
+        async_db, profile.id, seed.id, play_count=5, last_played_at=utcnow()
+    )
+    await async_db.commit()
+
+    suggestions, _ = await suggest_rediscovery(async_db, profile_id=profile.id)
+
+    assert suggestions
+    for s in suggestions:
+        assert s.because_of is not None
+        assert s.because_of.id == seed.id
+        assert s.similarity > 0
+
+
+@pytest.mark.asyncio
+async def test_a_track_in_rotation_is_not_suggested_back(async_db):
+    """Suggesting something played every week is the failure mode of a bad ranker."""
+    profile = await insert_test_profile(async_db)
+    seed = await _track_with_embedding(
+        async_db, title="Seed", artist="A", embedding=_vec(1.0)
+    )
+    in_rotation = await _track_with_embedding(
+        async_db, title="In Rotation", artist="B", embedding=_vec(0.99)
+    )
+    await insert_test_play_history(
+        async_db, profile.id, seed.id, play_count=20, last_played_at=utcnow()
+    )
+    await insert_test_play_history(
+        async_db,
+        profile.id,
+        in_rotation.id,
+        play_count=HEARD_THRESHOLD + 5,
+        last_played_at=utcnow(),
+    )
+    await async_db.commit()
+
+    suggestions, _ = await suggest_rediscovery(async_db, profile_id=profile.id)
+
+    assert in_rotation.id not in {s.track.id for s in suggestions}
+
+
+@pytest.mark.asyncio
+async def test_a_track_played_once_long_ago_can_still_come_back(async_db):
+    """The case the old `deep_cuts` list existed for, kept.
+
+    This section replaces that list rather than joining it, so excluding everything
+    with any play history at all would have silently dropped what it covered.
+    """
+    profile = await insert_test_profile(async_db)
+    seed = await _track_with_embedding(
+        async_db, title="Seed", artist="A", embedding=_vec(1.0)
+    )
+    forgotten = await _track_with_embedding(
+        async_db, title="Forgotten", artist="B", embedding=_vec(0.99)
+    )
+    await insert_test_play_history(
+        async_db, profile.id, seed.id, play_count=20, last_played_at=utcnow()
+    )
+    await insert_test_play_history(
+        async_db,
+        profile.id,
+        forgotten.id,
+        play_count=1,
+        last_played_at=utcnow() - timedelta(days=900),
+    )
+    await async_db.commit()
+
+    suggestions, _ = await suggest_rediscovery(async_db, profile_id=profile.id)
+
+    assert forgotten.id in {s.track.id for s in suggestions}, (
+        "a track sampled once years ago is exactly what rediscovery is for"
+    )

--- a/packages/frontend/src/api/library.ts
+++ b/packages/frontend/src/api/library.ts
@@ -562,8 +562,14 @@ export interface DiscoverRecommendedArtist {
 }
 
 export interface LibraryDiscoverResponse {
-  unheard_tracks: DiscoverTrack[];
-  deep_cuts: DiscoverTrack[];
+  /**
+   * Owned, unheard, ranked against listening (ADR-0101). Replaces `unheard_tracks`
+   * and `deep_cuts`, which were random picks limited to artists already played.
+   */
+  rediscovery: RediscoverySuggestion[];
+  /** Seeds behind the list, so an empty result can distinguish "no listening
+   *  history yet" from "nothing similar found". */
+  rediscovery_seed_count: number;
   recommended_artists: DiscoverRecommendedArtist[];
   recently_added_count: number;
 }

--- a/packages/frontend/src/components/Discovery/hooks/useLibraryDiscovery.tsx
+++ b/packages/frontend/src/components/Discovery/hooks/useLibraryDiscovery.tsx
@@ -41,9 +41,13 @@ export function useLibraryDiscovery({
         id: s.track.id,
         entityType: 'track' as const,
         name: s.track.title || 'Unknown Track',
+        // A self-reached track has no *other* track to justify it, so it says what
+        // is actually true about it instead of borrowing a reason.
         subtitle: s.because_of_title
           ? `${s.track.artist || 'Unknown Artist'} · because you play ${s.because_of_title}`
-          : s.track.artist || 'Unknown Artist',
+          : s.play_count > 0
+            ? `${s.track.artist || 'Unknown Artist'} · played ${s.play_count === 1 ? 'once' : `${s.play_count} times`}, long ago`
+            : s.track.artist || 'Unknown Artist',
         inLibrary: true,
         playbackContext: {
           artist: s.track.artist || '',

--- a/packages/frontend/src/components/Discovery/hooks/useLibraryDiscovery.tsx
+++ b/packages/frontend/src/components/Discovery/hooks/useLibraryDiscovery.tsx
@@ -29,55 +29,37 @@ export function useLibraryDiscovery({
 
     const sections: DiscoverySection[] = [];
 
-    // Section 1: Unheard tracks by top artists
-    if (data.unheard_tracks && data.unheard_tracks.length > 0) {
-      const items: DiscoveryItem[] = data.unheard_tracks.map((track) => ({
-        id: track.id,
+    // Section 1: rediscovery — owned, unheard, ranked against real listening.
+    //
+    // Replaces the old "Unheard in Your Library" and "Deep Cuts", which were
+    // `ORDER BY random()` over tracks by artists already played. The subtitle now
+    // carries *why* each track is here — a real played track, not a generated label
+    // (ADR-0101 point 3, inherited from ADR-0093's three failed attempts at naming a
+    // cluster).
+    if (data.rediscovery && data.rediscovery.length > 0) {
+      const items: DiscoveryItem[] = data.rediscovery.map((s) => ({
+        id: s.track.id,
         entityType: 'track' as const,
-        name: track.title || 'Unknown Track',
-        subtitle: track.artist || 'Unknown Artist',
+        name: s.track.title || 'Unknown Track',
+        subtitle: s.because_of_title
+          ? `${s.track.artist || 'Unknown Artist'} · because you play ${s.because_of_title}`
+          : s.track.artist || 'Unknown Artist',
         inLibrary: true,
         playbackContext: {
-          artist: track.artist || '',
-          album: track.album || undefined,
-          trackId: track.id,
+          artist: s.track.artist || '',
+          album: s.track.album || undefined,
+          trackId: s.track.id,
         },
       }));
 
       sections.push({
-        id: 'unheard-tracks',
-        title: 'Unheard in Your Library',
-        description: "Tracks by artists you love that you haven't played yet",
+        id: 'rediscovery',
+        title: 'In Your Library, Unheard',
+        description: 'Ranked against what you actually listen to',
         entityType: 'track',
         items,
         layout: 'tracklist',
-        rawTracks: data.unheard_tracks,
-      });
-    }
-
-    // Section 2: Deep cuts (low play count)
-    if (data.deep_cuts && data.deep_cuts.length > 0) {
-      const items: DiscoveryItem[] = data.deep_cuts.map((track) => ({
-        id: track.id,
-        entityType: 'track' as const,
-        name: track.title || 'Unknown Track',
-        subtitle: `${track.artist || 'Unknown Artist'} · ${track.play_count} ${track.play_count === 1 ? 'play' : 'plays'}`,
-        inLibrary: true,
-        playbackContext: {
-          artist: track.artist || '',
-          album: track.album || undefined,
-          trackId: track.id,
-        },
-      }));
-
-      sections.push({
-        id: 'deep-cuts',
-        title: 'Deep Cuts by Your Favorites',
-        description: 'Least-played tracks by your most-played artists',
-        entityType: 'track',
-        items,
-        layout: 'tracklist',
-        rawTracks: data.deep_cuts,
+        rawTracks: data.rediscovery.map((s) => s.track),
       });
     }
 

--- a/packages/frontend/src/components/Discovery/types.ts
+++ b/packages/frontend/src/components/Discovery/types.ts
@@ -204,32 +204,3 @@ export interface PlaylistDiscoveryInput {
   sourcesUsed: string[];
 }
 
-// From LibraryDiscoverResponse
-export interface LibraryDiscoveryInput {
-  unheardTracks: Array<{
-    id: string;
-    title: string | null;
-    artist: string | null;
-    album: string | null;
-    duration_seconds: number | null;
-    play_count: number;
-  }>;
-  deepCuts: Array<{
-    id: string;
-    title: string | null;
-    artist: string | null;
-    album: string | null;
-    duration_seconds: number | null;
-    play_count: number;
-  }>;
-  recommendedArtists: Array<{
-    name: string;
-    match_score: number;
-    in_library: boolean;
-    track_count: number | null;
-    image_url: string | null;
-    lastfm_url: string | null;
-    bandcamp_url: string | null;
-    based_on_artist: string;
-  }>;
-}


### PR DESCRIPTION
ADR-0101 points 2–5. The largest discovery opportunity in the product — **23,683 of 26,434 tracks have never been played** — and the one a streaming service structurally cannot compete on, because it cannot see a collection it doesn't host.

### What it replaces was worse than shallow

`unheard_tracks` and `deep_cuts` were `ORDER BY random()` over tracks by artists **already played**. Two limits, and the second is the one that mattered: the ordering wasn't a ranking at all, and the candidate pool could never contain an artist you hadn't already played. A record that sounds exactly like your favourite album was unreachable *by construction*.

### Nothing new is built

The mechanism is ADR-0093's `suggest_for_collection` pointed at a different collection: seeds are what you play (most-recent-first, so it tracks current taste), the exclusion is what you've heard, and the result is **agreement between seeds, never their average** — `collection_suggestions` records that averaging embeddings was tried at two scales and returned the library's most generically average music both times.

`profile_id` is passed through, so ADR-0004's rejection signal reaches discovery for the first time.

### Live on the 26k library

```
Interpol             — Anywhere                  played 1×, long ago
Plaid                — Buns                      because you play Equip — CEMETERY MOONGLOW
Black Rebel Motorcyc — In Like The Rose          because you play Interpol — Twice as Hard
Discoverer           — Memories                  because you play Ochre — Vegas
Mega Drive           — Dataline                  because you play Com Truise — Colorvision
Coldcut              — Colours The Soul          because you play The Chemical Brothers
```

1.4s, and every suggestion explains itself with a real pair of tracks.

### I diagnosed one defect wrong, twice

Four of the first fifteen suggestions read *"Interpol — Anywhere, because you play Interpol — Anywhere"*. I assumed duplicate files and spent two commits building a duplicate-recording filter. **Querying the library showed one row, not two.**

The real cause: a track played once is below `HEARD_THRESHOLD`, so it's both seed and candidate and reaches itself at similarity 1.0. The suggestion was *correct* — that's the forgotten-deep-cut case working. The reason was nonsense, because there was no other track to justify it and the code borrowed the only one it had. `because_of` is now `null` for those, and the UI says "played once, long ago".

Three tests passed throughout, because no fixture had a track that was both seed and candidate. There's now one that does.

The duplicate filter stays — built for the wrong reason, but the case is real (`_drop_duplicate_recordings` documents a library where a recording is filed twice) and it now guards it correctly, with the candidate exempt from its own key so deep cuts survive.

### Also recorded

`HEARD_THRESHOLD = 3` rather than excluding anything with a play, so a track sampled once years ago can still come back — the case `deep_cuts` existed for, which this replaces rather than joins.

The ranker requires `TrackAnalysis.energy`, not just an embedding, so a track analysed for embeddings but not features is **invisible here with no error anywhere** — 736 of 26,471, 2.8%. Small enough to accept, specific enough to write down.

`LibraryDiscoveryInput` deleted: declared, referenced nowhere, and its fields named the two lists this removes.

1,758 backend and 369 frontend tests pass; the 4 backend failures are pre-existing on `main`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01Emjrwedq7W1scadHdgiLfs