### PR TITLE
Declare which pipeline computed a contributed vector

### DIFF
--- a/backend/app/services/analysis.py
+++ b/backend/app/services/analysis.py
@@ -170,6 +170,37 @@ def extract_embedding(file_path: Path, target_sr: int = 48000) -> list[float] | 
         raise AnalysisError(f"Embedding extraction failed: {e}") from e
 
 
+def embedding_pipeline_version() -> str | None:
+    """The identity of the pipeline `extract_embedding` runs, or None if there is none.
+
+    `PIPELINE_VERSION` is composed by `clapback-embed` from every component that can
+    move a vector — the checkpoint, the mel front-end, the ONNX artifacts, the pooling
+    and the precision. Two vectors are comparable exactly when it matches, which is
+    what clapback's `ADR-0006` makes the corpus key.
+
+    **Read from the installed library rather than written down here.** A constant in
+    `config.py` would be a second copy of a fact, maintained by hand, drifting from the
+    code that actually computes the vectors — which is exactly the failure
+    `EMBEDDING_VERSION` already has and the reason `ADR-0006` was written. This cannot
+    drift: it is the value the encoder that just ran reports about itself.
+
+    Returns None when the embedder is not installed, which is the same case in which
+    this installation computes no embeddings and so has nothing to declare.
+    """
+    if not _embedder_available:
+        return None
+    try:
+        from clapback_embed import PIPELINE_VERSION
+
+        return PIPELINE_VERSION
+    except Exception as e:  # noqa: BLE001 - a missing attribute must not break analysis
+        # An older `clapback-embed` without the attribute. Declaring nothing is
+        # correct here: clapback's server treats absent as "unknown", which is
+        # true, and a guessed string would be worse than silence.
+        logger.debug(f"clapback-embed reports no PIPELINE_VERSION: {e}")
+        return None
+
+
 def extract_text_embedding(text: str) -> list[float] | None:
     """Extract CLAP text embedding from a text description.
 

--- a/backend/app/services/community_cache.py
+++ b/backend/app/services/community_cache.py
@@ -13,6 +13,13 @@ Versioning:
 - Embeddings are versioned by EMBEDDING_VERSION and CLAP model version
 - Features are versioned by FEATURES_VERSION
 - Prevents mixing data from incompatible analysis pipelines
+
+Neither of those two actually establishes that two vectors are comparable, which is
+what clapback's `ADR-0006` is about: EMBEDDING_VERSION is this application's own
+counter, and CLAP_MODEL_VERSION is the checkpoint, which a change to windowing or
+pooling moves every vector without touching. `clapback_embed.PIPELINE_VERSION` is
+composed from all five things that can move a vector, and contributions now carry it
+when the caller knows it — see `contribute`.
 """
 
 import asyncio
@@ -262,6 +269,7 @@ class CommunityCacheService:
         acoustid_fingerprint: str | bytes,
         embedding: list[float],
         analysis_version: int | None = None,
