### PR TITLE
Describe the client split the code already made

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -1,243 +1,184 @@
 # Familiar
 
-An LLM-powered local music player that combines library management with AI-powered discovery. Users describe what they want to listen to in natural language, and Codex creates playlists from a deeply-analyzed local music collection.
+Familiar is a self-hosted music library server with AI-assisted discovery. The server scans and
+analyzes a local music collection; the browser is now an administration surface; the Mac and iPhone
+listening clients live in the separate `familiar-apple` repository.
 
-## Architecture
+## Current Architecture
 
-- **Backend**: Python FastAPI + PostgreSQL (pgvector) + Redis
-- **Frontend**: React + TypeScript + Vite + Tailwind + Zustand (pnpm workspace monorepo)
-- **Analysis**: Audio embeddings and features extracted via librosa/torch
-- **LLM**: Codex API with tool-use
-- **Offline**: IndexedDB (Dexie) for track caching, download queue, playlist cache
+- **Backend**: Python FastAPI + PostgreSQL/pgvector + Redis
+- **Frontend**: React + TypeScript + Vite + Tailwind + Zustand in a pnpm workspace
+- **Analysis**: librosa feature extraction, CLAP embeddings through `clapback-embed`, and optional
+  deeper section/melodic analysis
+- **LLM surface**: server-side tools plus an MCP endpoint; clients bring their own assistant/provider
+- **Clients**: this repo owns the server, web administration UI, embedded discovery page, and
+  visualizer documents. Native Mac/iPhone playback is in `../familiar-apple`
+
+The old Capacitor app, browser player, PWA install path, service worker, Dexie offline store, and
+web playback engine were retired in August 2026. Do not reintroduce those shapes without an ADR.
 
 ## Key Directories
 
 ```
-packages/
-├── frontend/              # Shared React code (components, hooks, stores, types)
-│   └── src/
-│       ├── components/    # React components
-│       ├── hooks/         # Custom hooks (useFavorites, useAutoDownload, etc.)
-│       ├── stores/        # Zustand state stores (playerStore, downloadStore)
-│       ├── player/        # Audio engine abstraction, playback hooks
-│       ├── services/      # offlineService, playlistCache, syncService, profileService
-│       └── db/            # IndexedDB/Dexie storage
-└── web/                   # Web entry point + Web Audio engine + PWA
-    ├── src/
-    │   ├── main.tsx       # Registers WebAudioEngine, sets up SW
-    │   └── WebAudioEngine.ts
-    ├── e2e/               # Playwright E2E tests
-    └── vite.config.ts     # PWA plugin, dev proxy, manual chunks
-                           # The Apple clients live in the familiar-apple repo (ADR-0001);
-                           # packages/ios, the Capacitor app, was deleted 2026-08-11.
 backend/
 ├── app/
-│   ├── api/routes/        # FastAPI endpoints (~29 route files)
-│   ├── db/models.py       # SQLAlchemy models
-│   └── services/          # Business logic
-│       └── llm/           # LLM module (service.py, executor.py, tools.py, providers.py)
-├── migrations/versions/   # Alembic database migrations
-└── tests/                 # pytest tests
+│   ├── api/              # FastAPI dependencies, auth, errors, route registration
+│   ├── api/routes/       # REST endpoints, split by product surface/resource
+│   ├── api/schemas/      # Shared Pydantic response/request schemas
+│   ├── db/models/        # SQLAlchemy models
+│   ├── mcp/              # MCP endpoint and playback/tool bridge
+│   └── services/         # Domain logic, background jobs, scanners, analysis
+├── migrations/versions/  # Alembic migrations
+└── tests/                # pytest suite
+
+packages/
+├── frontend/             # Shared React code used by web/embed/visualizer entry points
+│   └── src/
+│       ├── api/          # Axios client modules and query defaults
+│       ├── app/          # App shell, top-level routes and navigation definitions
+│       ├── audio/        # Small audio contract used by embedded surfaces
+│       ├── components/   # Reusable UI and feature components
+│       ├── hooks/        # React hooks
+│       ├── panels/       # Library, tools and server panels
+│       ├── screens/      # Top-level web destinations
+│       ├── services/     # Browser-side service modules
+│       ├── stores/       # Zustand state stores
+│       └── utils/        # Formatting, logging, platform and error helpers
+├── web/                  # Vite web app, embed and visualizer HTML entry points
+└── visualizers/          # Bundled example/drop-in visualizer documents
+
+docs/
+├── decisions/            # ADRs
+└── *.md                  # Operator, API, installation and architecture docs
 ```
 
 ## Key Files
 
 | Task | Files |
 |------|-------|
