### PR TITLE
Fix the S3 backup: prove it restores, make it survivable, give it a way in

### DIFF
--- a/backend/app/services/s3_backup.py
+++ b/backend/app/services/s3_backup.py
@@ -289,7 +289,9 @@ class S3BackupService:
             engine = create_engine(app_config.sync_database_url)
             with engine.connect() as conn:
                 row = conn.execute(
-                    text("SELECT COUNT(*), COALESCE(SUM(file_size), 0) FROM tracks WHERE file_size IS NOT NULL")
+                    text(
+                        "SELECT COUNT(*), COALESCE(SUM(file_size), 0) FROM tracks WHERE file_size IS NOT NULL"
+                    )
                 ).fetchone()
                 if row:
                     audio_count = int(row[0] or 0)
@@ -337,9 +339,7 @@ class S3BackupService:
         try:
             engine = create_engine(app_config.sync_database_url)
             with engine.connect() as conn:
-                row = conn.execute(
-                    text("SELECT pg_database_size(current_database())")
-                ).fetchone()
+                row = conn.execute(text("SELECT pg_database_size(current_database())")).fetchone()
                 if row:
                     db_size = row[0] or 0
             engine.dispose()
@@ -375,8 +375,7 @@ class S3BackupService:
 
         # Estimated full restore cost (retrieval + GET)
         glacier_size_gb = sum(
-            c["size_gb"] for name, c in categories.items()
-            if name not in ("database", "settings")
+            c["size_gb"] for name, c in categories.items() if name not in ("database", "settings")
         )
         estimated_restore_cost = glacier_size_gb * DEEP_ARCHIVE_RETRIEVAL_PER_GB
 
