### PR TITLE
Install clapback-embed from PyPI, and bound it below the next minor

### DIFF
--- a/backend/pyproject.toml
+++ b/backend/pyproject.toml
@@ -81,7 +81,13 @@ dev = [
 analysis = [
     "librosa>=0.10.0",
     "numpy>=1.24.0",
-    "clapback-embed @ git+https://github.com/seethroughlab/clapback.git@main#subdirectory=packages/embed",
+    # Upper-bounded at the minor, which is not caution but the package's own contract:
+    # clapback's `ADR-0005` point 4 says any change that moves `PIPELINE_VERSION` is at
+    # minimum a minor bump and a patch release may never move it. So `<0.2` takes fixes
+    # and refuses, by construction, the release that would silently change what every
+    # vector in the library means. Raising it is a deliberate act with a re-analysis
+    # attached — see `EMBEDDING_VERSION` in app/config.py.
+    "clapback-embed>=0.1.0,<0.2",
     "soundfile>=0.12.0", # Audio file loading
     "umap-learn>=0.5.0", # Dimensionality reduction for music map
     "pyloudnorm>=0.1.0", # EBU R128 loudness measurement
@@ -95,12 +101,6 @@ build-backend = "hatchling.build"
 
 [tool.hatch.build.targets.wheel]
 packages = ["app"]
-
-# `clapback-embed` is installed from git rather than PyPI — it is published from
-# the clapback repository and has no release on an index yet. hatchling
-# refuses direct references without this.
-[tool.hatch.metadata]
-allow-direct-references = true
 
 [tool.ruff]
 line-length = 100

--- a/docs/decisions/ADR-0105-familiars-clap-runtime-is-an-external-package.md
+++ b/docs/decisions/ADR-0105-familiars-clap-runtime-is-an-external-package.md
@@ -11,6 +11,17 @@ Relates to [ADR-0102](ADR-0102-the-community-cache-gains-a-recording-key.md), wh
 only meaningful if independent installations compute the same function.
 
 Implementation:
+- **The package is installed from PyPI as of 2026-09-04.** It was a git reference to
+  `clapback.git@main` while no release existed, which meant every rebuild silently took whatever was
+  on that branch — including, in principle, a commit that moved `PIPELINE_VERSION` and therefore
+  every vector this installation would compute. `clapback-embed 0.1.0` is published, so the
+  dependency is an ordinary version specifier and the `[tool.hatch.metadata]
+  allow-direct-references` stanza that a direct reference required is gone.
+- **The constraint is upper-bounded at the minor on purpose.** clapback's `ADR-0005` point 4 makes a
+  pipeline-identity change at minimum a minor bump and forbids a patch from moving it, so
+  `>=0.1.0,<0.2` takes fixes and refuses the release that would change what the library's embeddings
+  mean. Raising it is a deliberate act that comes with an `EMBEDDING_VERSION` bump and a
+  re-analysis.
 - **The GPU made each analysis worker more expensive in host RAM, and the tail of a library is where
   that bites.** Every worker now holds a CUDA context alongside its decode buffer, so three workers
   that were comfortable on the CPU path were not on the GPU one. Measured 2026-09-03: a 57-minute


### PR DESCRIPTION
`clapback-embed 0.1.0` is [published](https://pypi.org/project/clapback-embed/), so the git reference ADR-0105 recorded as a workaround can go.

```diff
-    "clapback-embed @ git+https://github.com/seethroughlab/clapback.git@main#subdirectory=packages/embed",
+    "clapback-embed>=0.1.0,<0.2",
```

It was the only direct reference in the file, so `[tool.hatch.metadata] allow-direct-references = true` goes with it.

## Why the git reference mattered beyond tidiness

`@main` meant **every rebuild took whatever was on that branch** — including, in principle, a commit that moved `PIPELINE_VERSION` and with it every vector this installation computes: no release, no tag, no notes, and no way to notice until the embeddings had already been computed and contributed. clapback's ADR-0006 exists because that hazard is real.

## Why `<0.2` and not just `>=0.1.0`

The bound is the package's own contract, not caution. clapback's **ADR-0005 point 4** makes any change that moves `PIPELINE_VERSION` *at minimum* a minor bump, and forbids a patch release from moving it.

So `>=0.1.0,<0.2` takes fixes and refuses, by construction, the one release that would silently change what this library's embeddings mean. Raising it becomes a deliberate act that arrives with an `EMBEDDING_VERSION` bump and a re-analysis attached — which is exactly the coupling `EMBEDDING_VERSION`'s own comment describes.

## Verified

- Resolves to `clapback-embed==0.1.0` from PyPI (`uv pip install --dry-run`).
- `pyproject.toml` still parses; both extras (`analysis`, `dev`) intact; `tool.hatch.metadata` gone.
- Nothing else in the repository referenced the git URL or the escape hatch.

ADR-0105's `Implementation:` block records both the move and the reasoning for the bound.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_013y1g4m6RF7PW8gB27uutuU