### PR TITLE
Smoke-test the embedder that ships, not the torch that does not

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -210,17 +210,16 @@ jobs:
       - name: Pull built image (native arch)
         run: docker pull ${{ env.REGISTRY }}/${{ env.IMAGE_NAME }}:${{ needs.merge.outputs.version }}
 
-      - name: Smoke test (torch import only)
+      - name: Smoke test (imports, artifacts, providers)
         run: |
           docker run --rm \
             ${{ env.REGISTRY }}/${{ env.IMAGE_NAME }}:${{ needs.merge.outputs.version }} \
             python /app/scripts/smoke_test_clap.py --skip-model
 
-      - name: Smoke test (full CLAP)
+      - name: Smoke test (real embeddings)
         timeout-minutes: 15
         run: |
           docker run --rm \
-            -v familiar-hf-cache:/root/.cache/huggingface \
             ${{ env.REGISTRY }}/${{ env.IMAGE_NAME }}:${{ needs.merge.outputs.version }} \
             python /app/scripts/smoke_test_clap.py
 

--- a/backend/scripts/smoke_test_clap.py
+++ b/backend/scripts/smoke_test_clap.py
@@ -1,13 +1,27 @@
 #!/usr/bin/env python3
-"""Smoke test for PyTorch and CLAP embeddings.
+"""Smoke test for the CLAP embedder, inside the shipped image.
 
-Standalone script (no pytest, no app imports) designed to run inside the
-Docker container to verify that the scientific stack works on the current
-architecture (amd64 or arm64).
+Standalone (no pytest, no app imports) so it can run against a pulled image on
+either architecture and prove the scientific stack actually works there.
+
+**This used to test PyTorch.** ADR-0105 removed torch and transformers entirely;
+CLAP now runs through `clapback-embed` on ONNX Runtime. The old version asserted
+`import torch` and so failed the first release after that change — a check whose
+subject no longer existed, passing for years and then failing for the right
+reason at the wrong time.
+
+What it verifies now is stronger than the import it replaced:
+
+- the embedder imports and the ONNX encoders are present in the image
+- **which execution providers actually bound**, not which were requested — ONNX
+  Runtime falls back to CPU silently when CUDA fails to load, so a GPU image with
+  a broken CUDA stack is indistinguishable from a working one without this
+- a real audio embedding comes out 512-dimensional, finite and unit length
+- a real text embedding does too, from the same 512-d space
 
 Usage:
-    python scripts/smoke_test_clap.py                  # Full test (downloads ~1.5GB CLAP model)
-    python scripts/smoke_test_clap.py --skip-model      # Quick torch-import-only check
+    python scripts/smoke_test_clap.py               # full: runs real embeddings
+    python scripts/smoke_test_clap.py --skip-model  # imports and artifacts only
 """
 
 import argparse
@@ -18,90 +32,93 @@ import sys
 import time
 
 
-def check_torch():
-    """Verify torch imports and detect device."""
-    import torch
-
-    device = "cpu"
-    if torch.cuda.is_available():
-        device = "cuda"
-    elif torch.backends.mps.is_available():
-        device = "mps"
-
-    # Basic tensor operation
-    t = torch.randn(3, 3, device=device)
-    assert t.shape == (3, 3), f"Unexpected tensor shape: {t.shape}"
-    assert torch.isfinite(t).all(), "Tensor contains non-finite values"
+def check_embedder() -> dict:
+    """Import the embedder and report what it will actually run on."""
+    import clapback_embed
+    import onnxruntime as ort
+    from clapback_embed.artifacts import model_dir, providers
 
     return {
-        "torch_version": torch.__version__,
-        "device": device,
+        "pipeline_version": clapback_embed.PIPELINE_VERSION,
+        "onnxruntime": ort.__version__,
+        "model_dir": str(model_dir()),
+        # Requested. Not the same thing as bound — see check_providers.
+        "providers_requested": providers(),
+        "providers_available": ort.get_available_providers(),
     }
 
 
-def check_clap():
-    """Load CLAP model and produce audio + text embeddings."""
-    import numpy as np
-    import torch
-    from transformers import ClapModel, ClapProcessor
+def check_providers() -> dict:
+    """Load the audio encoder and report the providers actually bound to it.
 
