### PR TITLE
ListenBrainz becomes a discovery source, and Bandcamp does not

### DIFF
--- a/backend/app/services/background/manager.py
+++ b/backend/app/services/background/manager.py
@@ -23,6 +23,15 @@ logger = logging.getLogger(__name__)
 DISCOVERY_INTERVAL_MINUTES = 20
 DISCOVERY_BATCH_SIZE = 10
 
+#: ListenBrainz runs on its own, much slower cadence (ADR-0099 point 11).
+#:
+#: It is a different *shape* of request: one call returning every fresh release
+#: rather than one call per artist. Folding it into the twenty-minute batch would
+#: fetch well over a megabyte to look at ten artists. Three hours is eight calls a
+#: day against a limit that reports 30 remaining per window, and the source's
+#: thirty-day lookback means nothing is missed between runs.
+LISTENBRAINZ_INTERVAL_HOURS = 3
+
 
 class BackgroundManager(ExecutorMixin, AnalysisMixin, SyncMixin, BackupMixin):
     """Manages background tasks in the API process.
@@ -151,6 +160,16 @@ class BackgroundManager(ExecutorMixin, AnalysisMixin, SyncMixin, BackupMixin):
                 self._daily_external_albums_refresh,
                 CronTrigger(hour=3, minute=15),
                 id="daily_external_albums",
+                replace_existing=True,
+            )
+
+            self._scheduler.add_job(
+                self._listenbrainz_fresh_releases,
+                IntervalTrigger(hours=LISTENBRAINZ_INTERVAL_HOURS),
+                id="listenbrainz_fresh_releases",
+                max_instances=1,
+                coalesce=True,
+                misfire_grace_time=600,
                 replace_existing=True,
             )
 

--- a/backend/app/services/background/sync.py
+++ b/backend/app/services/background/sync.py
@@ -435,6 +435,22 @@ class SyncMixin(_SyncBase):
         except Exception as e:
             logger.warning(f"Discovery batch failed: {e}")
 
+    async def _listenbrainz_fresh_releases(self) -> None:
+        """APScheduler entry: one ListenBrainz call, filtered to this library.
+
+        No profile loop: unlike the recommendation refresh below, what ListenBrainz
+        returns is filtered by *library* artists rather than by anyone's play history,
+        so the result is the same for every listener and doing it once is right.
+        """
+        from app.services.tasks.listenbrainz_releases import (
+            run_listenbrainz_fresh_releases,
+        )
+
+        try:
+            await run_listenbrainz_fresh_releases()
+        except Exception as e:
+            logger.warning(f"ListenBrainz fresh releases failed: {e}")
+
     async def _daily_external_albums_refresh(self) -> None:
         """APScheduler entry: recompute "Albums you might want" for every profile.
 

