### PR TITLE
Let a sandboxed visualizer read cover art

### DIFF
--- a/backend/app/main.py
+++ b/backend/app/main.py
@@ -531,6 +531,59 @@ app.add_middleware(
 )
 
 
+#: Paths a visualizer plugin may read from an opaque origin.
+#:
+#: Media only, and read-only: cover art and the audio it is drawn over. Nothing here reveals
+#: anything a listener on the network could not already fetch, which is the same argument the media
+#: endpoints already rest on — a WiiM speaker holds no credential either.
+_OPAQUE_ORIGIN_READABLE = ("/artwork", "/stream")
+
+
+@app.middleware("http")
+async def allow_opaque_origin_media(request: Request, call_next):  # type: ignore[no-untyped-def]
+    """Let a sandboxed visualizer read cover art.
+
+    **A visualizer plugin has an opaque origin, so its requests arrive as `Origin: null`.** ADR-0087
+    point 1 loads plugin documents in an iframe with `sandbox="allow-scripts"` and deliberately
+    without `allow-same-origin`, which is what makes the origin opaque. `null` is not a URL, so it
+    matches neither `_get_cors_origins()` nor `allow_origin_regex`, and `CORSMiddleware` therefore
+    sends no `Access-Control-Allow-Origin` at all.
+
+    The symptom is silent and does not look like CORS: `beat-tiles` loads its cover with
+    `THREE.TextureLoader` and `setCrossOrigin('anonymous')`, so a refused read lands in the error
+    callback, which sets the texture to `null` — and the scene draws a grid of plain white cubes
+    with no error anywhere.
+
+    `familiar-apple` already fixed exactly this for the plugin's *own* folder: its custom scheme
+    handler attaches `Access-Control-Allow-Origin` with the same reasoning, found when a converted
+    visualizer could not load its own model. Artwork comes from this server instead, so it needs the
+    same answer here.
+
+    **Deliberately not `allow_credentials`.** The header is added only for `Origin: null`, only on
+    media paths, and only for reads. Adding `"null"` to the allow-list instead would have widened
+    every endpoint to opaque origins *with* credentials, which is a much larger claim than "a
+    sandboxed drawing surface may see the album cover".
+    """
+    response = await call_next(request)
+    if (
+        request.headers.get("origin") == "null"
+        and request.method in ("GET", "HEAD", "OPTIONS")
+        and any(part in request.url.path for part in _OPAQUE_ORIGIN_READABLE)
+        and "access-control-allow-origin" not in response.headers
+    ):
+        response.headers["Access-Control-Allow-Origin"] = "*"
+        # **And drop the credentials claim, which `CORSMiddleware` attaches to any request carrying
+        # an `Origin` — allowed or not.** `Allow-Origin: *` with `Allow-Credentials: true` is a
+        # contradiction: a browser refuses the pair outright for a credentialed request, and for the
+        # anonymous read this exists for the claim is untrue anyway. Leaving it would make the one
+        # response that says "anyone may read this" also say "and you may send cookies".
+        # `del`, not `pop`: Starlette's `MutableHeaders` has no `pop`, and calling it raises inside
+        # the middleware — which surfaces as the header simply never being set, not as an error.
+        if "access-control-allow-credentials" in response.headers:
+            del response.headers["access-control-allow-credentials"]
+    return response
+
+
 # Global exception handlers
 @app.exception_handler(RequestValidationError)
 async def validation_exception_handler(

--- a/backend/tests/test_opaque_origin_cors.py
+++ b/backend/tests/test_opaque_origin_cors.py
@@ -1,0 +1,70 @@
+"""A sandboxed visualizer can read cover art.
+
+**The bug this pins renders as a grid of plain white cubes, with no error anywhere.** A visualizer
+plugin is loaded in an iframe with `sandbox="allow-scripts"` and without `allow-same-origin`
+(ADR-0087 point 1), which gives it an opaque origin, so every CORS-checked request it makes arrives
+as `Origin: null`. That is not a URL, so it matches neither the allow-list nor `allow_origin_regex`,
+and `CORSMiddleware` sends no `Access-Control-Allow-Origin` header.
+
+`beat-tiles` loads the cover with `THREE.TextureLoader` and `setCrossOrigin('anonymous')`. A refused
+read lands in its error callback, which sets the texture to `null` — and the scene happily draws
+untextured cubes. Nothing logs, nothing throws, and the visualizer looks like it was written that
+way.
+
+`familiar-apple` hit the same class of failure for the plugin's *own folder* and fixed it in its
+custom scheme handler. Artwork is served from here, so it needs the same answer here.
+"""
+
+from __future__ import annotations
+
+import pytest
+
+
+class TestAnOpaqueOriginMayReadMedia:
+    """The headline: `Origin: null` must get a usable header on media reads."""
+
+    @pytest.mark.parametrize("path", ["/api/v1/tracks/x/artwork", "/api/v1/tracks/x/stream"])
+    def test_media_answers_a_null_origin(self, client, path):
+        # The track need not exist — CORS is decided by middleware, so a 404 carries the header
+        # just as a 200 does, and using a real id would make this depend on a seeded library.
+        response = client.get(path, headers={"Origin": "null"})
+        assert response.headers.get("access-control-allow-origin") == "*", (
+            "a sandboxed visualizer cannot read this, and draws untextured white cubes instead"
+        )
+
+    def test_credentials_are_not_offered_to_an_opaque_origin(self, client):
+        """The narrow part of the fix, and the reason it is not one line in the allow-list.
+
+        Adding `"null"` to `allow_origins` would have let *any* sandboxed document make credentialed
+        requests to *every* endpoint. This says only "a drawing surface may see the album cover".
+        """
+        response = client.get("/api/v1/tracks/x/artwork", headers={"Origin": "null"})
+        assert response.headers.get("access-control-allow-credentials") != "true"
+
+
+class TestItStaysNarrow:
+    def test_a_null_origin_gets_nothing_on_a_non_media_path(self, client):
+        """An opaque origin has no business reading the library, and does not need to."""
+        response = client.get("/api/v1/library/stats", headers={"Origin": "null"})
+        assert response.headers.get("access-control-allow-origin") is None
+
+    def test_a_null_origin_cannot_write(self, client):
+        """Read-only. The method check is what keeps this from being a general opening."""
+        response = client.post("/api/v1/tracks/x/artwork", headers={"Origin": "null"})
+        assert response.headers.get("access-control-allow-origin") is None
+
+
+class TestNormalOriginsAreUnaffected:
+    """Blast radius. `CORSMiddleware` still owns every origin that is a real URL."""
+
+    def test_a_browser_origin_still_gets_its_own_echo_not_a_wildcard(self, client):
+        response = client.get(
+            "/api/v1/tracks/x/artwork", headers={"Origin": "http://localhost:5173"}
+        )
+        # Echoed rather than `*`, because that request may carry credentials and a wildcard would
+        # be rejected by the browser for it.
+        assert response.headers.get("access-control-allow-origin") == "http://localhost:5173"
+
+    def test_a_request_with_no_origin_gains_no_header(self, client):
+        response = client.get("/api/v1/tracks/x/artwork")
+        assert response.headers.get("access-control-allow-origin") is None


### PR DESCRIPTION
`beat-tiles` drew a grid of **plain white cubes** where it should have textured their faces with the album cover — and nothing logged an error anywhere.

## The chain

A visualizer plugin loads in an iframe with `sandbox="allow-scripts"` and deliberately **without** `allow-same-origin` (ADR-0087 point 1). That gives it an **opaque origin**, so every CORS-checked request arrives as `Origin: null`.

`null` is not a URL, so it matches neither `_get_cors_origins()` nor:

```python
allow_origin_regex=r"^(https?|capacitor)://([a-zA-Z0-9-]+|\d+\.\d+\.\d+\.\d+)(:\d+)?$"
```

…and `CORSMiddleware` sends no `Access-Control-Allow-Origin` at all. Measured against the running server:

| Origin | result |
|---|---|
| `http://localhost:5173` | echoed |
| `http://openmediavault:4400` | echoed |
| `capacitor://localhost` | echoed |
| **`null`** | **no header** |

## Why it was silent

`beat-tiles` loads the cover with `THREE.TextureLoader` and `setCrossOrigin('anonymous')`. A refused read lands in the error callback, which sets the texture to `null` — and the scene draws untextured cubes. Nothing throws. It looks like a visualizer that was written that way.

## This is a known class of bug here

`familiar-apple` already fixed it **for the plugin's own folder** — its custom scheme handler attaches the header, with a comment recording that it was *"found by a converted visualizer failing to load its own car model, from its own folder."* Artwork comes from this server instead, so it needs the same answer here.

## Narrow on purpose

`Origin: null` only, media paths only (`/artwork`, `/stream`), reads only.

Adding `"null"` to the allow-list would have been one line — and would have opened **every** endpoint to opaque origins **with credentials**, a far larger claim than "a drawing surface may see the album cover".

The credentials header is stripped alongside: `Allow-Origin: *` with `Allow-Credentials: true` is a contradiction a browser refuses outright, and Starlette attaches that header to *any* request carrying an `Origin`, allowed or not.

## Verified

- **7 tests**, 3 of which fail against the previous code
- **124 pass** across the streaming, artwork and middleware suites
- `ruff` and `mypy` clean

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01Emjrwedq7W1scadHdgiLfs