### PR TITLE
Record what the GPU cost in memory, and drop to two workers

### DIFF
--- a/docker/docker-compose.prod.yml
+++ b/docker/docker-compose.prod.yml
@@ -81,7 +81,9 @@ services:
       resources:
         limits:
           cpus: '6.0'    # Max 6 CPU cores, leaving 2 for Postgres, Redis and the OS
-          memory: 10G    # Each analysis worker holds a CLAP model
+          memory: 12G    # Each worker holds a CLAP model, a CUDA context and up to
+                         # ~2 GB of decoded audio for a long file. Measured 1.57G
+                         # idle; the ceiling exists for the long-form tail.
         reservations:
           cpus: '0.5'    # Guaranteed 0.5 cores
           memory: 512M   # Guaranteed 512MB
@@ -106,6 +108,13 @@ services:
       # even amortise its own interpreter start. Measured on the deployment host —
       # 1 worker 15.7s/track, 3 workers 11.3s/track, and with the GPU 2.9s.
       #
+      # Two, not three, because the GPU changed the memory arithmetic: each worker
+      # now holds a CUDA context as well as its decode buffer, and a 57-minute DJ
+      # mix decodes to 2.0 GB. Three workers on long-form files exhausted both a
+      # 10 GB and a 12 GB limit (ADR-0105). Long files sort to the end of a
+      # re-analysis, so this only shows up in the last few hundred tracks of a run —
+      # the tail is the worst case, not the average.
+      #
       # Each worker holds a CLAP model, so this trades memory for throughput; raise
       # it and the `memory` limit together. Three workers measured 2.3 GiB against
       # the 10G limit, so there is room, but scaling is sub-linear because decode
@@ -115,7 +124,7 @@ services:
       # the environment at process start, so changing it needs the container
       # recreated. A recreate discards anything `deploy-dev.sh` copied in, so re-run
       # `make deploy-dev` afterwards or the container silently reverts to the image.
-      - MAX_ANALYSIS_WORKERS=${MAX_ANALYSIS_WORKERS:-3}
+      - MAX_ANALYSIS_WORKERS=${MAX_ANALYSIS_WORKERS:-2}
       # A single worker crash breaks the ProcessPoolExecutor. Without recovery,
       # every task after it fails against the dead pool until the circuit breaker
       # disables the executor outright — 10,283 consecutive failures on

--- a/docs/decisions/ADR-0105-familiars-clap-runtime-is-an-external-package.md
+++ b/docs/decisions/ADR-0105-familiars-clap-runtime-is-an-external-package.md
@@ -11,6 +11,32 @@ Relates to [ADR-0102](ADR-0102-the-community-cache-gains-a-recording-key.md), wh
 only meaningful if independent installations compute the same function.
 
 Implementation:
+- **The GPU made each analysis worker more expensive in host RAM, and the tail of a library is where
+  that bites.** Every worker now holds a CUDA context alongside its decode buffer, so three workers
+  that were comfortable on the CPU path were not on the GPU one. Measured 2026-09-03: a 57-minute
+  DJ mix decodes to **2.01 GB peak RSS**, and three workers on such files exhausted first a 10 GB and
+  then a 12 GB container limit — `memory.events` recorded `oom_kill 2` at both. The deployment now
+  runs **two** workers at 12 GB.
+- **This only appeared at the end of a full re-analysis, and not by chance.** Long files are the slow
+  ones, so they accumulate at the back of the queue; the last few hundred tracks of a 26,000-track
+  run were almost entirely DJ mixes and extended pieces. A library re-analysis is therefore not a
+  uniform workload — its tail is its worst case, and sizing from the average is sizing for the part
+  that already finished.
+- **`docker update` must never be used on a container with a GPU.** Raising the memory limit that way
+  avoids a recreate, which is exactly why it was chosen — and it silently rewrites the cgroup device
+  allowlist without the NVIDIA permissions. `/dev/nvidia0` remains present and `DeviceRequests` still
+  reads correctly, while every CUDA initialisation fails with *"no CUDA-capable device is
+  detected"*: a message that points at hardware when the cause is a container reconfiguration. It
+  produced 294 spurious embedding failures before it was spotted. Recreate from compose instead, so
+  the limit is recorded there rather than applied live.
+- **Verify a provider in a spawned worker, not just the main process.** `get_analysis_capabilities()`
+  reported CUDA bound in the API process while every analysis subprocess failed to initialise it.
+  The check that matters is the one run where the work happens.
+- **The real fix is not a worker count.** A 57-minute file should not need a gigabyte of resident
+  audio to produce one 512-float vector. `clapback-embed` decodes whole-file and then windows it;
+  decoding a window at a time would make the memory cost independent of track length and stop the
+  worker count from depending on what music somebody owns. Recorded as a follow-up against the
+  package rather than absorbed with RAM on every host that runs it.
 - Accepted and implemented 2026-09-02. `extract_embedding` and `extract_text_embedding` delegate to
   `clapback-embed`; `get_device()`, `load_clap_model()` and the module-level model cache are gone,
   along with `torch` and `transformers` from the `analysis` extra.


### PR DESCRIPTION
The GPU made each analysis worker more expensive in **host** RAM — every worker now holds a CUDA context alongside its decode buffer. Three workers were comfortable on the CPU path and are not on the GPU one.

Measured: a 57-minute DJ mix decodes to **2.01 GB peak RSS**, and three workers on such files exhausted first a 10 GB and then a 12 GB limit — `memory.events` recorded `oom_kill 2` at both. Now **two workers at 12 GB**.

## It only surfaced at the very end, and not by chance

Long files are the slow ones, so they accumulate at the back of the queue. The last few hundred tracks of a 26,000-track run were almost entirely DJ mixes and extended pieces.

**A library re-analysis is not a uniform workload — its tail is its worst case.** Everything measured mid-run (2.9 s/track, memory at 1.3 of 10 GB) described the part that had already finished.

## Three operational findings, all of which cost real time

- **Never `docker update` a GPU container.** It avoids a recreate — which is why it was chosen — and silently rewrites the cgroup device allowlist without NVIDIA permissions. `/dev/nvidia0` stays present and `DeviceRequests` still reads correctly while every CUDA init fails with *"no CUDA-capable device is detected"*. It produced 294 spurious failures.
- **Verify a provider in a spawned worker**, not the main process. `get_analysis_capabilities()` reported CUDA bound while every analysis subprocess failed to initialise it.
- **cgroup OOM kills do not reliably reach `dmesg`.** `docker inspect` and `memory.events` do — which is why this was misdiagnosed as "not memory" for most of a day.

## The worker count is a workaround

A 57-minute file should not need a gigabyte of resident audio to produce one 512-float vector. Recorded as a follow-up against `clapback-embed` rather than absorbed with RAM on every host that runs it.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01Emjrwedq7W1scadHdgiLfs