--- a/backend/app/services/discovery/listenbrainz.py
+++ b/backend/app/services/discovery/listenbrainz.py
@@ -1,0 +1,153 @@
+"""ListenBrainz fresh releases, filtered to artists in this library (ADR-0099 §11).
+
+**One request, then local filtering.** MusicBrainz discovery asks a question per
+artist and is bounded by a one-request-per-second limit; this asks once for
+everything released recently and intersects the answer with the library. Measured
+2026-08-31 against the live library: 7,713 releases in the last 30 days, 2,625
+library artists carrying a MusicBrainz id, **225 matches** — for a single HTTP call.
+
+**It shares MusicBrainz identifiers, which is the whole reason to prefer it.**
+`release_group_mbid` is the same id `external_album_cache.release_id` already holds
+for MusicBrainz-sourced rows, so a release found by both sources collapses onto one
+row through the existing partial unique index. No fuzzy artist matching anywhere,
+which is where cross-source discovery usually goes wrong — and where Bandcamp
+failed this same evaluation: its search has no release dates at all and returns
+*Dödsrit — Mortal Coil* when asked for *Coil*.
+
+It also rate-limits **explicitly**, returning `X-RateLimit-Remaining` and
+`X-RateLimit-Reset-In`, against MusicBrainz's silent 503 with a retry buried in a
+library's `INFO` log. A source that says how much budget is left can be treated
+honestly; one that does not has to be inferred from timeouts.
+
+No token is required for the sitewide endpoint. The personalised
+`/1/user/{user}/fresh_releases` would need a ListenBrainz account with listening
+history in it, which a Last.fm scrobbler does not have — so the personalisation
+here comes from *our* library rather than from theirs, which is both better and
+free.
+"""
+
+from __future__ import annotations
+
+import logging
+from datetime import datetime
+from typing import Any
+
+import httpx
+
+logger = logging.getLogger(__name__)
+
+FRESH_RELEASES_URL = "https://api.listenbrainz.org/1/explore/fresh-releases/"
+
+#: How far back to ask. Thirty days is the window that produced 225 matches; the job
+#: runs far more often than that, so the overlap is deliberate — a release added to
+#: MusicBrainz late still gets seen.
+DEFAULT_DAYS = 30
+
+#: The response is large (≈1.4 MB for 14 days, more for 30), so the timeout is
+#: generous relative to the rest of discovery. It is one call, not one per artist.
+REQUEST_TIMEOUT_SECONDS = 45.0
+
+#: MusicBrainz's "Various Artists" placeholder. **Excluded, and it is not a detail:**
+#: 81 of the 225 live matches were compilations credited to it. It is a credit, not
+#: an artist anyone follows, and leaving it in makes the surface look like a firehose
+#: of unrelated compilations.
+VARIOUS_ARTISTS_MBID = "89ad4ac3-39f7-470e-963a-56509c546377"
+
+#: Album and EP only. Of the live matches, 54 were singles — mostly promotional — and
+#: a handful were broadcasts. `recommendations.py` already draws this line at
+#: album+ep for its own MusicBrainz queries, so this agrees with it rather than
+#: inventing a second rule.
+WANTED_TYPES = {"Album", "EP"}
+
+
+def _parse_release_date(value: Any) -> datetime | None:
+    """ListenBrainz returns ISO dates; anything else is not worth a guess."""
+    if not isinstance(value, str) or not value:
+        return None
+    try:
+        return datetime.fromisoformat(value)
+    except ValueError:
+        return None
+
+
+async def fetch_fresh_releases(
+    *, days: int = DEFAULT_DAYS, client: httpx.AsyncClient | None = None
+) -> tuple[list[dict[str, Any]], dict[str, str]]:
+    """Every release ListenBrainz considers fresh, plus its rate-limit headers.
+
+    Returns the raw list unfiltered — deciding what is relevant needs the library,
+    which this module does not reach into. The headers are returned rather than
+    logged because the caller records them as health.
+    """
+    owns_client = client is None
+    client = client or httpx.AsyncClient(timeout=REQUEST_TIMEOUT_SECONDS)
+    try:
+        response = await client.get(
+            FRESH_RELEASES_URL,
+            params={"days": days, "sort": "release_date"},
+            headers={"User-Agent": "Familiar (https://github.com/seethroughlab/familiar)"},
+        )
+        rate = {
+            key: value
+            for key, value in response.headers.items()
+            if key.lower().startswith("x-ratelimit")
+        }
+        response.raise_for_status()
+        payload = response.json().get("payload") or {}
+        releases = payload.get("releases") or []
+        if not isinstance(releases, list):
+            # A 200 with an unexpected shape is a failure, not an empty result. The
+            # difference matters: one is "nothing new", the other is "we cannot read
+            # this any more", and they must not both render as silence.
+            raise ValueError(f"unexpected payload shape: {type(releases).__name__}")
+        return releases, rate
+    finally:
+        if owns_client:
+            await client.aclose()
+
+
+def select_for_library(
+    releases: list[dict[str, Any]],
+    library_artist_mbids: dict[str, str],
+) -> list[dict[str, Any]]:
+    """Releases by artists this library owns, normalised for the cache writer.
+
+    ``library_artist_mbids`` maps a MusicBrainz artist id to the library's own name
+    for that artist — the local name is preferred over ListenBrainz's
+    ``artist_credit_name`` so a release lands under the same spelling the rest of the
+    library uses, and joins the existing rows for that artist.
+    """
+    selected: list[dict[str, Any]] = []
+    for release in releases:
+        if release.get("release_group_primary_type") not in WANTED_TYPES:
+            continue
+        release_group = release.get("release_group_mbid")
+        if not release_group:
+            # Without it there is no stable identity, and the partial unique index
+            # that dedupes against MusicBrainz rows has nothing to key on.
+            continue
+
+        artist_mbids = release.get("artist_mbids") or []
+        if VARIOUS_ARTISTS_MBID in artist_mbids:
+            continue
+
+        matched = next((mbid for mbid in artist_mbids if mbid in library_artist_mbids), None)
+        if matched is None:
+            continue
+
+        selected.append(
+            {
+                "artist_name": library_artist_mbids[matched],
+                "musicbrainz_artist_id": matched,
+                "release_id": release_group,
+                "release_name": release.get("release_name") or "Unknown",
+                "release_type": (release.get("release_group_primary_type") or "").lower() or None,
+                "release_date": _parse_release_date(release.get("release_date")),
+                "artwork_url": (
+                    f"https://coverartarchive.org/release/{release['caa_release_mbid']}/front-250"
+                    if release.get("caa_release_mbid")
+                    else None
+                ),
+            }
+        )
+    return selected

