### PR TITLE
Reject ADR-0069, and implement the one part of it that mattered

### DIFF
--- a/.github/workflows/cloudflare-pages.yml
+++ b/.github/workflows/cloudflare-pages.yml
@@ -48,6 +48,13 @@ jobs:
           rm -rf _site/scripts _site/ILLUSTRATIONS.md _site/README.md \
                  _site/e2e _site/playwright.config.ts _site/visualizers.json
 
+      # ADR-0069 point 5's concern, kept after that ADR was rejected: the claim
+      # ledger is the only mechanism standing between this site and lying by
+      # attrition, and until now nothing ran it. `--offline` here because the
+      # external-link and live-site checks belong after the deploy, not before it.
+      - name: Check site claims
+        run: python3 site/scripts/check-claims.py --offline
+
       - name: Deploy to Cloudflare Pages
         uses: cloudflare/pages-action@v1
         with:
@@ -56,3 +63,11 @@ jobs:
           projectName: familiar-site
           directory: _site
           gitHubToken: ${{ secrets.GITHUB_TOKEN }}
+
+      # ADR-0097: the live site served an April build for four months while every
+      # check passed, because they all audited the working tree. This one fetches
+      # what is actually published, and it can only run after the deploy.
+      - name: Verify the deployed site
+        run: |
+          sleep 30
+          python3 site/scripts/check-claims.py

--- a/docs/decisions/ADR-0039-the-website-is-rebuilt-in-place.md
+++ b/docs/decisions/ADR-0039-the-website-is-rebuilt-in-place.md
@@ -1,6 +1,14 @@
 # ADR-0039: The Website Is Rebuilt in Place
 
-Status: accepted
+Status: accepted — point 1's "no build step" clause amended by
+[ADR-0103](ADR-0103-the-visualizer-contract-is-published-with-a-gallery.md)
+
+Point 1's other three clauses stand and were reaffirmed on 2026-08-31 when
+[ADR-0069](ADR-0069-the-site-adopts-a-static-site-generator.md) was **rejected**: still no
+generator, no new dependency, no `packages/` workspace. What changed is narrower than the
+clause reads — the deploy runs one script over one known file to render
+`docs/VISUALIZER_API.md`, which point 6 anticipated. Point 6 itself is untouched and is
+still the thing to consult before a second document, an index or permalinks exist.
 
 Date: 2026-08-06
 

--- a/docs/decisions/ADR-0069-the-site-adopts-a-static-site-generator.md
+++ b/docs/decisions/ADR-0069-the-site-adopts-a-static-site-generator.md
@@ -1,6 +1,29 @@
 # ADR-0069: The Site Adopts a Static Site Generator
 
-Status: proposed
+Status: rejected
+
+**Rejected 2026-08-31, and not because its reasoning was wrong.** Its trigger was
+`ADR-0039` point 6 — rendered docs arriving — and that condition did arrive: `ADR-0103`
+published `docs/VISUALIZER_API.md` on the site. It was done with **one script over one
+known file**, added to the `Assemble site` step that already copied and pruned, and the
+result was a rendered page with no toolchain, no plugins, no content model and no
+dependency. The migration this ADR describes — Eleventy, a dev dependency, byte-identical
+re-renders of every existing page — would have been a large change to reach the same place.
+
+Two things kept, because they were the valuable half:
+
+- **Point 5's concern is now implemented.** "`check-claims.py` runs against the build
+  output, and the build fails if it fails" — the script was run by no workflow at all, so
+  the ledger `ADR-0055` point 2 calls the only thing standing between this site and lying
+  by attrition was purely manual. `cloudflare-pages.yml` now runs it before the deploy and
+  again against the live site afterwards.
+- **`ADR-0039` point 6 still stands**, and this ADR's own framing is the reason. Point 6
+  asks for the decision to be *made again* when docs want to be a section with an index and
+  permalinks. One rendered document is not that. A second one, or an index, still is — and
+  this ADR remains the right starting point when it happens.
+
+`ADR-0055`, the condition in point 6, has since landed, so this was no longer blocked. It
+is rejected on its merits rather than left proposed indefinitely.
 
 Date: 2026-08-17
 


### PR DESCRIPTION
Its trigger was ADR-0039 point 6 — rendered docs arriving — and that condition **did** arrive: ADR-0103 published `docs/VISUALIZER_API.md` on the site. It took **one script over one known file**, added to the `Assemble site` step that already copied and pruned, producing a rendered page with no toolchain, no plugins, no content model and no dependency.

The migration ADR-0069 describes — Eleventy, a dev dependency, byte-identical re-renders of every existing page — would have been a large change to arrive at the same place. ADR-0055, the condition its point 6 gated on, has since landed, so it's rejected on its merits rather than left proposed indefinitely.

### Its point 5 is implemented, not discarded

That was the valuable half, and it named a real gap:

> `check-claims.py` runs against the build output, and the build fails if it fails.

**That script was run by no workflow at all.** The ledger ADR-0055 point 2 calls *"the only mechanism standing between this site and lying by attrition"* was purely manual — which rather undercuts ADR-0097.

The deploy now runs it twice: `--offline` before deploying as a gate, and **in full against the live site afterwards**, because the deployed-site and external-link checks can only mean anything after publication. That second run is ADR-0097's own lesson wired in — the site served an April build for four months while every check passed, because they all audited the working tree.

### ADR-0039 point 1 is annotated rather than quietly contradicted

It says *"No generator, no build step, no new dependency, no `packages/` workspace."* Three still hold and were reaffirmed by this rejection; **"no build step" no longer does.** Per the convention the Decision is left alone and the Status line records what amended it. Point 6 is untouched and remains what to consult before a second document, an index or permalinks exist.

### Nothing depended on it

ADR-0064 declares itself independent, ADR-0063 is superseded, and ADR-0095 plus `site/assets/install.js` reference it only as context for why the site had no build step.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01Emjrwedq7W1scadHdgiLfs