### PR TITLE
Make the GPU an opt-in override; the reservation is fatal without one

### DIFF
--- a/docker/docker-compose.gpu.yml
+++ b/docker/docker-compose.gpu.yml
@@ -1,0 +1,37 @@
+# GPU acceleration, opt-in.
+#
+#   docker compose -f docker-compose.prod.yml -f docker-compose.gpu.yml up -d
+#
+# This is a separate file because the device reservation below is **fatal** on a
+# host without the NVIDIA container runtime, not ignored:
+#
+#   Error response from daemon: could not select device driver "nvidia"
+#   with capabilities: [[gpu]]
+#
+# So it cannot live in the default compose. An earlier version of this change put
+# it there on the assumption that Docker would skip an unsatisfiable reservation;
+# it does not, and that would have stopped every installation without an NVIDIA
+# card from starting at all.
+#
+# What you need on the host, all three:
+#   - an NVIDIA driver whose kernel module matches its userspace libraries
+#     (a driver package upgrade without a reboot breaks this for every container)
+#   - `libcuda1` and ideally `nvidia-smi` — a display driver alone is not enough,
+#     libcuda.so is what CUDA actually needs and it ships separately
+#   - nvidia-container-toolkit, so Docker can pass the device through
+#
+# Verify before expecting a speedup — the embedder falls back to the CPU silently
+# and correctly, so "no error" is not evidence:
+#
+#   docker exec familiar-api python /app/scripts/smoke_test_clap.py
+#
+# and look for "CUDA requested and bound" rather than merely "requested".
+services:
+  api:
+    deploy:
+      resources:
+        reservations:
+          devices:
+            - driver: nvidia
+              count: all
+              capabilities: [gpu]

--- a/docker/docker-compose.prod.yml
+++ b/docker/docker-compose.prod.yml
@@ -85,13 +85,6 @@ services:
         reservations:
           cpus: '0.5'    # Guaranteed 0.5 cores
           memory: 512M   # Guaranteed 512MB
-          # GPU is optional: with no NVIDIA runtime present the container starts
-          # normally and the embedder uses the CPU, which produces the same vectors
-          # (6.6e-14 apart, against float4 storage's 6.0e-08).
-          devices:
-            - driver: nvidia
-              count: all
-              capabilities: [gpu]
     # Use journald for persistent logging that survives reboots
     logging:
       driver: journald


### PR DESCRIPTION
**As merged, `docker-compose.prod.yml` refuses to start on any host without an NVIDIA GPU.** Tested on a machine with none:

```
Error response from daemon: could not select device driver "nvidia" with capabilities: [[gpu]]
```

The comment I wrote beside that reservation in #262 claimed it was "ignored rather than fatal when no device matches". That was an assumption stated as fact, and it is wrong.

Nothing caught it: the only CI that runs compose builds `docker-compose.local.yml`, and the only host that runs the prod file has a GPU.

## The fix

The reservation moves to `docker-compose.gpu.yml`, added explicitly:

```bash
docker compose -f docker-compose.prod.yml -f docker-compose.gpu.yml up -d
```

Verified both directions on a GPU-less host:

| | result |
|---|---|
| `prod.yml` alone | **starts** |
| `prod.yml` + `gpu.yml` | fails — correct for a file you opt into |

The `NVIDIA_*` environment variables stay in the base file. They are read by the toolkit's hook, which is absent without a GPU, so they are genuinely inert — that is the distinction the original comment got wrong.

## The override documents what the host needs

None of it is obvious, and this deployment was missing two of the three:

- a driver whose kernel module matches its userspace libraries (a package upgrade without a reboot breaks it for **every** container)
- `libcuda1` — a display driver alone is not enough; `libcuda.so` ships separately and was absent entirely
- `nvidia-container-toolkit`

It also says to check for `CUDA requested and bound` rather than trusting the absence of an error, because the embedder falls back to the CPU silently and correctly.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01Emjrwedq7W1scadHdgiLfs