-| Database models | `backend/app/db/models.py` |
+| Architecture overview | `docs/ARCHITECTURE.md` |
+| Database models | `backend/app/db/models/*.py` |
 | Database migrations | `backend/migrations/versions/*.py` |
-| API routes | `backend/app/api/routes/*.py` |
-| Audio analysis | `backend/app/services/analysis.py` |
-| LLM tools | `backend/app/services/llm/tools.py`, `llm/executor.py` |
+| API route registration | `backend/app/api/routes/__init__.py` |
+| API dependencies/auth | `backend/app/api/deps.py`, `backend/app/api/auth.py` |
+| App startup/middleware | `backend/app/main.py` |
+| Audio feature versions | `backend/app/config.py`, `VERSIONING.md` |
+| Audio analysis | `backend/app/services/analysis.py`, `backend/app/services/track_analysis/` |
 | Library scanning | `backend/app/services/scanner.py` |
+| Background sync/analysis | `backend/app/services/tasks/`, `backend/app/services/background/` |
+| LLM tools | `backend/app/services/llm/tools.py`, `backend/app/services/llm/executor.py`, `backend/app/services/llm/handlers/` |
 | Smart playlists | `backend/app/services/smart_playlists.py` |
-| Background tasks | `backend/app/services/background.py`, `services/tasks.py` |
-| Audio engine abstraction | `packages/frontend/src/player/audio/types.ts`, `createEngine.ts` |
-| Audio playback | `packages/frontend/src/player/useAudioEngine.ts` |
-| Web Audio engine | `packages/web/src/WebAudioEngine.ts` |
-| Player state | `packages/frontend/src/stores/playerStore.ts` |
-| Download queue | `packages/frontend/src/stores/downloadStore.ts` |
-| Offline storage | `packages/frontend/src/services/offlineService.ts` |
-| Playlist caching | `packages/frontend/src/services/playlistCache.ts` |
-| Favorites | `packages/frontend/src/hooks/useFavorites.ts` |
-| IndexedDB schema | `packages/frontend/src/db/index.ts` |
-| Full player | `packages/frontend/src/components/FullPlayer/` |
-| Discovery | `packages/frontend/src/components/Discovery/` |
-| Smart playlists UI | `packages/frontend/src/components/SmartPlaylists/` |
-| Settings | `packages/frontend/src/components/Settings/` |
+| Frontend route map | `packages/frontend/src/app/routes.ts` |
+| Frontend API client | `packages/frontend/src/api/base.ts`, `packages/frontend/src/api/*.ts` |
+| Web entry points | `packages/web/src/main.tsx`, `packages/web/src/embed.tsx`, `packages/web/src/visualizer.tsx` |
+| Visualizer host/catalog | `packages/frontend/src/components/Visualizer/`, `packages/frontend/src/services/visualizerCatalog.ts` |
 
-## Frontend Architecture
+## Development Workflow
 
-The frontend uses a **registration pattern** for platform-specific code. The shared `@familiar/frontend` package has zero `@capacitor` dependencies:
+### Local Development
 
-- **`createEngine.ts`** — `registerEngineFactory(fn)` sets the audio engine constructor
-- **`api/base.ts`** — `registerPreferencesProvider(p)` for Capacitor Preferences
+```bash
+# Terminal 1: database + redis
+docker compose -f docker/docker-compose.yml up -d
 
-The web entry point (`packages/web/src/main.tsx`) registers its implementations before calling `renderApp()`. It is the only one left: the Capacitor app that was the other was retired with ADR-0001 point 6, and the registration pattern stays because `/embed` and `/visualizer` still use it.
+# Terminal 2: backend
+cd backend && make run
+
+# Terminal 3: frontend
+cd packages/web && pnpm dev
+```
+
+### Testing Against Remote NAS
+
+Use the faster project-specific paths during iteration:
+
+```bash
+make dev-remote   # frontend dev server proxies to the NAS backend
+make deploy-dev   # build + rsync to NAS + restart
+```
+
+Avoid the full Docker build/GitHub Actions path for routine iteration; it is much slower and is
+intended as CI/release validation.
 
 ## Common Tasks
 
 ### Add a new audio feature
