### PR TITLE
Name both apps on the front page, instead of one badge that hid the Mac

### DIFF
--- a/site/assets/site.css
+++ b/site/assets/site.css
@@ -349,7 +349,6 @@ a:hover { text-decoration: underline; }
 }
 
 .closing-cta-actions a:hover { background: var(--bg-tertiary); text-decoration: none; }
-.closing-cta-actions a.app-store-link { padding: 0; border: none; background: none; }
 
 .nav-links a.primary,
 .closing-cta-actions a.primary {
@@ -365,24 +364,50 @@ a:hover { text-decoration: underline; }
   border-color: var(--accent-green-hover);
 }
 
-.nav-links a.app-store-link {
-  padding: 0;
-  background: transparent;
-  border: none;
-  border-radius: 0;
-  transition: opacity 0.15s;
+/* --- The two apps ---
+   Named links rather than the single "Download on the App Store" badge these replace. One badge
+   could only point at one listing, and the Mac app was the half it hid.
+
+   Sized below `.hero-cta`'s primary button on purpose: ADR-0055 point 11 keeps Install as the
+   call to action, because an app without a server behind it stops at a setup screen. */
+
+.hero-apps { margin-top: 22px; }
+
+.hero-apps-label {
+  margin: 0 0 8px;
+  font-size: 13px;
+  color: var(--text-muted);
 }
 
-.nav-links a.app-store-link:hover {
-  background: transparent;
-  border: none;
-  opacity: 0.85;
+.app-links { display: flex; gap: 10px; flex-wrap: wrap; }
+
+.app-links a.app-link {
+  display: inline-flex;
+  flex-direction: column;
+  gap: 1px;
+  padding: 9px 16px;
+  background: var(--bg-tertiary);
+  border: 1px solid var(--border-color);
+  border-radius: 8px;
+  color: var(--text-primary);
+  transition: background 0.15s, border-color 0.15s, transform 0.05s;
 }
 
-.nav-links a.app-store-link img {
-  display: block;
-  height: 40px;
-  width: auto;
+.app-links a.app-link:hover {
+  background: #3f3f46;
+  border-color: var(--text-muted);
+  text-decoration: none;
+}
+
+.app-links a.app-link:active { transform: translateY(1px); }
+
+.app-link-platform { font-size: 14px; font-weight: 600; }
+.app-link-note { font-size: 12px; color: var(--text-muted); }
+
+.app-links-note {
+  margin: 8px 0 0;
+  font-size: 12px;
+  color: var(--text-muted);
 }
 
 /* --- Sections --- */

--- a/site/e2e/app-links.spec.ts
+++ b/site/e2e/app-links.spec.ts
@@ -1,0 +1,46 @@
+import { test, expect } from '@playwright/test';
+import { pathToFileURL } from 'node:url';
+import { join } from 'node:path';
+
+/**
+ * Both apps are reachable from the front page, and each names its platform.
+ *
+ * The page carried a single "Download on the App Store" badge, which could only point at one
+ * listing — so the Mac app existed and the site never said so. A badge is also exactly the thing
+ * a later redesign drops without noticing, because nothing named the platform it stood for.
+ *
+ * These assert the *destination*, not the styling, so the links can be restyled freely.
+ */
+
+const INDEX = pathToFileURL(join(__dirname, '..', 'index.html')).href;
+const APP_ID = 'id6759879772';
+
+test.beforeEach(async ({ page }) => {
+  await page.goto(INDEX);
+});
+
+test('the Mac App Store listing is linked, with its platform stated', async ({ page }) => {
+  // `?platform=mac` is load-bearing: without it Apple serves the iOS listing, and a Mac visitor
+  // is told the app needs an iPhone.
+  const mac = page.locator(`a[href*="${APP_ID}"][href*="platform=mac"]`);
+  await expect(mac.first()).toBeVisible();
+});
+
+test('the iPhone listing is linked', async ({ page }) => {
+  const ios = page.locator(`a[href*="${APP_ID}"]:not([href*="platform=mac"])`);
+  await expect(ios.first()).toBeVisible();
+});
+
+test('both platforms are reachable above the fold, not only in the footer', async ({ page }) => {
+  const hero = page.locator('.hero-apps');
+  await expect(hero).toBeVisible();
+  await expect(hero.locator(`a[href*="platform=mac"]`)).toHaveCount(1);
+  await expect(hero.locator(`a[href*="${APP_ID}"]`)).toHaveCount(2);
+});
+
+test('the apps still say they need a server', async ({ page }) => {
+  // The reason Install stays the primary call to action (ADR-0055 point 11). Someone who arrives
+  // at the App Store from here with no server gets a setup screen and nothing else, so removing
+  // this sentence turns a prominent link into a dead end.
+  await expect(page.locator('.app-links-note')).toContainText(/server/i);
+});

--- a/site/index.html
+++ b/site/index.html
@@ -75,12 +75,32 @@
            data" — it is a compliance fixture, and pointing a visitor at it implied you could try
            Familiar without your own server. You cannot: the app's first screen asks for an address. -->
     </div>
+    <!-- Both apps, named, rather than one badge that hides half of what exists. ADR-0055 point 11
+         still holds — Install is the primary call to action above and these are deliberately not
+         styled to compete with it — but "one call to action" had come to mean the Mac app was
+         mentioned nowhere on the page, so a visitor who owns a Mac could not learn it exists.
+
+         The requirement line is not decoration. The app's first screen asks for a server address,
+         so arriving at the App Store from here without a server is the dead end the comment above
+         describes. The closing CTA carries the same sentence for the same reason. -->
+    <div class="hero-apps">
+      <p class="hero-apps-label">Already running Familiar? Get the apps</p>
+      <div class="app-links">
+        <a href="https://apps.apple.com/us/app/familiar-player/id6759879772?platform=mac"
+           target="_blank" rel="noopener" class="app-link">
+          <span class="app-link-platform">Mac App Store</span>
+          <span class="app-link-note">macOS 14.4 or later</span>
+        </a>
+        <!-- Canonical URL rather than ?platform=iphone, which 301s to exactly this. -->
+        <a href="https://apps.apple.com/us/app/familiar-player/id6759879772"
+           target="_blank" rel="noopener" class="app-link">
+          <span class="app-link-platform">iPhone &amp; iPad</span>
+          <span class="app-link-note">App&nbsp;Store</span>
+        </a>
+      </div>
+      <p class="app-links-note">Both need a Familiar server to connect to.</p>
+    </div>
     <div class="nav-links">
-      <a href="https://apps.apple.com/us/app/familiar-player/id6759879772" target="_blank" rel="noopener" class="app-store-link" aria-label="Download Familiar on the App Store">
-        <img src="./assets/app-store-badge.svg" alt="Download on the App Store">
-      </a>
-      <!-- Secondary now that Install is the hero's own call to action. ADR-0055 point 11: one call
-           to action, repeated, and it is Install. -->
       <a href="#features">See what it does</a>
       </div>
     </div>
@@ -369,9 +389,8 @@ docker compose -f docker-compose.prod.yml build</code></pre>
   </div>
   <div class="closing-cta-actions">
     <a href="#install" class="primary">Install the server</a>
-    <a href="https://apps.apple.com/us/app/familiar-player/id6759879772" target="_blank" rel="noopener" class="app-store-link" aria-label="Download Familiar on the App Store">
-      <img src="./assets/app-store-badge.svg" alt="Download on the App Store">
-    </a>
+    <a href="https://apps.apple.com/us/app/familiar-player/id6759879772?platform=mac" target="_blank" rel="noopener">Mac app</a>
+    <a href="https://apps.apple.com/us/app/familiar-player/id6759879772" target="_blank" rel="noopener">iPhone &amp; iPad app</a>
     <a href="https://github.com/seethroughlab/familiar/issues" target="_blank" rel="noopener">Report a bug</a>
   </div>
 </section>


### PR DESCRIPTION
The site carried a single **"Download on the App Store"** badge in the hero and another in the closing CTA. A badge can only point at one listing — so the Mac app existed and the front page never said so.

## What changed

Two named links replace each badge: **Mac App Store** and **iPhone & iPad**, in the hero and in the closing CTA.

`?platform=mac` is load-bearing rather than cosmetic. Verified against Apple:

| URL | result |
|---|---|
| `…id6759879772?platform=mac` | **200** — *"Requires macOS 14.4 or later"*, matching `Package.swift`'s floor |
| `…id6759879772?platform=iphone` | **301** → canonical URL, which the iPhone link now uses directly |
| `…id6759879772` | **200** |

Without `platform=mac`, Apple serves the iOS listing and a Mac visitor is told the app needs an iPhone.

## The ADR this touches

**ADR-0055 point 11 — *"one call to action, repeated, and it is Install"* — still holds.** Install stays primary; these are deliberately smaller and quieter. But that rule had come to mean the Mac app was mentioned nowhere, which is not what it was for.

The block keeps a one-line **"Both need a Familiar server to connect to"**, and a test asserts that sentence survives. The hero comment already warned that the app's first screen asks for a server address — prominence without that caveat turns a good link into a dead end.

## Tests

Four new tests assert **destinations, not styling**, so this can be restyled freely. **Three fail against the previous page**; the fourth (the server caveat) is new.

Also verified:
- **11 site e2e tests pass**, including `no horizontal overflow at 420px` — exactly what a new two-button row could have broken
- `check-claims.py` passes, which link-checks both App Store URLs

## Cleanup

`.app-store-link` CSS is removed with its last caller. `app-store-badge.svg` stays on disk — Apple's official artwork, worth keeping if a badge is wanted again.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01Emjrwedq7W1scadHdgiLfs