### PR TITLE
Accept ADR-0108, and implement the one point that had no code

### DIFF
--- a/backend/app/services/llm/handlers/discovery.py
+++ b/backend/app/services/llm/handlers/discovery.py
@@ -82,7 +82,7 @@ class DiscoveryHandlersMixin:
         self: "ToolExecutor",
         seed_track_id: str,
         limit: int = 10,
-        profile: str = "radio",
+        profile: str | None = None,
     ) -> dict[str, Any]:
         """Familiar's own recommender, seeded from one track.
 
@@ -94,15 +94,25 @@ class DiscoveryHandlersMixin:
 
         Cheaper than it looks — roughly four queries and a 150-row vector search over precomputed
         embeddings, with no embedding inference and no model load.
+
+        **`profile` is accepted and ignored (ADR-0108 point 12).** It used to select `AMBIENT`,
+        which was coherent while ambient meant "these neighbours, weighted for continuity". It no
+        longer does: ambient composes its pool from three branches and two of them ignore the seed
+        entirely, so `profile="ambient"` would answer the promise made above — the seed's
+        neighbours plus this listener's taste — with quiet tracks from anywhere in the library.
+        The parameter is gone from the published `input_schema`, so nothing is offered the choice.
+        It survives here because `executor.py` dispatches with `handler(**tool_input)`, where an
+        unexpected keyword becomes a `TypeError` the model sees as a failed tool call; a stale
+        caller should get the right answer, not an error.
         """
         from app.services.ambient import get_candidates
-        from app.services.ranking_profiles import get_profile
+        from app.services.ranking_profiles import RADIO
 
         ids = self._safe_parse_uuids([seed_track_id])
         if not ids:
             return {"error": f"{seed_track_id!r} is not a valid track id."}
 