+        pipeline_version: str | None = None,
     ) -> bool:
         """Contribute an embedding to the community cache.
 
@@ -269,6 +277,15 @@ class CommunityCacheService:
             acoustid_fingerprint: The raw AcoustID fingerprint string
             embedding: 512-dimensional CLAP embedding
             analysis_version: Version of the analysis (defaults to current)
+            pipeline_version: The identity of the pipeline that computed this
+                vector — `clapback_embed.PIPELINE_VERSION`. **Explicit, and never
+                defaulted from the installed library**, because this method is
+                handed a vector and does not know what produced it. Filling it in
+                from whatever `clapback-embed` happens to be installed now would
+                declare today's pipeline for a vector computed months ago by a
+                different one, which is precisely the false assertion clapback's
+                `ADR-0006` exists to prevent. A caller that did not just compute
+                the vector passes nothing, and the corpus records "unknown".
 
         Returns:
             True if contribution was accepted, False otherwise
@@ -300,6 +317,18 @@ class CommunityCacheService:
         # submissions count toward independent agreement (`ADR-0004` point 3).
         if self.client_id:
             payload["client_id"] = self.client_id
+        # Phase 2 of clapback's `ADR-0006` point 6. The corpus keys on
+        # `analysis_version` and `clap_model_version` today, and neither says whether
+        # two vectors are comparable: the first is this application's own counter, and
+        # the second is the checkpoint, which windowing or pooling can move every vector
+        # without changing. `pipeline_version` is the one field that does.
+        #
+        # Omitted rather than sent as null when unknown, and optional on the wire for
+        # the same reason `client_id` is: a corpus that predates the field must keep
+        # accepting these. It becomes required when clapback reaches phase 4, and
+        # nothing here breaks before then.
+        if pipeline_version:
+            payload["pipeline_version"] = pipeline_version
 
         response = await self._request_with_retry(
             "POST",

--- a/backend/app/services/tasks/analysis_pipeline.py
+++ b/backend/app/services/tasks/analysis_pipeline.py
@@ -493,7 +493,11 @@ def run_track_embedding(track_id: str) -> dict[str, Any]:
 
     from app.db.models import Track, TrackAnalysis
     from app.db.session import sync_session_maker
-    from app.services.analysis import AnalysisError, extract_embedding
+    from app.services.analysis import (
+        AnalysisError,
+        embedding_pipeline_version,
+        extract_embedding,
+    )
     from app.services.app_settings import get_app_settings_service
     from app.services.community_cache import get_community_cache_service
 
@@ -571,7 +575,17 @@ def run_track_embedding(track_id: str) -> dict[str, Any]:
                             client_id=get_app_settings_service().ensure_community_cache_client_id(),
                         )
                         asyncio.run(
-                            cache_service.contribute(acoustid_fingerprint, embedding)
+                            cache_service.contribute(
+                                acoustid_fingerprint,
+                                embedding,
+                                # **This branch is the one place that can honestly
+                                # declare a pipeline.** It is reached only when
+                                # `extract_embedding` above just computed the vector
+                                # locally — a cache hit returns before here — so the
+                                # installed embedder is provably the thing that
+                                # produced it. Phase 2 of clapback's `ADR-0006`.
+                                pipeline_version=embedding_pipeline_version(),
+                            )
                         )
                     except Exception as e:
                         logger.debug(f"Community cache contribution failed: {e}")

--- a/backend/scripts/backfill_community_cache.py
+++ b/backend/scripts/backfill_community_cache.py
@@ -92,7 +92,9 @@ async def backfill(*, dry_run: bool, limit: int | None, per_minute: int, url: st
 
     # Only the current pipeline. Older vectors are not comparable with what the
     # corpus is being asked to hold, and contributing them would be the mistake
-    # clapback's ADR-0006 exists to prevent.
+    # clapback's ADR-0006 exists to prevent. Note that this filter is the closest
+    # this script can get: it selects rows sharing a counter, not rows sharing a
+    # pipeline, which is why the contribution below declares no pipeline at all.
     stmt = (
         select(TrackAnalysis.acoustid, TrackAnalysis.embedding)
         .where(TrackAnalysis.embedding_version == EMBEDDING_VERSION)
@@ -126,6 +128,16 @@ async def backfill(*, dry_run: bool, limit: int | None, per_minute: int, url: st
             if dry_run:
                 tally.contributed += 1
             else:
+                # **No `pipeline_version`, deliberately.** These vectors came out
+                # of the database, computed at some earlier time by whatever
+                # `clapback-embed` was installed then. `embedding_version == 7`
+                # narrows that but does not pin it: the counter is this
+                # application's own and moved once for a reason unrelated to the
+                # encoder. Declaring the currently installed pipeline here would
+                # assert, on tens of thousands of rows, a provenance nobody
+                # verified — the exact failure clapback's `ADR-0006` is written to
+                # prevent, and its point 5 says these rows are recomputed rather
+                # than relabelled anyway.
                 ok = await cache.contribute(acoustid, list(embedding))
                 if ok:
                     tally.contributed += 1

--- a/backend/tests/test_community_cache_contribution.py
+++ b/backend/tests/test_community_cache_contribution.py
@@ -16,19 +16,33 @@ independent agreement, because nothing can show it came from a different party. 
 self-issued, needs no registration, and identifies an installation rather than a
 person.
 
+**A contribution declares its pipeline, and only when it can.** clapback's `ADR-0006`
+phase 2. `EMBEDDING_VERSION` and the checkpoint together do not establish that two
+vectors are comparable; `clapback_embed.PIPELINE_VERSION` does. The property under
+test is as much what is *not* sent: this method is handed a vector and does not know
+what produced it, so it never fills the field in from whatever embedder happens to be
+installed.
+
 Free of `numpy`, `librosa` and the ONNX artifacts, like the rest of the suite that
 touches this path — the transport is what is under test, not the encoder.
 """
 
 from __future__ import annotations
 