--- a/backend/app/services/tasks/listenbrainz_releases.py
+++ b/backend/app/services/tasks/listenbrainz_releases.py
@@ -1,0 +1,125 @@
+"""Pull ListenBrainz fresh releases into the discovery cache (ADR-0099 §11).
+
+Runs on its own cadence rather than inside the per-artist batch, because it is a
+different shape of request: one large call covering every artist at once, instead
+of one small call per artist. Folding it into the twenty-minute batch would fetch
+a megabyte of releases to look at ten artists.
+"""
+
+from __future__ import annotations
+
+import logging
+from typing import Any
+
+import httpx
+from sqlalchemy import select
+
+logger = logging.getLogger(__name__)
+
+SOURCE = "listenbrainz"
+
+
+async def run_listenbrainz_fresh_releases(days: int | None = None) -> dict[str, Any]:
+    """Fetch fresh releases, keep the ones this library's artists made, cache them.
+
+    Writes through ``NewReleasesService.save_discovered_release``, so rows land in
+    the same ``artist_new_release`` context the MusicBrainz path uses and dedupe
+    against it on ``release_group_mbid`` through the existing partial unique index.
+    A release both sources know about becomes one row, not two.
+    """
+    from app.db.models import Artist, Track, TrackStatus
+    from app.db.session import create_task_engine_session
+    from app.services.discovery import get_recorder
+    from app.services.discovery.listenbrainz import (
+        DEFAULT_DAYS,
+        fetch_fresh_releases,
+        select_for_library,
+    )
+    from app.services.new_releases import NewReleasesService
+
+    health = get_recorder()
+    stats: dict[str, Any] = {
+        "releases_seen": 0,
+        "matched_library": 0,
+        "releases_new": 0,
+        "artists_with_mbid": 0,
+    }
+
+    if await health.should_skip(SOURCE):
+        logger.info("listenbrainz_skipped", extra={"reason": "backing off"})
+        return {"status": "skipped", **stats}
+
+    try:
+        releases, rate = await fetch_fresh_releases(days=days or DEFAULT_DAYS)
+    except httpx.HTTPStatusError as exc:
+        status = exc.response.status_code
+        # 429 is the one failure this source reports honestly, and it tells us how
+        # long to wait — so the backoff comes from the header rather than a guess.
+        retry_after = None
+        if status == 429:
+            raw = exc.response.headers.get("X-RateLimit-Reset-In")
+            retry_after = float(raw) if raw and raw.isdigit() else None
+        await health.record_failure(
+            SOURCE,
+            kind="rate_limited" if status == 429 else "http_error",
+            detail=f"HTTP {status}",
+            retry_after_seconds=retry_after,
+        )
+        return {"status": "error", "error": f"HTTP {status}", **stats}
+    except Exception as exc:
+        await health.record_failure(
+            SOURCE,
+            kind="bad_response" if isinstance(exc, ValueError) else "timeout",
+            detail=str(exc)[:500],
+        )
+        return {"status": "error", "error": str(exc), **stats}
+
+    stats["releases_seen"] = len(releases)
+    remaining = rate.get("X-RateLimit-Remaining")
+
+    engine, session_maker = create_task_engine_session()
+    try:
+        async with session_maker() as db:
+            rows = (
+                await db.execute(
+                    select(Artist.musicbrainz_id, Artist.name)
+                    .join(Track, Track.canonical_artist_id == Artist.id)
+                    .where(
+                        Artist.musicbrainz_id.isnot(None),
+                        Track.status == TrackStatus.ACTIVE,
+                    )
+                    .distinct()
+                )
+            ).all()
+            library = {mbid: name for mbid, name in rows}
+            stats["artists_with_mbid"] = len(library)
+
+            wanted = select_for_library(releases, library)
+            stats["matched_library"] = len(wanted)
+
+            service = NewReleasesService(db)
+            for item in wanted:
+                try:
+                    saved = await service.save_discovered_release(**item)
+                    if saved:
+                        stats["releases_new"] += 1
+                    # Committed per release for the same reason the artist batch is:
+                    # one bad row must cost one row (ADR-0099 point 9).
+                    await db.commit()
+                except Exception:
+                    await db.rollback()
+                    logger.warning(
+                        "listenbrainz_release_failed",
+                        extra={"release": item.get("release_name")},
+                        exc_info=True,
+                    )
+    finally:
+        await engine.dispose()
+
+    await health.record_success(SOURCE, items=stats["releases_new"])
+    logger.info(
+        "listenbrainz_fresh_releases_complete: "
+        f"{stats['releases_seen']} seen, {stats['matched_library']} match the library, "
+        f"{stats['releases_new']} new (rate limit remaining: {remaining})"
+    )
+    return {"status": "success", **stats}

