### PR TITLE
Discovery can be turned off, and being off is visible

### DIFF
--- a/backend/app/api/routes/health.py
+++ b/backend/app/api/routes/health.py
@@ -502,7 +502,8 @@ class DiscoverySourceHealthResponse(BaseModel):
     """Whether one discovery source is working — not whether it is configured."""
 
     source: str
-    #: working | degraded | backing_off | failing | never_succeeded | not_instrumented
+    #: working | degraded | backing_off | failing | never_succeeded |
+    #: not_instrumented | disabled
     state: str
     last_success_at: str | None = None
     last_failure_at: str | None = None
@@ -521,7 +522,7 @@ class DiscoveryHealthResponse(BaseModel):
     status: str
 
 
-def _source_state(row: Any, now: datetime) -> str:
+def _source_state(row: Any, now: datetime, enabled: bool = True) -> str:
     """Turn a health row into the word a person reads.
 
     **`never_succeeded` is its own state and not a kind of "no data"** (ADR-0099
@@ -536,6 +537,13 @@ def _source_state(row: Any, now: datetime) -> str:
     aggregate badge permanently alarming and would conflate "unmonitored" with
     "broken" — the exact conflation this surface exists to remove.
     """
+    # **Checked first, because a disabled source keeps its last success forever.**
+    # Without this it would read `working` indefinitely after being switched off, and
+    # "off" would be indistinguishable from "fine" — the confusion this whole surface
+    # exists to remove, reintroduced by the switch meant to give the owner control.
+    if not enabled:
+        return "disabled"
+
     if row.backoff_until is not None and row.backoff_until > now:
         return "backing_off"
     if row.last_attempt_at is None and row.last_success_at is None:
