### PR TITLE
Default to the commons that answers

### DIFF
--- a/backend/app/services/app_settings.py
+++ b/backend/app/services/app_settings.py
@@ -79,7 +79,10 @@ class AppSettings(BaseModel):
     # Community embedding cache (share CLAP embeddings with other users)
     community_cache_enabled: bool = True  # Look up embeddings from community cache
     community_cache_contribute: bool = False  # Contribute computed embeddings (opt-in)
-    community_cache_url: str = "https://familiar-cache.fly.dev"  # Cache server URL
+    #: The commons this installation talks to. Keep in step with
+    #: `community_cache.DEFAULT_CACHE_URL` — they are the same fact written twice, and
+    #: a test asserts they agree.
+    community_cache_url: str = "https://clapback.seethroughlab.com"
 
     # Opaque per-installation identifier sent with every embedding contribution, so the
     # commons can tell "two installations computed the same vector" from "one installation

--- a/backend/app/services/community_cache.py
+++ b/backend/app/services/community_cache.py
@@ -40,8 +40,20 @@ DEFAULT_RETRY_DELAY = 5.0  # seconds
 CLAP_MODEL_VERSION = "laion/clap-htsat-unfused:v1"
 EMBEDDING_DIM = 512
 
-# Default community cache server
-DEFAULT_CACHE_URL = "https://familiar-cache.fly.dev"
+# Default community cache server — the public commons, and the only one now.
+#
+# It was `familiar-cache.fly.dev` until 2026-09-06, which had not resolved since the
+# service left Fly. A default that points at nothing is not merely untidy: this is the
+# value an installation uses when it has no setting of its own, so a fresh install
+# looked up and contributed into a void, and every one of those requests failed in a
+# way that looks exactly like a cache miss.
+#
+# The same day, the local `familiar-cache` container this deployment had been pointed
+# at was decommissioned for the sister reason — it accepted contributions and returned
+# `201 Created` while silently discarding the `pipeline_version` its schema predated,
+# which is worse than failing. There is now one address, it is public, and anything
+# aimed elsewhere errors instead of appearing to work.
+DEFAULT_CACHE_URL = "https://clapback.seethroughlab.com"
 
 
 @dataclass

--- a/backend/tests/test_community_cache_contribution.py
+++ b/backend/tests/test_community_cache_contribution.py
@@ -358,3 +358,47 @@ class TestALookupOnlyAcceptsItsOwnPipeline:
                 assert asyncio.run(service.lookup("fp")) is None
         assert "pipeline_version" not in sent
         assert sent["analysis_version"] == EMBEDDING_VERSION
+
+
+class TestTheDefaultAddressIsOneThatAnswers:
+    """The default is what an installation uses when it has no setting of its own.
+
+    It pointed at `familiar-cache.fly.dev` until 2026-09-06 — a host that had not
+    resolved since the service left Fly. **A default aimed at nothing fails in the
+    shape of a cache miss**: lookups return None and contributions are swallowed by
+    the same `except` that handles a server being briefly down, so a fresh install
+    contributed nothing and nobody would have seen an error.
+    """
+
+    RETIRED = "familiar-cache.fly.dev"
+
+    def test_the_two_defaults_are_the_same_fact(self):
+        """`AppSettings.community_cache_url` and `DEFAULT_CACHE_URL` are written
+        twice and must not drift — one is used when a settings file exists without
+        the key, the other when the service is built without one."""
+        from app.services.app_settings import AppSettings
+        from app.services.community_cache import DEFAULT_CACHE_URL
+
+        assert AppSettings().community_cache_url == DEFAULT_CACHE_URL
+
+    def test_neither_points_at_the_retired_host(self):
+        from app.services.app_settings import AppSettings
+        from app.services.community_cache import DEFAULT_CACHE_URL
+
+        assert self.RETIRED not in DEFAULT_CACHE_URL
+        assert self.RETIRED not in AppSettings().community_cache_url
+
+    def test_a_service_built_without_a_url_uses_it(self):
+        """The path that matters: `get_community_cache_service()` with no argument."""
+        from app.services.community_cache import DEFAULT_CACHE_URL
+
+        service = CommunityCacheService()
+        assert service.cache_url == DEFAULT_CACHE_URL
+
+    def test_it_is_https(self):
+        """The commons is reached over the public internet now, not a Docker network
+        alias on one NAS. Contributions carry no personal data, but a plaintext
+        default would still be a decision nobody took."""
+        from app.services.community_cache import DEFAULT_CACHE_URL
+
+        assert DEFAULT_CACHE_URL.startswith("https://")

--- a/docs/analysis-datapoints.md
+++ b/docs/analysis-datapoints.md
@@ -446,7 +446,7 @@ Each descriptor has a natural-language description (e.g., "happy uplifting joyfu
 | | |
 |---|---|
 | **Service** | `community_cache.py:CommunityCacheService` |
-| **Server** | `https://familiar-cache.fly.dev` |
+| **Server** | `https://clapback.seethroughlab.com` (was `familiar-cache.fly.dev`, retired when the service left Fly) |
 | **Key** | SHA256 hash of AcoustID fingerprint (privacy-preserving) |
 | **Data types** | Embeddings (512-dim CLAP), features (all scalar columns), analysis_detail (full structured data) |
 | **Versioning** | Matched by `EMBEDDING_VERSION`, `FEATURES_VERSION`, and CLAP model version |


### PR DESCRIPTION
`DEFAULT_CACHE_URL` and `AppSettings.community_cache_url` both pointed at `familiar-cache.fly.dev`, which has not resolved since the service left Fly.

**A default aimed at nothing fails in the shape of a cache miss.** It is the value an installation uses when it has no setting of its own, so a fresh install looked up into a void and had its contributions swallowed by the same `except` that handles a server being briefly down — no error, nothing contributed, and nobody would have seen it.

The same day, the local `familiar-cache` container this deployment had been pointed at was decommissioned for the sister reason: it accepted contributions and returned `201 Created` while **silently discarding the `pipeline_version`** its schema predated, which is worse than failing. There is now one address, it is public, and anything aimed elsewhere errors instead of appearing to work.

## Changes

| file | |
|---|---|
| `services/community_cache.py` | `DEFAULT_CACHE_URL` → `https://clapback.seethroughlab.com` |
| `services/app_settings.py` | the `AppSettings` default, to match |
| `docs/analysis-datapoints.md` | the server it names, with the old one noted as retired |

The two constants are the same fact written twice — one is used when a settings file exists without the key, the other when the service is built without one — so a test asserts they agree, that neither names the retired host, and that a service built with no argument picks it up.

**The deployed instance is unaffected**: it carries the URL explicitly in its settings. This is for installs that have no setting.

The ADRs that mention the old address are **left alone**. They record what was true when written; `docs/analysis-datapoints.md` is a live reference rather than a record, so that is what gets corrected.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_013y1g4m6RF7PW8gB27uutuU