### PR TITLE
Only accept a cached vector from the pipeline we run

### DIFF
--- a/backend/app/services/community_cache.py
+++ b/backend/app/services/community_cache.py
@@ -53,6 +53,9 @@ class CachedEmbedding:
     analysis_version: int
     clap_model_version: str
     contributor_count: int = 1  # How many users have contributed this embedding
+    #: What produced it. None from a corpus predating clapback's `ADR-0006`; every
+    #: row in a current one declares it.
+    pipeline_version: str | None = None
 
 
 @dataclass
@@ -202,28 +205,52 @@ class CommunityCacheService:
         self,
         acoustid_fingerprint: str | bytes,
         analysis_version: int | None = None,
+        pipeline_version: str | None = None,
     ) -> CachedEmbedding | None:
         """Look up an embedding from the community cache.
 
         Args:
             acoustid_fingerprint: The raw AcoustID fingerprint string
             analysis_version: Version to match (defaults to current EMBEDDING_VERSION)
+            pipeline_version: Only accept a vector from this pipeline. **This is the
+                parameter that makes the answer usable**, since clapback's `ADR-0006`
+                phase 4: it is half the corpus key, so it selects exactly one row,
+                and it is the only field that establishes the vector is comparable
+                with the ones this installation computes. `analysis_version` and the
+                checkpoint are filters on metadata — a corpus holding two pipelines
+                can answer a query by those alone with a vector we cannot use, and
+                nothing downstream would notice, because it is a well-formed 512-dim
+                unit vector that simply means something else.
 
         Returns:
             CachedEmbedding if found, None otherwise
         """
         if analysis_version is None:
             analysis_version = self._embedding_version
+        if pipeline_version is None:
+            # Imported here rather than at module scope: `analysis` pulls in numpy
+            # and acoustid, and this module is imported by paths that need neither.
+            from app.services.analysis import embedding_pipeline_version
+
+            pipeline_version = embedding_pipeline_version()
 
         fp_hash = self.hash_fingerprint(acoustid_fingerprint)
+
+        params: dict[str, Any] = {
+            "analysis_version": analysis_version,
+            "clap_model_version": CLAP_MODEL_VERSION,
+        }
+        # Omitted rather than sent empty when this installation has no embedder, and
+        # therefore no pipeline of its own to match against. httpx escapes the `+`
+        # in the identity, which matters: unescaped it decodes as a space server-side
+        # and matches nothing, 404ing as though the recording were absent.
+        if pipeline_version:
+            params["pipeline_version"] = pipeline_version
 
         response = await self._request_with_retry(
             "GET",
             f"{self.cache_url}/v1/embeddings/{fp_hash}",
-            params={
-                "analysis_version": analysis_version,
-                "clap_model_version": CLAP_MODEL_VERSION,
-            },
+            params=params,
         )
 
         if response is None:
@@ -248,6 +275,22 @@ class CommunityCacheService:
                 )
                 return None
 
+            # **Check what came back, do not assume the filter was honoured.** A
+            # corpus predating clapback's phase 4 ignores `pipeline_version`
+            # entirely and answers on the metadata alone, so the request being
+            # correct does not make the response right. Accepting a vector from
+            # another pipeline is silent and permanent: it is a valid 512-dim unit
+            # vector that means something else, and it would be stored as this
+            # track's embedding and compared against everything.
+            returned = data.get("pipeline_version")
+            if pipeline_version and returned and returned != pipeline_version:
+                logger.warning(
+                    "Community cache returned a vector from %s, not %s — ignoring it",
+                    returned,
+                    pipeline_version,
+                )
+                return None
+
             logger.info(
                 f"Community cache hit for {fp_hash[:16]}... "
                 f"(contributed by {data.get('contributor_count', 1)} users)"
@@ -259,6 +302,7 @@ class CommunityCacheService:
                 analysis_version=data.get("analysis_version", analysis_version),
                 clap_model_version=data.get("clap_model_version", CLAP_MODEL_VERSION),
                 contributor_count=data.get("contributor_count", 1),
+                pipeline_version=returned,
             )
         except Exception as e:
             logger.warning(f"Community cache lookup failed to parse response: {e}")

--- a/backend/tests/test_community_cache_contribution.py
+++ b/backend/tests/test_community_cache_contribution.py
@@ -263,3 +263,98 @@ class TestTheEmbeddingVersionDocumentsItself:
         history = self._history()
         assert "ADR-0006" in history, "the reason for the v8 bump is not recorded"
         assert "do not change" in history or "does not mean" in history
