### PR TITLE
Give analysis three workers, and say why cpus alone was not enough

### DIFF
--- a/docker/docker-compose.prod.yml
+++ b/docker/docker-compose.prod.yml
@@ -81,7 +81,8 @@ services:
       resources:
         limits:
           cpus: '6.0'    # Max 6 CPU cores, leaving 2 for Postgres, Redis and the OS
-          memory: 6G     # Max 6GB RAM (CLAP model needs ~4GB peak)
+          memory: 10G    # Each analysis worker holds a CLAP model; 3 workers need
+                         # room. Measured 1.57G total with one worker running.
         reservations:
           cpus: '0.5'    # Guaranteed 0.5 cores
           memory: 512M   # Guaranteed 512MB
@@ -101,6 +102,14 @@ services:
       - DATABASE_URL=postgresql+asyncpg://familiar:${POSTGRES_PASSWORD:-familiar}@postgres:5432/familiar
       - REDIS_URL=redis://redis:6379/0
       - MUSIC_LIBRARY_PATH=/music
+      # Analysis process pool size. One worker leaves most of the CPU limit above
+      # idle: a track is one process, and `max_tasks_per_child=1` means it does not
+      # even amortise its own interpreter start. Each worker holds a CLAP model, so
+      # this trades memory for throughput — raise it and the `memory` limit together.
+      # Unlike `cpus`, this cannot be applied with `docker update`; changing it needs
+      # the container recreated, which discards any code `deploy-dev.sh` copied in.
+      # Re-run `make deploy-dev` afterwards or the container reverts to the image.
+      - MAX_ANALYSIS_WORKERS=${MAX_ANALYSIS_WORKERS:-3}
       - ART_PATH=/data/art
       - VIDEOS_PATH=/data/videos
       - MIXTAPES_PATH=/data/mixtapes


### PR DESCRIPTION
The re-analysis from #258 was running at **31.7 s/track, ~230 hours**. Two changes take it well below that, and the first cost nothing at all.

## The CPU limit was already right in this file, and inert on the machine

`docker-compose.prod.yml` has said `cpus: '6.0'` since issue #13. The running container had **2.0**. The comment directly above the limit already explains why:

> `deploy-dev.sh` does `docker cp` + `docker restart`, which preserves the container's existing HostConfig — it will **NOT** apply a change made here.

So the fix needed no restart and no code:

```
docker update --cpus=6 familiar-api
```

**31.7 s/track → 15.7 s/track.** Measured over 600 s in both cases. ~230 h → ~112 h.

That is this project's recurring shape again — a change correct in the repo and absent from the running system — except here the file had already documented its own failure mode and nobody had run the one command.

## Workers need a recreate, which has a trap

`MAX_ANALYSIS_WORKERS` is read from the environment at process start, so `docker update` cannot set it. Recreating the container **discards whatever `deploy-dev` copied in** — verified rather than assumed:

| | chunked-mean markers | EMBEDDING_VERSION |
|---|---|---|
| running container | 2 | **7** |
| `ghcr.io/...:latest` image | 0 | **6** |

After the recreate the container was serving middle-ten-second embeddings again until `make deploy-dev` was re-run. The sequence is now documented beside the setting.

## Sizing

One worker leaves most of a six-core allowance idle — a track is one process, and `max_tasks_per_child=1` means it does not even amortise its own interpreter start.

Memory goes 6G → 10G because each worker holds a CLAP model. The old comment claimed "~4GB peak"; measured reality was **1.57 G total** with one worker running, so this is headroom rather than a requirement.

## Applied to the NAS

Live now: 6 CPUs, 10 G, 3 workers, chunked-mean code restored and verified. Three-worker throughput is being measured.

**Note:** the NAS copy of this file had drifted from the repo — still `cpus: '2.0'`, music mounted `rw` rather than `ro`, no mixtapes volume, plus `ANTHROPIC_API_KEY`/`SPOTIFY_*` this repo dropped with ADR-0048. I patched it surgically rather than overwriting, since reconciling that drift is a separate change and this one was made mid-re-analysis. Worth doing deliberately later.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01Emjrwedq7W1scadHdgiLfs