-1. Add extraction logic in `analysis.py` — `derive_features()` for librosa scalars (`extract_features()`
-   is a thin wrapper), or `services/track_analysis/analyzers.py` for the section analyzers, mapped
-   through `extract_feature_scalars()` in `track_analysis/pipeline.py`
-2. **Add a typed column** to `TrackAnalysis` in `backend/app/db/models/tracks.py`, list it in
-   `ANALYSIS_FEATURE_COLUMNS`, and write an Alembic migration. Features were promoted out of JSONB
-   into typed columns — a new feature that skips this is computed and then silently dropped
-3. Bump `FEATURES_VERSION` in `config.py` and add a line to the history comment beside it. There is
-   **no `ANALYSIS_VERSION`**; the constants are per phase, so bumping features leaves embeddings and
-   melodic data alone
-4. Re-analysis only happens during a **library sync** — nothing is scheduled. Budget for it: one
-   worker, a fresh interpreter per track, and an 8-hour cap on the features phase, so a large
-   library takes several consecutive syncs. See `VERSIONING.md`
+
+1. Add extraction logic in `backend/app/services/analysis.py` for scalar features, or
+   `backend/app/services/track_analysis/` for section/melodic analysis.
+2. Add a typed column to `TrackAnalysis` in `backend/app/db/models/tracks.py`.
+3. Add the column name to `ANALYSIS_FEATURE_COLUMNS`.
+4. Write an Alembic migration.
+5. Bump only the relevant phase constant in `backend/app/config.py` and update its history comment.
+   See `VERSIONING.md`.
+
+Features were promoted from JSONB into typed columns. A computed feature that is not listed in the
+model and `ANALYSIS_FEATURE_COLUMNS` will be dropped on persistence.
 
 ### Add a new LLM tool
-1. Define tool schema in `MUSIC_TOOLS` list in `services/llm/tools.py`
-2. Implement handler in `ToolExecutor` class in `services/llm/executor.py`
-3. Tools can query JSONB with PostgreSQL `->` operator
+
+1. Define the schema in `MUSIC_TOOLS` in `backend/app/services/llm/tools.py`.
+2. Implement the handler in `ToolExecutor` or an existing handler module under
+   `backend/app/services/llm/handlers/`.
+3. Add tests for the tool schema and execution path.
 
 ### Add a new API endpoint
-1. Create route in `backend/app/api/routes/`
-2. Register router in `main.py`
-3. Use dependency injection from `deps.py` for DB/auth
+
+1. Create or extend a route module in `backend/app/api/routes/`.
+2. Register new route modules in `backend/app/api/routes/__init__.py`.
+3. Use dependencies from `backend/app/api/deps.py` for database/profile handling.
+4. Return shared schemas from `backend/app/api/schemas/` when the shape is reused.
+5. Add or update API/client tests and regenerate OpenAPI if the schema changes.
 
 ### Add a database migration
-1. Create file in `backend/migrations/versions/` named `YYYYMMDD_slug.py`
-2. **Revision ID must be ≤32 characters** (alembic_version column limit)
-3. Always use the `_column_exists()` guard pattern for idempotent migrations:
-```python
-def _column_exists(table_name: str, column_name: str) -> bool:
-    conn = op.get_bind()
-    result = conn.execute(sa.text(
-        "SELECT column_name FROM information_schema.columns "
-        "WHERE table_name = :table AND column_name = :column"
-    ), {"table": table_name, "column": column_name})
-    return result.fetchone() is not None
-```
-4. Add corresponding field to the SQLAlchemy model in `models.py`
-5. `deploy-dev.sh` auto-runs `alembic upgrade head` on deploy
 
