### PR TITLE
Stop the churn guard punishing a phase for being busy

### DIFF
--- a/backend/app/services/tasks/library_sync.py
+++ b/backend/app/services/tasks/library_sync.py
@@ -22,7 +22,7 @@ from app.services.tasks.library_sync_progress import (
     SYNC_MAX_REQUEUE_ATTEMPTS_PER_WINDOW,
     SYNC_QUEUE_CHURN_WINDOW_SECONDS,
     SyncProgressReporter,
-    _register_phase_requeue_attempt,
+    should_force_exit_for_churn,
 )
 from app.utils.time import utcnow
 
@@ -279,11 +279,26 @@ async def run_library_sync(
         *,
         limit: int,
         stall_recovery: bool = False,
+        made_progress: bool = False,
     ) -> tuple[int, bool]:
-        """Queue tracks while enforcing per-phase churn guardrails."""
+        """Queue tracks while enforcing per-phase churn guardrails.
+
+        `made_progress` says whether tracks completed since the last call, and
+        resets the window when they did.
+
+        Without it the guard counted *every* attempt, productive or not. The loops
+        below sleep 2s and queue on each pass, so a phase with work to do makes
+        150 attempts per 300s window against a limit of 60 — meaning **any phase
+        that ran longer than about two minutes force-exited**, regardless of how
+        well it was going. Observed as `queue_churn_limit_exceeded:61/60:300s` on
+        both the features and embeddings phases of a healthy sync.
+
+        Churn is re-queueing that achieves nothing. Queueing while tracks are
+        completing is the loop working, so it must not count against the limit.
+        """
         now = time.monotonic()
         attempts = phase_requeue_windows.setdefault(phase, deque())
