### PR TITLE
Bump the clapback-embed lock to the CUDA-guard commit

### DIFF
--- a/backend/uv.lock
+++ b/backend/uv.lock
@@ -630,7 +630,7 @@ wheels = [
 [[package]]
 name = "clapback-embed"
 version = "0.1.0"
-source = { git = "https://github.com/seethroughlab/familiar-cache.git?subdirectory=packages%2Fembed&rev=main#c2bcbf4fa1c135a78090aad620694217f63adc50" }
+source = { git = "https://github.com/seethroughlab/familiar-cache.git?subdirectory=packages%2Fembed&rev=main#1623538905e5b38256f29fb5ce67deb30cb5d652" }
 dependencies = [
     { name = "huggingface-hub" },
     { name = "librosa" },


### PR DESCRIPTION
`uv.lock` pins the git dependency to a **resolved commit**:

```
rev=main#c2bcbf4fa1c135a78090aad620694217f63adc50   <- before
rev=main#1623538905e5b38256f29fb5ce67deb30cb5d652   <- after
```

So `uv sync --frozen` would have rebuilt the image with `c2bcbf4` — the version that **segfaults when CUDA is requested without a driver** — regardless of the fix being merged to clapback's main. The build would have been green and shipped the crash.

A lockfile is precisely the mechanism that makes *merged upstream* and *present in the artifact* two different facts.

Any future clapback-embed fix needs this bump too, until the package is published to an index and the dependency stops being a git reference. That is now two workarounds (this, plus git in the builder stage) pointing at the same missing piece.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01Emjrwedq7W1scadHdgiLfs