--- a/backend/migrations/versions/20260831_seed_listenbrainz.py
+++ b/backend/migrations/versions/20260831_seed_listenbrainz.py
@@ -1,0 +1,39 @@
+"""Seed the ListenBrainz row in discovery_source_health.
+
+The table's own migration seeds the sources known when it was written. This adds
+one, separately, because that migration has already run everywhere — editing it in
+place would seed the row on fresh installs and silently skip every existing one,
+which is the drift these idempotent inserts exist to avoid.
+
+Revision ID: 20260831_seed_listenbrainz
+Revises: 20260831_disc_src_health
+"""
+
+import sqlalchemy as sa
+from alembic import op
+
+from migrations.helpers import table_exists
+
+revision: str = "20260831_seed_listenbrainz"
+down_revision: str | None = "20260831_disc_src_health"
+branch_labels = None
+depends_on = None
+
+
+def upgrade() -> None:
+    if table_exists("discovery_source_health"):
+        op.execute(
+            sa.text(
+                "INSERT INTO discovery_source_health "
+                "  (source, consecutive_failures, items_contributed) "
+                "VALUES ('listenbrainz', 0, 0) "
+                "ON CONFLICT (source) DO NOTHING"
+            )
+        )
+
+
+def downgrade() -> None:
+    if table_exists("discovery_source_health"):
+        op.execute(
+            sa.text("DELETE FROM discovery_source_health WHERE source = 'listenbrainz'")
+        )