@@ -560,6 +568,7 @@ async def discovery_source_health(db: DbSession) -> DiscoveryHealthResponse:
     also a different question from "is the process up".
     """
     from app.db.models import DiscoverySourceHealth
+    from app.services.discovery import source_enabled
 
     now = utcnow().replace(tzinfo=None)
     rows = (
@@ -571,7 +580,7 @@ async def discovery_source_health(db: DbSession) -> DiscoveryHealthResponse:
     sources = [
         DiscoverySourceHealthResponse(
             source=row.source,
-            state=_source_state(row, now),
+            state=_source_state(row, now, enabled=source_enabled(row.source)),
             last_success_at=row.last_success_at.isoformat() if row.last_success_at else None,
             last_failure_at=row.last_failure_at.isoformat() if row.last_failure_at else None,
             last_failure_kind=row.last_failure_kind,
@@ -587,6 +596,9 @@ async def discovery_source_health(db: DbSession) -> DiscoveryHealthResponse:
     # `not_instrumented` sits at the bottom so it never drives the aggregate: a source
     # nothing has attempted is not evidence that discovery is unhealthy.
     severity = {
+        # Neither of these drives the aggregate: a source the owner turned off is not
+        # evidence that discovery is unhealthy, any more than an unmonitored one is.
+        "disabled": -2,
         "not_instrumented": -1,
         "working": 0,
         "degraded": 1,

--- a/backend/app/api/routes/settings.py
+++ b/backend/app/api/routes/settings.py
@@ -56,6 +56,9 @@ class SettingsResponse(BaseModel):
     queue_sync_enabled: bool
 
     # Community cache
+    discovery_enabled: bool
+    discovery_musicbrainz_enabled: bool
+    discovery_listenbrainz_enabled: bool
     community_cache_enabled: bool
     community_cache_contribute: bool
     community_cache_url: str
@@ -99,6 +102,9 @@ class SettingsUpdateRequest(BaseModel):
     queue_sync_enabled: bool | None = None
 
     # Community cache
+    discovery_enabled: bool | None = None
+    discovery_musicbrainz_enabled: bool | None = None
+    discovery_listenbrainz_enabled: bool | None = None
     community_cache_enabled: bool | None = None
     community_cache_contribute: bool | None = None
     community_cache_url: str | None = None

--- a/backend/app/services/app_settings.py
+++ b/backend/app/services/app_settings.py
@@ -56,6 +56,25 @@ class AppSettings(BaseModel):
     # External feature lookup (skip local librosa analysis when possible)
     external_features_enabled: bool = True  # Look up features from external services
 
+    # Discovery — finding music you do not own (ADR-0099 point 12).
+    #
+    # **This exists because the posture changed.** Discovery was an occasional nightly
+    # job; it is now a process that contacts MusicBrainz every twenty minutes and
+    # ListenBrainz every three hours, about what this listener plays. That is a
+    # different thing to run on someone's own hardware without an off switch, and a
+    # self-hosted music server should let its owner decline it in one place.
+    #
+    # Off means no discovery request leaves the machine. The read path still serves
+    # whatever is already cached — turning it off stops new lookups, it does not
+    # empty the shelf.
+    discovery_enabled: bool = True
+
+    # Per source, because they fail and cost differently and are polled independently.
+    # Turning one off in response to it misbehaving must not mean turning discovery
+    # off entirely — which is effectively what happened on 2026-08-30.
+    discovery_musicbrainz_enabled: bool = True
+    discovery_listenbrainz_enabled: bool = True
+
     # Community embedding cache (share CLAP embeddings with other users)
     community_cache_enabled: bool = True  # Look up embeddings from community cache
     community_cache_contribute: bool = False  # Contribute computed embeddings (opt-in)

--- a/backend/app/services/discovery/__init__.py
+++ b/backend/app/services/discovery/__init__.py
@@ -8,6 +8,7 @@ from app.services.discovery.sources import (
     SourceHealthRecorder,
     backoff_seconds,
     get_recorder,
+    source_enabled,
 )
 
-__all__ = ["SourceHealthRecorder", "backoff_seconds", "get_recorder"]
+__all__ = ["SourceHealthRecorder", "backoff_seconds", "get_recorder", "source_enabled"]

--- a/backend/app/services/discovery/sources.py
+++ b/backend/app/services/discovery/sources.py
@@ -143,6 +143,34 @@ class SourceHealthRecorder:
             return False
 
 
+def source_enabled(source: str) -> bool:
+    """Whether this source may be contacted at all (ADR-0099 point 12).
+
+    Two gates, and the master one is the point: `discovery_enabled` off means **no
+    discovery request leaves the machine**, whichever source is asking. The
+    per-source flags exist so that turning one off in response to it misbehaving is
+    not the same as turning discovery off entirely.
+
+    Read at call time rather than cached, so a toggle in the admin UI takes effect on
+    the next batch rather than at the next restart.
+
+    **Read off the settings object directly, not through `get_effective`.** That
+    helper resolves precedence with `if app_value:` — plain truthiness — so a boolean
+    explicitly set to `False` falls through every branch and comes back as `None`,
+    indistinguishable from unset. It is fine for the API keys it was written for,
+    where empty means absent; it cannot express a disabled flag. Every other boolean
+    setting in the codebase reads the attribute directly for the same reason.
+    """
+    from app.services.app_settings import get_app_settings_service
+
+    app_settings = get_app_settings_service().get()
+    if not getattr(app_settings, "discovery_enabled", True):
+        return False
+    # A source with no flag of its own is governed by the master switch alone —
+    # `discovery_batch` is the job itself, not an upstream.
+    return bool(getattr(app_settings, f"discovery_{source}_enabled", True))
+
+
 def get_recorder() -> SourceHealthRecorder:
     """A recorder backed by its own engine, per the class docstring."""
     from app.db.session import create_task_engine_session

--- a/backend/app/services/tasks/listenbrainz_releases.py
+++ b/backend/app/services/tasks/listenbrainz_releases.py
@@ -29,7 +29,7 @@ async def run_listenbrainz_fresh_releases(days: int | None = None) -> dict[str, 
     """
     from app.db.models import Artist, Track, TrackStatus
     from app.db.session import create_task_engine_session
-    from app.services.discovery import get_recorder
+    from app.services.discovery import get_recorder, source_enabled
     from app.services.discovery.listenbrainz import (
         DEFAULT_DAYS,
         fetch_fresh_releases,
@@ -44,6 +44,12 @@ async def run_listenbrainz_fresh_releases(days: int | None = None) -> dict[str, 
         "releases_new": 0,
         "artists_with_mbid": 0,
     }
+
+    # Checked before backoff: being switched off is not a fault, so it records
+    # nothing and reports a state of its own (ADR-0099 point 12).
+    if not source_enabled(SOURCE):
+        logger.info("listenbrainz_skipped", extra={"reason": "disabled"})
+        return {"status": "disabled", **stats}
 
     if await health.should_skip(SOURCE):
         logger.info("listenbrainz_skipped", extra={"reason": "backing off"})

--- a/backend/app/services/tasks/new_releases.py
+++ b/backend/app/services/tasks/new_releases.py
@@ -451,7 +451,14 @@ async def run_prioritized_new_releases_check(
         "artists_timed_out": 0,
     }
 
-    from app.services.discovery import get_recorder
+    from app.services.discovery import get_recorder, source_enabled
+
+    # ADR-0099 point 12. Checked before anything else, including backoff: when
+    # discovery is off, no request leaves the machine and nothing is recorded as a
+    # failure either — being switched off is not a fault.
+    if not source_enabled("musicbrainz"):
+        logger.info("discovery_batch_skipped", extra={"reason": "disabled"})
+        return {"status": "disabled", **stats}
 
     health = get_recorder()
 

--- a/backend/openapi.json
+++ b/backend/openapi.json
@@ -8157,6 +8157,18 @@
             "title": "Community Cache Url",
             "type": "string"
           },