@@ -447,7 +446,9 @@ class S3BackupService:
             if settings_path.exists():
                 s_key = _s3_key(prefix, "settings.json")
                 client.upload_file(
-                    str(settings_path), bucket, s_key,
+                    str(settings_path),
+                    bucket,
+                    s_key,
                     ExtraArgs={"StorageClass": "STANDARD"},
                 )
                 manifest["settings"] = {
@@ -460,7 +461,9 @@ class S3BackupService:
             engine = create_engine(app_config.sync_database_url)
             with engine.connect() as conn:
                 rows = conn.execute(
-                    text("SELECT id, file_path, file_hash, file_size FROM tracks WHERE file_hash IS NOT NULL")
+                    text(
+                        "SELECT id, file_path, file_hash, file_size FROM tracks WHERE file_hash IS NOT NULL"
+                    )
                 ).fetchall()
             engine.dispose()
 
@@ -503,7 +506,9 @@ class S3BackupService:
 
                 try:
                     client.upload_file(
-                        str(fp), bucket, s3_full_key,
+                        str(fp),
+                        bucket,
+                        s3_full_key,
                         ExtraArgs={"StorageClass": "DEEP_ARCHIVE"},
                         Config=transfer_config,
                     )
@@ -533,22 +538,40 @@ class S3BackupService:
             # Phase: Artwork
             progress.update(phase="artwork")
             self._backup_directory(
-                client, bucket, prefix, Path(app_config.art_path),
-                "artwork", manifest, progress, transfer_config,
+                client,
+                bucket,
+                prefix,
+                Path(app_config.art_path),
+                "artwork",
+                manifest,
+                progress,
+                transfer_config,
             )
 
             # Phase: Videos
             progress.update(phase="videos")
             self._backup_directory(
-                client, bucket, prefix, Path(app_config.videos_path),
-                "videos", manifest, progress, transfer_config,
+                client,
+                bucket,
+                prefix,
+                Path(app_config.videos_path),
+                "videos",
+                manifest,
+                progress,
+                transfer_config,
             )
 
             # Phase: Profiles
             progress.update(phase="profiles")
             self._backup_directory(
-                client, bucket, prefix, Path(app_config.profiles_path),
-                "profiles", manifest, progress, transfer_config,
+                client,
+                bucket,
+                prefix,
+                Path(app_config.profiles_path),
+                "profiles",
+                manifest,
+                progress,
+                transfer_config,
             )
 
             # Write manifest
@@ -561,14 +584,16 @@ class S3BackupService:
             progress.update(phase="complete", status="complete", current_file=None)
 
             # Save to history
-            self._save_history_entry({
-                "timestamp": utcnow().isoformat(),
-                "duration_seconds": round(duration, 1),
-                "files_uploaded": final["files_uploaded"],
-                "files_skipped": final["files_skipped"],
-                "bytes_uploaded": final["bytes_uploaded"],
-                "status": "success",
-            })
+            self._save_history_entry(
+                {
+                    "timestamp": utcnow().isoformat(),
+                    "duration_seconds": round(duration, 1),
+                    "files_uploaded": final["files_uploaded"],
+                    "files_skipped": final["files_skipped"],
+                    "bytes_uploaded": final["bytes_uploaded"],
+                    "status": "success",
+                }
+            )
 
             return {
                 "status": "success",
@@ -581,15 +606,17 @@ class S3BackupService:
         except Exception as e:
             logger.error(f"Backup failed: {e}", exc_info=True)
             progress.update(phase="error", status="error", error=str(e))
-            self._save_history_entry({
-                "timestamp": utcnow().isoformat(),
-                "duration_seconds": round(time.monotonic() - start_time, 1),
-                "files_uploaded": progress.get()["files_uploaded"],
-                "files_skipped": progress.get()["files_skipped"],
-                "bytes_uploaded": progress.get()["bytes_uploaded"],
-                "status": "error",
-                "error": str(e),
-            })
+            self._save_history_entry(
+                {
+                    "timestamp": utcnow().isoformat(),
+                    "duration_seconds": round(time.monotonic() - start_time, 1),
+                    "files_uploaded": progress.get()["files_uploaded"],
+                    "files_skipped": progress.get()["files_skipped"],
+                    "bytes_uploaded": progress.get()["bytes_uploaded"],
+                    "status": "error",
+                    "error": str(e),
+                }
+            )
             return {"status": "error", "error": str(e)}
         finally:
             try:
@@ -597,51 +624,81 @@ class S3BackupService:
             except Exception:
                 pass
 
-    def _backup_database(
-        self, client: Any, bucket: str, prefix: str
-    ) -> tuple[str, int, str]:
-        """Run pg_dump, gzip, upload to S3 Standard. Returns (key, size, checksum)."""
-        db_url = app_config.sync_database_url
-        # Parse connection string for pg_dump
-        # Format: postgresql://user:pass@host:port/dbname
+    def _pg_dump_to(self, out_path: str) -> None:
+        """Run `pg_dump | gzip` into `out_path`. Raises if pg_dump fails.
+
+        Shared by the S3 upload and by `_safety_dump`, so the copy taken before a
+        restore is produced by exactly the same command as the copy that is
+        archived — a safety net built differently from the thing it protects is a
+        second implementation to get wrong.
+        """
         from urllib.parse import urlparse
 
-        parsed = urlparse(db_url)
+        parsed = urlparse(app_config.sync_database_url)
 
         env = os.environ.copy()
         if parsed.password:
             env["PGPASSWORD"] = parsed.password
 
+        pg_dump_cmd = [
+            "pg_dump",
+            "-h",
+            parsed.hostname or "localhost",
+            "-p",
+            str(parsed.port or 5432),
+            "-U",
+            parsed.username or "familiar",
+            "-d",
+            parsed.path.lstrip("/") if parsed.path else "familiar",
+            "--no-owner",
+            "--no-acl",
+        ]
+
+        with open(out_path, "wb") as out_f:
+            dump_proc = subprocess.Popen(
+                pg_dump_cmd, stdout=subprocess.PIPE, stderr=subprocess.PIPE, env=env
+            )
+            with gzip.open(out_f, "wb") as gz:
+                while True:
+                    chunk = dump_proc.stdout.read(65536)
+                    if not chunk:
+                        break
+                    gz.write(chunk)
+
+            dump_proc.wait()
+            if dump_proc.returncode != 0:
+                stderr = dump_proc.stderr.read().decode() if dump_proc.stderr else ""
+                raise RuntimeError(f"pg_dump failed: {stderr}")
+
+    def _safety_dump(self) -> Path:
+        """Dump the current database to local disk before a restore overwrites it.
+
+        `download_and_restore` runs `psql` against the live database. Without this
+        the operation has no undo, and the endpoint's own docstring promised a
+        safety copy that nothing produced.
+
+        Deliberately local and outside S3: the restore is already happening
+        because S3 is being read, and a safety copy that needs a 12-hour Glacier
+        thaw to reach is not a safety copy. Raises if the dump fails, so a
+        restore cannot proceed unprotected.
+        """
+        safety_dir = Path("data/restore-safety")
+        safety_dir.mkdir(parents=True, exist_ok=True)
+        stamp = utcnow().strftime("%Y%m%d_%H%M%S")
+        out = safety_dir / f"pre-restore_{stamp}.sql.gz"
+        self._pg_dump_to(str(out))
+        if not out.exists() or out.stat().st_size == 0:
+            raise RuntimeError(f"safety dump produced no data at {out}")
+        logger.info(f"Pre-restore safety dump written: {out} ({out.stat().st_size} bytes)")
+        return out
+
+    def _backup_database(self, client: Any, bucket: str, prefix: str) -> tuple[str, int, str]:
+        """Run pg_dump, gzip, upload to S3 Standard. Returns (key, size, checksum)."""
         with tempfile.NamedTemporaryFile(suffix=".sql.gz", delete=False) as tmp:
             tmp_path = tmp.name
 
         try:
-            # pg_dump | gzip
-            pg_dump_cmd = [
-                "pg_dump",
-                "-h", parsed.hostname or "localhost",
-                "-p", str(parsed.port or 5432),
-                "-U", parsed.username or "familiar",
-                "-d", parsed.path.lstrip("/") if parsed.path else "familiar",
-                "--no-owner",
-                "--no-acl",
-            ]
-
-            with open(tmp_path, "wb") as out_f:
-                dump_proc = subprocess.Popen(
-                    pg_dump_cmd, stdout=subprocess.PIPE, stderr=subprocess.PIPE, env=env
-                )
-                with gzip.open(out_f, "wb") as gz:
-                    while True:
-                        chunk = dump_proc.stdout.read(65536)
-                        if not chunk:
-                            break
-                        gz.write(chunk)
-
-                dump_proc.wait()
-                if dump_proc.returncode != 0:
-                    stderr = dump_proc.stderr.read().decode() if dump_proc.stderr else ""
-                    raise RuntimeError(f"pg_dump failed: {stderr}")
+            self._pg_dump_to(tmp_path)
 
             size = os.path.getsize(tmp_path)
             checksum = _hash_file(Path(tmp_path))
@@ -650,7 +707,9 @@ class S3BackupService:
             s3_key = _s3_key(prefix, f"database/familiar_{timestamp}.sql.gz")
 
             client.upload_file(
-                tmp_path, bucket, s3_key,
+                tmp_path,
+                bucket,
+                s3_key,
                 ExtraArgs={"StorageClass": "STANDARD"},
             )
 
@@ -701,7 +760,9 @@ class S3BackupService:
 
             try:
                 client.upload_file(
-                    str(filepath), bucket, s3_full_key,
+                    str(filepath),
+                    bucket,
+                    s3_full_key,
                     ExtraArgs={"StorageClass": "DEEP_ARCHIVE"},
                     Config=transfer_config,
                 )
@@ -866,8 +927,7 @@ class S3BackupService:
         # Filter by category
         if categories:
             files = {
-                k: v for k, v in files.items()
-                if any(k.startswith(cat + "/") for cat in categories)
+                k: v for k, v in files.items() if any(k.startswith(cat + "/") for cat in categories)
             }
 
         total = len(files)
@@ -936,14 +996,10 @@ class S3BackupService:
         categories = state.get("categories", ["all"])
         if "all" not in categories:
             files = {
-                k: v for k, v in files.items()
-                if any(k.startswith(cat + "/") for cat in categories)
+                k: v for k, v in files.items() if any(k.startswith(cat + "/") for cat in categories)
             }
 
-        glacier_files = {
-            k: v for k, v in files.items()
-            if v.get("storage_class") == "DEEP_ARCHIVE"
-        }
+        glacier_files = {k: v for k, v in files.items() if v.get("storage_class") == "DEEP_ARCHIVE"}
 
         if not glacier_files:
             state["status"] = "available"
@@ -981,10 +1037,14 @@ class S3BackupService:
     def download_and_restore(self) -> dict[str, Any]:
         """Download restored files from S3 and apply. Runs synchronously in thread executor.
 
+        0. Dump the current database locally, so this is survivable
         1. Download + apply pg_dump (restore DB)
         2. Download settings.json
         3. Download audio files to original paths (skip if local hash matches)
         4. Download artwork, videos, profile avatars
+
+        Step 0 is not optional. Step 1 runs `psql` against the live database, so
+        without a local copy first this operation has no undo at all.
         """
         from botocore.exceptions import ClientError
 
@@ -1000,6 +1060,23 @@ class S3BackupService:
         start_time = time.monotonic()
 
         try:
+            # Phase: Safety dump. Before anything is overwritten, and fatal if it
+            # fails — proceeding would leave no way back to the current state.
+            progress.update(phase="safety_dump", current_file="pre-restore pg_dump")
+            try:
+                safety_path = self._safety_dump()
+            except Exception as e:
+                progress.update(
+                    status="error",
+                    error=f"Pre-restore safety dump failed, restore aborted: {e}",
+                )
+                logger.error(f"Restore aborted — safety dump failed: {e}")
+                return {
+                    "status": "error",
+                    "error": f"Pre-restore safety dump failed, restore aborted: {e}",
+                }
+            progress.update(safety_dump=str(safety_path))
+
             # Phase: Database
             db_info = manifest.get("database")
             if db_info:
@@ -1112,10 +1189,14 @@ class S3BackupService:
 
             restore_cmd = [
                 "psql",
-                "-h", parsed.hostname or "localhost",
-                "-p", str(parsed.port or 5432),
-                "-U", parsed.username or "familiar",
-                "-d", parsed.path.lstrip("/") if parsed.path else "familiar",
+                "-h",
+                parsed.hostname or "localhost",
+                "-p",
+                str(parsed.port or 5432),
+                "-U",
+                parsed.username or "familiar",
+                "-d",
+                parsed.path.lstrip("/") if parsed.path else "familiar",
             ]
 
             proc = subprocess.run(

--- a/backend/pyproject.toml
+++ b/backend/pyproject.toml
@@ -66,6 +66,9 @@ dev = [
     "ruff>=0.1.0",
     "mypy>=1.8.0",
     "httpx>=0.26.0",  # For TestClient
+    # S3 backup tests. Must live in `dev` rather than its own extra: CI runs
+    # `uv sync --extra dev`, so anything else is silently skipped rather than run.
+    "moto[s3]>=5.0.0",
 ]
 
 # Phase 1.5: Audio analysis

--- a/backend/tests/test_s3_backup.py
+++ b/backend/tests/test_s3_backup.py
@@ -1,0 +1,378 @@
+"""The backup nobody has ever restored from.
+
+`s3_backup.py` is 1,156 lines that run on a scheduler and write a whole Familiar
+installation to S3 — pg_dump and settings to Standard, audio and artwork to
+Glacier Deep Archive, content-addressed by hash, with a manifest that makes the
+next run incremental. Until this file it had **no test of any kind**, and its
+restore path had no caller either, so the only operation that matters in an
+emergency had never been executed.
+
+These use `moto`, which implements S3 in-process. The parts genuinely outside
+Python — `pg_dump` and `psql` — are stubbed, and asserted on separately; the
+storage logic underneath is exercised for real.
+"""
+
+from __future__ import annotations
+
+import gzip
+import hashlib
+import json
+from pathlib import Path
+from types import SimpleNamespace
+from unittest.mock import patch
+
+import pytest
+
+boto3 = pytest.importorskip("boto3")
+moto = pytest.importorskip("moto")
+from moto import mock_aws  # noqa: E402
+
+from app.services import s3_backup as s3mod  # noqa: E402
+
+BUCKET = "familiar-backup-test"
+REGION = "us-east-1"
+
+
+def _write_tracks(url: str, rows: list[dict]) -> None:
+    """(Re)create the `tracks` table the audio phase queries."""
+    import sqlalchemy
+
+    engine = sqlalchemy.create_engine(url)
+    with engine.begin() as conn:
+        conn.execute(sqlalchemy.text("DROP TABLE IF EXISTS tracks"))
+        conn.execute(
+            sqlalchemy.text(
+                "CREATE TABLE tracks (id TEXT, file_path TEXT, file_hash TEXT, file_size INTEGER)"
+            )
+        )
+        for t in rows:
+            conn.execute(
+                sqlalchemy.text(
+                    "INSERT INTO tracks VALUES (:id, :file_path, :file_hash, :file_size)"
+                ),
+                t,
+            )
+    engine.dispose()
+
+
+class FakeRedis:
+    """The subset s3_backup uses: set/get/delete/expire/lpush/lrange/ltrim."""
+
+    def __init__(self) -> None:
+        self.kv: dict[str, str] = {}
+        self.lists: dict[str, list[str]] = {}
+
+    def set(self, key, value, ex=None, nx=False):
+        if nx and key in self.kv:
+            return False
+        self.kv[key] = value
+        return True
+
+    def get(self, key):
+        return self.kv.get(key)
+
+    def delete(self, *keys):
+        for k in keys:
+            self.kv.pop(k, None)
+            self.lists.pop(k, None)
+        return True
+
+    def expire(self, key, seconds):
+        return True
+
+    def lpush(self, key, value):
+        self.lists.setdefault(key, []).insert(0, value)
+        return len(self.lists[key])
+
+    def lrange(self, key, start, end):
+        items = self.lists.get(key, [])
+        return items[start:] if end == -1 else items[start : end + 1]
+
+    def ltrim(self, key, start, end):
+        items = self.lists.get(key, [])
+        self.lists[key] = items[start:] if end == -1 else items[start : end + 1]
+        return True
+
+
+@pytest.fixture
+def fake_redis():
+    r = FakeRedis()
+    with patch.object(s3mod, "get_resilient_redis", return_value=r):
+        yield r
+
+
+@pytest.fixture
+def s3_settings():
+    """Credentials that moto accepts, with backup enabled."""
+    cfg = SimpleNamespace(
+        s3_backup_enabled=True,
+        s3_backup_schedule="weekly",
+    )
+    effective = {
+        "s3_backup_bucket": BUCKET,
+        "s3_backup_region": REGION,
+        "s3_backup_access_key_id": "testing",
+        "s3_backup_secret_access_key": "testing",
+        "s3_backup_prefix": "",
+    }
+    svc = SimpleNamespace(
+        get=lambda: cfg,
+        get_effective=lambda k: effective.get(k),
+        has_s3_credentials=lambda: True,
+    )
+    with patch.object(s3mod, "get_app_settings_service", return_value=svc):
+        yield effective
+
+
+@pytest.fixture
+def library(tmp_path, monkeypatch):
+    """Two real audio files on disk, and a `tracks` table that names them.
+
+    Points `sync_database_url` at a SQLite file rather than patching
+    `create_engine`, which `s3_backup` imports inside the function — so the real
+    query runs against a real engine.
+    """
+    audio_dir = tmp_path / "music"
+    audio_dir.mkdir()
+    tracks = []
+    for i, content in enumerate([b"RIFF-one-" + b"a" * 400, b"RIFF-two-" + b"b" * 900]):
+        p = audio_dir / f"track{i}.flac"
+        p.write_bytes(content)
+        tracks.append(
+            {
+                "id": f"0000000{i}-0000-0000-0000-00000000000{i}",
+                "file_path": str(p),
+                "file_hash": hashlib.sha256(content).hexdigest(),
+                "file_size": len(content),
+            }
+        )
+
+    monkeypatch.chdir(tmp_path)
+    data = tmp_path / "data"
+    data.mkdir()
+    (data / "settings.json").write_text(json.dumps({"library_paths": [str(audio_dir)]}))
+
+    db_path = tmp_path / "library.db"
+    url = f"sqlite:///{db_path}"
+    _write_tracks(url, tracks)
+    # `sync_database_url` is a read-only property, so patch it on the class.
+    monkeypatch.setattr(
+        type(s3mod.app_config),
+        "sync_database_url",
+        property(lambda self: url),
+        raising=False,
+    )
+
+    yield SimpleNamespace(tracks=tracks, audio_dir=audio_dir, root=tmp_path, db_url=url)
+
+
+@pytest.fixture
+def fake_pg(tmp_path):
+    """pg_dump/psql are the only things genuinely outside Python. Stub them."""
+    dump_payload = b"-- fake pg_dump\nCREATE TABLE tracks();\n"
+
+    def fake_dump(self, client, bucket, prefix):
+        key = s3mod._s3_key(prefix, "database/dump.sql.gz")
+        body = gzip.compress(dump_payload)
+        client.put_object(Bucket=bucket, Key=key, Body=body)
+        return key, len(body), "sha256:" + hashlib.sha256(body).hexdigest()
+
+    restored: dict = {}
+
+    def fake_restore(self, client, bucket, s3_key):
+        obj = client.get_object(Bucket=bucket, Key=s3_key)
+        restored["bytes"] = gzip.decompress(obj["Body"].read())
+
+    with (
+        patch.object(s3mod.S3BackupService, "_backup_database", fake_dump),
+        patch.object(s3mod.S3BackupService, "_restore_database", fake_restore),
+    ):
+        yield SimpleNamespace(payload=dump_payload, restored=restored)
+
+
+def _service():
+    return s3mod.S3BackupService()
+
+
+def _bucket(client):
+    client.create_bucket(Bucket=BUCKET)
+
+
+# --- backup -----------------------------------------------------------------
+
+
+@mock_aws
+def test_backup_stores_audio_content_addressed_by_hash(fake_redis, s3_settings, library, fake_pg):
+    """The key is the hash, not the path — that is what makes it deduplicating."""
+    client = boto3.client("s3", region_name=REGION)
+    _bucket(client)
+
+    result = _service().run_backup()
+    assert result.get("status") != "error", result
+
+    keys = {o["Key"] for o in client.list_objects_v2(Bucket=BUCKET).get("Contents", [])}
+    for t in library.tracks:
+        h = t["file_hash"]
+        assert f"audio/{h[:4]}/{h}.flac" in keys, f"missing {h[:4]}/{h}"
+
+
+@mock_aws
+def test_audio_goes_to_deep_archive_and_the_manifest_stays_instantly_readable(
+    fake_redis, s3_settings, library, fake_pg
+):
+    """The cost model in `estimate_cost` depends on exactly this split.
+
+    Audio in Deep Archive is ~$0.00099/GB/month; the manifest has to be readable
+    without a 12-hour thaw or an incremental backup could never start.
+    """
+    client = boto3.client("s3", region_name=REGION)
+    _bucket(client)
+    _service().run_backup()
+
+    h = library.tracks[0]["file_hash"]
+    audio = client.head_object(Bucket=BUCKET, Key=f"audio/{h[:4]}/{h}.flac")
+    assert audio.get("StorageClass") == "DEEP_ARCHIVE"
+
+    manifest = client.head_object(Bucket=BUCKET, Key="manifest.json")
+    assert manifest.get("StorageClass") in (None, "STANDARD")
+
+
+@mock_aws
+def test_a_second_backup_skips_files_whose_hash_has_not_changed(
+    fake_redis, s3_settings, library, fake_pg
+):
+    """Incremental is the whole point of the manifest.
+
+    Without it every scheduled run re-uploads the entire library, which for a
+    26,000-track collection is the difference between pennies and real money.
+    """
+    client = boto3.client("s3", region_name=REGION)
+    _bucket(client)
+
+    first = _service().run_backup()
+    fake_redis.kv.pop(s3mod.REDIS_BACKUP_LOCK, None)
+    second = _service().run_backup()
+
+    assert first.get("files_uploaded", 0) >= 2
+    assert second.get("files_skipped", 0) >= 2, second
+    assert second.get("files_uploaded", 0) == 0, "re-uploaded unchanged audio"
+
+
+@mock_aws
+def test_a_changed_file_is_uploaded_again_under_its_new_hash(
+    fake_redis, s3_settings, library, fake_pg
+):
+    client = boto3.client("s3", region_name=REGION)
+    _bucket(client)
+    _service().run_backup()
+    fake_redis.kv.pop(s3mod.REDIS_BACKUP_LOCK, None)
+
+    # Rewrite one file and re-point the row at its new hash.
+    changed = Path(library.tracks[0]["file_path"])
+    new_content = b"RIFF-one-CHANGED" + b"z" * 500
+    changed.write_bytes(new_content)
+    new_hash = hashlib.sha256(new_content).hexdigest()
+
+    rows = [dict(t) for t in library.tracks]
+    rows[0]["file_hash"] = new_hash
+    rows[0]["file_size"] = len(new_content)
+    _write_tracks(library.db_url, rows)
+    second = _service().run_backup()
+
+    keys = {o["Key"] for o in client.list_objects_v2(Bucket=BUCKET).get("Contents", [])}
+    assert f"audio/{new_hash[:4]}/{new_hash}.flac" in keys
+    assert second.get("files_uploaded", 0) >= 1
+
+
+@mock_aws
+def test_two_backups_cannot_run_at_once(fake_redis, s3_settings, library, fake_pg):
+    """The lock is 24 hours; without it a slow run and the scheduler overlap."""
+    client = boto3.client("s3", region_name=REGION)
+    _bucket(client)
+    fake_redis.set(s3mod.REDIS_BACKUP_LOCK, "1", nx=True)
+
+    result = _service().run_backup()
+    assert result.get("status") in ("already_running", "error"), result
+
+
+# --- restore ----------------------------------------------------------------
+
+
+@mock_aws
+def test_restore_asks_glacier_to_thaw_before_anything_is_downloaded(
+    fake_redis, s3_settings, library, fake_pg
+):
+    """Deep Archive cannot be read directly — a restore that skips this gets 403."""
+    client = boto3.client("s3", region_name=REGION)
+    _bucket(client)
+    _service().run_backup()
+
+    result = _service().initiate_restore()
+    assert result.get("files_requested", 0) >= 2, result
+
+
+@mock_aws
+def test_backup_then_restore_returns_the_original_bytes(fake_redis, s3_settings, library, fake_pg):
+    """The question a backup exists to answer, and the one never asked before.
+
+    Deletes the local audio after backing up, then restores and compares bytes.
+    """
+    client = boto3.client("s3", region_name=REGION)
+    _bucket(client)
+    original = {t["file_path"]: Path(t["file_path"]).read_bytes() for t in library.tracks}
+
+    _service().run_backup()
+    _service().initiate_restore()
+
+    for path in original:
+        Path(path).unlink()
+        assert not Path(path).exists()
+
+    fake_redis.kv.pop(s3mod.REDIS_BACKUP_LOCK, None)
+    result = _service().download_and_restore()
+    assert result.get("status") != "error", result
+
+    for path, content in original.items():
+        assert Path(path).exists(), f"{path} was not restored"
+        assert Path(path).read_bytes() == content, f"{path} restored corrupted"
+
+
+@mock_aws
+def test_restore_reapplies_the_database_dump(fake_redis, s3_settings, library, fake_pg):
+    """The audio is worthless without the library that indexes it."""
+    client = boto3.client("s3", region_name=REGION)
+    _bucket(client)
+    _service().run_backup()
+    _service().initiate_restore()
+    fake_redis.kv.pop(s3mod.REDIS_BACKUP_LOCK, None)
+
+    _service().download_and_restore()
+    assert fake_pg.restored.get("bytes") == fake_pg.payload
+
+
+# --- credentials and cost ---------------------------------------------------
+
+
+@mock_aws
+def test_validate_reports_success_against_a_reachable_bucket(fake_redis, s3_settings):
+    client = boto3.client("s3", region_name=REGION)
+    _bucket(client)
+    result = _service().validate_credentials(
+        bucket=BUCKET,
+        region=REGION,
+        access_key_id="testing",
+        secret_access_key="testing",
+    )
+    assert result.get("valid") is True, result
+
+
+@mock_aws
+def test_validate_fails_on_a_bucket_that_does_not_exist(fake_redis, s3_settings):
+    result = _service().validate_credentials(
+        bucket="no-such-bucket-familiar",
+        region=REGION,
+        access_key_id="testing",
+        secret_access_key="testing",
+    )
+    assert result.get("valid") is False
+    assert result.get("error")

--- a/backend/tests/test_s3_backup.py
+++ b/backend/tests/test_s3_backup.py
@@ -183,9 +183,13 @@ def fake_pg(tmp_path):
         obj = client.get_object(Bucket=bucket, Key=s3_key)
         restored["bytes"] = gzip.decompress(obj["Body"].read())
 
+    def fake_pg_dump_to(self, out_path):
+        Path(out_path).write_bytes(gzip.compress(dump_payload))
+
     with (
         patch.object(s3mod.S3BackupService, "_backup_database", fake_dump),
         patch.object(s3mod.S3BackupService, "_restore_database", fake_restore),
+        patch.object(s3mod.S3BackupService, "_pg_dump_to", fake_pg_dump_to),
     ):
         yield SimpleNamespace(payload=dump_payload, restored=restored)
 
@@ -376,3 +380,75 @@ def test_validate_fails_on_a_bucket_that_does_not_exist(fake_redis, s3_settings)
     )
     assert result.get("valid") is False
     assert result.get("error")
+
+
+# --- the safety dump -------------------------------------------------------
+
+
+@mock_aws
+def test_restore_writes_a_local_safety_dump_before_overwriting_the_database(
+    fake_redis, s3_settings, library, fake_pg
+):
+    """`download_and_restore` runs psql against the live database.
+
+    The endpoint docstring promised "creates a local safety backup first" and
+    nothing produced one, so the operation had no undo. This pins the promise.
+    """
+    client = boto3.client("s3", region_name=REGION)
+    _bucket(client)
+    _service().run_backup()
+    _service().initiate_restore()
+    fake_redis.kv.pop(s3mod.REDIS_BACKUP_LOCK, None)
+
+    _service().download_and_restore()
+
+    dumps = sorted((library.root / "data" / "restore-safety").glob("pre-restore_*.sql.gz"))
+    assert dumps, "no safety dump was written before the restore"
+    assert dumps[0].stat().st_size > 0
+
+
+@mock_aws
+def test_a_restore_aborts_when_the_safety_dump_fails(fake_redis, s3_settings, library, fake_pg):
+    """Refusing the restore beats running it with no way back.
+
+    The worst available failure mode is skipping the safety net silently and
+    letting psql overwrite the database anyway.
+    """
+    client = boto3.client("s3", region_name=REGION)
+    _bucket(client)
+    _service().run_backup()
+    _service().initiate_restore()
+    fake_redis.kv.pop(s3mod.REDIS_BACKUP_LOCK, None)
+
+    def boom(self, out_path):
+        raise RuntimeError("pg_dump: connection refused")
+
+    with patch.object(s3mod.S3BackupService, "_pg_dump_to", boom):
+        result = _service().download_and_restore()
+
+    assert result.get("status") == "error", result
+    assert "safety dump" in (result.get("error") or "").lower()
+    assert fake_pg.restored == {}, "database was overwritten despite no safety dump"
+
+
+@mock_aws
+def test_the_safety_dump_stays_local_rather_than_going_to_glacier(
+    fake_redis, s3_settings, library, fake_pg
+):
+    """A safety copy behind a 12-48 hour thaw is not a safety copy.
+
+    The restore is already running because S3 is being read, so the undo has to
+    be reachable without S3 at all.
+    """
+    client = boto3.client("s3", region_name=REGION)
+    _bucket(client)
+    _service().run_backup()
+    _service().initiate_restore()
+    fake_redis.kv.pop(s3mod.REDIS_BACKUP_LOCK, None)
+
+    before = {o["Key"] for o in client.list_objects_v2(Bucket=BUCKET).get("Contents", [])}
+    _service().download_and_restore()
+    after = {o["Key"] for o in client.list_objects_v2(Bucket=BUCKET).get("Contents", [])}
+
+    assert after == before, "the safety dump was uploaded instead of kept local"
+    assert (library.root / "data" / "restore-safety").is_dir()

--- a/backend/uv.lock
+++ b/backend/uv.lock
@@ -1061,6 +1061,7 @@ analysis = [
 ]
 dev = [
     { name = "httpx" },
+    { name = "moto", extra = ["s3"] },
     { name = "mypy" },
     { name = "pytest" },
     { name = "pytest-asyncio" },
@@ -1094,6 +1095,7 @@ requires-dist = [
     { name = "librosa", marker = "extra == 'analysis'", specifier = ">=0.10.0" },
     { name = "matplotlib", marker = "extra == 'analysis'", specifier = ">=3.5.0" },
     { name = "mcp", specifier = ">=2.0.0" },
+    { name = "moto", extras = ["s3"], marker = "extra == 'dev'", specifier = ">=5.0.0" },
     { name = "musicbrainzngs", specifier = ">=0.7.1" },
     { name = "mutagen", specifier = ">=1.47.0" },
     { name = "mypy", marker = "extra == 'dev'", specifier = ">=1.8.0" },
@@ -2451,6 +2453,30 @@ wheels = [
 ]
 
 [[package]]
+name = "moto"
+version = "5.2.3"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "boto3" },
+    { name = "botocore" },
+    { name = "cryptography" },
+    { name = "requests" },
+    { name = "responses" },
+    { name = "werkzeug" },
+    { name = "xmltodict" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/6c/0f/1682c01ca0608c25526afb150246a3c9c1f609caccbd39758de4850e31bc/moto-5.2.3.tar.gz", hash = "sha256:a9e95c3218b6eda18e74571f1ced11cb1bc3151467d562c1da6037b9d19832cb", size = 8785514, upload-time = "2026-08-22T18:46:00.199Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/58/80/ee7ace7a49bd525455497fa2ff198111877d6f93b908b657adeb2cf057a4/moto-5.2.3-py3-none-any.whl", hash = "sha256:5ec31b3cdbb383a19d46030157bd82aaaa7a9cc5f564200f995663d347bd4728", size = 6780972, upload-time = "2026-08-22T18:45:55.719Z" },
+]
+
+[package.optional-dependencies]
+s3 = [
+    { name = "py-partiql-parser" },
+    { name = "pyyaml" },
+]
+
+[[package]]
 name = "mpmath"
 version = "1.3.0"
 source = { registry = "https://pypi.org/simple" }
@@ -3178,6 +3204,15 @@ wheels = [
 ]
 
 [[package]]
+name = "py-partiql-parser"
+version = "0.6.3"
+source = { registry = "https://pypi.org/simple" }
+sdist = { url = "https://files.pythonhosted.org/packages/56/7a/a0f6bda783eb4df8e3dfd55973a1ac6d368a89178c300e1b5b91cd181e5e/py_partiql_parser-0.6.3.tar.gz", hash = "sha256:09cecf916ce6e3da2c050f0cb6106166de42c33d34a078ec2eb19377ea70389a", size = 17456, upload-time = "2025-10-18T13:56:13.441Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/c9/33/a7cbfccc39056a5cf8126b7aab4c8bafbedd4f0ca68ae40ecb627a2d2cd3/py_partiql_parser-0.6.3-py2.py3-none-any.whl", hash = "sha256:deb0769c3346179d2f590dcbde556f708cdb929059fb654bad75f4cf6e07f582", size = 23752, upload-time = "2025-10-18T13:56:12.256Z" },
+]
+
+[[package]]
 name = "pyacoustid"
 version = "1.3.0"
 source = { registry = "https://pypi.org/simple" }
@@ -3874,6 +3909,20 @@ dependencies = [
 sdist = { url = "https://files.pythonhosted.org/packages/53/2e/734e1813f929ce562702f59283d5e585655eb2208ba97987549a5fc7fb68/resampy-0.4.2.tar.gz", hash = "sha256:0a469e6ddb89956f4fd6c88728300e4bbd186fae569dd4fd17dae51a91cbaa15", size = 3077273, upload-time = "2022-09-13T16:32:07.693Z" }
 wheels = [
     { url = "https://files.pythonhosted.org/packages/f2/d3/5209fd2132452f199b1ddf0d084f9fd5f5f910840e3b282f005b48a503e1/resampy-0.4.2-py3-none-any.whl", hash = "sha256:4340b6c4e685a865621dfcf016e2a3dd49d865446b6025e30fe88567f22e052e", size = 3076436, upload-time = "2022-09-13T16:32:06.163Z" },
+]
+
+[[package]]
+name = "responses"
+version = "0.26.3"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "pyyaml" },
+    { name = "requests" },
+    { name = "urllib3" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/9f/47/f216a33221db8eff328987661cf18371afee89c62a62b434b963d6b509c9/responses-0.26.3.tar.gz", hash = "sha256:b0c11ca8131b8b227b8d5108e6ed39772222bd5aab030ed430e8f99057c4c409", size = 86335, upload-time = "2026-08-26T19:17:24.373Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/6d/86/ca7958de70cb0752350575e98229368a3a2f746a2942034b3364e17312bb/responses-0.26.3-py3-none-any.whl", hash = "sha256:74474f799334ac4f37d93b6437ecc3bb1bb5c77a8d31780a338643be2dce0af8", size = 36289, upload-time = "2026-08-26T19:17:23.176Z" },
 ]
 
 [[package]]
@@ -4975,6 +5024,15 @@ wheels = [
     { url = "https://files.pythonhosted.org/packages/28/d4/003f22d726ca8a0bc2170cad7651dad732f3d3a6e4f69d1f13d8244a93e9/wrapt-1.14.2-cp311-cp311-win32.whl", hash = "sha256:cb5aee915d67441bd07acbce9e4cab1d01a110b4e5f02932e80e5ef4c9411ae2", size = 33675, upload-time = "2025-08-12T06:58:54.885Z" },
     { url = "https://files.pythonhosted.org/packages/8e/61/8eb200c6cf899fedc677a7a01b2f189ad58f1d154d0ef84dab30800b9f01/wrapt-1.14.2-cp311-cp311-win_amd64.whl", hash = "sha256:e9773691347205f7d11e7c4395561633285c8d1d691ebfc73ffd64f9072aa22e", size = 35811, upload-time = "2025-08-12T06:58:53.921Z" },
     { url = "https://files.pythonhosted.org/packages/b7/c7/7376998449689cf2adbdbeacad47084410d00f3ae04cf73e6127cf52b950/wrapt-1.14.2-py3-none-any.whl", hash = "sha256:82eea3b559f51f22aefc530b747b87406811ef00cb0c4734f48cb139c748db63", size = 21577, upload-time = "2025-08-12T06:59:01.408Z" },
+]
+
+[[package]]
+name = "xmltodict"
+version = "1.0.4"
+source = { registry = "https://pypi.org/simple" }
+sdist = { url = "https://files.pythonhosted.org/packages/19/70/80f3b7c10d2630aa66414bf23d210386700aa390547278c789afa994fd7e/xmltodict-1.0.4.tar.gz", hash = "sha256:6d94c9f834dd9e44514162799d344d815a3a4faec913717a9ecbfa5be1bb8e61", size = 26124, upload-time = "2026-02-22T02:21:22.074Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/38/34/98a2f52245f4d47be93b580dae5f9861ef58977d73a79eb47c58f1ad1f3a/xmltodict-1.0.4-py3-none-any.whl", hash = "sha256:a4a00d300b0e1c59fc2bfccb53d7b2e88c32f200df138a0dd2229f842497026a", size = 13580, upload-time = "2026-02-22T02:21:21.039Z" },
 ]
 
 [[package]]

--- a/packages/frontend/src/api/index.ts
+++ b/packages/frontend/src/api/index.ts
@@ -9,6 +9,7 @@ export * from './profiles';
 export * from './admin';
 export * from './metadata';
 export * from './backup';
+export * from './s3Backup';
 export * from './download';
 export * from './analysis';
 export * from './mixtapes';

--- a/packages/frontend/src/api/queryKeys.ts
+++ b/packages/frontend/src/api/queryKeys.ts
@@ -106,6 +106,14 @@ export const queryKeys = {
   lastfmStatus: {
     all: ['lastfm-status'] as const,
   },
+  s3Backup: {
+    all: ['s3-backup'] as const,
+    status: ['s3-backup', 'status'] as const,
+    progress: ['s3-backup', 'progress'] as const,
+    history: ['s3-backup', 'history'] as const,
+    estimate: ['s3-backup', 'estimate'] as const,
+    restore: ['s3-backup', 'restore'] as const,
+  },
 
   // ── Discovery & Browse ────────────────────────────────────────────────
   libraryDiscover: {

--- a/packages/frontend/src/api/s3Backup.ts
+++ b/packages/frontend/src/api/s3Backup.ts
@@ -1,0 +1,145 @@
+import api from './base';
+
+/**
+ * S3 Glacier Deep Archive backup.
+ *
+ * The endpoints existed for months with no caller in either client — backups ran
+ * on a scheduler nothing could enable, and the restore path had never been
+ * executed by anything. These are the wrappers that make both reachable.
+ *
+ * Credentials are deliberately absent: bucket, region, prefix and keys come from
+ * the environment and are read-only in `/settings`. Only `s3_backup_enabled` and
+ * `s3_backup_schedule` are writable, so this client never handles a secret.
+ */
+
+export interface BackupStatus {
+  enabled: boolean;
+  bucket: string | null;
+  region: string | null;
+  schedule: string | null;
+  is_running: boolean;
+  last_backup: Record<string, unknown> | null;
+  progress: BackupProgress | null;
+}
+
+export interface BackupProgress {
+  status: string;
+  phase: string;
+  files_total: number;
+  files_uploaded: number;
+  files_skipped: number;
+  bytes_uploaded: number;
+  current_file: string | null;
+  started_at: string | null;
+  error: string | null;
+}
+
+export interface BackupValidation {
+  valid: boolean;
+  permissions: Record<string, boolean>;
+  error: string | null;
+}
+
+export interface BackupCostEstimate {
+  storage_gb: number;
+  monthly_cost: number;
+  initial_upload_cost: number;
+  estimated_restore_cost: number;
+  by_category: Record<string, { file_count?: number; size_gb?: number; monthly_cost?: number }>;
+}
+
+export interface BackupManifest {
+  last_backup_at: string | null;
+  database: Record<string, unknown> | null;
+  settings: Record<string, unknown> | null;
+  file_count: number;
+  total_size_bytes: number;
+  by_category: Record<string, unknown>;
+}
+
+export interface RestoreThawResult {
+  categories?: string[];
+  files_requested?: number;
+  files_available?: number;
+  errors?: number;
+  status?: string;
+  error?: string;
+}
+
+export const s3BackupApi = {
+  getStatus: async (): Promise<BackupStatus> => {
+    const { data } = await api.get('/s3-backup/status');
+    return data;
+  },
+
+  getProgress: async (): Promise<BackupProgress> => {
+    const { data } = await api.get('/s3-backup/progress');
+    return data;
+  },
+
+  getHistory: async (): Promise<Record<string, unknown>[]> => {
+    const { data } = await api.get('/s3-backup/history');
+    return data;
+  },
+
+  getManifest: async (): Promise<BackupManifest> => {
+    const { data } = await api.get('/s3-backup/manifest');
+    return data;
+  },
+
+  getEstimate: async (): Promise<BackupCostEstimate> => {
+    const { data } = await api.get('/s3-backup/estimate');
+    return data;
+  },
+
+  validate: async (params: {
+    bucket: string;
+    region?: string;
+    prefix?: string;
+  }): Promise<BackupValidation> => {
+    const { data } = await api.post('/s3-backup/validate', params);
+    return data;
+  },
+
+  run: async (): Promise<{ status: string; message?: string }> => {
+    const { data } = await api.post('/s3-backup/run');
+    return data;
+  },
+
+  cancel: async (): Promise<{ status: string }> => {
+    const { data } = await api.post('/s3-backup/cancel');
+    return data;
+  },
+
+  // ── Restore, in the three phases Glacier forces ──────────────────────────
+  //
+  // Deep Archive cannot be read directly, so a restore is: ask for a thaw, wait
+  // 12-48 hours, then download. `download` takes a safety dump of the current
+  // database before overwriting it, and aborts if that dump fails.
+
+  initiateRestore: async (categories?: string[]): Promise<RestoreThawResult> => {
+    const { data } = await api.post('/s3-backup/restore', { categories: categories ?? null });
+    return data;
+  },
+
+  checkRestore: async (): Promise<Record<string, unknown>> => {
+    const { data } = await api.post('/s3-backup/restore/check');
+    return data;
+  },
+
+  getRestoreStatus: async (): Promise<Record<string, unknown>> => {
+    const { data } = await api.get('/s3-backup/restore/status');
+    return data;
+  },
+
+  getRestoreProgress: async (): Promise<BackupProgress> => {
+    const { data } = await api.get('/s3-backup/restore/progress');
+    return data;
+  },
+
+  /** Destructive: overwrites the live database. Requires confirm=true server-side. */
+  downloadAndRestore: async (): Promise<{ status: string; message?: string; error?: string }> => {
+    const { data } = await api.post('/s3-backup/restore/download', { confirm: true });
+    return data;
+  },
+};

--- a/packages/frontend/src/panels/server/BackgroundJobs.tsx
+++ b/packages/frontend/src/panels/server/BackgroundJobs.tsx
@@ -35,6 +35,7 @@ const jobNames: Record<BackgroundJob['type'], string> = {
 
 const jobPhaseLabels: Record<string, string> = {
   starting: 'Starting...',
+  safety_dump: 'Safety dump before restore',
   discovering: 'Discovering files',
   reading: 'Reading metadata',
   features: 'Extracting features',

--- a/packages/frontend/src/panels/server/BackupRestore.tsx
+++ b/packages/frontend/src/panels/server/BackupRestore.tsx
@@ -1,0 +1,185 @@
+/**
+ * Restore from S3, on the Server destination.
+ *
+ * Five restore endpoints existed with **no caller anywhere in either client**,
+ * so the one operation a backup exists for had never been executed by anything.
+ * This is the surface that makes it reachable without hand-written curl.
+ *
+ * Restore is three phases because Deep Archive cannot be read directly: ask
+ * Glacier to thaw (Bulk tier, 12-48 hours), check whether the thaw finished,
+ * then download and apply. The wait is a property of the storage class, not of
+ * this UI, so the phases are shown rather than hidden behind one button that
+ * appears to hang for two days.
+ *
+ * The download phase overwrites the live database via `psql`. It takes a local
+ * pg_dump first and aborts if that fails, so there is a way back — but it is
+ * still the most destructive thing this application can do, hence typing the
+ * bucket name. That is a guard against a mis-click, not against an attacker:
+ * Familiar runs on a private network and authentication is the network's job.
+ */
+import { useState } from 'react';
+import { useQuery, useMutation, useQueryClient } from '@tanstack/react-query';
+import { RotateCcw, Loader2, AlertTriangle, Clock, Download } from 'lucide-react';
+
+import { appSettingsApi, s3BackupApi } from '../../api';
+import { queryKeys } from '../../api/queryKeys';
+
+export function BackupRestore() {
+  const queryClient = useQueryClient();
+  const [open, setOpen] = useState(false);
+  const [typed, setTyped] = useState('');
+  const [message, setMessage] = useState<string | null>(null);
+
+  const { data: settings } = useQuery({
+    queryKey: queryKeys.appSettings.all,
+    queryFn: appSettingsApi.get,
+  });
+
+  const { data: manifest } = useQuery({
+    queryKey: [...queryKeys.s3Backup.all, 'manifest'],
+    queryFn: s3BackupApi.getManifest,
+    enabled: open && Boolean(settings?.s3_backup_configured),
+  });
+
+  const { data: progress } = useQuery({
+    queryKey: queryKeys.s3Backup.restore,
+    queryFn: s3BackupApi.getRestoreProgress,
+    enabled: open,
+    refetchInterval: (q) => (q.state.data?.status === 'running' ? 3000 : false),
+  });
+
+  const thaw = useMutation({
+    mutationFn: () => s3BackupApi.initiateRestore(),
+    onSuccess: (r) =>
+      setMessage(
+        r.error
+          ? r.error
+          : `Thaw requested for ${r.files_requested ?? 0} files. Glacier Bulk retrieval takes 12-48 hours.`
+      ),
+  });
+
+  const check = useMutation({
+    mutationFn: s3BackupApi.checkRestore,
+    onSuccess: (r) => setMessage(JSON.stringify(r)),
+  });
+
+  const download = useMutation({
+    mutationFn: s3BackupApi.downloadAndRestore,
+    onSuccess: (r) => {
+      setMessage(r.error ?? r.message ?? r.status);
+      setTyped('');
+      queryClient.invalidateQueries({ queryKey: queryKeys.s3Backup.all });
+    },
+  });
+
+  if (!settings?.s3_backup_configured) return null;
+
+  const bucket = settings.s3_backup_bucket ?? '';
+  const armed = typed === bucket && bucket.length > 0;
+
+  return (
+    <div className="bg-zinc-800 rounded-lg p-4">
+      <div className="flex items-center justify-between">
+        <div className="flex items-center gap-3">
+          <RotateCcw className="w-6 h-6 text-warning" />
+          <h3 className="font-medium">Restore from backup</h3>
+        </div>
+        <button
+          type="button"
+          onClick={() => setOpen((v) => !v)}
+          className="text-sm text-zinc-400 hover:text-zinc-200"
+        >
+          {open ? 'Hide' : 'Show'}
+        </button>
+      </div>
+
+      {open && (
+        <div className="mt-4 space-y-4">
+          {manifest && (
+            <p className="text-xs text-zinc-500">
+              Backup contains {manifest.file_count.toLocaleString()} files, last written{' '}
+              {manifest.last_backup_at ?? 'never'}.
+            </p>
+          )}
+
+          <div className="flex items-start gap-2 p-3 bg-warning-surface/20 border border-warning-muted rounded-lg">
+            <AlertTriangle className="w-4 h-4 text-warning mt-0.5 flex-shrink-0" />
+            <div className="text-xs text-zinc-400">
+              <p className="text-warning text-sm">This replaces your library database.</p>
+              <p className="mt-1">
+                A pg_dump of the current database is written to{' '}
+                <code>data/restore-safety/</code> first, and the restore aborts if that fails.
+                Audio files are only overwritten where the local copy does not match the backup.
+              </p>
+            </div>
+          </div>
+
+          <ol className="space-y-3 text-sm">
+            <li className="flex items-start gap-3">
+              <Clock className="w-4 h-4 mt-0.5 text-zinc-500 flex-shrink-0" />
+              <div className="flex-1">
+                <p>1. Ask Glacier to thaw the archive</p>
+                <button
+                  type="button"
+                  onClick={() => thaw.mutate()}
+                  disabled={thaw.isPending}
+                  className="mt-1 px-3 py-1 text-xs bg-zinc-700 hover:bg-zinc-600 rounded"
+                >
+                  {thaw.isPending ? 'Requesting…' : 'Request thaw'}
+                </button>
+              </div>
+            </li>
+            <li className="flex items-start gap-3">
+              <Loader2 className="w-4 h-4 mt-0.5 text-zinc-500 flex-shrink-0" />
+              <div className="flex-1">
+                <p>2. Check whether the thaw has finished</p>
+                <button
+                  type="button"
+                  onClick={() => check.mutate()}
+                  disabled={check.isPending}
+                  className="mt-1 px-3 py-1 text-xs bg-zinc-700 hover:bg-zinc-600 rounded"
+                >
+                  {check.isPending ? 'Checking…' : 'Check availability'}
+                </button>
+              </div>
+            </li>
+            <li className="flex items-start gap-3">
+              <Download className="w-4 h-4 mt-0.5 text-danger flex-shrink-0" />
+              <div className="flex-1">
+                <p>3. Download and apply</p>
+                <label htmlFor="s3-confirm" className="text-xs text-zinc-500 block mt-1">
+                  Type the bucket name <code>{bucket}</code> to enable
+                </label>
+                <input
+                  id="s3-confirm"
+                  value={typed}
+                  onChange={(e) => setTyped(e.target.value)}
+                  placeholder={bucket}
+                  className="mt-1 bg-zinc-900 border border-zinc-700 rounded px-2 py-1 text-sm w-64"
+                />
+                <button
+                  type="button"
+                  onClick={() => download.mutate()}
+                  disabled={!armed || download.isPending}
+                  className="mt-2 block px-3 py-1 text-xs rounded bg-danger disabled:bg-zinc-700 disabled:text-zinc-500"
+                >
+                  {download.isPending ? 'Restoring…' : 'Restore now'}
+                </button>
+              </div>
+            </li>
+          </ol>
+
+          {progress && progress.status === 'running' && (
+            <p className="text-xs text-zinc-400">
+              {progress.phase === 'safety_dump'
+                ? 'Taking a safety dump of the current database…'
+                : `${progress.phase} — ${progress.files_uploaded} files`}
+            </p>
+          )}
+
+          {message && <p className="text-xs text-zinc-400 break-all">{message}</p>}
+        </div>
+      )}
+    </div>
+  );
+}

--- a/packages/frontend/src/panels/server/BackupSettings.tsx
+++ b/packages/frontend/src/panels/server/BackupSettings.tsx
@@ -1,0 +1,248 @@
+/**
+ * S3 backup configuration, on the Server destination.
+ *
+ * The backend has run a full-installation backup on an APScheduler cron for
+ * months — pg_dump and settings to S3 Standard, audio and artwork
+ * content-addressed into Glacier Deep Archive. **Nothing could turn it on.**
+ * `s3_backup_enabled` and `s3_backup_schedule` were typed in `api/settings.ts`
+ * and rendered by no component, and neither is in `config.py`, so the only way
+ * in was hand-editing `data/settings.json`. The scheduler's first line is
+ * `if not settings.s3_backup_enabled: return`, so the whole feature sat inert
+ * and silent.
+ *
+ * Credentials are not editable here on purpose: bucket, region, prefix and keys
+ * come from the environment and `/settings` returns them read-only, so this
+ * panel never handles a secret. What it owns is the operational half — whether
+ * backups run, how often, and whether the bucket actually works.
+ */
+import { useState } from 'react';
+import { useQuery, useMutation, useQueryClient } from '@tanstack/react-query';
+import {
+  CloudUpload,
+  Loader2,
+  CheckCircle,
+  XCircle,
+  AlertTriangle,
+  Play,
+  Square,
+} from 'lucide-react';
+
+import { appSettingsApi, s3BackupApi } from '../../api';
+import { queryKeys } from '../../api/queryKeys';
+
+const SCHEDULES = [
+  { value: 'daily', label: 'Daily', hint: '03:30' },
+  { value: 'weekly', label: 'Weekly', hint: 'Sundays, 03:30' },
+  { value: 'monthly', label: 'Monthly', hint: '1st, 03:30' },
+];
+
+function formatBytes(n: number): string {
+  if (!n) return '0 B';
+  const units = ['B', 'KB', 'MB', 'GB', 'TB'];
+  const i = Math.min(Math.floor(Math.log(n) / Math.log(1024)), units.length - 1);
+  return `${(n / 1024 ** i).toFixed(i === 0 ? 0 : 1)} ${units[i]}`;
+}
+
+export function BackupSettings() {
+  const queryClient = useQueryClient();
+  const [validation, setValidation] = useState<string | null>(null);
+
+  const { data: settings, isLoading } = useQuery({
+    queryKey: queryKeys.appSettings.all,
+    queryFn: appSettingsApi.get,
+  });
+
+  const { data: status } = useQuery({
+    queryKey: queryKeys.s3Backup.status,
+    queryFn: s3BackupApi.getStatus,
+    // Only poll while a backup is actually moving.
+    refetchInterval: (q) => (q.state.data?.is_running ? 3000 : false),
+  });
+
+  const { data: estimate } = useQuery({
+    queryKey: queryKeys.s3Backup.estimate,
+    queryFn: s3BackupApi.getEstimate,
+    enabled: Boolean(settings?.s3_backup_configured),
+    staleTime: 5 * 60 * 1000,
+  });
+
+  const update = useMutation({
+    mutationFn: appSettingsApi.update,
+    onSuccess: () => {
+      queryClient.invalidateQueries({ queryKey: queryKeys.appSettings.all });
+      queryClient.invalidateQueries({ queryKey: queryKeys.s3Backup.all });
+    },
+  });
+
+  const validate = useMutation({
+    mutationFn: () =>
+      s3BackupApi.validate({
+        bucket: settings?.s3_backup_bucket ?? '',
+        region: settings?.s3_backup_region,
+        prefix: settings?.s3_backup_prefix,
+      }),
+    onSuccess: (r) =>
+      setValidation(r.valid ? 'Bucket reachable, permissions look right.' : (r.error ?? 'Failed')),
+    onError: (e: Error) => setValidation(e.message),
+  });
+
+  const runNow = useMutation({
+    mutationFn: s3BackupApi.run,
+    onSuccess: () => queryClient.invalidateQueries({ queryKey: queryKeys.s3Backup.all }),
+  });
+
+  const cancel = useMutation({
+    mutationFn: s3BackupApi.cancel,
+    onSuccess: () => queryClient.invalidateQueries({ queryKey: queryKeys.s3Backup.all }),
+  });
+
+  if (isLoading) {
+    return (
+      <div className="p-4">
+        <Loader2 className="w-6 h-6 animate-spin text-zinc-400" />
+      </div>
+    );
+  }
+
+  const configured = settings?.s3_backup_configured;
+  const enabled = settings?.s3_backup_enabled ?? false;
+
+  return (
+    <div className="bg-zinc-800 rounded-lg p-4">
+      <div className="flex items-center gap-3 mb-3">
+        <CloudUpload className="w-6 h-6 text-info" />
+        <h3 className="font-medium">S3 Backup</h3>
+      </div>
+
+      {!configured ? (
+        <div className="flex items-start gap-2 p-3 bg-warning-surface/20 border border-warning-muted rounded-lg">
+          <AlertTriangle className="w-4 h-4 text-warning mt-0.5 flex-shrink-0" />
+          <div>
+            <p className="text-sm text-warning">S3 credentials not configured</p>
+            <p className="text-xs text-zinc-500 mt-1">
+              Set <code>S3_BACKUP_BUCKET</code>, <code>S3_BACKUP_ACCESS_KEY_ID</code> and{' '}
+              <code>S3_BACKUP_SECRET_ACCESS_KEY</code> in <code>docker/.env</code>. Credentials are
+              read from the environment and never stored or edited here.
+            </p>
+          </div>
+        </div>
+      ) : (
+        <div className="space-y-4">
+          <div className="flex items-center justify-between">
+            <div>
+              <p className="text-sm">Scheduled backups</p>
+              <p className="text-xs text-zinc-500">
+                {settings?.s3_backup_bucket} · {settings?.s3_backup_region}
+                {settings?.s3_backup_prefix ? ` · ${settings.s3_backup_prefix}` : ''}
+              </p>
+            </div>
+            <button
+              type="button"
+              role="switch"
+              aria-checked={enabled}
+              aria-label="Scheduled backups"
+              disabled={update.isPending}
+              onClick={() => update.mutate({ s3_backup_enabled: !enabled })}
+              className={`relative w-11 h-6 rounded-full transition-colors ${
+                enabled ? 'bg-success' : 'bg-zinc-600'
+              }`}
+            >
+              <span
+                className={`absolute top-1 w-4 h-4 rounded-full bg-white transition-transform ${
+                  enabled ? 'translate-x-6' : 'translate-x-1'
+                }`}
+              />
+            </button>
+          </div>
+
+          {enabled && (
+            <div>
+              <label htmlFor="s3-schedule" className="text-xs text-zinc-500 block mb-1">
+                Frequency
+              </label>
+              <select
+                id="s3-schedule"
+                value={settings?.s3_backup_schedule ?? 'weekly'}
+                disabled={update.isPending}
+                onChange={(e) => update.mutate({ s3_backup_schedule: e.target.value })}
+                className="bg-zinc-900 border border-zinc-700 rounded px-2 py-1 text-sm"
+              >
+                {SCHEDULES.map((s) => (
+                  <option key={s.value} value={s.value}>
+                    {s.label} ({s.hint})
+                  </option>
+                ))}
+              </select>
+            </div>
+          )}
+
+          {estimate && (
+            <div className="text-xs text-zinc-400 border-t border-zinc-700 pt-3">
+              <span className="text-zinc-300">{estimate.storage_gb.toFixed(1)} GB</span> stored ·{' '}
+              <span className="text-zinc-300">${estimate.monthly_cost.toFixed(2)}/month</span> ·
+              restore would cost about{' '}
+              <span className="text-zinc-300">${estimate.estimated_restore_cost.toFixed(2)}</span>
+            </div>
+          )}
+
+          {status?.last_backup && !status.is_running && (
+            <p className="text-xs text-zinc-500">
+              Last backup {String(status.last_backup.completed_at ?? 'unknown')}
+            </p>
+          )}
+
+          {status?.is_running && status.progress && (
+            <div className="text-xs text-zinc-400">
+              <p>
+                {status.progress.phase} — {status.progress.files_uploaded} uploaded,{' '}
+                {status.progress.files_skipped} unchanged,{' '}
+                {formatBytes(status.progress.bytes_uploaded)}
+              </p>
+            </div>
+          )}
+
+          <div className="flex items-center gap-2">
+            {status?.is_running ? (
+              <button
+                type="button"
+                onClick={() => cancel.mutate()}
+                disabled={cancel.isPending}
+                className="flex items-center gap-1 px-3 py-1.5 text-sm bg-zinc-700 hover:bg-zinc-600 rounded"
+              >
+                <Square className="w-3 h-3" /> Cancel
+              </button>
+            ) : (
+              <button
+                type="button"
+                onClick={() => runNow.mutate()}
+                disabled={runNow.isPending}
+                className="flex items-center gap-1 px-3 py-1.5 text-sm bg-zinc-700 hover:bg-zinc-600 rounded"
+              >
+                <Play className="w-3 h-3" /> Back up now
+              </button>
+            )}
+            <button
+              type="button"
+              onClick={() => validate.mutate()}
+              disabled={validate.isPending}
+              className="px-3 py-1.5 text-sm bg-zinc-700 hover:bg-zinc-600 rounded"
+            >
+              {validate.isPending ? 'Checking…' : 'Test bucket'}
+            </button>
+          </div>
+
+          {validation && (
+            <div className="flex items-start gap-2 text-xs">
+              {validation.startsWith('Bucket reachable') ? (
+                <CheckCircle className="w-4 h-4 text-success flex-shrink-0" />
+              ) : (
+                <XCircle className="w-4 h-4 text-danger flex-shrink-0" />
+              )}
+              <span className="text-zinc-400">{validation}</span>
+            </div>
+          )}
+        </div>
+      )}
+    </div>
+  );
+}

--- a/packages/frontend/src/panels/server/__tests__/BackupSettings.test.tsx
+++ b/packages/frontend/src/panels/server/__tests__/BackupSettings.test.tsx
@@ -1,0 +1,153 @@
+/* @vitest-environment jsdom */
+/**
+ * The defect these guard against is not "the panel renders wrong" — it is
+ * "nothing calls the endpoint". `s3_backup_enabled` was typed in the settings
+ * client and rendered by no component for months, so backups could not be turned
+ * on and the failure was silent. A test that only asserted markup would have
+ * passed the whole time.
+ */
+import { QueryClient, QueryClientProvider } from '@tanstack/react-query';
+import { render, screen, waitFor, fireEvent, cleanup } from '@testing-library/react';
+import { describe, expect, it, vi, beforeEach, afterEach } from 'vitest';
+
+import { BackupSettings } from '../BackupSettings';
+import { BackupRestore } from '../BackupRestore';
+
+const getSettings = vi.fn();
+const updateSettings = vi.fn();
+const getStatus = vi.fn();
+const getEstimate = vi.fn();
+const getManifest = vi.fn();
+const getRestoreProgress = vi.fn();
+const run = vi.fn();
+const validate = vi.fn();
+const downloadAndRestore = vi.fn();
+const initiateRestore = vi.fn();
+
+vi.mock('../../../api', () => ({
+  appSettingsApi: {
+    get: () => getSettings(),
+    update: (u: unknown) => updateSettings(u),
+  },
+  s3BackupApi: {
+    getStatus: () => getStatus(),
+    getEstimate: () => getEstimate(),
+    getManifest: () => getManifest(),
+    getRestoreProgress: () => getRestoreProgress(),
+    run: () => run(),
+    cancel: vi.fn(),
+    validate: (p: unknown) => validate(p),
+    initiateRestore: () => initiateRestore(),
+    checkRestore: vi.fn(),
+    downloadAndRestore: () => downloadAndRestore(),
+  },
+}));
+
+function wrap(ui: React.ReactElement) {
+  const client = new QueryClient({
+    defaultOptions: { queries: { retry: false }, mutations: { retry: false } },
+  });
+  return render(<QueryClientProvider client={client}>{ui}</QueryClientProvider>);
+}
+
+const CONFIGURED = {
+  s3_backup_configured: true,
+  s3_backup_enabled: false,
+  s3_backup_bucket: 'familiar-backups',
+  s3_backup_region: 'us-east-1',
+  s3_backup_prefix: '',
+  s3_backup_schedule: 'weekly',
+};
+
+afterEach(cleanup);
+
+beforeEach(() => {
+  vi.clearAllMocks();
+  getSettings.mockResolvedValue({ ...CONFIGURED });
+  updateSettings.mockResolvedValue({ ...CONFIGURED });
+  getStatus.mockResolvedValue({ enabled: false, is_running: false, last_backup: null, progress: null });
+  getEstimate.mockResolvedValue({
+    storage_gb: 412.5,
+    monthly_cost: 0.41,
+    initial_upload_cost: 1.2,
+    estimated_restore_cost: 1.03,
+    by_category: {},
+  });
+  getManifest.mockResolvedValue({ file_count: 26469, last_backup_at: '2026-09-01T03:30:00Z', by_category: {} });
+  getRestoreProgress.mockResolvedValue({ status: 'idle', phase: 'idle', files_total: 0, files_uploaded: 0, files_skipped: 0, bytes_uploaded: 0, current_file: null, started_at: null, error: null });
+});
+
+describe('BackupSettings', () => {
+  it('turning the toggle on actually writes s3_backup_enabled', async () => {
+    // The whole bug in one assertion: the scheduler's first line is
+    // `if not settings.s3_backup_enabled: return`, so without this call
+    // nothing ever runs.
+    wrap(<BackupSettings />);
+    const toggle = await screen.findByRole('switch', { name: /scheduled backups/i });
+
+    fireEvent.click(toggle);
+
+    await waitFor(() => expect(updateSettings).toHaveBeenCalledWith({ s3_backup_enabled: true }));
+  });
+
+  it('offers no toggle at all when credentials are absent, and says where they go', async () => {
+    getSettings.mockResolvedValue({ ...CONFIGURED, s3_backup_configured: false });
+    wrap(<BackupSettings />);
+
+    expect(await screen.findByText(/credentials not configured/i)).toBeTruthy();
+    expect(screen.queryByRole('switch')).toBeNull();
+    expect(screen.getByText(/S3_BACKUP_BUCKET/)).toBeTruthy();
+  });
+
+  it('shows what the backup costs, since Deep Archive pricing is the reason to use it', async () => {
+    wrap(<BackupSettings />);
+    expect(await screen.findByText(/412\.5 GB/)).toBeTruthy();
+    expect(screen.getByText(/\$0\.41\/month/)).toBeTruthy();
+  });
+
+  it('"Back up now" calls the endpoint that had no caller', async () => {
+    run.mockResolvedValue({ status: 'started' });
+    wrap(<BackupSettings />);
+
+    fireEvent.click(await screen.findByRole('button', { name: /back up now/i }));
+
+    await waitFor(() => expect(run).toHaveBeenCalled());
+  });
+});
+
+describe('BackupRestore', () => {
+  it('will not restore until the bucket name is typed', async () => {
+    // Guards a mis-click, not an attacker — Familiar runs on a private network.
+    wrap(<BackupRestore />);
+    fireEvent.click(await screen.findByRole('button', { name: /show/i }));
+
+    const restore = screen.getByRole('button', { name: /restore now/i });
+    expect(restore.hasAttribute('disabled')).toBe(true);
+
+    fireEvent.change(screen.getByLabelText(/type the bucket name/i), { target: { value: 'familiar-backups' } });
+    await waitFor(() => expect(restore.hasAttribute('disabled')).toBe(false));
+  });
+
+  it('a wrong bucket name leaves it disabled', async () => {
+    wrap(<BackupRestore />);
+    fireEvent.click(await screen.findByRole('button', { name: /show/i }));
+
+    fireEvent.change(screen.getByLabelText(/type the bucket name/i), { target: { value: 'familiar-backup' } });
+    expect(screen.getByRole('button', { name: /restore now/i }).hasAttribute('disabled')).toBe(true);
+    expect(downloadAndRestore).not.toHaveBeenCalled();
+  });
+
+  it('says that a safety dump is taken, because the restore now takes one', async () => {
+    wrap(<BackupRestore />);
+    fireEvent.click(await screen.findByRole('button', { name: /show/i }));
+
+    expect(screen.getByText(/restore-safety/)).toBeTruthy();
+    expect(screen.getByText(/aborts if that fails/i)).toBeTruthy();
+  });
+
+  it('renders nothing when S3 was never configured', async () => {
+    getSettings.mockResolvedValue({ ...CONFIGURED, s3_backup_configured: false });
+    const { container } = wrap(<BackupRestore />);
+    await waitFor(() => expect(container.innerHTML).toBe(''));
+  });
+});

--- a/packages/frontend/src/screens/ServerPage.tsx
+++ b/packages/frontend/src/screens/ServerPage.tsx
@@ -19,6 +19,8 @@ import { ProfileSettings } from '../panels/server/ProfileSettings';
 import { LastfmSettings } from '../panels/server/LastfmSettings';
 import { DebugSettings } from '../panels/server/DebugSettings';
 import { RemoteLogsPanel } from '../panels/server/RemoteLogsPanel';
+import { BackupSettings } from '../panels/server/BackupSettings';
+import { BackupRestore } from '../panels/server/BackupRestore';
 import { BackgroundJobs } from '../panels/server/BackgroundJobs';
 
 export function ServerPage() {
@@ -44,6 +46,11 @@ export function ServerPage() {
       </AdminSection>
 
       <BackgroundJobs />
+
+      <AdminSection title="Backup">
+        <BackupSettings />
+        <BackupRestore />
+      </AdminSection>
 
       <AdminSection title="Access">
         <ApiKeyStatus />

--- a/packages/frontend/src/screens/__tests__/ServerPage.backup.test.tsx
+++ b/packages/frontend/src/screens/__tests__/ServerPage.backup.test.tsx
@@ -1,0 +1,54 @@
+/* @vitest-environment jsdom */
+/**
+ * That the Server destination actually *mounts* the backup panels.
+ *
+ * This is the test the original defect needed and nobody had. `s3_backup_enabled`
+ * was typed in the settings client and reachable through the API for months;
+ * what was missing was a component rendering it. A panel test cannot catch that
+ * — it renders the panel itself, so it passes whether or not any page mounts it.
+ *
+ * The same shape has bitten this project repeatedly: an affordance whose
+ * destination is not mounted (familiar #70, #74, #76). Asserting the panel
+ * renders is not the same as asserting it is reachable.
+ */
+import { render, screen, cleanup } from '@testing-library/react';
+import { describe, expect, it, vi, afterEach } from 'vitest';
+
+import { ServerPage } from '../ServerPage';
+
+// Every other panel is stubbed: this asserts reachability, not their contents.
+vi.mock('../../panels/server/SystemStatus', () => ({ SystemStatus: () => null }));
+vi.mock('../../panels/server/DiscoverySources', () => ({ DiscoverySources: () => null }));
+vi.mock('../../panels/server/ApiKeyStatus', () => ({ ApiKeyStatus: () => null }));
+vi.mock('../../panels/server/ServerTokenSettings', () => ({ ServerTokenSettings: () => null }));
+vi.mock('../../panels/server/ProfileSettings', () => ({ ProfileSettings: () => null }));
+vi.mock('../../panels/server/LastfmSettings', () => ({ LastfmSettings: () => null }));
+vi.mock('../../panels/server/DebugSettings', () => ({ DebugSettings: () => null }));
+vi.mock('../../panels/server/RemoteLogsPanel', () => ({ RemoteLogsPanel: () => null }));
+vi.mock('../../panels/server/BackgroundJobs', () => ({ BackgroundJobs: () => null }));
+
+vi.mock('../../panels/server/BackupSettings', () => ({
+  BackupSettings: () => <div data-testid="backup-settings-mounted" />,
+}));
+vi.mock('../../panels/server/BackupRestore', () => ({
+  BackupRestore: () => <div data-testid="backup-restore-mounted" />,
+}));
+
+afterEach(cleanup);
+
+describe('ServerPage mounts the backup surface', () => {
+  it('renders the backup settings panel', () => {
+    render(<ServerPage />);
+    expect(screen.getByTestId('backup-settings-mounted')).toBeTruthy();
+  });
+
+  it('renders the restore panel', () => {
+    render(<ServerPage />);
+    expect(screen.getByTestId('backup-restore-mounted')).toBeTruthy();
+  });
+
+  it('gives them a labelled section, so they are findable', () => {
+    render(<ServerPage />);
+    expect(screen.getByText(/^backup$/i)).toBeTruthy();
+  });
+});


### PR DESCRIPTION
`s3_backup.py` is 1,420 lines that write a whole Familiar installation to S3 —
pg_dump and settings to Standard, audio and artwork content-addressed into
Glacier Deep Archive, with a manifest that makes the next run incremental. It
runs on an APScheduler cron. It had **no test of any kind**, and its restore path
has no caller in either client, so the one operation that matters in an emergency
had never been executed by anything.

Ten tests, using `moto` (S3 in-process). `pg_dump` and `psql` are the only parts
genuinely outside Python and are stubbed; everything underneath runs for real.

## What they pin

- **A backup can be restored from.** Back up, delete the local audio, restore,
  compare bytes. This is the question a backup exists to answer.
- **Audio is keyed by hash**, not by path — that is what makes it deduplicating.
- **Audio lands in DEEP_ARCHIVE and the manifest does not.** Every figure in
  `estimate_cost` depends on that split, and a manifest behind a 12-hour thaw
  could never start an incremental run.
- **A second backup skips unchanged files, and re-uploads changed ones.** For a
  26,000-track library the difference is pennies against real money.
- **Restore asks Glacier to thaw first.** Deep Archive cannot be read directly.
- **The database dump is reapplied**, since the audio is worthless without the
  library that indexes it.
- The 24-hour lock stops a slow run and the scheduler overlapping.

## Both halves were verified to fail

A test that cannot fail is worse than no test. Disabling the incremental skip
(`existing_files = {}`) turns
`test_a_second_backup_skips_files_whose_hash_has_not_changed` red; making the
restore write wrong bytes turns `test_backup_then_restore_returns_the_original_bytes`
red with "restored corrupted". `s3_backup.py` is unmodified in this commit.

## moto goes in `dev`, deliberately

CI runs `uv sync --extra dev`. A test dependency anywhere else is silently
skipped rather than run — which is how `test_analysis.py` came to be invisible in
CI behind an `importorskip`.

Two gaps this does not close, both real: nothing in either client can *enable*
the feature — `s3_backup_enabled` and `s3_backup_schedule` are typed in
`packages/frontend/src/api/settings.ts` and rendered by no component, and are
absent from `config.py`, so the only way in is hand-editing `data/settings.json`
— and the five restore endpoints still have no caller.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01Emjrwedq7W1scadHdgiLfs