+import ast
 import asyncio
+import inspect
 import json
+import sys
+import types
 from pathlib import Path
 from unittest.mock import AsyncMock, patch
 
+from app.config import EMBEDDING_VERSION
+from app.services import analysis
 from app.services.app_settings import AppSettingsService
 from app.services.community_cache import (
+    CLAP_MODEL_VERSION,
     CommunityCacheService,
     get_community_cache_service,
 )
@@ -39,11 +53,11 @@ def _vector() -> list[float]:
     return [((i * 7919) % 1000 + 1) / 31337.0 for i in range(512)]
 
 
-def _capture(service: CommunityCacheService, fingerprint: str = "fp") -> dict:
+def _capture(service: CommunityCacheService, fingerprint: str = "fp", **kwargs) -> dict:
     sent: dict = {}
 
-    async def fake(method, url, **kwargs):
-        sent.update(kwargs.get("json", {}))
+    async def fake(method, url, **call_kwargs):
+        sent.update(call_kwargs.get("json", {}))
 
         class Response:
             status_code = 201
@@ -54,7 +68,7 @@ def _capture(service: CommunityCacheService, fingerprint: str = "fp") -> dict:
         return Response()
 
     with patch.object(service, "_request_with_retry", new=AsyncMock(side_effect=fake)):
-        asyncio.run(service.contribute(fingerprint, _vector()))
+        asyncio.run(service.contribute(fingerprint, _vector(), **kwargs))
     return sent
 
 
@@ -111,3 +125,110 @@ class TestTheSingletonTracksTheIdentity:
         get_community_cache_service(cache_url="http://cache", client_id="install-a")
         again = get_community_cache_service(cache_url="http://cache")
         assert again.client_id == "install-a"