-### Add a new settings section
-1. Add component in `packages/frontend/src/components/Settings/`
-2. Export from `Settings/index.tsx`
-3. Add to settings tabs in main Settings component
+1. Create `backend/migrations/versions/YYYYMMDD_slug.py`.
+2. Keep the Alembic revision ID at 32 characters or less.
+3. Prefer the shared guard helpers in `backend/migrations/helpers.py`.
+4. Add the matching SQLAlchemy model field.
+5. Run the migration lint and migration tests.
+
+### Add a web surface
+
+1. Add the screen or panel under `packages/frontend/src/screens/` or `packages/frontend/src/panels/`.
+2. Update `packages/frontend/src/app/routes.ts` and `packages/frontend/src/app/App.tsx`.
+3. Add navigation integrity coverage if a new destination is linked.
+4. Keep web responsibilities administrative: library management, tools, server state, embedded
+   discovery, and visualizer hosting. Playback UX belongs in `familiar-apple`.
 
 ### Regenerate README screenshots
-Screenshots for the README are auto-generated using Playwright:
 
-1. Ensure backend is running: `cd backend && make run`
-2. Start frontend dev server: `cd packages/web && pnpm dev`
-3. Run screenshot script: `cd packages/web && BASE_URL=http://localhost:3000 npx playwright test --grep="screenshot"`
+1. Ensure the backend is running.
+2. Start the web dev server from `packages/web`.
+3. Run the screenshot Playwright spec from `packages/web`.
+4. Commit the updated files in `screenshots/`.
 
-Screenshots are saved to `screenshots/` directory. The script is in `packages/web/e2e/screenshots.spec.ts`.
+## Guardrails
 
-To add new screenshots:
-1. Add a new test case to `screenshots.spec.ts`
-2. Use the `selectBrowser()` helper to switch library views
-3. Use `navigateToTab()` helper to switch between Library/Playlists/Settings
-4. Update README.md to include the new screenshot
+- Do not import `@capacitor` in `@familiar/frontend`.
+- Do not add service workers, PWA install prompts, IndexedDB playback caches, or browser playback
+  state without an ADR.
+- Keep API error envelopes consistent; contract tests exist for this.
+- Keep generated OpenAPI current because the Apple clients consume it.
+- Avoid route ordering hazards. Dynamic `/{id}` routes must be registered after more specific paths.
+- When touching streaming/download routes, release database connections before sending long bodies.
+- When fixing a bug, ask whether a focused test could have caught it.
 
-## Configuration
-
-Most settings are configured via the admin UI (Settings panel):
-- **Music library paths** - Settings > Library Management
-- **API keys** - Admin page (Anthropic, Spotify, Last.fm, AcoustID)
-- **LLM provider** - Settings > AI Assistant
-
-Settings are stored in `data/settings.json` and persist across restarts.
-
-## Environment Variables
-
-Only infrastructure settings require environment variables:
+## Quality Checks
 
 ```bash
-# Required (from docker-compose or shell)
-DATABASE_URL=postgresql+asyncpg://familiar:familiar@localhost:5432/familiar
-REDIS_URL=redis://localhost:6379/0
+# Backend
+cd backend
+uv run ruff check .
+uv run mypy app --ignore-missing-imports
+uv run pytest tests/ -x -q
 
-# Optional (for Docker volume mounting only - actual paths configured in UI)
-MUSIC_LIBRARY_PATH=/data/music
+# Frontend
+pnpm --filter @familiar/frontend run lint
+pnpm --filter @familiar/frontend run check:boundaries
+pnpm --filter @familiar/frontend test
+pnpm --filter @familiar/web run build
 ```
 