+          "discovery_enabled": {
+            "title": "Discovery Enabled",
+            "type": "boolean"
+          },
+          "discovery_listenbrainz_enabled": {
+            "title": "Discovery Listenbrainz Enabled",
+            "type": "boolean"
+          },
+          "discovery_musicbrainz_enabled": {
+            "title": "Discovery Musicbrainz Enabled",
+            "type": "boolean"
+          },
           "external_features_enabled": {
             "title": "External Features Enabled",
             "type": "boolean"
@@ -8235,6 +8247,9 @@
           "clap_status",
           "external_features_enabled",
           "queue_sync_enabled",
+          "discovery_enabled",
+          "discovery_musicbrainz_enabled",
+          "discovery_listenbrainz_enabled",
           "community_cache_enabled",
           "community_cache_contribute",
           "community_cache_url",
@@ -8295,6 +8310,27 @@
             "title": "Device Stream Base Url",
             "type": [
               "string",
+              "null"
+            ]
+          },
+          "discovery_enabled": {
+            "title": "Discovery Enabled",
+            "type": [
+              "boolean",
+              "null"
+            ]
+          },
+          "discovery_listenbrainz_enabled": {
+            "title": "Discovery Listenbrainz Enabled",
+            "type": [
+              "boolean",
+              "null"
+            ]
+          },
+          "discovery_musicbrainz_enabled": {
+            "title": "Discovery Musicbrainz Enabled",
+            "type": [
+              "boolean",
               "null"
             ]
           },

--- a/backend/tests/test_discovery_enabled.py
+++ b/backend/tests/test_discovery_enabled.py
@@ -101,3 +101,35 @@ def test_disabled_beats_every_other_state():
     now = utcnow().replace(tzinfo=None)
     assert _source_state(_Failing(), now, enabled=True) == "backing_off"
     assert _source_state(_Failing(), now, enabled=False) == "disabled"
+
+
+# ---------------------------------------------------------------------------
+# The switch has to be reachable, or it is not a switch
+# ---------------------------------------------------------------------------
+
+
+def test_the_flags_are_on_the_settings_api(client):
+    """Point 12 says "edited in the admin UI", which means the API carries them.
+
+    Found by toggling on the live server and watching nothing happen: the values
+    persisted to `settings.json` but `PUT /settings` silently ignored the fields and
+    `GET` never returned them, because that route has its own allowlisting schema.
+    A setting the API does not expose is a setting nobody can change.
+    """
+    body = client.get("/api/v1/settings").json()
+    for key in (
+        "discovery_enabled",
+        "discovery_musicbrainz_enabled",
+        "discovery_listenbrainz_enabled",
+    ):
+        assert key in body, f"{key} is not exposed by GET /settings"
+
+
+def test_the_flags_can_be_written_through_the_settings_api(client):
+    updated = client.put(
+        "/api/v1/settings", json={"discovery_musicbrainz_enabled": False}
+    ).json()
+    assert updated["discovery_musicbrainz_enabled"] is False
+
+    client.put("/api/v1/settings", json={"discovery_musicbrainz_enabled": True})
+    assert client.get("/api/v1/settings").json()["discovery_musicbrainz_enabled"] is True