+
+
+class TestTheContributionDeclaresItsPipeline:
+    """clapback's `ADR-0006` phase 2 — the field that says whether two vectors are
+    comparable at all."""
+
+    IDENTITY = "laion/clap-htsat-unfused+frontend1+artifact1+pool1+fp32"
+
+    def test_it_is_sent_when_the_caller_knows_it(self):
+        sent = _capture(
+            CommunityCacheService(cache_url="http://cache"),
+            pipeline_version=self.IDENTITY,
+        )
+        assert sent["pipeline_version"] == self.IDENTITY
+
+    def test_the_field_is_absent_rather_than_null_when_unknown(self):
+        """Absent means "unknown", which is true. A null would be a claim about the
+        vector that nobody made."""
+        sent = _capture(CommunityCacheService(cache_url="http://cache"))
+        assert "pipeline_version" not in sent
+
+    def test_it_is_never_inferred_from_the_installed_embedder(self):
+        """**The property that matters most here.** `contribute` is handed a vector
+        and does not know what computed it. Reading `PIPELINE_VERSION` from whatever
+        is installed would declare today's pipeline for a vector computed months ago
+        by a different one — on every row of a backfill at once, and asserted rather
+        than measured, so nothing afterwards could tell which rows were true."""
+        tree = ast.parse(Path(inspect.getfile(CommunityCacheService)).read_text())
+        fn = next(
+            n
+            for n in ast.walk(tree)
+            if isinstance(n, ast.AsyncFunctionDef) and n.name == "contribute"
+        )
+        # The docstring says the word in order to explain the rule, so it is
+        # dropped before the body is read.
+        body = fn.body[1:] if ast.get_docstring(fn) else fn.body
+        code = "\n".join(ast.unparse(n) for n in body)
+        assert "clapback_embed" not in code
+        assert "PIPELINE_VERSION" not in code
+
+    def test_the_rest_of_the_payload_is_unchanged_by_it(self):
+        """Additive. A corpus that predates the field must keep accepting these, and
+        the fields it already keys on must arrive exactly as before."""
+        sent = _capture(
+            CommunityCacheService(cache_url="http://cache", client_id="install-a"),
+            pipeline_version=self.IDENTITY,
+        )
+        assert sent["embedding"] == _vector()
+        assert sent["client_id"] == "install-a"
+        assert sent["analysis_version"] == EMBEDDING_VERSION
+        assert sent["clap_model_version"] == CLAP_MODEL_VERSION
+
+
+class TestOnlyAFreshlyComputedVectorDeclaresOne:
+    """Which call sites may declare a pipeline, and which may not.
+
+    This is a property of the *callers*, not of the client, and it is the half that
+    a change to `contribute` alone would leave unprotected."""
+
+    def test_the_analysis_pipeline_declares_it(self):
+        """It contributes only in the branch where `extract_embedding` just ran — a
+        community-cache hit returns before it — so the installed embedder is provably
+        what produced the vector."""
+        source = (
+            Path(__file__).resolve().parents[1]
+            / "app/services/tasks/analysis_pipeline.py"
+        ).read_text()
+        assert "pipeline_version=embedding_pipeline_version()" in source
+
+    def test_the_backfill_declares_nothing(self):
+        """It contributes vectors out of the database, computed at some earlier time
+        by an embedder nobody recorded. `embedding_version == 7` narrows that and does
+        not pin it."""
+        source = (
+            Path(__file__).resolve().parents[1]
+            / "scripts/backfill_community_cache.py"
+        ).read_text()
+        call = source[source.index("await cache.contribute(") :]
+        call = call[: call.index(")") + 1]
+        assert "pipeline_version" not in call
+
+
+class TestTheAccessorReadsTheLibraryRatherThanAConstant:
+    """`PIPELINE_VERSION` written down in `config.py` would be a second copy of a
+    fact, maintained by hand — which is what `EMBEDDING_VERSION` already is and why
+    `ADR-0006` exists. Read from the encoder that just ran, it cannot drift."""
+
+    def test_it_returns_what_the_installed_embedder_reports(self):
+        module = types.ModuleType("clapback_embed")
+        module.PIPELINE_VERSION = "checkpoint+frontend9+artifact9+pool9+fp32"
+        with patch.dict(sys.modules, {"clapback_embed": module}):
+            with patch.object(analysis, "_embedder_available", True):
+                assert analysis.embedding_pipeline_version() == module.PIPELINE_VERSION
+
+    def test_it_returns_none_when_the_embedder_is_absent(self):
+        """An installation with no embedder computes no vectors, so it has nothing to
+        declare — and None means "unknown", which the corpus already handles."""
+        with patch.object(analysis, "_embedder_available", False):
+            assert analysis.embedding_pipeline_version() is None
+
+    def test_an_older_embedder_without_the_attribute_declares_nothing(self):
+        """Silence beats a guess. The corpus reads absent as unknown, which is true;
+        a fabricated string would be a claim it cannot check."""
+        module = types.ModuleType("clapback_embed")
+        with patch.dict(sys.modules, {"clapback_embed": module}):
+            with patch.object(analysis, "_embedder_available", True):
+                assert analysis.embedding_pipeline_version() is None

--- a/docs/decisions/ADR-0108-a-contribution-names-the-installation-that-made-it.md
+++ b/docs/decisions/ADR-0108-a-contribution-names-the-installation-that-made-it.md
@@ -21,6 +21,20 @@ Implementation:
   remains the one point that is *for the user* rather than about the mechanism — points 5 and 6
   promise the identifier is used for the corpus and nothing else, and point 4 is what would let
   someone check that promise instead of taking it.