-    model_name = "laion/clap-htsat-unfused"
-    print(f"Loading CLAP model: {model_name} ...", flush=True)
+    The distinction matters more than it looks. Requesting
+    `CUDAExecutionProvider` and getting it are different facts: when the CUDA
+    libraries are missing or mismatched, ONNX Runtime logs a warning, falls back
+    to CPU, and returns correct vectors — so nothing downstream fails, and the
+    GPU quietly does nothing forever.
+    """
+    from clapback_embed.artifacts import audio_session
+
     t0 = time.time()
+    session = audio_session()
+    return {
+        "providers_active": list(session.get_providers()),
+        "session_load_s": round(time.time() - t0, 2),
+    }
 
-    processor = ClapProcessor.from_pretrained(model_name)
-    model = ClapModel.from_pretrained(model_name)
-    model.eval()
 
-    load_time = time.time() - t0
-    print(f"Model loaded in {load_time:.1f}s", flush=True)
+def check_embeddings() -> dict:
+    """Produce a real audio and text embedding from synthetic input."""
+    import numpy as np
+    from clapback_embed import embed_audio, embed_text
+    from clapback_embed.mel import SAMPLE_RATE
 
-    # Generate synthetic audio: 3-second 440Hz sine wave at 48kHz
-    sr = 48000
-    duration = 3.0
-    t_arr = np.linspace(0, duration, int(sr * duration), dtype=np.float32)
-    audio = 0.5 * np.sin(2 * np.pi * 440 * t_arr)
+    # 25 seconds, so the whole-track path runs two windows and drops a tail —
+    # a single-window clip would not exercise the pooling at all.
+    duration = 25.0
+    t_arr = np.arange(int(SAMPLE_RATE * duration), dtype=np.float64) / SAMPLE_RATE
+    audio = (0.5 * np.sin(2 * np.pi * 440 * t_arr)).astype(np.float32)
 
-    # Audio embedding
-    inputs = processor(audio=audio, sampling_rate=sr, return_tensors="pt")
-    with torch.no_grad():
-        audio_embed = model.get_audio_features(**inputs)
-    audio_embedding = audio_embed.cpu().numpy().flatten().tolist()
+    t0 = time.time()
+    audio_embedding = embed_audio(audio)
+    audio_s = time.time() - t0
 
     assert len(audio_embedding) == 512, f"Expected 512-dim, got {len(audio_embedding)}"
-    assert all(math.isfinite(v) for v in audio_embedding), "Audio embedding has non-finite values"
+    assert all(math.isfinite(v) for v in audio_embedding), "Audio embedding is not finite"
+    norm_a = math.sqrt(sum(v * v for v in audio_embedding))
+    assert abs(norm_a - 1.0) < 1e-5, f"Audio embedding is not unit length: {norm_a}"
 
-    # Text embedding
     text = "electronic ambient music"
-    text_inputs = processor(text=[text], return_tensors="pt", padding=True)
-    with torch.no_grad():
-        text_embed = model.get_text_features(**text_inputs)
-    text_embedding = text_embed.cpu().numpy().flatten().tolist()
+    t0 = time.time()
+    text_embedding = embed_text(text)
+    text_s = time.time() - t0
 
     assert len(text_embedding) == 512, f"Expected 512-dim, got {len(text_embedding)}"
-    assert all(math.isfinite(v) for v in text_embedding), "Text embedding has non-finite values"
+    assert all(math.isfinite(v) for v in text_embedding), "Text embedding is not finite"
 
-    # Cosine similarity sanity check
+    # Audio and text share one space, so a similarity is defined. Not asserted
+    # against a threshold: a 440 Hz sine is not "ambient music", and pinning a
+    # number here would be asserting something about the model rather than the
+    # image.
     dot = sum(a * b for a, b in zip(audio_embedding, text_embedding))
-    norm_a = math.sqrt(sum(a * a for a in audio_embedding))
-    norm_b = math.sqrt(sum(b * b for b in text_embedding))
+    norm_b = math.sqrt(sum(v * v for v in text_embedding))
     cosine_sim = dot / (norm_a * norm_b) if norm_a > 0 and norm_b > 0 else 0.0
 
     return {
-        "model": model_name,
-        "load_time_s": round(load_time, 1),
         "audio_embedding_dim": len(audio_embedding),
         "text_embedding_dim": len(text_embedding),
+        "audio_embed_s": round(audio_s, 2),
+        "text_embed_s": round(text_s, 2),
         "cosine_similarity": round(cosine_sim, 4),
     }
 
 
 def main():
-    parser = argparse.ArgumentParser(description="Smoke test PyTorch and CLAP embeddings")
+    parser = argparse.ArgumentParser(description="Smoke test the CLAP embedder")
     parser.add_argument(
         "--skip-model",
         action="store_true",
-        help="Only test torch import and device detection (no 1.5GB model download)",
+        help="Only check imports, artifacts and providers (no inference)",
     )
     args = parser.parse_args()
 
@@ -116,24 +133,37 @@ def main():
         print(f"Architecture: {platform.machine()}", flush=True)
         print(f"Python: {platform.python_version()}", flush=True)
 
-        # Step 1: torch
-        print("\n--- Checking PyTorch ---", flush=True)
-        torch_info = check_torch()
-        result.update(torch_info)
-        print(f"torch {torch_info['torch_version']}, device: {torch_info['device']}", flush=True)
+        print("\n--- Checking embedder ---", flush=True)
+        info = check_embedder()
+        result.update(info)
+        print(f"pipeline: {info['pipeline_version']}", flush=True)
+        print(f"onnxruntime {info['onnxruntime']}", flush=True)
+        print(f"requested: {info['providers_requested']}", flush=True)
+
+        print("\n--- Loading encoder ---", flush=True)
+        prov = check_providers()
+        result.update(prov)
+        print(f"active:    {prov['providers_active']}  ({prov['session_load_s']}s)", flush=True)
+        if "CUDAExecutionProvider" in info["providers_requested"]:
+            if "CUDAExecutionProvider" in prov["providers_active"]:
+                print("CUDA requested and bound", flush=True)
+            else:
+                # Not a failure: images are built with CUDA for hosts that have a
+                # GPU and run unchanged on hosts that do not. Saying so out loud
+                # is the point — this is the state that otherwise hides.
+                print("CUDA requested but NOT bound — running on CPU", flush=True)
 
         if args.skip_model:
             result["status"] = "pass"
-            result["note"] = "torch-only (--skip-model)"
-            print("\n--- Skipping CLAP model (--skip-model) ---", flush=True)
+            result["note"] = "imports, artifacts and providers only (--skip-model)"
+            print("\n--- Skipping inference (--skip-model) ---", flush=True)
         else:
-            # Step 2: CLAP
-            print("\n--- Checking CLAP ---", flush=True)
-            clap_info = check_clap()
-            result.update(clap_info)
-            print(f"Audio embedding: {clap_info['audio_embedding_dim']}-dim", flush=True)
-            print(f"Text embedding: {clap_info['text_embedding_dim']}-dim", flush=True)
-            print(f"Cosine similarity: {clap_info['cosine_similarity']}", flush=True)
+            print("\n--- Embedding ---", flush=True)
+            emb = check_embeddings()
+            result.update(emb)
+            print(f"audio: {emb['audio_embedding_dim']}-dim in {emb['audio_embed_s']}s", flush=True)
+            print(f"text:  {emb['text_embedding_dim']}-dim in {emb['text_embed_s']}s", flush=True)
+            print(f"cosine similarity: {emb['cosine_similarity']}", flush=True)
             result["status"] = "pass"
 
         print(f"\n{json.dumps(result, indent=2)}")


### PR DESCRIPTION
The `v0.2.0-alpha3` release built both architectures and pushed the manifest, then failed here:

```
FAILED: No module named 'torch'
```

`ADR-0105` removed torch and transformers; the smoke test still asserted `import torch`. A check whose subject no longer exists — it passed for as long as the thing it tested was there, then failed for the right reason at the wrong moment. The GitHub Release was skipped as a result.

## What replaces it

Stronger than the import it removes:

- loads the ONNX encoders **from the image** (proving the `onnx-export` stage's output actually landed)
- runs a real 25-second audio embedding — two windows, so the pooling path executes rather than a single-window shortcut
- runs a real text embedding
- asserts 512 dimensions, finiteness, and unit length

## The part that matters most

It reports **which providers actually bound**, not which were requested:

```
requested: ['CUDAExecutionProvider', 'CPUExecutionProvider']
active:    ['CPUExecutionProvider']
CUDA requested but NOT bound — running on CPU
```

ONNX Runtime falls back to CPU **silently**. Four different CUDA stacks did exactly that while building `ADR-0105`, each reporting success. Without this line a GPU image with a broken CUDA stack is indistinguishable from a working one.

Not-bound is deliberately **not** a failure — one image runs on hosts with and without a GPU. It is printed so the state cannot hide.

Also drops the HuggingFace cache mount from the full run: the encoders ship in the image now, so nothing is downloaded.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01Emjrwedq7W1scadHdgiLfs