+
+
+class TestALookupOnlyAcceptsItsOwnPipeline:
+    """clapback's `ADR-0006` phase 4 made `pipeline_version` half the corpus key, so
+    a recording can hold one vector per pipeline.
+
+    The failure this guards is silent and permanent. A vector from another pipeline
+    is a well-formed 512-dimensional unit vector that simply means something else;
+    accepted, it would be stored as the track's embedding and compared against
+    everything in the library, and nothing downstream could tell.
+    """
+
+    IDENTITY = "laion/clap-htsat-unfused+frontend1+artifact1+pool1+fp32"
+
+    def _lookup(self, *, returns: dict, declared: str | None = "unset") -> tuple:
+        """Returns `(params_sent, result)`."""
+        service = CommunityCacheService(cache_url="http://cache")
+        sent: dict = {}
+
+        async def fake(method, url, **kwargs):
+            sent.update(kwargs.get("params", {}))
+
+            class Response:
+                status_code = 200
+
+                def json(self):
+                    return returns
+
+            return Response()
+
+        kw = {} if declared == "unset" else {"pipeline_version": declared}
+        with patch.object(service, "_request_with_retry", new=AsyncMock(side_effect=fake)):
+            with patch.object(analysis, "_embedder_available", True):
+                module = types.ModuleType("clapback_embed")
+                module.PIPELINE_VERSION = self.IDENTITY
+                with patch.dict(sys.modules, {"clapback_embed": module}):
+                    result = asyncio.run(service.lookup("fp", **kw))
+        return sent, result
+
+    def _hit(self, pipeline: str | None) -> dict:
+        body = {
+            "embedding": _vector(),
+            "analysis_version": EMBEDDING_VERSION,
+            "clap_model_version": CLAP_MODEL_VERSION,
+            "contributor_count": 1,
+        }
+        if pipeline is not None:
+            body["pipeline_version"] = pipeline
+        return body
+
+    def test_the_request_names_the_pipeline_this_install_runs(self):
+        sent, _ = self._lookup(returns=self._hit(self.IDENTITY))
+        assert sent["pipeline_version"] == self.IDENTITY
+
+    def test_a_matching_vector_is_accepted(self):
+        _, result = self._lookup(returns=self._hit(self.IDENTITY))
+        assert result is not None
+        assert result.pipeline_version == self.IDENTITY
+
+    def test_a_vector_from_another_pipeline_is_refused(self):
+        """**The point of the class.** A corpus predating phase 4 ignores the
+        parameter and answers on metadata alone, so a correct request does not make
+        the response right — the answer has to be checked, not assumed."""
+        _, result = self._lookup(returns=self._hit("something+else+entirely"))
+        assert result is None
+
+    def test_an_undeclared_vector_is_still_accepted(self):
+        """An older corpus declares nothing. Refusing those would turn every lookup
+        against one into a miss, which breaks a client against a server that is
+        merely older rather than wrong."""
+        _, result = self._lookup(returns=self._hit(None))
+        assert result is not None
+
+    def test_an_install_without_an_embedder_sends_nothing(self):
+        """It has no pipeline of its own to match against, and an empty parameter
+        would be a filter on the empty string."""
+        service = CommunityCacheService(cache_url="http://cache")
+        sent: dict = {}
+
+        async def fake(method, url, **kwargs):
+            sent.update(kwargs.get("params", {}))
+
+            class Response:
+                status_code = 404
+
+                def json(self):
+                    return {}
+
+            return Response()
+
+        with patch.object(service, "_request_with_retry", new=AsyncMock(side_effect=fake)):
+            with patch.object(analysis, "_embedder_available", False):
+                assert asyncio.run(service.lookup("fp")) is None
+        assert "pipeline_version" not in sent
+        assert sent["analysis_version"] == EMBEDDING_VERSION

--- a/docs/decisions/ADR-0108-a-contribution-names-the-installation-that-made-it.md
+++ b/docs/decisions/ADR-0108-a-contribution-names-the-installation-that-made-it.md
@@ -41,6 +41,15 @@ Implementation:
   vectors and is an exception to the rule in
   [`ADR-0104`](ADR-0104-familiar-embeds-whole-tracks-by-chunked-mean.md) point 6, which records it
   along with the measurement showing what a recompute does and does not change.
+- **Lookups name the pipeline too** (2026-09-06), which is the read-side half of clapback's phase 4.
+  Once the corpus keys on `(fingerprint_hash, pipeline_version)` a recording can hold one vector per
+  pipeline, and a query by `analysis_version` and the checkpoint alone can be answered with a vector
+  this installation cannot use — a well-formed 512-dimensional unit vector that means something
+  else, which would be stored as the track's embedding and compared against the whole library with
+  nothing downstream able to tell. The response is checked as well as the request filtered: a corpus
+  predating that phase ignores the parameter, so asking correctly does not make the answer right. A
+  vector declaring *nothing* is still accepted, because refusing it would break this client against
+  a server that is merely older.
 
 ## Context
 


### PR DESCRIPTION
The read-side half of clapback's `ADR-0006` phase 4 ([clapback#37](https://github.com/seethroughlab/clapback/pull/37)).

Once the corpus keys on `(fingerprint_hash, pipeline_version)`, a recording can hold **one vector per pipeline** — and a lookup by `analysis_version` and the checkpoint alone can be answered with a vector this installation cannot use.

**That failure is silent and permanent.** What comes back is a well-formed 512-dimensional unit vector that simply means something else. Accepted, it is stored as the track's embedding and compared against the whole library, and nothing downstream can tell.

## Both halves are needed

- **Filter the request** — send `pipeline_version`, read from the installed embedder via the same accessor contribution uses.
- **Check the response** — a corpus predating phase 4 ignores the parameter and answers on metadata alone, so asking correctly does not make the answer right.

A vector declaring *nothing* is still accepted. Refusing those would turn every lookup against an older corpus into a miss, which breaks this client against a server that is merely older rather than wrong.

An installation with no embedder sends no parameter at all — it has no pipeline of its own to match against, and an empty value would be a filter on the empty string.

`httpx` escapes the `+` in the identity, which matters: unescaped it decodes server-side as a space and matches nothing, 404ing as though the recording were absent.

## Tests

5 new, covering the request, the accept, the refuse, the older-corpus case, and the no-embedder case. 25 pass in the file.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_013y1g4m6RF7PW8gB27uutuU