### PR TITLE
A restore replaces the database, and says so when it cannot

### DIFF
--- a/backend/app/services/s3_backup.py
+++ b/backend/app/services/s3_backup.py
@@ -652,6 +652,12 @@ class S3BackupService:
             parsed.path.lstrip("/") if parsed.path else "familiar",
             "--no-owner",
             "--no-acl",
+            # Without these the dump is INSERTs against tables that already
+            # exist, so `psql` *appends*: restoring a 26,469-track library into a
+            # live database leaves ~53,000 rows and looks like it worked.
+            # Measured against real S3 — a two-row table came back with four.
+            "--clean",
+            "--if-exists",
         ]
 
         with open(out_path, "wb") as out_f:
@@ -1098,6 +1104,8 @@ class S3BackupService:
             total_files = len(files)
             downloaded = 0
             skipped = 0
+            failed = 0
+            not_thawed = 0
 
             progress.update(phase="downloading", files_total=total_files)
 
@@ -1145,19 +1153,52 @@ class S3BackupService:
                         bytes_uploaded=cur["bytes_uploaded"] + info.get("size_bytes", 0),
                     )
                 except ClientError as e:
+                    failed += 1
+                    if e.response.get("Error", {}).get("Code") == "InvalidObjectState":
+                        # Deep Archive cannot be read until a thaw completes.
+                        # This is the ordinary mistake — restoring before the
+                        # 12-48 hour Bulk retrieval has finished — so it is
+                        # counted separately and reported in words.
+                        not_thawed += 1
                     logger.error(f"Failed to download {s3_path}: {e}")
 
             duration = time.monotonic() - start_time
-            progress.update(phase="complete", status="complete", current_file=None)
+
+            # A restore that downloaded nothing is not a success. Reporting one
+            # is worse than failing: the audio is absent and the operator has
+            # been told it is present.
+            if not_thawed:
+                outcome = "error"
+                message = (
+                    f"{not_thawed} file(s) are still in Glacier Deep Archive. Run the "
+                    "thaw step and wait for it to finish (12-48 hours on the Bulk "
+                    "tier) before restoring."
+                )
+            elif failed:
+                outcome = "incomplete"
+                message = f"{failed} file(s) could not be downloaded."
+            else:
+                outcome = "success"
+                message = None
+
+            progress.update(
+                phase="complete" if outcome == "success" else "error",
+                status="complete" if outcome == "success" else "error",
+                current_file=None,
+                error=message,
+            )
 
             # Update restore state
             state = {"status": "complete", "completed_at": utcnow().isoformat()}
             redis.set(REDIS_RESTORE_STATE, json.dumps(state), ex=7 * 86400)
 
             return {
-                "status": "success",
+                "status": outcome,
+                "error": message,
                 "files_downloaded": downloaded,
                 "files_skipped": skipped,
+                "files_failed": failed,
+                "files_not_thawed": not_thawed,
                 "duration_seconds": round(duration, 1),
             }
 

--- a/backend/tests/test_s3_backup.py
+++ b/backend/tests/test_s3_backup.py
@@ -16,6 +16,7 @@ from __future__ import annotations
 
 import gzip
 import hashlib
+import io
 import json
 from pathlib import Path
 from types import SimpleNamespace