--- a/backend/tests/test_listenbrainz_discovery.py
+++ b/backend/tests/test_listenbrainz_discovery.py
@@ -1,0 +1,109 @@
+"""ListenBrainz fresh releases, filtered to the library (ADR-0099 point 11).
+
+Chosen over Bandcamp after both were probed against the live services on
+2026-08-31. Bandcamp's search returns no release dates at all — from either the
+search or the album endpoint — and answers "Coil" with *Dödsrit — Mortal Coil*.
+ListenBrainz returns 7,713 releases in one call, each carrying MusicBrainz ids, of
+which 225 matched this library.
+"""
+
+from datetime import datetime
+
+from app.services.discovery.listenbrainz import (
+    VARIOUS_ARTISTS_MBID,
+    WANTED_TYPES,
+    select_for_library,
+)
+
+LIBRARY = {"artist-mbid-1": "Boards of Canada", "artist-mbid-2": "Tycho"}
+
+
+def _release(**over):
+    base = {
+        "release_group_mbid": "rg-1",
+        "release_name": "Some Record",
+        "release_group_primary_type": "Album",
+        "artist_mbids": ["artist-mbid-1"],
+        "artist_credit_name": "BoC",
+        "release_date": "2026-08-17",
+        "caa_release_mbid": None,
+    }
+    base.update(over)
+    return base
+
+
+def test_a_release_by_a_library_artist_is_selected():
+    got = select_for_library([_release()], LIBRARY)
+    assert len(got) == 1
+    assert got[0]["release_id"] == "rg-1"
+    assert got[0]["musicbrainz_artist_id"] == "artist-mbid-1"
+
+
+def test_the_librarys_own_spelling_of_the_artist_wins():
+    """So the release joins the rows already filed under that artist.
+
+    ListenBrainz credits it as "BoC"; the library calls it "Boards of Canada". Using
+    the remote spelling would file a new release under a name nothing else uses.
+    """
+    got = select_for_library([_release(artist_credit_name="BoC")], LIBRARY)
+    assert got[0]["artist_name"] == "Boards of Canada"
+
+
+def test_a_release_by_an_artist_not_in_the_library_is_ignored():
+    got = select_for_library([_release(artist_mbids=["someone-else"])], LIBRARY)
+    assert got == []
+
+
+def test_various_artists_is_excluded():
+    """81 of 225 live matches were compilations credited to this placeholder.
+
+    It is a credit, not an artist anyone follows, and leaving it in turns the surface
+    into a firehose of unrelated compilations.
+    """
+    got = select_for_library(
+        [_release(artist_mbids=[VARIOUS_ARTISTS_MBID, "artist-mbid-1"])], LIBRARY
+    )
+    assert got == []
+
+
+def test_singles_and_broadcasts_are_excluded_but_eps_are_not():
+    releases = [
+        _release(release_group_mbid="a", release_group_primary_type="Album"),
+        _release(release_group_mbid="b", release_group_primary_type="EP"),
+        _release(release_group_mbid="c", release_group_primary_type="Single"),
+        _release(release_group_mbid="d", release_group_primary_type="Broadcast"),
+        _release(release_group_mbid="e", release_group_primary_type=None),
+    ]
+    ids = {r["release_id"] for r in select_for_library(releases, LIBRARY)}
+    assert ids == {"a", "b"}
+    assert WANTED_TYPES == {"Album", "EP"}
+
+
+def test_a_release_with_no_release_group_is_dropped():
+    """Without it there is no identity to dedupe on.
+
+    `release_group_mbid` is the same id `external_album_cache.release_id` holds for
+    MusicBrainz rows, which is what lets a release found by both sources collapse
+    onto one row. A release lacking it would be filed as a permanent duplicate.
+    """
+    assert select_for_library([_release(release_group_mbid=None)], LIBRARY) == []
+
+
+def test_the_release_date_is_parsed_not_passed_through():
+    got = select_for_library([_release(release_date="2026-08-17")], LIBRARY)
+    assert isinstance(got[0]["release_date"], datetime)
+    assert got[0]["release_date"].year == 2026
+
+
+def test_an_unparseable_date_does_not_drop_the_release():
+    """A record with a bad date is still a record. `plausible_release_date` and the
+    `nullslast` ordering already handle a missing date downstream."""
+    got = select_for_library([_release(release_date="not a date")], LIBRARY)
+    assert len(got) == 1
+    assert got[0]["release_date"] is None
+
+
+def test_artwork_url_is_built_only_when_cover_art_exists():
+    with_art = select_for_library([_release(caa_release_mbid="caa-1")], LIBRARY)
+    assert "caa-1" in with_art[0]["artwork_url"]
+    assert select_for_library([_release()], LIBRARY)[0]["artwork_url"] is None

