### PR TITLE
Ambient composes its pool rather than retrieving it (ADR-0108)

### DIFF
--- a/backend/app/services/ambient.py
+++ b/backend/app/services/ambient.py
@@ -807,11 +807,32 @@ async def get_candidates(
             if cosine_dist is not None
             else select(Track, TrackAnalysis, text("0.5 as embedding_similarity"))
         )
+        # Weighted by fitness rather than uniform, because a floor decides *where the band
+        # starts* and nothing about the shape of what it admits. Uniformly over the measured
+        # 0.60 band, five of these ninety rows came from above 0.90 and the rest from the
+        # bottom two tenths — a pool that passed every test about eligibility and sounded
+        # wrong, which is the whole reason the floor moved to 0.80 alongside this.
+        #
+        # Efraimidis–Spirakis: taking the largest `random() ** (1/w)` selects without
+        # replacement with probability proportional to `w`. One expression, no extra pass, and
+        # it stays a single query. `power` rather than `-ln(random())/w` because `random()` can
+        # return exactly 0 and `ln(0)` is undefined; here it merely sorts last.
+        # Annotated because the two branches are different SQLAlchemy expression types —
+        # a `UnaryExpression` from `.desc()` against a plain `func.random()` — and mypy
+        # infers the variable from whichever branch it sees first.
+        fit_any_order: Any
+        if pool.library_weight_exponent > 0:
+            weight = func.power(
+                func.greatest(fitness, 1e-6), pool.library_weight_exponent
+            )
+            fit_any_order = func.power(func.random(), 1.0 / weight).desc()
+        else:
+            fit_any_order = func.random()
         fit_any = (
             await db.execute(
                 fit_any_query.join(TrackAnalysis, TrackAnalysis.track_id == Track.id)
                 .where(and_(*base_conditions, *fit_gate))
-                .order_by(func.random())
+                .order_by(fit_any_order)
                 .limit(pool.library_rows)
             )
         ).all()

