### PR TITLE
Recompute the library under a declared pipeline

### DIFF
--- a/backend/app/config.py
+++ b/backend/app/config.py
@@ -172,13 +172,29 @@ FEATURES_VERSION = 8
 #   v5: Re-extract (psutil fix)
 #   v6: Matched features version at loudness addition
 #   v7: Whole track by chunked mean, L2-normalised, instead of the middle 10s (ADR-0104)
+#   v8: Recompute under a declared pipeline. The vectors do not change — see below.
 #
 # This constant is the identity of the embedding *pipeline*, not of the checkpoint.
 # ADR-0104 point 6: windowing, pooling, mel parameters, truncation and precision all
 # belong to it, and any change moving vectors by more than ~1e-6 must bump it — the
 # community cache keys on this value, and vectors from two pipelines are not
 # comparable. `laion/clap-htsat-unfused:v1` staying fixed does not make them so.
-EMBEDDING_VERSION = 7
+#
+# **v8 is the exception to that rule, and it is deliberate rather than an oversight.**
+# Nothing about the pipeline changed: `clapback_embed.PIPELINE_VERSION` is unmoved,
+# and a fresh computation reproduces a stored v7 vector to 5e-16 — measured over a
+# random sample of the library on 2026-09-06, not assumed. The bump exists to make
+# the re-analysis path recompute, which is phase 3 of clapback's `ADR-0006`: the
+# corpus holds 25,596 of our v7 vectors with no record of what produced them, its
+# phase 4 keys on the pipeline and drops rows that cannot say, and point 5 of that
+# record recomputes rather than relabels. Relabelling would assert a provenance
+# nobody verified; recomputing earns it, and this constant is the only lever we hold
+# that makes the existing re-analysis path do the work.
+#
+# So the bump does not mean "the vectors moved". It means "the vectors are being
+# produced again, this time saying who made them". A reader comparing v7 and v8 rows
+# in the corpus and finding them identical is seeing the intended outcome.
+EMBEDDING_VERSION = 8
 
 # Melodic history:
 #   v5: basic-pitch MIDI transcription + melodic feature extraction

--- a/backend/tests/test_community_cache_contribution.py
+++ b/backend/tests/test_community_cache_contribution.py
@@ -232,3 +232,34 @@ class TestTheAccessorReadsTheLibraryRatherThanAConstant:
         with patch.dict(sys.modules, {"clapback_embed": module}):
             with patch.object(analysis, "_embedder_available", True):
                 assert analysis.embedding_pipeline_version() is None
+
+
+class TestTheEmbeddingVersionDocumentsItself:
+    """`EMBEDDING_VERSION` is a number whose meaning lives entirely in a comment.
+
+    Every other component of a vector's identity is now carried by
+    `clapback_embed.PIPELINE_VERSION`, which is composed from the code that computes
+    it and cannot drift. This one is still maintained by hand, and v8 is the first
+    bump that does **not** mean "the vectors moved" — it triggers a recompute so the
+    corpus can be told what produced them (clapback's `ADR-0006` phase 3). A future
+    reader who finds v7 and v8 vectors identical needs the comment to know that was
+    intended, so an undocumented bump is a real defect rather than untidiness.
+    """
+
+    def _history(self) -> str:
+        source = (
+            Path(__file__).resolve().parents[1] / "app/config.py"
+        ).read_text()
+        start = source.index("# Embedding history:")
+        return source[start : source.index("EMBEDDING_VERSION = ", start)]
+
+    def test_the_current_version_has_a_history_entry(self):
+        assert f"#   v{EMBEDDING_VERSION}:" in self._history()
+
+    def test_the_bump_that_moves_no_vectors_says_so(self):
+        """The constant's own rule is "bump when vectors move by more than ~1e-6".
+        v8 breaks that rule deliberately, and a deliberate exception that is not
+        written down is indistinguishable from a mistake."""
+        history = self._history()
+        assert "ADR-0006" in history, "the reason for the v8 bump is not recorded"
+        assert "do not change" in history or "does not mean" in history