-        if _register_phase_requeue_attempt(attempts, now):
+        if should_force_exit_for_churn(attempts, now, made_progress=made_progress):
             reason = (
                 f"queue_churn_limit_exceeded:{len(attempts)}/"
                 f"{SYNC_MAX_REQUEUE_ATTEMPTS_PER_WINDOW}:{int(SYNC_QUEUE_CHURN_WINDOW_SECONDS)}s"
@@ -384,7 +399,8 @@ async def run_library_sync(
                     break
 
                 # Check for stall (no progress in stall_threshold seconds)
-                if features_done > last_features_done:
+                features_progressed = features_done > last_features_done
+                if features_progressed:
                     last_features_progress_time = time.time()
                     last_features_done = features_done
                 elif time.time() - last_features_progress_time > features_stall_threshold:
@@ -401,6 +417,7 @@ async def run_library_sync(
                         queue_tracks_for_features,
                         limit=200,
                         stall_recovery=True,
+                        made_progress=features_progressed,
                     )
                     if forced_exit:
                         break
@@ -420,6 +437,7 @@ async def run_library_sync(
                         "features",
                         queue_tracks_for_features,
                         limit=100,
+                        made_progress=features_progressed,
                     )
                     if forced_exit:
                         break
@@ -505,7 +523,8 @@ async def run_library_sync(
                         break
 
                     # Check for stall (no progress in stall_threshold seconds)
-                    if embeddings_done > last_embeddings_done:
+                    embeddings_progressed = embeddings_done > last_embeddings_done
+                    if embeddings_progressed:
                         last_progress_time = time.time()
                         last_embeddings_done = embeddings_done
                     elif time.time() - last_progress_time > stall_threshold:
@@ -524,6 +543,7 @@ async def run_library_sync(
                             queue_tracks_for_embeddings,
                             limit=200,
                             stall_recovery=True,
+                            made_progress=embeddings_progressed,
                         )
                         if forced_exit:
                             analyzed_count = embeddings_success
@@ -548,6 +568,7 @@ async def run_library_sync(
                             "embeddings",
                             queue_tracks_for_embeddings,
                             limit=100,
+                            made_progress=embeddings_progressed,
                         )
                         if forced_exit:
                             analyzed_count = embeddings_success

--- a/backend/app/services/tasks/library_sync_progress.py
+++ b/backend/app/services/tasks/library_sync_progress.py
@@ -34,6 +34,34 @@ def _register_phase_requeue_attempt(
     return len(attempts) > max_attempts
 
 
+def should_force_exit_for_churn(
+    attempts: deque[float],
+    now: float,
+    *,
+    made_progress: bool,
+    window_seconds: float = SYNC_QUEUE_CHURN_WINDOW_SECONDS,
+    max_attempts: int = SYNC_MAX_REQUEUE_ATTEMPTS_PER_WINDOW,
+) -> bool:
+    """Should this phase give up because it is re-queueing to no effect?
+
+    Churn is queueing that achieves nothing. Queueing while tracks are completing
+    is the loop doing its job, so `made_progress` resets the window.
+
+    Without that reset the guard counted every attempt: the phase loops sleep 2s
+    and queue on each pass, giving 150 attempts per 300s window against a limit
+    of 60, so **any phase running longer than about two minutes force-exited**
+    however well it was going. Observed as
+    `queue_churn_limit_exceeded:61/60:300s` on both features and embeddings
+    during a healthy sync.
+
+    Kept here rather than inline in `_guarded_queue` so it can be tested: the
+    caller is a closure over sync state and cannot be imported.
+    """
+    if made_progress:
+        attempts.clear()
+    return _register_phase_requeue_attempt(attempts, now, window_seconds, max_attempts)
+
+
 class SyncProgressReporter:
     """Reports unified sync progress to Redis for API consumption.
 

--- a/backend/tests/test_sync_guardrails.py
+++ b/backend/tests/test_sync_guardrails.py
@@ -8,9 +8,10 @@ from app.services.tasks.analysis_pipeline import (
     ANALYSIS_RETRY_WINDOW_HOURS,
     _analysis_failure_cutoff,
 )
-from app.services.tasks.library_sync import (
-    SyncProgressReporter,
+from app.services.tasks.library_sync import SyncProgressReporter
+from app.services.tasks.library_sync_progress import (
     _register_phase_requeue_attempt,
+    should_force_exit_for_churn,
 )
 from app.utils.time import utcnow
 
@@ -147,3 +148,77 @@ class TestSyncLeavesEditedMetadataAlone:
             "the guard that keeps edited metadata has moved or changed shape — check what the Mac's "
             "track editor and sync pane now promise"
         )
+
+
+class TestChurnGuardDoesNotPunishProgress:
+    """The guard must distinguish churn from a phase that is simply busy.
+
+    It could not. The phase loops sleep 2s and queue on every pass, so a phase
+    with work to do makes 150 attempts per 300s window against a limit of 60 —
+    meaning **any phase running longer than about two minutes force-exited**,
+    however well it was going. Seen in production as
+    `queue_churn_limit_exceeded:61/60:300s` on both features and embeddings
+    during a healthy sync, capping every run at roughly two minutes of queueing.
+
+    It stayed hidden because the background worker keeps draining the queue after
+    the loop exits, so throughput looked fine until the work got fast enough to
+    empty the queue before the next sync refilled it.
+    """
+
+    def test_the_loop_cadence_alone_exceeds_the_limit(self) -> None:
+        """The arithmetic that made the old behaviour unavoidable.
+
+        This asserts the *relationship* between the constants and the loop, which
+        is what was actually wrong — not a bug in the counting.
+        """
+        from app.services.tasks.library_sync_progress import (
+            SYNC_MAX_REQUEUE_ATTEMPTS_PER_WINDOW,
+            SYNC_QUEUE_CHURN_WINDOW_SECONDS,
+        )
+
+        loop_sleep_seconds = 2
+        attempts_per_window = SYNC_QUEUE_CHURN_WINDOW_SECONDS / loop_sleep_seconds
+        assert attempts_per_window > SYNC_MAX_REQUEUE_ATTEMPTS_PER_WINDOW, (
+            "a busy phase cannot stay under the limit on cadence alone, so the "
+            "guard must be reset by progress rather than counting every attempt"
+        )
+
+    def test_progress_resets_the_window(self) -> None:
+        """A phase completing tracks can queue indefinitely.
+
+        200 iterations is 400 simulated seconds — well past the point where the
+        old behaviour force-exited at 60.
+        """
+        attempts: deque[float] = deque()
+        now = 0.0
+        for _ in range(200):
+            assert not should_force_exit_for_churn(attempts, now, made_progress=True)
+            now += 2.0
+
+    def test_churn_without_progress_still_trips(self) -> None:
+        """The guard must keep doing its actual job.
+
+        Queueing repeatedly while nothing completes is a genuine infinite loop and
+        has to be caught — the fix must not amount to disabling it.
+        """
+        attempts: deque[float] = deque()
+        now = 0.0
+        tripped = False
+        for _ in range(200):
+            if should_force_exit_for_churn(attempts, now, made_progress=False):
+                tripped = True
+                break
+            now += 2.0
+        assert tripped, "no progress for 200 attempts must still force an exit"
+
+    def test_progress_after_near_miss_clears_accumulated_attempts(self) -> None:
+        """Intermittent progress must not leave the phase one attempt from death."""
+        attempts: deque[float] = deque()
+        now = 0.0
+        for _ in range(59):
+            assert not should_force_exit_for_churn(attempts, now, made_progress=False)
+            now += 2.0
+        assert len(attempts) == 59
+        # one track completes
+        assert not should_force_exit_for_churn(attempts, now, made_progress=True)
+        assert len(attempts) == 1, "the window must reset, not merely not-trip"


### PR DESCRIPTION
The guard counted **every** queue attempt, productive or not:

```
Sync features phase forced exit:   queue_churn_limit_exceeded:61/60:300s
Sync embeddings phase forced exit: queue_churn_limit_exceeded:61/60:300s
```

The phase loops sleep 2 s and queue on each pass, so a phase with work to do makes **150 attempts per 300 s window against a limit of 60**. There is no cadence at which a busy sync survives it — **any phase running longer than about two minutes force-exited**, however well it was going.

## It had been happening for weeks

Syncs reporting `analyzed=4`, `60`, `86`, `241` looked like ordinary batching. They were phases being cut off after two minutes.

It stayed hidden because the background worker keeps draining the queue after the loop exits, so throughput looked normal. **Adopting the GPU is what exposed it**: at 2.9 s/track the worker empties the queue long before the next two-hourly sync refills it, and the library stopped dead at 5,819 of 26,471.

## The fix

Churn is re-queueing that achieves nothing. Queueing while tracks are completing is the loop working, so `made_progress` resets the window. The guard still fires when nothing completes — that infinite loop is what it exists to catch, and `test_churn_without_progress_still_trips` holds it to that.

## The tests could not have caught it before

`_guarded_queue` is a closure over sync state and cannot be imported, so the existing tests exercised only the deque beneath it — and would have passed against the broken behaviour. The decision now lives in `should_force_exit_for_churn`, which is importable and directly tested.

Verified the two new regression tests fail against the old semantics, restored with `git show`:

```
FAILED test_progress_resets_the_window
FAILED test_progress_after_near_miss_clears_accumulated_attempts
2 failed, 11 passed
```

One test asserts the *relationship* rather than the behaviour — `test_the_loop_cadence_alone_exceeds_the_limit` — because the real defect was the constants being unsatisfiable given the loop, not an error in the counting.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01Emjrwedq7W1scadHdgiLfs