--- a/backend/tests/test_discovery_enabled.py
+++ b/backend/tests/test_discovery_enabled.py
@@ -1,0 +1,103 @@
+"""Discovery can be turned off, and being off is visible (ADR-0099 point 12).
+
+The reason this exists: discovery went from an occasional nightly job to a process
+contacting MusicBrainz every twenty minutes and ListenBrainz every three hours,
+about what one person listens to. That is a change in posture, and a self-hosted
+music server should let its owner decline it in one place.
+"""
+
+from datetime import timedelta
+
+import pytest
+
+from app.services.app_settings import get_app_settings_service
+from app.services.discovery import source_enabled
+from app.utils.time import utcnow
+
+
+@pytest.fixture
+def settings_off():
+    """Turn discovery off for one test, then put it back."""
+    service = get_app_settings_service()
+    original = {
+        key: service.get_effective(key)
+        for key in (
+            "discovery_enabled",
+            "discovery_musicbrainz_enabled",
+            "discovery_listenbrainz_enabled",
+        )
+    }
+    yield service
+    for key, value in original.items():
+        service.update(**{key: value})
+
+
+def test_enabled_by_default():
+    """Defaulting to on matters: a discovery server that discovers nothing until
+    somebody finds a switch is a worse default than the posture question."""
+    assert source_enabled("musicbrainz") is True
+    assert source_enabled("listenbrainz") is True
+
+
+def test_the_master_switch_stops_every_source(settings_off):
+    settings_off.update(**{"discovery_enabled": False})
+    assert source_enabled("musicbrainz") is False
+    assert source_enabled("listenbrainz") is False
+
+
+def test_one_source_can_be_turned_off_without_the_others(settings_off):
+    """Otherwise the response to one source misbehaving is to disable discovery
+    entirely — which is effectively what happened on 2026-08-30."""
+    settings_off.update(**{"discovery_musicbrainz_enabled": False})
+    assert source_enabled("musicbrainz") is False
+    assert source_enabled("listenbrainz") is True
+
+
+def test_the_job_itself_has_no_flag_of_its_own(settings_off):
+    """`discovery_batch` is the job, not an upstream, so only the master switch
+    governs it. A missing per-source flag must not read as "disabled"."""
+    assert source_enabled("discovery_batch") is True
+    settings_off.update(**{"discovery_enabled": False})
+    assert source_enabled("discovery_batch") is False
+
+
+# ---------------------------------------------------------------------------
+# Off must not look like fine
+# ---------------------------------------------------------------------------
+
+
+def test_a_disabled_source_does_not_report_as_working():
+    """**The load-bearing test of this change.**
+
+    A disabled source keeps its last success forever, so without an explicit state
+    it would read `working` indefinitely after being switched off — and "off" would
+    be indistinguishable from "fine". That is the exact confusion this health surface
+    exists to remove, reintroduced by the switch meant to give the owner control.
+    """
+    from app.api.routes.health import _source_state
+
+    class _Row:
+        backoff_until = None
+        last_attempt_at = utcnow().replace(tzinfo=None) - timedelta(hours=1)
+        last_success_at = utcnow().replace(tzinfo=None) - timedelta(hours=1)
+        consecutive_failures = 0
+
+    now = utcnow().replace(tzinfo=None)
+    assert _source_state(_Row(), now, enabled=True) == "working"
+    assert _source_state(_Row(), now, enabled=False) == "disabled"
+
+
+def test_disabled_beats_every_other_state():
+    """Including failure. A source that was failing and has since been turned off is
+    off — continuing to alarm about an upstream nobody is contacting is noise."""
+    from app.api.routes.health import _source_state
+
+    class _Failing:
+        backoff_until = utcnow().replace(tzinfo=None) + timedelta(minutes=5)
+        last_attempt_at = utcnow().replace(tzinfo=None)
+        last_success_at = None
+        consecutive_failures = 9
+
+    now = utcnow().replace(tzinfo=None)
+    assert _source_state(_Failing(), now, enabled=True) == "backing_off"
+    assert _source_state(_Failing(), now, enabled=False) == "disabled"

--- a/packages/frontend/src/panels/server/DiscoverySources.tsx
+++ b/packages/frontend/src/panels/server/DiscoverySources.tsx
@@ -12,7 +12,7 @@
  * throughout the outage.
  */
 import { useQuery } from '@tanstack/react-query';
-import { AlertTriangle, CheckCircle, Clock, HelpCircle, XCircle } from 'lucide-react';
+import { AlertTriangle, CheckCircle, Clock, HelpCircle, PowerOff, XCircle } from 'lucide-react';
 import { healthApi, type DiscoverySourceHealth } from '../../api/admin';
 import { queryKeys } from '../../api/queryKeys';
 
