### PR TITLE
Accept ADR-0102

### DIFF
--- a/docs/decisions/ADR-0102-the-community-cache-gains-a-recording-key.md
+++ b/docs/decisions/ADR-0102-the-community-cache-gains-a-recording-key.md
@@ -1,6 +1,6 @@
 # ADR-0102: The Community Cache Gains a Recording Key
 
-Status: proposed
+Status: accepted
 
 Date: 2026-08-31
 


### PR DESCRIPTION
Approved. The community cache gains a MusicBrainz recording id as a second key, so an installation can ask what a record sounds like without holding it — the only mechanism in sight that lets discovery rank music nobody here owns by how it actually sounds.

Accepting decides the direction, not a disclosure: `community_cache_contribute` stays `False` by default, so nothing leaves this installation until its owner opts in, and the fingerprint-hash key is unchanged for anyone who ignores the feature.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01Emjrwedq7W1scadHdgiLfs