--- a/docs/decisions/ADR-0104-familiar-embeds-whole-tracks-by-chunked-mean.md
+++ b/docs/decisions/ADR-0104-familiar-embeds-whole-tracks-by-chunked-mean.md
@@ -9,6 +9,46 @@ Implementation:
   (`app/services/analysis.py`) now walks consecutive 480,000-sample windows, mean-pools the raw
   encoder outputs and L2-normalises; `EMBEDDING_VERSION` is 7. The re-analysis of 26,471 embeddings
   drives itself from the existing two-hourly sync — nothing was scheduled for it.
+- **`EMBEDDING_VERSION` is 8 as of 2026-09-06, and point 6's rule is deliberately broken to get
+  there.** That rule says the constant bumps when vectors move by more than ~1e-6. Nothing about
+  the pipeline changed and the vectors do not move; the bump exists to make this same re-analysis
+  path recompute the library, which is phase 3 of clapback's
+  [`ADR-0006`](https://github.com/seethroughlab/clapback/blob/main/docs/decisions/ADR-0006-the-pipeline-identity-is-the-corpus-key.md).
+  Its point 5 recomputes rather than relabels, because the corpus holds 25,596 of our vectors with
+  no record of what produced them and relabelling would assert a provenance nobody verified. This
+  constant is the only lever we hold that drives the existing path. An exception to a written rule
+  that is not itself written down is indistinguishable from a mistake, so it is recorded here and
+  in the constant's own comment, and a test asserts the comment says it.
+
+### What a recompute actually changes, measured 2026-09-06
+
+Fifty tracks drawn at random from the 26,471 at `embedding_version = 7`, recomputed through the
+installed `clapback-embed` and compared with what is stored:
+
+| | tracks | cosine distance from stored |
+|---|---|---|
+| reproduced exactly | 43 | ≤ 6.7e-16, the float64 floor |
+| reproduced closely | 7 | 1.3e-12 – 5.5e-11 |
+
+So the recompute is very nearly a no-op on the numbers, which is the intended outcome — it is the
+*declaration* that phase 3 buys, not different vectors. Two things follow that are worth having
+written down rather than rediscovered:
+
+**The stored v7 vectors really are from the current pipeline.** That was an assumption before this
+measurement — v7 was declared 2026-09-01 and `clapback-embed` adopted 2026-09-02, one day apart,
+so a mixture of the old torch path and the ONNX path was entirely plausible. It is not what
+happened.
+
+**The audio decoder is not pinned, and `PIPELINE_VERSION` does not cover it.** All seven inexact
+tracks logged librosa's `PySoundFile failed. Trying audioread instead.` fallback. Embedding one of
+them twice in a single process gives 0.0 and -2.2e-16 — the fallback is deterministic *within* a
+run, so the difference is against whatever decoded the file when it was first stored, not run-to-run
+noise. Which decoder handles a file depends on the installed `libsndfile` and what it was built to
+read, and none of that appears in `PIPELINE_VERSION` despite its claim to pin everything that can
+move a vector. At 5.5e-11 it is four orders of magnitude inside clapback's 1e-6 "identical" band and
+seven inside the 3e-4 that two rips of one recording differ by, so it threatens no comparability —
+but it is a hole in the claim rather than an absence of one, and belongs to `clapback-embed` rather
+than here.
 - **Point 2 turned out to change more than pooling.** The previous implementation returned the raw
   encoder output *un-normalised*. Every consumer uses cosine — `cosine_distance` in pgvector,
   `cosine_similarity` in `ego_map.py` and `embedding_map.py`, no L2 or inner-product operator

--- a/docs/decisions/ADR-0108-a-contribution-names-the-installation-that-made-it.md
+++ b/docs/decisions/ADR-0108-a-contribution-names-the-installation-that-made-it.md
@@ -35,6 +35,12 @@ Implementation:
   the backfill script may not, because its vectors came out of the database and
   `embedding_version == 7` narrows their provenance without pinning it. Declaring there would
   assert, on tens of thousands of rows at once, something nobody verified.
+- **`EMBEDDING_VERSION` is 8 as of 2026-09-06**, which is phase 3 of the same record: the existing
+  re-analysis path recomputes the library, and each track is contributed again through the path
+  above — this time declaring the pipeline, because the vector was just computed. The bump moves no
+  vectors and is an exception to the rule in
+  [`ADR-0104`](ADR-0104-familiar-embeds-whole-tracks-by-chunked-mean.md) point 6, which records it
+  along with the measurement showing what a recompute does and does not change.
 
 ## Context
 


### PR DESCRIPTION
Phase 3 of clapback's [`ADR-0006`](https://github.com/seethroughlab/clapback/blob/main/docs/decisions/ADR-0006-the-pipeline-identity-is-the-corpus-key.md) point 6. `EMBEDDING_VERSION` goes to 8, which makes the existing re-analysis path pick up all 26,471 tracks. [#290](https://github.com/seethroughlab/familiar/pull/290) already added the declaration, so each recomputed vector is contributed with `pipeline_version` set.

## This bump breaks a rule on purpose

`ADR-0104` point 6 says the constant moves when vectors move by more than ~1e-6. **Nothing about the pipeline changed and the vectors do not move.** The bump exists because it is the only lever that drives the existing re-analysis path, and clapback's phase 4 keys on the pipeline and drops rows that cannot say what produced them — its point 5 recomputes rather than relabels, because relabelling asserts a provenance nobody verified.

An exception to a written rule that is not itself written down is indistinguishable from a mistake. It is recorded in the constant's comment, in `ADR-0104`, and in a test that asserts the comment says it.

## Measured before committing the CPU

Fifty tracks drawn at random from the 26,471, recomputed and compared with what is stored:

| | tracks | cosine distance from stored |
|---|---|---|
| reproduced exactly | 43 | ≤ 6.7e-16, the float64 floor |
| reproduced closely | 7 | 1.3e-12 – 5.5e-11 |

The recompute is very nearly a no-op on the numbers. That is the intended outcome — it buys the declaration, not different vectors.

### Two findings worth having in the record

**The stored v7 vectors really are from the current pipeline.** That was an assumption. v7 was declared 2026-09-01 and `clapback-embed` adopted 2026-09-02 — one day and three commits apart — so a mixture of the old torch path and the ONNX path was entirely plausible. It is not what happened.

**The audio decoder is not pinned, and `PIPELINE_VERSION` does not cover it.** All seven inexact tracks logged librosa's `PySoundFile failed. Trying audioread instead.` Embedding one of them twice in a single process gives `0.0` and `-2.2e-16`, so the fallback is deterministic *within* a run and the difference is against whatever decoded the file when it was first stored. Which decoder handles a file depends on the installed `libsndfile` and what it was built to read, and none of that appears in `PIPELINE_VERSION` despite its claim to pin everything that can move a vector.

At 5.5e-11 that is four orders of magnitude inside clapback's 1e-6 "identical" band and seven inside the 3e-4 that two rips of one recording differ by — it threatens no comparability. But it is a hole in the claim rather than an absence of one, and it belongs to `clapback-embed` rather than here.

## What happens on deploy

The background queue picks up `embedding_version < 8` and re-embeds 26,471 tracks over the following days, exactly as the v7 re-analysis did (`ADR-0104`: "drives itself from the existing two-hourly sync — nothing was scheduled for it").

- **Nothing functional degrades.** No search or similarity query filters on `embedding_version`; only the queue, the health coverage stat and library sync read it. Each row is updated in place with an identical vector, so there is no window where a track has no embedding.
- **The admin dashboard will read 0 embeddings done** and climb back to 26,471. Expected.
- **The corpus gains ~26,471 rows** keyed at `analysis_version = 8`, taking it from 47,486 to ~74,000 against a 500,000 ceiling. clapback's phase 4 drops the undeclared ones.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_013y1g4m6RF7PW8gB27uutuU