-## Running Locally
-
-```bash
-# Backend (from backend/)
-DATABASE_URL="..." REDIS_URL="..." uv run uvicorn app.main:app --reload --port 4400
-
-# Frontend (from packages/web/)
-pnpm dev
-```
-
-## Development Workflow
-
-### Local Development (Default)
-Backend and frontend run locally with hot-reload:
-```bash
-# Terminal 1: Start database + redis
-docker compose -f docker/docker-compose.yml up -d
-
-# Terminal 2: Backend with hot-reload
-cd backend && make run
-
-# Terminal 3: Frontend dev server
-cd packages/web && pnpm dev
-```
-
-### Testing Against Remote NAS (openmediavault)
-For testing with the real 23K track library via Tailscale:
-
-**Frontend-only changes (fastest):**
-```bash
-make dev-remote  # Vite dev server proxies to NAS backend
-```
-
-**Full-stack changes:**
-```bash
-make deploy-dev  # Build + rsync to NAS + restart (~16-30s)
-```
-
-**IMPORTANT:** Do NOT use the full Docker build + GitHub Actions workflow for iterative development - that takes ~1 hour per change. Use `make deploy-dev` instead.
-
-### Running Tests
-
-```bash
-# Backend (from backend/)
-make test                    # pytest with coverage
-uv run pytest tests/ -x -q   # quick run, stop on first failure
-
-# Frontend unit tests (from packages/frontend/)
-pnpm test                   # vitest run
-pnpm test:watch             # vitest watch mode
-
-# Frontend E2E tests (requires backend + frontend running)
-cd packages/web && npx playwright test                # Playwright headless
-cd packages/web && npx playwright test --ui           # Playwright UI mode
-```
-
-### iOS Development
-
-**Not in this repo.** The phone and Mac apps are built from `familiar-apple` (ADR-0001); the
-Capacitor app that used to live in `packages/ios` was deleted on 2026-08-11, once the native client
-had shipped a TestFlight build of its own.
-
-```bash
-cd ../familiar-apple && ./scripts/release-testflight.sh   # archive, sign, upload
-```
-
-Same App Store Connect record (`com.familiar.player`), so it replaces rather than migrates. `make
-release-testflight` and `make deploy-device` still exist here and print this, then exit non-zero.
-
-## Code Conventions
-
-- Backend uses async SQLAlchemy with `DbSession` dependency
-- Frontend uses Zustand for global state, React Query for server state
-- Profile-based multi-user (no traditional auth) - profile ID in header
-- Audio features stored as JSONB for flexibility
-- Embeddings stored in pgvector for similarity search
-- SmartPlaylistService uses `**kwargs` with `setattr()` for flexible updates - new model fields work automatically
-- Offline-first: `offlineService.ts` manages IndexedDB track storage, `playlistCache.ts` caches playlists, `downloadStore.ts` manages download queue with persistence and resume
-- iOS Safari flexbox: nested `flex-1` inside `flex-col` needs explicit `min-h-0` for `overflow-y-auto` to work - add at every level of the flex chain
-- Platform-specific code uses registration pattern — never import `@capacitor` packages in `@familiar/frontend`
-
-- When fixing a bug, ask yourself: can we add a test that could have caught this?
+Backend tests require PostgreSQL and Redis. CI provisions those services; local runs need the Docker
+compose stack or equivalent services already running.

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -1,0 +1,81 @@
+# Contributing to Familiar
+
+Thanks for helping with Familiar. The project has moved quickly, so the most useful habit is to
+preserve the current boundaries while making focused improvements.
+
+## Start Here
+
+1. Read `README.md` for product context.
+2. Read `docs/ARCHITECTURE.md` for the current system map.
+3. Skim `VERSIONING.md` before changing analysis code.
+4. Check `docs/ERROR-CONTRACTS.md` before adding or changing API errors.
+5. Look for a relevant ADR in `docs/decisions/` when a choice seems surprising.
+
+## Local Setup
+
+```bash
+docker compose -f docker/docker-compose.yml up -d
+
+cd backend
+make run
+
+cd ../packages/web
+pnpm dev
+```
+
+Backend tests need PostgreSQL and Redis. The compose stack above provides them for local work.
+
+## Before Opening a PR
+
+Run the focused checks for the area you touched.
+
+```bash
+# Backend
+cd backend
+uv run ruff check .
+uv run mypy app --ignore-missing-imports
+uv run pytest tests/ -x -q
+
+# Frontend
+pnpm --filter @familiar/frontend run lint
+pnpm --filter @familiar/frontend run check:boundaries
+pnpm --filter @familiar/frontend test
+pnpm --filter @familiar/web run build
+```
+
+If a check cannot run locally because an external service is missing, say that in the PR.
+
+## Code Guidelines
+
+- Keep changes scoped to the feature or bug being fixed.
+- Prefer existing patterns over new abstractions.
+- Add tests for bug fixes when a reasonable focused test can catch the behavior.
+- Keep SQLAlchemy models and Alembic migrations in sync.
+- Regenerate and commit `backend/openapi.json` when the public API changes.
+- Do not import `@capacitor` from `packages/frontend`.
+- Do not reintroduce PWA/player/offline-browser behavior without a fresh ADR.
+
+## Backend Notes
+
+- Use `DbSession`, `CurrentProfile` or `RequiredProfile` from `backend/app/api/deps.py`.
+- Streaming or download handlers should call `release_connection()` after reading database metadata
+  and before sending long response bodies.
+- New route modules are registered in `backend/app/api/routes/__init__.py`, not directly in
+  `main.py`.
+- Migration revision IDs must be 32 characters or shorter.
+- New analysis features need a typed `TrackAnalysis` column and an entry in
+  `ANALYSIS_FEATURE_COLUMNS`.
+
+## Frontend Notes
+
+- Top-level navigation lives in `packages/frontend/src/app/routes.ts`.
+- API calls should use modules under `packages/frontend/src/api/`; raw `fetch` is reserved for
+  assets, streams and other cases where axios is a poor fit.
+- Keep service modules independent from UI stores unless the dependency-cruiser rule has an explicit
+  reason to allow it.
+- The browser app is an administration tool. Native listening UX belongs in `familiar-apple`.
+
+## Documentation
+
+Update docs in the same PR when behavior, setup, architecture or public contracts change. Prefer one
+current explanation over preserving obsolete guidance in place. Historical context belongs in ADRs.