--- a/packages/frontend/src/panels/server/DiscoverySources.tsx
+++ b/packages/frontend/src/panels/server/DiscoverySources.tsx
@@ -21,6 +21,7 @@ const REFRESH_MS = 30_000;
 /** Human labels. The source key is an implementation detail, not a name. */
 const SOURCE_LABELS: Record<string, string> = {
   musicbrainz: 'MusicBrainz',
+  listenbrainz: 'ListenBrainz',
   lastfm: 'Last.fm',
   bandcamp: 'Bandcamp',
   discovery_batch: 'Discovery job',


### PR DESCRIPTION
ADR-0099 point 11, chosen over point 5's Last.fm and Bandcamp **after probing all three against the live services**. The ADR's "both are already integrated" is true and misleading.

| source | what the probe found |
|---|---|
| **Last.fm** | No release API — retired 2016. Offers similar artists only, so it cannot produce a release; it feeds more artists into MusicBrainz, and therefore does **not** remove the single-upstream exposure point 5 claims. That pipeline already exists as the daily external-albums refresh. |
| **Bandcamp** | **No release dates.** Not from search, not from the album endpoint — you cannot tell a 2026 record from a 2002 one. Search answers "Coil" with *Dödsrit — Mortal Coil* and *Rush Coil*. The date is on the page in `data-tralbum`, so it's reachable at 1.9s per album, scraped, with no API contract. A project, not an integration. |
| **ListenBrainz** | **7,713 releases in one unauthenticated call**, each carrying MusicBrainz ids, with explicit `X-RateLimit-Remaining` headers. |

### Live result

```
7,714 seen → 87 match the library → 63 new
releases 703 → 766
```

**87 matched but only 63 were new** — MusicBrainz had already found the other 24, and they collapsed onto the same rows. That's the shared-identifier payoff, demonstrated rather than asserted: `release_group_mbid` *is* `external_album_cache.release_id`, so the existing partial unique index dedupes across sources with no fuzzy matching anywhere.

What it added: SAINT PEPSI, Soft Cell, Colin Stetson, Bloc Party, Bonobo, Hercules and Love Affair, Prince, a Can live album, a T. Rex EP.

### One request, then local filtering

MusicBrainz asks per artist and is bounded by one request a second. This asks once for everything recent and intersects with the library. Three-hour interval — eight calls a day — because folding it into the 20-minute batch would fetch a megabyte to look at ten artists.

### Two filters, both measured

**Various Artists excluded** — 81 of 225 raw matches were compilations credited to that placeholder. It's a credit, not an artist anyone follows.

**Album and EP only** — 54 raw matches were singles, mostly promotional. `recommendations.py` already draws this line, so this agrees with it rather than inventing a second rule.

The library's own spelling of an artist wins over ListenBrainz's credit, so releases file under the name the rest of the library uses.

### No `source` column

The id space is shared, so such a column would record which source happened to see a release *first* — not a stable fact. Health already counts contribution per source: `listenbrainz items=63`, flipped from `not_instrumented`.

Seeded by a **new** migration rather than editing the one that created the table: that has already run, so an in-place edit would seed fresh installs and silently skip every existing one.

1,768 backend and 369 frontend tests pass; the 4 backend failures are pre-existing on `main`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01Emjrwedq7W1scadHdgiLfs