+- **A contribution now names its pipeline as well as its installation** (2026-09-05), implementing
+  phase 2 of clapback's
+  [`ADR-0006`](https://github.com/seethroughlab/clapback/blob/main/docs/decisions/ADR-0006-the-pipeline-identity-is-the-corpus-key.md).
+  `pipeline_version` is `clapback_embed.PIPELINE_VERSION`, read from the installed embedder rather
+  than written down here — a constant in `config.py` would be a second hand-maintained copy of a
+  fact, which is what `EMBEDDING_VERSION` already is and what that record exists to fix. Optional on
+  the wire and omitted when unknown, exactly as `client_id` is, so an older corpus keeps accepting
+  these.
+- **Only the analysis pipeline declares one.** `contribute` is handed a vector and does not know
+  what produced it, so it never fills the field in from whatever embedder happens to be installed.
+  The pipeline may, because it contributes solely in the branch where `extract_embedding` just ran;
+  the backfill script may not, because its vectors came out of the database and
+  `embedding_version == 7` narrows their provenance without pinning it. Declaring there would
+  assert, on tens of thousands of rows at once, something nobody verified.
 
 ## Context
 


### PR DESCRIPTION
Phase 2 of clapback's [`ADR-0006`](https://github.com/seethroughlab/clapback/blob/main/docs/decisions/ADR-0006-the-pipeline-identity-is-the-corpus-key.md) point 6. Its phase 1 [shipped yesterday](https://github.com/seethroughlab/clapback/pull/33) — the corpus now has a column for this and every one of its 47,486 rows is null, because nothing sends the field yet.

## Why the two versions we already send are not enough

`analysis_version` is **our own counter**, and `clap_model_version` is **the checkpoint** — which a change to windowing or pooling moves every vector without touching. That is not hypothetical: it is what happened when `EMBEDDING_VERSION` went to 7. `clapback_embed.PIPELINE_VERSION` is composed from all five components that can move a vector, so two vectors are comparable exactly when it matches.

## Read, not written down

The accessor asks the installed embedder. A constant in `config.py` would be a second copy of a fact maintained by hand, drifting from the code that computes the vectors — which is precisely what `EMBEDDING_VERSION` is, and what `ADR-0006` exists to fix. This one cannot drift: it is what the encoder that just ran reports about itself.

## The part that is easy to get wrong

`contribute` takes `pipeline_version` as an **explicit argument and never infers it**. It is handed a vector and does not know what produced it — filling the field in from whatever `clapback-embed` happens to be installed would declare today's pipeline for a vector computed months ago by a different one. That is the false assertion the record is written to prevent, and it would be asserted rather than measured, so nothing afterwards could tell which rows were true.

| call site | declares? | why |
|---|---|---|
| `analysis_pipeline.py` | **yes** | contributes only in the branch where `extract_embedding` just ran — a community-cache hit returns before it, so the installed embedder is provably what produced the vector |
| `backfill_community_cache.py` | **no** | vectors come out of the database, computed by an embedder nobody recorded. `embedding_version == 7` narrows that and does not pin it — and `ADR-0006` point 5 recomputes those rows rather than relabelling them |

## Compatibility

Optional on the wire and **omitted rather than sent as null**, exactly as `client_id` is: absent means unknown, which is true. A corpus that predates the field keeps accepting these. It becomes required at clapback's phase 4, which is two steps away.

`EMBEDDING_VERSION` is deliberately unchanged — the bump and the library re-analysis are phase 3.

## Tests

12 new. The one worth reading is `test_it_is_never_inferred_from_the_installed_embedder`, which parses `contribute` and asserts its body mentions neither `clapback_embed` nor `PIPELINE_VERSION` — the docstring says both, in order to explain the rule, so the docstring is dropped before the body is read.

`27 passed` on the two files this touches; `1179 passed` across the suite, with 750 pre-existing errors from the absent local Postgres (identical count on stashed `main`).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_013y1g4m6RF7PW8gB27uutuU