--- a/README.md
+++ b/README.md
@@ -21,7 +21,7 @@
 | Self-hosted / no cloud | Yes | Yes | Yes | Partial |
 | Music video playback | Yes | — | Yes | Yes |
 | Smart playlists | Rules-based | — | — | Yes |
-| Mobile PWA | Yes | Web only | Web + apps | Apps |
+| Native Mac/iPhone clients | Yes | — | Apps | Apps |
 
 ## Screenshots
 
@@ -128,10 +128,11 @@ Three destinations — the library, the tools you run against it, and the server
 - **AcoustID fingerprinting** - Identify unknown tracks
 - **Cloud backup** - S3 Glacier Deep Archive backup (~$1/TB/month) with scheduled backups and restore
 
-### Mobile & Offline
-- **PWA support** - Install on mobile or desktop, works offline
-- **Download tracks** - Cache music for offline playback
-- **Lock screen controls** - Media notifications and controls
+### Native Clients & Remote Access
+- **Mac and iPhone clients** - Listening happens in the native apps from
+  [`familiar-apple`](https://github.com/seethroughlab/familiar-apple)
+- **Offline listening** - Native clients handle downloaded tracks and mobile playback
+- **Lock screen controls** - Media notifications and controls in the native clients
 - **Works over Tailscale** - Access your library anywhere with HTTPS
 
 ### Sharing
@@ -187,30 +188,15 @@ includes Find Similar and suggested tracks. It can be enabled later on a bigger 
 This used to be documented as an ARM64 caveat and as "4 GB recommended". Both were wrong: the
 constraint is memory rather than architecture, and 4 GB is what the model alone needs.
 
-## Keyboard Shortcuts
-
-Press `?` anytime to see all shortcuts.
-
-| Key | Action |
-|-----|--------|
-| `Space` | Play / Pause |
-| `←` / `→` | Previous / Next track |
-| `↑` / `↓` | Volume up / down |
-| `J` / `L` | Seek backward / forward 10s |
-| `S` | Toggle shuffle |
-| `R` | Cycle repeat mode |
-| `M` | Mute / Unmute |
-| `F` | Toggle full player |
-| `Esc` | Close overlay |
-| `?` | Show shortcuts help |
-
 ## Documentation
 
 - **[Installation Guide](docs/INSTALLATION.md)** - Docker, OpenMediaVault, Synology NAS, and development setup
+- **[Architecture](docs/ARCHITECTURE.md)** - Current server/web/native-client boundaries
 - **[macOS Guide](docs/MACOS.md)** - Docker Desktop setup, Apple Silicon, music library paths
 - **[Configuration](docs/CONFIGURATION.md)** - Environment variables, API keys, Tailscale HTTPS, cloud backup
 - **[Library Browser API](docs/LIBRARY_BROWSERS.md)** - Create custom 2D/3D library visualizations
 - **[REST API Reference](docs/REST-API.md)** - Backend REST API documentation
+- **[Contributing](CONTRIBUTING.md)** - Local workflow, guardrails and PR checks
 
 ## Coming Soon
 
@@ -247,21 +233,26 @@ familiar/
 │   │   ├── services/ # Business logic + background tasks
 │   │   └── utils/    # Utilities
 │   └── tests/
-├── frontend/         # React + TypeScript PWA
-│   ├── src/
-│   │   ├── api/      # API client modules
-│   │   ├── components/
-│   │   ├── hooks/
-│   │   ├── player/   # Audio engine, stores, persistence
-│   │   ├── services/ # Offline, sync services
-│   │   └── stores/   # Zustand state
+├── packages/
+│   ├── frontend/     # Shared React code for web, embed and visualizer entry points
+│   │   └── src/
+│   │       ├── api/        # API client modules
+│   │       ├── app/        # Routes and app shell
+│   │       ├── components/
+│   │       ├── hooks/
+│   │       ├── panels/     # Library, tools and server panels
+│   │       ├── screens/    # Top-level web destinations
+│   │       ├── services/
+│   │       └── stores/     # Zustand state
+│   ├── web/          # Vite web/admin/embed/visualizer entry points
+│   └── visualizers/  # Bundled visualizer documents and examples
 ├── docker/           # Docker configuration
 └── docs/             # Documentation
 ```
 
 ## Contributing
 
-Contributions are welcome! Please read our contributing guidelines before submitting PRs.
+Contributions are welcome. Please read [CONTRIBUTING.md](CONTRIBUTING.md) before submitting PRs.
 
 ## License
 

--- a/docs/ARCHITECTURE.md
+++ b/docs/ARCHITECTURE.md
@@ -1,0 +1,82 @@
+# Familiar Architecture
+
+Familiar is split around ownership of responsibility rather than around every UI that can display
+music.
+
+## System Boundaries
+
+| Layer | Owned here | Not owned here |
+|------|------------|----------------|
+| Server | Scanning, metadata, analysis, discovery, playlists, profiles, REST API, MCP API | Native playback UI |
+| Web | Library administration, tools, server settings/status, embedded discovery, visualizer hosting | General-purpose player, offline listening, mobile playback |
+| Apple clients | The REST/OpenAPI contract they consume | Native playback implementation, library listening UX |
+| Visualizers | Document contract, catalog, bundled examples, sandboxed iframe host | Arbitrary in-page plugin execution |
+
+The browser used to be a PWA/player. That path was retired: the current web app intentionally has no
+service worker, no install prompt, no browser playback engine, and no offline track cache. The Mac
+and iPhone apps own listening.
+
+## Backend Shape
+
+The backend is a FastAPI app backed by PostgreSQL, pgvector and Redis.
+
+- `backend/app/main.py` wires startup, middleware, static files, OpenAPI customization and error
+  handlers.
+- `backend/app/api/routes/__init__.py` aggregates the REST surface once, preserving route order where
+  dynamic paths could otherwise swallow specific routes.
+- `backend/app/api/deps.py` owns database/profile dependencies and the streaming connection-release
+  helper.
+- `backend/app/api/auth.py` owns the server token gate for REST and MCP paths.
+- `backend/app/db/models/` contains SQLAlchemy models. Fresh database shape must be represented here,
+  not only in migrations.
+- `backend/app/services/` contains domain services. Larger domains have been split into packages such
+  as `background/`, `export_import/`, `llm/`, `metadata/`, `tasks/` and `track_analysis/`.
+
+## Analysis Pipeline
+
+Analysis is versioned by phase in `backend/app/config.py`:
+
+- `FEATURES_VERSION` for scalar feature extraction
+- `EMBEDDING_VERSION` for CLAP embedding pipeline changes
+- `MELODIC_VERSION` for melodic analysis
+- `GENERATIVE_ART_VERSION` for generated artwork
+- `MOOD_TAGS_VERSION` for mood tag generation
+
+Only bump the phase that changed. Re-analysis is triggered by library sync, not by a scheduler.
+
+## Frontend Shape
+
+The frontend workspace has two main packages:
+
+- `packages/frontend`: shared React modules, API clients, Zustand stores, hooks, panels and screens.
+- `packages/web`: Vite entry points for the administration app, embedded discovery document and
+  visualizer document host.
+
+Important boundaries:
+
+- `packages/frontend/src/app/routes.ts` is the source of truth for top-level web destinations.
+- `packages/frontend/src/api/base.ts` owns API origin, server token and profile headers.
+- `packages/frontend/.dependency-cruiser.cjs` enforces cross-module import rules.
+- `packages/web/src/main.tsx` deliberately does not register an audio engine.
+- `packages/web/src/embed.tsx` and `packages/web/src/visualizer.tsx` register the small null/audio
+  contracts needed by embedded surfaces.
+
+## Contracts
+
+- The REST schema in `backend/openapi.json` is committed because external clients generate from it.
+- Error responses use a standard envelope. See `docs/ERROR-CONTRACTS.md`.
+- Visualizers are sandboxed documents, not React components injected into the host page.
+- Profile IDs select a listener. The server token, when configured, authorizes access to the server.
+
+## Known Large Surfaces
+
+These modules are important and large enough to treat with extra care:
+
+- `backend/app/services/track_analysis/analyzers.py`
+- `backend/app/services/outputs.py`
+- `backend/app/services/s3_backup.py`
+- `backend/app/services/llm/tools.py`
+- `backend/app/services/scanner.py`
+- `backend/app/main.py`
+
+Prefer small, tested extractions when touching these files. Avoid opportunistic rewrites.

--- a/docs/CONFIGURATION.md
+++ b/docs/CONFIGURATION.md
@@ -60,7 +60,9 @@ not here**, and Familiar never sees it.
 
 ## Tailscale HTTPS
 
-If you access Familiar over [Tailscale](https://tailscale.com/), you can enable HTTPS for full PWA support (install prompts, background sync, etc.).
+If you access Familiar over [Tailscale](https://tailscale.com/), you can enable HTTPS for secure
+remote access to the web administration UI, API and native clients. The browser app is no longer a
+PWA, so HTTPS is for transport security rather than install prompts or background sync.
 
 1. **Enable HTTPS certificates** in your Tailscale admin console:
    - Go to [DNS settings](https://login.tailscale.com/admin/dns)


### PR DESCRIPTION
The documentation still described a **mobile PWA** that installs, works offline and caches tracks for playback. That hasn't been true since listening moved to the native Mac and iPhone clients and the web app became an administration surface — ADR-0001, ADR-0050, ADR-0057 and ADR-0058 between them. A reader following the README arrived expecting a product this repository stopped shipping.

## What changed

**`README.md`** — "Mobile & Offline" becomes "Native Clients & Remote Access". Offline listening, downloaded tracks and lock-screen controls are attributed to the native clients. The comparison table row goes from `Mobile PWA | Yes` to `Native Mac/iPhone clients | Yes`. The keyboard-shortcuts section goes with the surface it documented.

**`docs/CONFIGURATION.md`** — Tailscale HTTPS is reframed as transport security for the admin UI, API and native clients, rather than the thing that unlocks PWA install prompts and background sync. Same setup, honest reason.

**`AGENTS.md`** — restructured around what an agent working here actually needs: current architecture, key directories and files, a development workflow covering both local and testing against the remote NAS, common tasks, guardrails, quality checks. `Frontend Architecture`, `Configuration` and `Environment Variables` leave it — they belong in `ARCHITECTURE.md` and `CONFIGURATION.md`, and were drifting in three places at once.

**`docs/ARCHITECTURE.md`** and **`CONTRIBUTING.md`** — new, and included here rather than separately because `README.md:194` and `:199` already link to both. Committing the rewrite without them would put dangling links on `main`.

## Authorship

The documentation in this PR is **Jeff's work**, written before the session that opened this PR. It was restored from a local APFS snapshot after I destroyed it with a `git reset --hard` while syncing a branch — noted here and in the commit so the recovery is legible if the file dates ever look strange.

Verified after restore: no truncation, no conflict markers, and the cross-references between the five files resolve.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_013y1g4m6RF7PW8gB27uutuU