### PR TITLE
Point at the renamed clapback repository

### DIFF
--- a/backend/pyproject.toml
+++ b/backend/pyproject.toml
@@ -78,7 +78,7 @@ dev = [
 analysis = [
     "librosa>=0.10.0",
     "numpy>=1.24.0",
-    "clapback-embed @ git+https://github.com/seethroughlab/familiar-cache.git@main#subdirectory=packages/embed",
+    "clapback-embed @ git+https://github.com/seethroughlab/clapback.git@main#subdirectory=packages/embed",
     "soundfile>=0.12.0", # Audio file loading
     "umap-learn>=0.5.0", # Dimensionality reduction for music map
     "pyloudnorm>=0.1.0", # EBU R128 loudness measurement
@@ -94,7 +94,7 @@ build-backend = "hatchling.build"
 packages = ["app"]
 
 # `clapback-embed` is installed from git rather than PyPI — it is published from
-# the familiar-cache repository and has no release on an index yet. hatchling
+# the clapback repository and has no release on an index yet. hatchling
 # refuses direct references without this.
 [tool.hatch.metadata]
 allow-direct-references = true

--- a/backend/uv.lock
+++ b/backend/uv.lock
@@ -630,7 +630,7 @@ wheels = [
 [[package]]
 name = "clapback-embed"
 version = "0.1.0"
-source = { git = "https://github.com/seethroughlab/familiar-cache.git?subdirectory=packages%2Fembed&rev=main#1623538905e5b38256f29fb5ce67deb30cb5d652" }
+source = { git = "https://github.com/seethroughlab/clapback.git?subdirectory=packages%2Fembed&rev=main#1623538905e5b38256f29fb5ce67deb30cb5d652" }
 dependencies = [
     { name = "huggingface-hub" },
     { name = "librosa" },
@@ -1083,7 +1083,7 @@ requires-dist = [
     { name = "basic-pitch", extras = ["onnx"], marker = "extra == 'analysis'", specifier = ">=0.3.0" },
     { name = "beautifulsoup4", specifier = ">=4.14.3" },
     { name = "boto3", specifier = ">=1.34.0" },
-    { name = "clapback-embed", marker = "extra == 'analysis'", git = "https://github.com/seethroughlab/familiar-cache.git?subdirectory=packages%2Fembed&rev=main" },
+    { name = "clapback-embed", marker = "extra == 'analysis'", git = "https://github.com/seethroughlab/clapback.git?subdirectory=packages%2Fembed&rev=main" },
     { name = "curl-cffi", specifier = ">=0.7.0" },
     { name = "fastapi", specifier = ">=0.109.0" },
     { name = "greenlet", specifier = ">=3.0.0" },

--- a/docker/Dockerfile
+++ b/docker/Dockerfile
@@ -63,7 +63,7 @@ FROM python-base AS python-deps
 
 # g++ is needed to compile miniaudio (a pyatv dependency) which has no aarch64 wheel
 # git is needed by uv to resolve `clapback-embed @ git+...`, which is published
-# from the familiar-cache repository and not yet on an index. This is a builder
+# from the clapback repository and not yet on an index. This is a builder
 # stage, so git does not reach the production image — and if the package ever
 # ships to PyPI, this line goes with the git dependency.
 RUN apt-get update && apt-get install -y --no-install-recommends g++ git && rm -rf /var/lib/apt/lists/*
@@ -139,7 +139,7 @@ RUN --mount=type=cache,target=/root/.cache/uv \
 # Fetched rather than COPY --from: `scripts/` is not part of the wheel, so it does
 # not exist in the installed package. Same mechanism the image already uses for
 # silero_vad.onnx below.
-ADD https://raw.githubusercontent.com/seethroughlab/familiar-cache/main/packages/embed/scripts/export_models.py ./export_models.py
+ADD https://raw.githubusercontent.com/seethroughlab/clapback/main/packages/embed/scripts/export_models.py ./export_models.py
 RUN --mount=type=cache,target=/root/.cache/huggingface \
     /opt/exportenv/bin/python export_models.py --out /models
 


### PR DESCRIPTION
`familiar-cache` is now [`seethroughlab/clapback`](https://github.com/seethroughlab/clapback), which `ADR-0001` point 2 decided and its deferred table put **last**, on the grounds that nothing depended on it.

Publishing the package to an index is what makes it depend on it: a release's metadata is permanent, so `v0.1.0` on PyPI would point forever at a repository name that had already moved.

Updates:

- the `clapback-embed` git dependency in `backend/pyproject.toml`
- the Dockerfile's `ADD` of `export_models.py`
- the resolved URL in `uv.lock`

Same commit, same code — only the host path changes. GitHub redirects the old URLs (both return 200), so this was never urgent for correctness; it is here so the reference matches reality before anything permanent is published against it.

## Deliberately unchanged

`fly.toml` still says `app = 'familiar-cache'` and the README still points at `familiar-cache.fly.dev`. **That is a running service, not a repository.** Renaming it is a deploy with its own consequences, and `ADR-0001`'s deferred item 6 pairs it with the question of what the domain should serve.

## Also worth knowing

`clapback` is **already taken on PyPI**. `clapback-embed` and `clapback_embed` are both free, so the package name is unaffected — but the bare name is not available if an umbrella package is ever wanted.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01Emjrwedq7W1scadHdgiLfs