@@ -37,6 +37,9 @@ const STATE_STYLES: Record<string, { label: string; cls: string; Icon: typeof Ch
   // purpose: colouring it would make the panel cry wolf about a source that is
   // simply not wired to the recorder until ADR-0099 point 5.
   not_instrumented: { label: 'Not monitored', cls: 'text-zinc-500', Icon: HelpCircle },
+  // Switched off by the owner. Neutral, and distinct from every failure state: "off"
+  // must not look like "broken", which is the confusion this panel exists to remove.
+  disabled: { label: 'Off', cls: 'text-zinc-500', Icon: PowerOff },
 };
 
 function relative(iso: string | null): string | null {
@@ -76,7 +79,9 @@ function SourceRow({ source }: { source: DiscoverySourceHealth }) {
 
         {/* "Last found something", not "last ran" — the distinction the outage turned on. */}
         <p className="text-xs text-zinc-400 mt-0.5">
-          {lastSuccess
+          {source.state === 'disabled'
+            ? 'Turned off in settings; cached results are still served'
+            : lastSuccess
             ? `Last found something ${lastSuccess}`
             : source.state === 'not_instrumented'
               ? 'Used for recommendations; not yet reporting health'

--- a/packages/frontend/src/panels/server/__tests__/DiscoverySources.test.tsx
+++ b/packages/frontend/src/panels/server/__tests__/DiscoverySources.test.tsx
@@ -132,3 +132,20 @@ describe('DiscoverySources — unmonitored sources', () => {
     expect(screen.queryByText(/never found anything/)).toBeNull();
   });
 });
+
+describe('DiscoverySources — switched off', () => {
+  it('a disabled source reads as off, not as broken or as working', async () => {
+    vi.mocked(healthApi.getDiscoverySources).mockResolvedValue({
+      status: 'working',
+      sources: [source({ state: 'disabled', last_success_at: iso(30) })],
+    });
+    renderPanel();
+
+    expect(await screen.findByText('Off')).toBeTruthy();
+    expect(screen.getByText(/cached results are still served/)).toBeTruthy();
+    // It kept a last_success_at from before it was switched off; that must not be
+    // what the row leads with, or "off" reads as "fine".
+    expect(screen.queryByText(/Last found something/)).toBeNull();
+    expect(screen.queryByText('Failing')).toBeNull();
+  });
+});


### PR DESCRIPTION
ADR-0099 point 12. Discovery went from an occasional nightly job to a process contacting **MusicBrainz every 20 minutes and ListenBrainz every 3 hours**, about what one person listens to. That's a change in posture, not cadence — and there was no way to decline it. `community_cache_enabled` and `s3_backup_enabled` exist; discovery had no equivalent.

Verified on the live server:

```
MusicBrainz off only →  musicbrainz=disabled  listenbrainz=working   batch: disabled
Master switch off    →  both disabled, overall=disabled
Restored             →  both working
```

Off means **no discovery request leaves the machine**. The read path still serves what's cached — turning it off stops new lookups, it doesn't empty the shelf.

### The half that needed care: "off" must not look like "fine"

A disabled source keeps its last success forever, so without an explicit state it would read `working` indefinitely after being switched off — **reintroducing the exact confusion this health surface exists to remove, via the switch meant to give the owner control.** `disabled` is checked before backoff and before failure, sorts below `working` so it can't drive the aggregate, and renders neutral with "turned off in settings; cached results are still served".

Both jobs check enablement *before* backoff and record nothing when off: being switched off is not a fault, and writing a failure would make the panel argue with itself.

### Two bugs found by testing on the running system

**The switch persisted but couldn't be operated.** `PUT /settings` silently ignored the fields and `GET` never returned them — that route allowlists through its own models rather than mirroring `AppSettings`. Every unit test passed throughout, because they called `source_enabled()` directly and never crossed the boundary where the field was dropped. Two tests now cross it.

**`get_effective()` cannot express a boolean `False`.** It resolves precedence with `if app_value:` — plain truthiness — so a flag set to `False` falls through every branch and returns `None`, indistinguishable from unset. Fine for the API keys it was written for; useless for a disabled flag. Every other boolean setting reads the attribute directly, and this now does too. **Left unfixed deliberately** — changing it would alter how empty strings resolve for every credential that uses it.

### Two sub-points deliberately not implemented

*Enabled-but-unconfigured is an error state* — neither MusicBrainz nor ListenBrainz needs credentials, so nothing can currently reach that state. Building a state no source can occupy is the capability-with-no-caller pattern this ADR keeps finding.

*Cadence as a setting* — the two intervals are already single constants rather than per-source knobs, which is what that bullet guarded against. Making them user-tunable needs live rescheduling and isn't what point 12 was worried about.

1,776 backend and 370 frontend tests pass; the 4 backend failures are pre-existing on `main`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01Emjrwedq7W1scadHdgiLfs