### PR TITLE
A sync DSN must be one psycopg2 will accept

### DIFF
--- a/backend/app/config.py
+++ b/backend/app/config.py
@@ -90,8 +90,67 @@ class Settings(BaseSettings):
 
     @property
     def sync_database_url(self) -> str:
-        """Synchronous database URL for Alembic or sync operations."""
-        return self.database_url.replace("+asyncpg", "")
+        """Synchronous database URL for Alembic or sync operations.
+
+        Dropping `+asyncpg` is not enough: the query string may carry options
+        only asyncpg understands, and psycopg2 rejects the whole DSN rather than
+        ignoring them. The demo server's backups failed on every run with
+
+            (psycopg2.ProgrammingError) invalid dsn:
+            invalid connection option "ssl"
+
+        because its URL ends `?ssl=require`. The NAS has no such parameter, so
+        the nightly backups there were green throughout and said nothing about
+        this path.
+
+        `ssl` is translated rather than dropped — silently discarding it would
+        turn a TLS connection into a plaintext one, which is worse than failing.
+        """
+        from urllib.parse import parse_qsl, urlencode, urlsplit, urlunsplit
+
+        url = self.database_url.replace("+asyncpg", "")
+        parts = urlsplit(url)
+        if not parts.query:
+            return url
+
+        # asyncpg's `ssl` maps onto libpq's `sslmode`; the truthy spellings all
+        # mean "require TLS".
+        ssl_to_sslmode = {
+            "true": "require",
+            "1": "require",
+            "require": "require",
+            "yes": "require",
+            "on": "require",
+            "false": "disable",
+            "0": "disable",
+            "disable": "disable",
+            "off": "disable",
+            "prefer": "prefer",
+            "allow": "allow",
+            "verify-ca": "verify-ca",
+            "verify-full": "verify-full",
+        }
+        # Options asyncpg accepts and libpq does not. Passing any of them makes
+        # psycopg2 reject the entire DSN.
+        asyncpg_only = {
+            "server_settings",
+            "command_timeout",
+            "statement_cache_size",
+            "prepared_statement_cache_size",
+            "max_cached_statement_lifetime",
+            "max_cacheable_statement_size",
+        }
+
+        kept: list[tuple[str, str]] = []
+        for key, value in parse_qsl(parts.query, keep_blank_values=True):
+            if key == "ssl":
+                kept.append(("sslmode", ssl_to_sslmode.get(value.lower(), "require")))
+            elif key in asyncpg_only:
+                continue
+            else:
+                kept.append((key, value))
+
+        return urlunsplit(parts._replace(query=urlencode(kept)))
 
 
 # Per-phase analysis version constants