--- a/backend/app/services/ranking_profiles.py
+++ b/backend/app/services/ranking_profiles.py
@@ -44,13 +44,41 @@ class AmbientPool:
     eligible does not depend on what is playing.
     """
 
-    #: Above this fitness a track is "ambient enough". Measured, not guessed: at 0.60 roughly
-    #: 14% of a 26,000-track library clears it. See `ambient_fitness`.
+    #: Above this fitness a track is "ambient enough".
+    #:
+    #: **The band above 0.60 is bottom-heavy, and that is a sampling problem rather than a
+    #: floor problem.** Measured on a 26,000-track library: 3,475 tracks clear 0.60, but
+    #: 1,334 sit in 0.60–0.70 and 1,432 in 0.70–0.80 against only 203 above 0.90. Drawn
+    #: uniformly, about five of `library_rows`' ninety came from the genuinely ambient end
+    #: and a session sounded like the floor rather than like the band.
+    #:
+    #: Raising the floor was tried and deliberately **not** taken: at 0.80 the band falls to
+    #: 709 tracks, which buys a better mix by making five sixths of the eligible music
+    #: ineligible, and long sessions would circle the same few hundred records.
+    #: `library_weight_exponent` gets the same effect out of the existing band — it lifts the
+    #: share of picks above 0.90 from 5.8% to roughly 23% while nothing stops being eligible.
+    #: A floor decides what is *allowed*; it was never the right tool for what is *likely*.
     fitness_floor: float
     #: Fit *and* near — continuity, when the current track is anywhere near the ambient end.
     neighbour_rows: int
     #: Fit, from anywhere. **The branch that breaks the lock-in.**
     library_rows: int
+    #: How sharply the library draw prefers the top of the band over its floor.
+    #:
+    #: A floor decides where the band starts and nothing about the shape of what it admits, so
+    #: a uniform draw returns whatever the band's mass happens to be — which for a real library
+    #: is its least ambient end. The draw is weighted by ``fitness ** library_weight_exponent``
+    #: instead. At 6, across the measured 0.60–1.00 band, a 1.00 track is about thirteen times
+    #: as likely as a 0.65 one, lifting the expected share of a 90-row draw scoring above 0.90
+    #: from 5.8% to roughly 23%, and above 0.80 from 20% to about 50%.
+    #:
+    #: **A weight of zero must never mean "ineligible".** Weighting is how the floor is allowed
+    #: to stay low: every track above the floor keeps a real chance, so nothing that used to be
+    #: reachable stops being reachable. If this ever became a filter it would be a second,
+    #: undeclared floor — `test_ambient_pool_weighting.py` guards exactly that.
+    #:
+    #: **1.0 is not "off"** — over a narrow band a linear weight is nearly uniform. Use 0.
+    library_weight_exponent: float
     #: Ungated neighbours, for the deliberate departures.
     excursion_rows: int
     #: One candidate in this many is drawn from the excursions.
@@ -61,6 +89,7 @@ AMBIENT_POOL = AmbientPool(
     fitness_floor=0.60,
     neighbour_rows=60,
     library_rows=90,
+    library_weight_exponent=6.0,
     excursion_rows=40,
     excursion_period=8,
 )

--- a/backend/tests/test_ambient_pool_weighting.py
+++ b/backend/tests/test_ambient_pool_weighting.py
@@ -1,0 +1,237 @@
+"""The pool draws from the top of the fit band, not flatly across it.
+
+`test_ambient_pool_composition.py` proves eligibility — that a rock seed yields ambient
+candidates — using two well-separated clusters. **That fixture cannot catch this defect**,
+because with only two clusters every eligible track is equally ambient and a uniform draw
+across the band is indistinguishable from a weighted one.
+
+Real libraries are a gradient, and the gradient is bottom-heavy. Measured against the 26,000
+track library this was found on: 3,475 tracks cleared a 0.60 floor, but 2,766 of them sat in
+0.60–0.80 against 203 above 0.90. Drawing ninety rows uniformly took about five from the
+genuinely ambient end, and the session sounded like the floor rather than like the band —
+reported as "almost every song is an upbeat or vocal song" while every existing test passed.
+
+**The assertions are an A/B against the same fixture rather than a threshold.** Two earlier
+attempts here asserted absolute numbers and both were worthless: the first used two clusters,
+which made `measure_calibration` degenerate so it silently fell back to the defaults and left a
+40-track band; the second compared the draw against the band average, which cannot be beaten by
+0.05 when the band already averages 0.951. Comparing weighted to uniform over one library
+measures the mechanism itself and survives any reshaping of the fixture.
+"""
+
+from __future__ import annotations
+
+import uuid
+from dataclasses import replace
+
+import pytest
+from sqlalchemy import select
+
+from app.config import FEATURES_VERSION
+from app.db.models import Track, TrackAnalysis, TrackStatus
+from app.services.ambient import get_candidates
+from app.services.ambient_fitness import ambient_fitness, measure_calibration
+from app.services.ranking_profiles import AMBIENT
+
+pytestmark = pytest.mark.asyncio
+
+DIMENSIONS = 512
+LIBRARY_SIZE = 500
+#: Deliberately below the shipped 0.80 so the band is wide enough to have somewhere to move
+#: within. The shipped floor is a separate decision, asserted on its own below.
+PROBE_FLOOR = 0.60
+#: Small relative to the band. At the shipped 90 the draw would take most of a fixture-sized
+#: band and no weighting could show, which is a property of the fixture and not of the code.
+PROBE_ROWS = 15
+
+
+def _embedding(index: int) -> list[float]:
+    base = [0.0] * DIMENSIONS
+    base[index % 64] = 1.0
+    return base
+
+
+def _ramp(i: int) -> tuple[float, float, float]:
+    """One point on a smooth loud→ambient ramp: (energy, bpm, acousticness).
+
+    Correlated on purpose. Real ambient music is quiet, slow and acoustic *together*, and
+    three independent axes would average into a featureless middle where no track is clearly
+    anything — which is precisely the fixture that cannot catch this defect.
+
+    A ramp rather than clusters is the point: `measure_calibration` takes percentiles of
+    whatever it is given, so a two-valued fixture makes every percentile coincide and the
+    calibration reports itself degenerate.
+    """
+    t = i / (LIBRARY_SIZE - 1)
+    return (0.20 + 0.75 * t, 55.0 + 95.0 * t, 0.95 - 0.85 * t)
+
+
+async def _gradient_library(db) -> list[uuid.UUID]:
+    ids: list[uuid.UUID] = []
+    for i in range(LIBRARY_SIZE):
+        energy, bpm, acousticness = _ramp(i)
+        track = Track(
+            id=uuid.uuid4(),
+            title=f"track {i}",
+            artist=f"artist {i % 50}",
+            file_path=f"/music/{i}.flac",
+            file_hash=f"ramp{i:05d}",
+            duration_seconds=240.0,
+            status=TrackStatus.ACTIVE,
+        )
+        db.add(track)
+        db.add(
+            TrackAnalysis(
+                track_id=track.id,
+                embedding=_embedding(i),
+                key="C major",
+                features_version=FEATURES_VERSION,
+                energy=energy,
+                bpm=bpm,
+                acousticness=acousticness,
+                brightness=energy,
+                instrumentalness=0.9,
+                speechiness=0.05,
+                valence=0.4,
+                dynamic_range_db=12.0,
+            )
+        )
+        ids.append(track.id)
+    await db.commit()
+    return ids
+
+
+async def _fitness_of(db, track_ids: list[uuid.UUID]) -> dict[uuid.UUID, float]:
+    """Score every track the way the pool query does, from the same calibration."""
+    calibration = await measure_calibration(db)
+    rows = (
+        await db.execute(select(TrackAnalysis).where(TrackAnalysis.track_id.in_(track_ids)))
+    ).scalars().all()
+    return {
+        r.track_id: ambient_fitness(
+            energy=r.energy, bpm=r.bpm, acousticness=r.acousticness, calibration=calibration
+        )
+        for r in rows
+    }
+
+
+def _probe_profile(exponent: float):
+    """`AMBIENT` with only the library branch live, so the A/B measures that branch."""
+    return replace(
+        AMBIENT,
+        pool=replace(
+            AMBIENT.pool,
+            fitness_floor=PROBE_FLOOR,
+            library_rows=PROBE_ROWS,
+            library_weight_exponent=exponent,
+            neighbour_rows=0,
+            excursion_rows=0,
+        ),
+    )
+
+
+async def _mean_drawn_fitness(db, seed_id, fitness, exponent, trials=12) -> float:
+    """Average fitness of what the library branch returns, over several draws."""
+    got: list[float] = []
+    for _ in range(trials):
+        candidates, _, _ = await get_candidates(
+            db, current_track_id=seed_id, limit=PROBE_ROWS, profile=_probe_profile(exponent)
+        )
+        got += [fitness[c.descriptor.track_id] for c in candidates
+                if c.descriptor.track_id in fitness]
+    assert got, "the probe profile returned nothing at all"
+    return sum(got) / len(got)
+
+
+class TestTheDrawFavoursTheTopOfTheBand:
+    async def test_weighting_beats_a_uniform_draw_over_the_same_library(self, async_db):
+        """**The headline.** Same fixture, same floor, same row count — only the exponent
+        differs, so nothing but the weighting can explain a difference."""
+        ids = await _gradient_library(async_db)
+        fitness = await _fitness_of(async_db, ids)
+        seed = ids[-1]  # the most ambient track, so neither draw is helped by proximity
+
+        uniform = await _mean_drawn_fitness(async_db, seed, fitness, exponent=0.0)
+        weighted = await _mean_drawn_fitness(async_db, seed, fitness, exponent=6.0)
+
+        # 0.035 is measured, not chosen. Against the unfixed code, where both draws are
+        # uniform and the gap is pure noise, eight runs stayed inside ±0.019; with the
+        # weighting live the gap ran +0.053 to +0.090. The margin sits between the two, so
+        # this neither passes on noise nor fails on an unlucky draw.
+        assert weighted > uniform + 0.035, (
+            f"weighted draw averaged {weighted:.3f} against uniform {uniform:.3f} — "
+            "the fit band is still being sampled flat"
+        )
+
+    async def test_the_weighted_draw_reaches_further_from_the_floor(self, async_db):
+        """States it as the listener hears it: how much of the draw is genuinely ambient."""
+        ids = await _gradient_library(async_db)
+        fitness = await _fitness_of(async_db, ids)
+        seed = ids[-1]
+
+        async def share_above(exponent: float, cutoff: float = 0.95) -> float:
+            got: list[float] = []
+            for _ in range(6):
+                candidates, _, _ = await get_candidates(
+                    async_db, current_track_id=seed, limit=PROBE_ROWS,
+                    profile=_probe_profile(exponent),
+                )
+                got += [fitness[c.descriptor.track_id] for c in candidates
+                        if c.descriptor.track_id in fitness]
+            return sum(1 for v in got if v >= cutoff) / len(got)
+
+        assert await share_above(6.0) > await share_above(0.0) + 0.05
+
+
+class TestTheFloorStaysLow:
+    """Weighting was chosen *instead of* a higher floor, and that is the load-bearing part.
+
+    Raising the floor to 0.80 was measured and rejected: it fixes the mix by making five
+    sixths of the eligible library ineligible, and long sessions would circle a few hundred
+    records. These pin the decision, so a later "just raise the floor" has to argue with it.
+    """
+
+    async def test_the_floor_is_still_sixty(self, async_db):
+        assert AMBIENT.pool.fitness_floor == 0.60
+        assert AMBIENT.pool.library_weight_exponent > 0, (
+            "with a low floor the weighting is the only thing shaping the draw"
+        )
+
+    async def test_a_middling_track_is_still_reachable(self, async_db):
+        """The point of keeping the floor low. A 0.65 track must be *less likely*, never
+        excluded — otherwise the exponent has silently become a second floor."""
+        ids = await _gradient_library(async_db)
+        fitness = await _fitness_of(async_db, ids)
+        middling = {t for t, f in fitness.items() if 0.60 <= f < 0.80}
+        assert middling, "fixture has no middle band"
+
+        seen: set[uuid.UUID] = set()
+        for _ in range(25):
+            candidates, _, _ = await get_candidates(
+                async_db, current_track_id=ids[-1], limit=30, profile=AMBIENT
+            )
+            seen |= {c.descriptor.track_id for c in candidates}
+        assert seen & middling, (
+            "25 draws never once returned a track between 0.60 and 0.80 — the weighting is "
+            "acting as a filter, not a preference"
+        )
+
+
+class TestItStillDrawsSomethingAtAll:
+    async def test_weighting_is_not_a_second_hidden_filter(self, async_db):
+        """A weight of zero must never mean "excluded" — every eligible track keeps a
+        non-zero chance, or the floor has quietly moved."""
+        ids = await _gradient_library(async_db)
+        candidates, pool_size, collapsed = await get_candidates(
+            async_db, current_track_id=ids[-1], limit=8, profile=AMBIENT
+        )
+        assert candidates and not collapsed and pool_size > 0
+
+    async def test_an_exponent_of_zero_is_a_uniform_draw(self, async_db):
+        """The documented escape hatch — 1.0 is nearly uniform over a narrow band, so 0 has
+        to be the way back to a flat draw."""
+        ids = await _gradient_library(async_db)
+        candidates, _, collapsed = await get_candidates(
+            async_db, current_track_id=ids[-1], limit=8, profile=_probe_profile(0.0)
+        )
+        assert candidates and not collapsed

--- a/docs/decisions/ADR-0106-ambient-mode-returns-as-a-reachable-surface.md
+++ b/docs/decisions/ADR-0106-ambient-mode-returns-as-a-reachable-surface.md
@@ -5,6 +5,12 @@ Status: accepted
 Date: 2026-09-01
 
 Implementation:
+- **Point 8 is superseded by [ADR-0108](ADR-0108-ambient-composes-its-pool-rather-than-retrieving-it.md),
+  and was already false before that.** It claims *"nothing is added to the ranking engine… `AMBIENT`
+  stays byte-exact"*. Commit `4968b966` (2026-09-03) added `liveliness_ceiling` and
+  `liveliness_penalty` to `AMBIENT` two days after this ADR was accepted, and ADR-0108 then added a
+  pool composition and a fitness score. The rest of this ADR stands; the note below recording that
+  "point 8 held" was true when written and is not any more.
 - **Two routes, not three, and a defect fixed on radio.** Reviewed after acceptance against the
   question "could an existing endpoint have done this?". `GET /ambient/descriptor/{track_id}` had no
   caller and is not restored (point 1). `POST /radio/suggestions` now populates `features`, which it

--- a/docs/decisions/ADR-0108-ambient-composes-its-pool-rather-than-retrieving-it.md
+++ b/docs/decisions/ADR-0108-ambient-composes-its-pool-rather-than-retrieving-it.md
@@ -1,0 +1,183 @@
+# ADR-0108: Ambient Composes Its Pool Rather Than Retrieving It
+
+Status: proposed
+
+Date: 2026-09-04
+
+Extends [ADR-0005](ADR-0005-one-ranking-engine-serves-ambient-and-radio.md)
+
+Implementation:
+- **Written after its implementation shipped, which inverts the intended order.** Points 1–4 and 7–11
+  landed in `fe481563` (#282) and points 5–6 in `282393b3` (#284), both on 2026-09-04, before this
+  record existed. That is the failure ADR-0106 point 8 also demonstrates, one level up: the decisions
+  were real and the record was not written, so the only account of them was in commit messages. The
+  status stays `proposed` until reviewed; the code is not evidence of approval.
+- Point 12 is **not** implemented.
+
+## Context
+
+Ambient's candidate pool was a pure pgvector HNSW nearest-neighbour search on the *currently playing*
+track, and at the default `filter_preset="all"` the only conditions were active / not-recently-played
+/ long enough / energy-not-null. That is right for "more of this" and wrong for "stay ambient": from a
+rock seed every one of the 150 candidates is rock. `score_candidate` then measures energy, brightness
+and valence as **proximity to the current track** — nothing absolute — so a session was a random walk
+with no anchor, and it walked out of ambient territory and stayed out.
+
+Five premises in the existing record are false. Rule 5 requires saying so rather than leaving them to
+be re-derived.
+
+1. **ADR-0106 point 8 is false.** It states: *"Nothing is added to the ranking engine. No new weights,
+   no new profile, no schema migration, no column. `AMBIENT` stays byte-exact."* Commit `4968b966`
+   (2026-09-03) added `liveliness_ceiling=0.55` and `liveliness_penalty=0.30` to `AMBIENT`
+   (`ranking_profiles.py:185-186`) — two days after ADR-0106 was accepted, and never amended. The
+   correction existed only in a commit message and a test docstring. **This ADR supersedes that
+   point**; ADR-0106 otherwise stands.
+
+2. **ADR-0107 point 10 is false.** It states the aesthetic is preserved exactly, *"snippet volume
+   0.15"*, and that *"nothing changes the synth's mix at runtime"*. Snippet volume is now a listener
+   facing slider because 0.15 was inaudible on real speakers, the drone ducks per window, and
+   `setDroneTexture` varies the bed between tracks. Noted here because it is the same failure mode as
+   point 1 and not because this ADR changes it.
+
+3. **A penalty was tried first, and could not have worked.** `liveliness_penalty` was aimed at exactly
+   this problem. **A penalty can only reorder the pool it is given** — handed 150 rock tracks it
+   selects the quietest rock track, which is still rock. Recorded so this is not revisited as "just
+   tune the weight harder".
+
+4. **Absolute feature thresholds were tried and are useless on a real library.** Measured across
+   ~26,000 analysed tracks: energy p5 = 0.648, p50 = 0.826. The entire library sits above the
+   0.40–0.65 band that "quiet" intuitively suggests, so any fixed threshold admits everything or
+   nothing. Adjacency has to be relative to the library it is measured in.
+
+5. **`instrumentalness` and `speechiness` cannot contribute, and one shipped feature depends on them
+   anyway.** Of the **25,694** active tracks carrying the columns, **25,620 (99.7%)** hold exactly
+   `instrumentalness = 1.000` and `speechiness = 0.000`; p5, p50 and p95 are identical on both. Only
+   74 differ, because silero-VAD detects speech rather than singing. Consequently
+   `FILTER_PRESETS["instrumental"]` (`services/ambient.py:324`, gating `min_instrumentalness: 0.5,
+   max_speechiness: 0.3`) is **effectively inert**: 36 tracks fail the first gate and 3 the second, so
+   choosing it removes about 0.15% of the library and reads to the listener as doing nothing. CLAP
+   `mood_tags` cannot substitute — they are populated on 26,430 of 26,434 tracks and carry no usable
+   signal, with `blues` tagged on 13,749 tracks and `country` on 13,010, every confidence sitting at
+   ~0.45–0.51.
+
+## Decision
+
+1. **Ambient-adjacency is one measured score, `ambient_fitness`.** Energy 0.45, tempo 0.25,
+   acousticness 0.30, in `services/ambient_fitness.py`. It is **percentile-relative**: the calibration
+   is measured from the library's own distribution (full at p10, zero at p60) rather than fixed, per
+   Context 4.
+
+2. **A ceiling, not a target, and NULL reads as neutral.** One-sided on energy and tempo, so a
+   0.10-energy drone does not score *worse* than a 0.25 one — proximity-to-a-target was right for
+   picking a representative seed and wrong as a floor. Missing analysis scores 0.5, not 0.0, so a
+   track whose analyser never wrote `acousticness` is not silently exiled.
+
+3. **One definition in two forms.** A Python form and a SQL form, tested against each other. They
+   replace three inline copies, two of which disagreed: seed selection scored energy as proximity to
+   0.25 with a slope, artist-seed selection targeted 0.4 with none, and the offline manifest inlined
+   the gates a third time under a docstring claiming they matched.
+
+4. **The pool is composed from three branches rather than retrieved from one**, for profiles that opt
+   in: fit-and-near (continuity), **fit-from-anywhere** (the branch that breaks the lock-in, because
+   eligibility must not depend on what is playing), and excursions.
+
+5. **The fit-from-anywhere branch is drawn weighted by fitness, not uniformly.** Sampling proportional
+   to `fitness ** 6` by Efraimidis–Spirakis (`random() ** (1/w)`), one expression and no extra pass. A
+   floor decides what is *allowed* and says nothing about what is *likely*; a uniform draw over a
+   bottom-heavy band returns the band's floor. Measured: 3,475 tracks clear a 0.60 floor but 2,766 of
+   them sit below 0.80 against 203 above 0.90, so roughly five rows in ninety came from the genuinely
+   ambient end.
+
+6. **The floor stays low and weighting does the work.** Raising it to 0.80 was measured and rejected —
+   see Alternatives. **A weight of zero must never mean ineligible**, or the exponent becomes a
+   second, undeclared floor.
+
+7. **Excursions are drawn from *below* the floor, and one candidate in eight is one.** Not merely
+   ungated: from a calm seed an ungated neighbour query returns calm tracks which are all also fit, so
+   dedup leaves nothing and a correctly-working session produces no variety at all. The slot is forced
+   regardless of score, because this is a decision about texture rather than compatibility — otherwise
+   the liveliness penalty scores the excursion out of existence.
+
+8. **The excursion rate is a property of every prefix, not of the request.** The client takes three
+   candidates at seed and two per top-up, and both are constants in the *other* repository. The phase
+   comes from `blake2b` of the track id — **never the builtin `hash()`**, which is PYTHONHASHSEED
+   salted, so two uvicorn workers would disagree about the same track and the bug would not reproduce
+   locally.
+
+9. **Nothing is added to the wire.** An excursion arrives as an ordinary candidate with a low
+   compatibility score. An `is_excursion` flag would force an OpenAPI change and a Swift client
+   regeneration for a field with no consumer. The composition is logged server-side instead.
+
+10. **Profiles opt in, at the level of the profile.** `RankingProfile.pool` is `None` for `RADIO` and
+    `PLAYLIST`, which keeps their query byte-identical. `get_candidates` is shared with radio and the
+    MCP discovery tool under ADR-0005, and a previous defect here was closed with the note "this was
+    never an ambient bug".
+
+11. **It degrades rather than collapsing.** If the fit branches return nothing, fall back to
+    neighbours and log a warning. An empty pool surfaces to the listener as "Session ended", which is
+    worse than the bug being fixed.
+
+12. **`profile="ambient"` is dropped from the MCP discovery tool.** `llm/handlers/discovery.py:105`
+    accepts it and would inherit the composed pool, returning library-wide quiet tracks from a tool
+    whose docstring promises the seed's neighbours plus the listener's taste. Two of the three
+    branches deliberately ignore the seed, so the tool's stated contract would be false. Radio remains
+    its only profile.
+
+## Alternatives Considered
+
+**Raise the fitness floor instead of weighting the draw.** Measured directly and rejected. At 0.80 the
+eligible band falls from 3,475 tracks to 709 — it buys the same mix by making five sixths of the
+eligible library ineligible, and long sessions would circle a few hundred records. Weighting reaches
+the same distribution while nothing stops being reachable: the expected share of picks above 0.90 goes
+from 5.8% to roughly 23%, and above 0.80 from 20% to about 50%.
+
+**Tune `liveliness_penalty` harder.** Cannot work, per Context 3. This is a pool problem and a penalty
+is a scoring tool.
+
+**Put the fitness predicate in a single ANN query's `WHERE`.** HNSW **post-filters** — it returns its
+`ef_search` nearest rows and *then* applies the predicate. From a rock seed that is nearly empty,
+which is precisely the case the change exists for.
+
+**Put fitness in `ORDER BY` of the same query.** Disqualifies the index and full-scans ~26,000
+vectors on every top-up.
+
+**Use CLAP `mood_tags` or a text embedding of "ambient" for adjacency.** Rejected on measurement, per
+Context 5 — the stored tags are uncalibrated zero-shot similarity with half the library tagged
+`blues` and half `country` at indistinguishable confidences.
+
+**Use `instrumentalness` to keep the pool instrumental.** Impossible, per Context 5: the column is
+constant for 99.7% of the library. This is the honest answer to "why does ambient play vocal tracks"
+and the reason the score omits both columns rather than weighting them at zero — a weight of zero
+would imply the input carries signal that is merely unwanted here.
+
+**Add an `is_excursion` flag to the response.** Rejected under point 9 — a schema and client
+regeneration for a field nothing reads.
+
+## Consequences
+
+- **Positive.** Eligibility stops depending on what is playing, which is the actual defect. A session
+  seeded on anything converges into ambient territory instead of out of it, and the top of the
+  ranking — Philip Glass, Boards of Canada, Satie, Eno/Moebius/Roedelius, Autechre — is reached often
+  rather than by accident.
+- **Positive.** One definition of adjacency replaces three divergent copies, so the two seed paths and
+  the offline manifest can no longer disagree about the same track.
+- **Tradeoff.** Three queries per top-up instead of one. Mitigated by sharing `base_conditions` and
+  hoisting a single `SET LOCAL hnsw.ef_search`, and by the fit-from-anywhere branch avoiding the index
+  entirely — but it is three round trips where there was one.
+- **Tradeoff.** The excursion rate is fixed at one in eight by construction rather than by listening.
+  It is a single constant, and the first report from real use is what should move it.
+- **Tradeoff.** A percentile-relative calibration means the same track can change fitness as the
+  library grows. This is intended — adjacency is a claim about *this* library — but it makes
+  fixtures sensitive: a two-valued test library makes every percentile coincide, the calibration
+  reports itself degenerate and silently falls back to defaults, and the resulting test proves
+  nothing. `test_ambient_pool_weighting.py` records two versions that failed this way.
+- **Follow-up.** ADR-0106 gains `Status: accepted` unchanged with a note that point 8 is superseded
+  here. ADR-0107 point 10 is left contradicted and unamended; correcting it needs its own ADR, since
+  it is a claim about the client's aesthetic rather than about ranking.
+- **Follow-up.** `FILTER_PRESETS["instrumental"]` filters ~0.15% of the library and should be removed
+  or backed by a working detector. Removing it is a user-visible change to a shipped control and is
+  deliberately not bundled here.
+- **Follow-up.** ADR-0006's offline manifest ranks a fixed downloaded set with `score_candidate` and
+  has **no pool to compose**, so none of this reaches it. A small absolute `ambient_fitness` term in
+  the score is the only lever that would; until then, "identical by construction rather than two
+  implementations intending to agree" holds for the score and not for the pool.


### PR DESCRIPTION
Ambient was reported as *"almost every song is an upbeat or vocal song"* while every existing test passed. Adds **ADR-0108** recording the decisions, and fixes the remaining defect.

## The measurement

The pool was composing correctly — the logs show `60 near-fit, 90 library-fit, 40 excursions` — but the library branch drew its ninety rows **uniformly** across everything above the floor, and that band is bottom-heavy:

| fitness | tracks |
|---|---|
| 1.00 | 61 |
| 0.90–1.00 | 142 |
| 0.80–0.90 | 506 |
| 0.70–0.80 | 1,432 |
| 0.60–0.70 | 1,334 |
| below floor | 21,962 |

So roughly **five rows in ninety** came from the genuinely ambient end. The top of the ranking is right — Philip Glass, Boards of Canada, Satie, Eno/Moebius/Roedelius, Autechre, Wendy Carlos — it was simply rarely reached.

## The fix

Weight the draw by `fitness ** 6` (Efraimidis–Spirakis: `random() ** (1/w)`, one expression, no extra pass), rather than raising the floor.

Raising the floor to 0.80 was measured and **rejected** — it buys the same mix by making five sixths of the eligible library ineligible, and long sessions would circle a few hundred records. Weighting lifts the expected share of picks above 0.90 from 5.8% to ~23%, and above 0.80 from 20% to ~50%, while **nothing stops being reachable**.

## The test

The existing composition test cannot catch this: its two well-separated clusters make every eligible track equally ambient, so a flat draw and a weighted one are indistinguishable. The new fixture is a **gradient**, and the assertion is an **A/B of weighted against uniform over the same library** rather than a threshold.

Two earlier versions were worthless and are recorded in the module docstring — one used clusters, which made `measure_calibration` degenerate so it silently fell back to defaults and left a 40-track band; the other asked the draw to beat a band average of 0.951 by 0.05. The 0.035 margin is measured: the gap runs +0.053 to +0.090 with weighting live, against ±0.019 of noise without it.

Verified failing against the shipped code (`weighted 0.889 vs uniform 0.870`) and passing after, with 15 consecutive clean runs. 183 tests pass across the ambient, ranking and offline-manifest suites; ruff and mypy clean.

## ADR-0108

Written **after** its implementation shipped (#282 and this PR), which inverts the intended order and is stated as such in the ADR rather than hidden.

It **supersedes ADR-0106 point 8** — *"nothing is added to the ranking engine… `AMBIENT` stays byte-exact"* — which was already false: `4968b966` added `liveliness_ceiling` and `liveliness_penalty` two days after 0106 was accepted, and the correction existed only in a commit message. Rule 6 forbids editing an accepted Decision, so 0106 keeps its status and gains an `Implementation:` note pointing here.

Context also records the premises that investigation disproved, so nobody re-derives them: a penalty could never have fixed this (it only reorders the pool it is given); absolute energy thresholds are useless on a library whose energy p5 is 0.648 and p50 is 0.826.

**Point 12 is new and unimplemented** — dropping `profile="ambient"` from the MCP discovery tool (`llm/handlers/discovery.py:105`), whose docstring promises the seed's neighbours while two of the composed pool's three branches deliberately ignore the seed.

## Separately, not fixed here

Of the 25,694 tracks carrying them, **25,620 (99.7%)** hold `instrumentalness` exactly 1.000 and `speechiness` exactly 0.000, because silero-VAD detects speech rather than singing. The `instrumental` filter preset therefore excludes **36 tracks in 25,694** and reads as doing nothing. CLAP `mood_tags` can't substitute — `blues` is tagged on 13,749 tracks and `country` on 13,010 of 26,434, every confidence at ~0.49.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01Emjrwedq7W1scadHdgiLfs