@@ -452,3 +453,143 @@ def test_the_safety_dump_stays_local_rather_than_going_to_glacier(
 
     assert after == before, "the safety dump was uploaded instead of kept local"
     assert (library.root / "data" / "restore-safety").is_dir()
+
+
+# --- restore correctness ---------------------------------------------------
+#
+# Both of these were found by running the real service against real S3 with a
+# real postgres. `moto` cannot surface either: one is `psql` semantics and the
+# other is a Glacier state transition mocks do not model.
+
+
+def test_the_dump_replaces_the_database_rather_than_appending_to_it(tmp_path):
+    """Restoring into a live database must not double it.
+
+    Measured against real S3 and a real postgres before this: a two-row `marker`
+    table came back with four rows, and a two-row `tracks` came back with four.
+    `pg_dump` without `--clean` emits INSERTs against tables that already exist,
+    so `psql` appends. On the real library that turns 26,469 tracks into ~53,000
+    and still reports success.
+
+    Asserts the argv actually handed to `pg_dump`, not the source text, so
+    reformatting cannot make this pass vacuously.
+    """
+    seen = {}
+
+    class FakeProc:
+        returncode = 0
+
+        def __init__(self):
+            self.stdout = io.BytesIO(b"-- dump\n")
+            self.stderr = io.BytesIO(b"")
+
+        def wait(self):
+            return 0
+
+    def fake_popen(cmd, *a, **kw):
+        seen["cmd"] = cmd
+        return FakeProc()
+
+    with patch.object(s3mod.subprocess, "Popen", fake_popen):
+        s3mod.S3BackupService()._pg_dump_to(str(tmp_path / "out.sql.gz"))
+
+    cmd = seen["cmd"]
+    assert "--clean" in cmd, f"pg_dump would append rather than replace: {cmd}"
+    assert "--if-exists" in cmd, f"--clean without --if-exists errors on a fresh db: {cmd}"
+
+
+@mock_aws
+def test_a_restore_that_cannot_read_glacier_reports_an_error_not_success(
+    fake_redis, s3_settings, library, fake_pg
+):
+    """The ordinary mistake: restoring before the 12-48 hour thaw finishes.
+
+    Every audio object answers `InvalidObjectState`, nothing is downloaded, and
+    the result used to be `{"status": "success", "files_downloaded": 0}` — the
+    audio absent and the operator told otherwise.
+    """
+    from botocore.exceptions import ClientError
+
+    client = boto3.client("s3", region_name=REGION)
+    _bucket(client)
+    _service().run_backup()
+    fake_redis.kv.pop(s3mod.REDIS_BACKUP_LOCK, None)
+    # Remove the local copies, or the restore skips them as already-matching.
+    for t in library.tracks:
+        Path(t["file_path"]).unlink()
+
+    svc = _service()
+    real_client = svc._get_client()
+
+    def frozen_download(bucket, key, path):
+        raise ClientError(
+            {"Error": {"Code": "InvalidObjectState", "Message": "not restored"}},
+            "GetObject",
+        )
+
+    with patch.object(
+        s3mod.S3BackupService, "_get_client", return_value=real_client
+    ):
+        real_client.download_file = frozen_download
+        result = svc.download_and_restore()
+
+    assert result["status"] == "error", result
+    assert result["files_not_thawed"] >= 2, result
+    assert result["files_downloaded"] == 0
+    assert "thaw" in (result.get("error") or "").lower()
+
+
+@mock_aws
+def test_a_partly_failed_restore_is_reported_as_incomplete(
+    fake_redis, s3_settings, library, fake_pg
+):
+    """A failure that is not a thaw problem still must not read as success."""
+    from botocore.exceptions import ClientError
+
+    client = boto3.client("s3", region_name=REGION)
+    _bucket(client)
+    _service().run_backup()
+    # Thaw first, so the only failure in this test is the injected one.
+    _service().initiate_restore()
+    fake_redis.kv.pop(s3mod.REDIS_BACKUP_LOCK, None)
+    # Remove the local copies, or the restore skips them as already-matching.
+    for t in library.tracks:
+        Path(t["file_path"]).unlink()
+
+    svc = _service()
+    real_client = svc._get_client()
+    calls = {"n": 0}
+    original = real_client.download_file
+
+    def flaky(bucket, key, path):
+        calls["n"] += 1
+        if calls["n"] == 1:
+            raise ClientError(
+                {"Error": {"Code": "AccessDenied", "Message": "nope"}}, "GetObject"
+            )
+        return original(bucket, key, path)
+
+    with patch.object(s3mod.S3BackupService, "_get_client", return_value=real_client):
+        real_client.download_file = flaky
+        result = svc.download_and_restore()
+
+    assert result["status"] == "incomplete", result
+    assert result["files_failed"] == 1, result
+    assert result["files_downloaded"] >= 1
+
+
+@mock_aws
+def test_a_fully_successful_restore_still_reports_success(
+    fake_redis, s3_settings, library, fake_pg
+):
+    """The counters must not make the happy path look broken."""
+    client = boto3.client("s3", region_name=REGION)
+    _bucket(client)
+    _service().run_backup()
+    _service().initiate_restore()
+    fake_redis.kv.pop(s3mod.REDIS_BACKUP_LOCK, None)
+
+    result = _service().download_and_restore()
+    assert result["status"] == "success", result
+    assert result["files_failed"] == 0
+    assert result["files_not_thawed"] == 0


### PR DESCRIPTION
Both defects were found by running the real service against real S3 with a real
postgres. Neither is reachable through `moto`: one is `psql` semantics, the
other a Glacier state transition mocks do not model.

## The restore was appending, not replacing

`pg_dump` ran with `--no-owner --no-acl` and **no `--clean --if-exists`**, so the
dump is INSERTs against tables that already exist and `psql` merges into them.
Measured: a two-row `marker` table came back holding both the old and the new
row, and a two-row `tracks` came back with four. On the real library that turns
26,469 tracks into ~53,000 — a database that reports as restored and is silently
doubled, which is worse than a restore that fails.

Re-run against real S3 after the fix: `tracks` 3 -> 2 and `marker`
`MUTATED` -> `original-database`. It replaces.

## A restore that downloaded nothing reported success

Every audio object answered `InvalidObjectState` — Deep Archive, not thawed —
and the result was `{"status": "success", "files_downloaded": 0}`. That is the
ordinary mistake, restoring before the 12-48 hour Bulk retrieval finishes, and
it told the operator the audio was back when none of it was.

Failures are now counted and classified. `not_thawed` reports `error` and names
the thaw step; other failures report `incomplete`; only a clean run reports
`success`. `files_failed` and `files_not_thawed` are in the result.

## Tests

Four, each verified to fail with its fix reverted. The dump test asserts the
**argv actually handed to pg_dump** rather than the source text, so reformatting
cannot make it pass vacuously.

Two things this run also settled, both worth knowing:

- **`data/settings.json` beats environment variables.** `get_effective` is
  settings.json -> env -> default, so an `S3_BACKUP_PREFIX` env var is ignored
  when the key is present in settings. Two runs I believed were writing to
  different prefixes were writing to one.
- The safety dump from the previous commit fires on real infrastructure: a
  `pre-restore_*.sql.gz` appeared before each restore.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01Emjrwedq7W1scadHdgiLfs