--- a/backend/tests/test_sync_database_url.py
+++ b/backend/tests/test_sync_database_url.py
@@ -1,0 +1,82 @@
+"""`sync_database_url` has to produce a DSN psycopg2 will actually accept.
+
+Found on the demo server: every backup failed with
+
+    (psycopg2.ProgrammingError) invalid dsn: invalid connection option "ssl"
+
+because its `DATABASE_URL` ends `?ssl=require`. Dropping `+asyncpg` leaves the
+query string untouched, and psycopg2 rejects the whole DSN rather than ignoring
+an option it does not know. The NAS's URL has no such parameter, so its nightly
+backups were green throughout — a code path that only fails against a
+configuration the primary host does not use.
+"""
+
+from __future__ import annotations
+
+import pytest
+
+from app.config import Settings
+
+
+def url(dsn: str) -> str:
+    return Settings(database_url=dsn).sync_database_url
+
+
+def test_the_asyncpg_driver_is_dropped():
+    assert url("postgresql+asyncpg://u:p@h:5432/db") == "postgresql://u:p@h:5432/db"
+
+
+def test_a_url_with_no_query_string_is_untouched():
+    assert url("postgresql+asyncpg://u:p@h/db") == "postgresql://u:p@h/db"
+
+
+@pytest.mark.parametrize(
+    "value,expected",
+    [
+        ("require", "require"),
+        ("true", "require"),
+        ("1", "require"),
+        ("verify-full", "verify-full"),
+        ("prefer", "prefer"),
+        ("disable", "disable"),
+        ("false", "disable"),
+    ],
+)
+def test_ssl_becomes_sslmode(value, expected):
+    """Translated, never dropped.
+
+    Discarding `ssl` would silently downgrade a TLS connection to plaintext,
+    which is a worse outcome than the error it replaces.
+    """
+    out = url(f"postgresql+asyncpg://u:p@h/db?ssl={value}")
+    assert f"sslmode={expected}" in out
+    assert "ssl=" not in out.replace("sslmode=", "")
+
+
+def test_an_unrecognised_ssl_value_still_requires_tls():
+    """Fail closed: an unknown spelling must not become plaintext."""
+    assert "sslmode=require" in url("postgresql+asyncpg://u:p@h/db?ssl=banana")
+
+
+def test_asyncpg_only_options_are_removed():
+    out = url(
+        "postgresql+asyncpg://u:p@h/db?command_timeout=60&statement_cache_size=0&server_settings=x"
+    )
+    for gone in ("command_timeout", "statement_cache_size", "server_settings"):
+        assert gone not in out, f"{gone} would make psycopg2 reject the DSN"
+
+
+def test_options_libpq_understands_are_kept():
+    out = url("postgresql+asyncpg://u:p@h/db?application_name=familiar&connect_timeout=5")
+    assert "application_name=familiar" in out
+    assert "connect_timeout=5" in out
+
+
+def test_the_demo_shaped_url_is_accepted_by_psycopg2():
+    """The exact failure, end to end: psycopg2 must parse the result."""
+    psycopg2 = pytest.importorskip("psycopg2")
+    out = url("postgresql+asyncpg://u:p@h:5432/db?ssl=require")
+    # `parse_dsn` is what raised ProgrammingError on the demo.
+    parsed = psycopg2.extensions.parse_dsn(out.replace("postgresql://", "postgresql://"))
+    assert parsed["sslmode"] == "require"
+    assert "ssl" not in parsed


### PR DESCRIPTION
The demo server's backups failed on every run:

    (psycopg2.ProgrammingError) invalid dsn: invalid connection option "ssl"

`sync_database_url` dropped `+asyncpg` and left the query string alone. Its URL
ends `?ssl=require`, which asyncpg understands and libpq does not — and psycopg2
rejects the **whole DSN** rather than ignoring an option it does not recognise.
So `pg_dump`, the audio-file query and `migration_preflight` were all
unreachable on that host.

The NAS has no such parameter, which is why ten consecutive green nightly
backups said nothing about it. A code path that only fails against a
configuration the primary host does not use.

`ssl` is now translated to `sslmode` rather than dropped. Dropping it would turn
a TLS connection into a plaintext one — a worse outcome than the error it
replaces — and an unrecognised value maps to `require` so the failure is closed
rather than open. Options only asyncpg accepts (`command_timeout`,
`statement_cache_size`, `server_settings`, …) are removed, since any one of them
invalidates the DSN.

## How it was found

Running the backup round-trip against the demo, which was possible only because
#280 had just made a failed run visible. On the previous release this run
answered `{"status": "started"}` and left no trace at all — the bug and the
thing that would have hidden it were fixed hours apart.

## Tests

Thirteen, ten of which fail against the old one-line implementation. The last
one runs the result through `psycopg2.extensions.parse_dsn` — the call that
actually raised — rather than asserting on the string.

**Not fixed here:** `app/db/session.py` does its own `asyncpg` → `psycopg2`
conversion and has the same gap. It is used for the worker pool rather than for
backups, so it fails differently and is worth its own change.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01Emjrwedq7W1scadHdgiLfs