-        ranking = get_profile(profile if profile in ("radio", "ambient") else "radio")
+        ranking = RADIO
         candidates, pool_size, collapsed = await get_candidates(
             self.db,
             current_track_id=ids[0],

--- a/backend/app/services/llm/tools.py
+++ b/backend/app/services/llm/tools.py
@@ -730,11 +730,11 @@ MUSIC_TOOLS: list[dict[str, Any]] = [
             "properties": {
                 "seed_track_id": {"type": "string", "description": "Local track UUID to seed from."},
                 "limit": {"type": "integer", "description": "How many suggestions, up to 20."},
-                "profile": {
-                    "type": "string",
-                    "enum": ["radio", "ambient"],
-                    "description": "'radio' follows taste more strongly; 'ambient' favours continuity and low disruption.",
-                },
+                # `profile` was offered here with `enum: ["radio", "ambient"]` and is gone under
+                # ADR-0108 point 12. Ambient stopped meaning "the same neighbours, weighted for
+                # continuity": two of its three pool branches deliberately ignore the seed, so it
+                # would answer this tool's promise of the seed's neighbours with library-wide quiet
+                # tracks. Radio is the only profile whose contract matches the description above.
             },
             "required": ["seed_track_id"],
         },

--- a/backend/tests/test_llm_library_tools.py
+++ b/backend/tests/test_llm_library_tools.py
@@ -177,3 +177,45 @@ class TestRadioReadsTheRealCandidateShape:
         assert "error" not in result, result
         assert result["suggestions"][0]["score"] == 0.8765
         assert result["pool_size"] == 150
+
+
+class TestTheAmbientProfileIsNoLongerOffered:
+    """ADR-0108 point 12: `get_radio_suggestions` ranks with `RADIO` and nothing else.
+
+    `profile="ambient"` was coherent while ambient meant "these neighbours, weighted for
+    continuity". Ambient now composes its pool from three branches and **two of them ignore the
+    seed**, so the option would answer this tool's stated promise — the seed's neighbours plus
+    this listener's taste — with quiet tracks from anywhere in the library.
+
+    Both halves are asserted because they fail differently: the schema half stops a model being
+    offered the choice, and the handler half stops a stale caller getting the wrong ranking.
+    """
+
+    def test_the_published_schema_offers_no_profile(self):
+        from app.services.llm.tools import MUSIC_TOOLS
+
+        tool = next(t for t in MUSIC_TOOLS if t["name"] == "get_radio_suggestions")
+        assert "profile" not in tool["input_schema"]["properties"]
+
+    @pytest.mark.asyncio
+    async def test_a_stale_caller_passing_ambient_is_answered_with_radio(self, monkeypatch):
+        """**Accepted and ignored, not rejected.** `executor.py` dispatches with
+        `handler(**tool_input)`, so removing the keyword outright turns a stale call into a
+        `TypeError` the model reads as a failed tool. It must still answer, and answer as radio."""
+        from app.services.ranking_profiles import RADIO
+
+        seen: dict = {}
+
+        async def fake_candidates(*args, **kwargs):
+            seen["profile"] = kwargs.get("profile")
+            return [], 0, False
+
+        monkeypatch.setattr("app.services.ambient.get_candidates", fake_candidates)
+
+        executor = ToolExecutor(db=None, profile_id=uuid4())  # type: ignore[arg-type]
+        result = await executor._get_radio_suggestions(str(uuid4()), limit=3, profile="ambient")
+
+        assert "error" not in result, result
+        assert seen["profile"] is RADIO, (
+            f"asked for {seen['profile'].name if seen['profile'] else None}, not radio"
+        )

--- a/docs/decisions/ADR-0108-ambient-composes-its-pool-rather-than-retrieving-it.md
+++ b/docs/decisions/ADR-0108-ambient-composes-its-pool-rather-than-retrieving-it.md
@@ -1,6 +1,6 @@
 # ADR-0108: Ambient Composes Its Pool Rather Than Retrieving It
 
-Status: proposed
+Status: accepted
 
 Date: 2026-09-04
 
@@ -11,8 +11,13 @@ Implementation:
   landed in `fe481563` (#282) and points 5–6 in `282393b3` (#284), both on 2026-09-04, before this
   record existed. That is the failure ADR-0106 point 8 also demonstrates, one level up: the decisions
   were real and the record was not written, so the only account of them was in commit messages. The
-  status stays `proposed` until reviewed; the code is not evidence of approval.
-- Point 12 is **not** implemented.
+  code was never evidence of approval; approval came separately, on review.
+- **Point 12 is implemented** — the one point that had no code when this was written. `profile` is
+  gone from `get_radio_suggestions`' published `input_schema` in `services/llm/tools.py`, so a model
+  is no longer offered a choice, and `_get_radio_suggestions` now always ranks with `RADIO`. The
+  keyword survives in the handler signature deliberately: `executor.py` dispatches with
+  `handler(**tool_input)`, so a stale or hallucinated `profile` argument would otherwise become a
+  `TypeError` surfaced to the model as a failed tool call. It is accepted and ignored instead.
 
 ## Context
 


### PR DESCRIPTION
Approved on review. `Status: proposed` → `accepted`, and **point 12** — the only point written as a decision rather than a description of already-shipped code — is now implemented, so the record and the system agree.

## Point 12

`profile` is gone from `get_radio_suggestions`' published `input_schema`, so a model is no longer offered the choice, and the handler always ranks with `RADIO`.

`profile="ambient"` was coherent while ambient meant *"these neighbours, weighted for continuity"*. It stopped being coherent under ADR-0108: ambient composes its pool from three branches and **two of them ignore the seed entirely**, so the option answered this tool's stated promise — the seed's neighbours plus this listener's taste — with quiet tracks from anywhere in the library.

**The keyword survives in the handler signature on purpose.** `executor.py` dispatches with `handler(**tool_input)`, so removing it outright turns a stale or hallucinated `profile` argument into a `TypeError` that the model reads as a failed tool call. It is accepted and ignored instead.

## Tests

Both were confirmed to fail against the previous code:

- schema test — `assert 'profile' not in {...}` with the `["radio", "ambient"]` enum still published
- handler test — `AssertionError: asked for ambient, not radio`

The second asserts the stale-caller path specifically: passing `profile="ambient"` must still return an answer, ranked as radio, rather than erroring.

## Verified

`ruff` clean, `mypy` clean, **309 passed / 4 skipped** across the llm, ambient, ranking, discovery and rediscovery suites.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01Emjrwedq7W1scadHdgiLfs